### PR TITLE
Add Clickbench Test

### DIFF
--- a/test/sql/clickbench/clickbench.test_slow
+++ b/test/sql/clickbench/clickbench.test_slow
@@ -1,246 +1,250 @@
 # name: test/sql/clickbench/clickbench.test_slow
-# description: Test running TPC-H on DuckLake
+# description: Test running Clickbench on DuckLake
 # group: [tpch]
 
 require ducklake
 
 require parquet
 
-# statement ok
-# CREATE MACRO toDateTime(t) AS epoch_ms(t * 1000);
-#
-# statement ok
-# CREATE TABLE hits AS
-# SELECT *
-#     REPLACE (make_date(EventDate) AS EventDate, toDateTime(EventTime) AS EventTime)
-# FROM read_parquet('/Users/holanda/Downloads/hits.parquet', binary_as_string=True);
-#
-# # Not yet supported
-# statement ok
-# DROP MACRO toDateTime;
+mode skip
+# wget https://datasets.clickhouse.com/hits_compatible/hits.parquet
+
+statement ok
+CREATE MACRO toDateTime(t) AS epoch_ms(t * 1000);
+
+statement ok
+CREATE TABLE hits AS
+SELECT *
+    REPLACE (make_date(EventDate) AS EventDate, toDateTime(EventTime) AS EventTime)
+FROM read_parquet('/Users/holanda/Downloads/hits.parquet', binary_as_string=True);
+
+# Not yet supported
+statement ok
+DROP MACRO toDateTime;
 
 statement ok
 ATTACH 'ducklake:ducklake_clickbench.db' AS ducklake (DATA_PATH '/Users/holanda/Documents/Projects/ducklake/clickbench/')
 
-# statement ok
-# COPY FROM DATABASE memory TO ducklake
+statement ok
+COPY FROM DATABASE memory TO ducklake
 
 statement ok
 USE ducklake
 
-
 query I
 SELECT COUNT(*) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q01.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q00.csv
 
 query I
 SELECT COUNT(*) FROM ducklake.hits WHERE AdvEngineID <> 0;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q02.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q01.csv
 
 query I
 SELECT SUM(AdvEngineID), COUNT(*), AVG(ResolutionWidth) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q03.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q02.csv
 
 query I
 SELECT AVG(UserID) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q04.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q03.csv
 
 query I
 SELECT COUNT(DISTINCT UserID) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q05.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q04.csv
 
 query I
 SELECT COUNT(DISTINCT SearchPhrase) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q06.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q05.csv
 
 query I
 SELECT MIN(EventDate), MAX(EventDate) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q07.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q06.csv
 
 query I
 SELECT AdvEngineID, COUNT(*) FROM ducklake.hits WHERE AdvEngineID <> 0 GROUP BY AdvEngineID ORDER BY COUNT(*) DESC;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q08.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q07.csv
 
 query I
 SELECT RegionID, COUNT(DISTINCT UserID) AS u FROM ducklake.hits GROUP BY RegionID ORDER BY u DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q09.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q08.csv
 
 query I
 SELECT RegionID, SUM(AdvEngineID), COUNT(*) AS c, AVG(ResolutionWidth), COUNT(DISTINCT UserID) FROM ducklake.hits GROUP BY RegionID ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q10.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q09.csv
 
 query I
 SELECT MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM ducklake.hits WHERE MobilePhoneModel <> '' GROUP BY MobilePhoneModel ORDER BY u DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q11.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q10.csv
 
 query I
 SELECT MobilePhone, MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM ducklake.hits WHERE MobilePhoneModel <> '' GROUP BY MobilePhone, MobilePhoneModel ORDER BY u DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q12.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q11.csv
 
 query I
 SELECT SearchPhrase, COUNT(*) AS c FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q13.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q12.csv
 
 query I
 SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q14.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q13.csv
 
 query I
 SELECT SearchEngineID, SearchPhrase, COUNT(*) AS c FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q15.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q14.csv
 
 query I
 SELECT UserID, COUNT(*) FROM ducklake.hits GROUP BY UserID ORDER BY COUNT(*) DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q16.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q15.csv
 
 query I
 SELECT UserID, COALESCE(NULLIF(SearchPhrase, ''), NULL) AS SearchPhrase , COUNT(*) FROM ducklake.hits GROUP BY UserID, COALESCE(NULLIF(SearchPhrase, ''), NULL) ORDER BY COUNT(*) DESC LIMIT 10;
 ----
+<FILE>:duckdb/benchmark/clickbench/answers/q16.csv
+
+query I
+SELECT COUNT(*) AS count FROM (SELECT UserID, SearchPhrase FROM (SELECT UserID, SearchPhrase, COUNT(*) FROM ducklake.hits GROUP BY UserID, SearchPhrase LIMIT 10) GROUP BY UserID, SearchPhrase) t
+----
 <FILE>:duckdb/benchmark/clickbench/answers/q17.csv
 
 query I
-SELECT UserID, SearchPhrase, COUNT(*) FROM ducklake.hits GROUP BY UserID, SearchPhrase LIMIT 10;
+SELECT * FROM (SELECT UserID, extract(minute FROM EventTime) AS m, COALESCE(NULLIF(SearchPhrase, ''), NULL), COUNT(*) FROM ducklake.hits GROUP BY UserID, m, COALESCE(NULLIF(SearchPhrase, ''), NULL) ORDER BY COUNT(*) DESC LIMIT 10) ORDER BY 4 DESC, 1 ;
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q18.csv
 
 query I
-SELECT * FROM (SELECT UserID, extract(minute FROM EventTime) AS m, SearchPhrase, COUNT(*) FROM ducklake.hits GROUP BY UserID, m, SearchPhrase ORDER BY COUNT(*) DESC LIMIT 10) ORDER BY 4 DESC, 1 ;
+SELECT UserID FROM ducklake.hits WHERE UserID = 435090932899640449;
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q19.csv
 
 query I
-SELECT UserID FROM ducklake.hits WHERE UserID = 435090932899640449;
+SELECT COUNT(*) FROM ducklake.hits WHERE URL LIKE '%google%';
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q20.csv
 
 query I
-SELECT COUNT(*) FROM ducklake.hits WHERE URL LIKE '%google%';
+SELECT * FROM (SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM ducklake.hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10) ORDER BY c DESC, SearchPhrase LIMIT 8
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q21.csv
 
 query I
-SELECT * FROM (SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM ducklake.hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY ALL DESC LIMIT 10) ORDER BY c DESC, SearchPhrase LIMIT 5
+SELECT * FROM (SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM ducklake.hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10) ORDER BY c DESC LIMIT 10
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q22.csv
 
-query I
-SELECT * FROM (SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM ducklake.hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10) ORDER BY c DESC LIMIT 6
-----
-<FILE>:duckdb/benchmark/clickbench/answers/q23.csv
+# Invalid Error: mutex lock failed: Invalid argument
+# query I
+# SELECT * FROM ducklake.hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10;
+# ----
+# <FILE>:duckdb/benchmark/clickbench/answers/q23.csv
 
-query I
-SELECT * FROM ducklake.hits WHERE URL LIKE '%google%' ORDER BY ALL LIMIT 10;
-----
-<FILE>:duckdb/benchmark/clickbench/answers/q24.csv
-
-query I
-SELECT SearchPhrase FROM ducklake.hits WHERE SearchPhrase <> '' ORDER BY ALL LIMIT 10;
-----
-<FILE>:duckdb/benchmark/clickbench/answers/q25.csv
+# Segfault
+# query I
+# SELECT * FROM (SELECT * FROM (SELECT SearchPhrase FROM ducklake.hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10) LIMIT 4) ORDER BY SearchPhrase
+# ----
+# <FILE>:duckdb/benchmark/clickbench/answers/q24.csv
 
 query I
 SELECT SearchPhrase FROM ducklake.hits WHERE SearchPhrase <> '' ORDER BY SearchPhrase LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q26.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q25.csv
 
 query I
 SELECT SearchPhrase FROM ducklake.hits WHERE SearchPhrase <> '' ORDER BY EventTime, SearchPhrase LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q27.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q26.csv
 
 query I
 SELECT CounterID, AVG(STRLEN(URL)) AS l, COUNT(*) AS c FROM ducklake.hits WHERE URL <> '' GROUP BY CounterID HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q28.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q27.csv
 
 query I
 SELECT REGEXP_REPLACE(Referer, '^https?://(?:www\.)?([^/]+)/.*$', '\1') AS k, AVG(STRLEN(Referer)) AS l, COUNT(*) AS c, MIN(Referer) FROM ducklake.hits WHERE Referer <> '' GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q29.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q28.csv
 
 query I
 SELECT SUM(ResolutionWidth), SUM(ResolutionWidth + 1), SUM(ResolutionWidth + 2), SUM(ResolutionWidth + 3), SUM(ResolutionWidth + 4), SUM(ResolutionWidth + 5), SUM(ResolutionWidth + 6), SUM(ResolutionWidth + 7), SUM(ResolutionWidth + 8), SUM(ResolutionWidth + 9), SUM(ResolutionWidth + 10), SUM(ResolutionWidth + 11), SUM(ResolutionWidth + 12), SUM(ResolutionWidth + 13), SUM(ResolutionWidth + 14), SUM(ResolutionWidth + 15), SUM(ResolutionWidth + 16), SUM(ResolutionWidth + 17), SUM(ResolutionWidth + 18), SUM(ResolutionWidth + 19), SUM(ResolutionWidth + 20), SUM(ResolutionWidth + 21), SUM(ResolutionWidth + 22), SUM(ResolutionWidth + 23), SUM(ResolutionWidth + 24), SUM(ResolutionWidth + 25), SUM(ResolutionWidth + 26), SUM(ResolutionWidth + 27), SUM(ResolutionWidth + 28), SUM(ResolutionWidth + 29), SUM(ResolutionWidth + 30), SUM(ResolutionWidth + 31), SUM(ResolutionWidth + 32), SUM(ResolutionWidth + 33), SUM(ResolutionWidth + 34), SUM(ResolutionWidth + 35), SUM(ResolutionWidth + 36), SUM(ResolutionWidth + 37), SUM(ResolutionWidth + 38), SUM(ResolutionWidth + 39), SUM(ResolutionWidth + 40), SUM(ResolutionWidth + 41), SUM(ResolutionWidth + 42), SUM(ResolutionWidth + 43), SUM(ResolutionWidth + 44), SUM(ResolutionWidth + 45), SUM(ResolutionWidth + 46), SUM(ResolutionWidth + 47), SUM(ResolutionWidth + 48), SUM(ResolutionWidth + 49), SUM(ResolutionWidth + 50), SUM(ResolutionWidth + 51), SUM(ResolutionWidth + 52), SUM(ResolutionWidth + 53), SUM(ResolutionWidth + 54), SUM(ResolutionWidth + 55), SUM(ResolutionWidth + 56), SUM(ResolutionWidth + 57), SUM(ResolutionWidth + 58), SUM(ResolutionWidth + 59), SUM(ResolutionWidth + 60), SUM(ResolutionWidth + 61), SUM(ResolutionWidth + 62), SUM(ResolutionWidth + 63), SUM(ResolutionWidth + 64), SUM(ResolutionWidth + 65), SUM(ResolutionWidth + 66), SUM(ResolutionWidth + 67), SUM(ResolutionWidth + 68), SUM(ResolutionWidth + 69), SUM(ResolutionWidth + 70), SUM(ResolutionWidth + 71), SUM(ResolutionWidth + 72), SUM(ResolutionWidth + 73), SUM(ResolutionWidth + 74), SUM(ResolutionWidth + 75), SUM(ResolutionWidth + 76), SUM(ResolutionWidth + 77), SUM(ResolutionWidth + 78), SUM(ResolutionWidth + 79), SUM(ResolutionWidth + 80), SUM(ResolutionWidth + 81), SUM(ResolutionWidth + 82), SUM(ResolutionWidth + 83), SUM(ResolutionWidth + 84), SUM(ResolutionWidth + 85), SUM(ResolutionWidth + 86), SUM(ResolutionWidth + 87), SUM(ResolutionWidth + 88), SUM(ResolutionWidth + 89) FROM ducklake.hits;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q30.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q29.csv
 
-# Modified for correctness
 query I
-SELECT * FROM (SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, ClientIP ORDER BY c DESC LIMIT 10) ORDER BY c DESC, ClientIP
+SELECT * FROM (SELECT * FROM (SELECT SearchEngineID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, ClientIP ORDER BY c DESC LIMIT 10) ORDER BY c DESC, ClientIP) ORDER BY c DESC, ClientIP LIMIT 9
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q31.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q30.csv
 
 query I
 SELECT MIN(c), MAX(c), COUNT(*) FROM (SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits WHERE SearchPhrase <> '' GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10)
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q32.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q31.csv
 
 # Invalid Error: TProtocolException: Invalid data
-query I
-SELECT MIN(c), MAX(c), COUNT(*) FROM (SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits GROUP BY WatchID, ClientIP ORDER BY ALL DESC LIMIT 10)
-----
-<FILE>:duckdb/benchmark/clickbench/answers/q33.csv
+# query I
+# SELECT MIN(c), MAX(c), COUNT(*) FROM (SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10)
+# ----
+# <FILE>:duckdb/benchmark/clickbench/answers/q32.csv
 
 query I
 SELECT URL, COUNT(*) AS c FROM ducklake.hits GROUP BY URL ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q34.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q33.csv
 
 query I
 SELECT 1, URL, COUNT(*) AS c FROM ducklake.hits GROUP BY 1, URL ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q35.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q34.csv
 
 query I
 SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM ducklake.hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q36.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q35.csv
 
 query I
 SELECT URL, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND DontCountHits = 0 AND IsRefresh = 0 AND URL <> '' GROUP BY URL ORDER BY PageViews DESC LIMIT 10;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q37.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q36.csv
 
 query I
 SELECT Title, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND DontCountHits = 0 AND IsRefresh = 0 AND Title <> '' GROUP BY Title ORDER BY PageViews DESC LIMIT 10;
 ----
+<FILE>:duckdb/benchmark/clickbench/answers/q37.csv
+
+query I
+SELECT MIN(PageViews), MAX(PageViews), COUNT(*) FROM (SELECT URL, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND IsLink <> 0 AND IsDownload = 0 GROUP BY ALL ORDER BY PageViews DESC LIMIT 10 OFFSET 1000)
+----
 <FILE>:duckdb/benchmark/clickbench/answers/q38.csv
 
 query I
-SELECT MIN(PageViews), MAX(PageViews), COUNT(*) FROM (SELECT URL, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND IsLink <> 0 AND IsDownload = 0 GROUP BY ALL ORDER BY ALL DESC LIMIT 10 OFFSET 1000)
+SELECT MIN(PageViews), MAX(PageViews), COUNT(*) FROM (SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN (SearchEngineID = 0 AND AdvEngineID = 0) THEN Referer ELSE '' END AS Src, URL AS Dst, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 GROUP BY TraficSourceID, SearchEngineID, AdvEngineID, Src, Dst ORDER BY PageViews DESC LIMIT 10 OFFSET 1000)
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q39.csv
 
 query I
-SELECT MIN(PageViews), MAX(PageViews), COUNT(*) FROM (SELECT TraficSourceID, SearchEngineID, AdvEngineID, CASE WHEN (SearchEngineID = 0 AND AdvEngineID = 0) THEN Referer ELSE '' END AS Src, URL AS Dst, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 GROUP BY TraficSourceID, SearchEngineID, AdvEngineID, Src, Dst ORDER BY ALL DESC LIMIT 10 OFFSET 1000)
+SELECT * FROM (SELECT URLHash, EventDate, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND TraficSourceID IN (-1, 6) AND RefererHash = 3594120000172545465 GROUP BY URLHash, EventDate ORDER BY PageViews DESC LIMIT 10 OFFSET 100) ORDER BY PageViews DESC, URLHash OFFSET 2 LIMIT 5
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q40.csv
 
 query I
-SELECT * FROM (SELECT URLHash, EventDate, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND TraficSourceID IN (-1, 6) AND RefererHash = 3594120000172545465 GROUP BY URLHash, EventDate ORDER BY ALL DESC LIMIT 10 OFFSET 100) ORDER BY PageViews DESC, URLHash OFFSET 3 LIMIT 6
+SELECT MIN(PageViews), MAX(PageViews), COUNT(*) FROM (SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND DontCountHits = 0 AND URLHash = 2868770270353813622 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY PageViews DESC LIMIT 10 OFFSET 10000)
 ----
 <FILE>:duckdb/benchmark/clickbench/answers/q41.csv
 
 query I
-SELECT WindowClientWidth, WindowClientHeight, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND IsRefresh = 0 AND DontCountHits = 0 AND URLHash = 2868770270353813622 GROUP BY WindowClientWidth, WindowClientHeight ORDER BY ALL DESC LIMIT 10 OFFSET 10000;
-----
-<FILE>:duckdb/benchmark/clickbench/answers/q42.csv
-
 SELECT DATE_TRUNC('minute', EventTime) AS M, COUNT(*) AS PageViews FROM ducklake.hits WHERE CounterID = 62 AND EventDate >= '2013-07-14' AND EventDate <= '2013-07-15' AND IsRefresh = 0 AND DontCountHits = 0 GROUP BY DATE_TRUNC('minute', EventTime) ORDER BY DATE_TRUNC('minute', EventTime) LIMIT 10 OFFSET 1000;
 ----
-<FILE>:duckdb/benchmark/clickbench/answers/q43.csv
+<FILE>:duckdb/benchmark/clickbench/answers/q42.csv


### PR DESCRIPTION
This PR adds clickbench with result verification as a slow test for Ducklake.

There are currently 3 queries being problematic:

Query 23 has a mutex lock failed error.
```
# Invalid Error: mutex lock failed: Invalid argument
# query I
# SELECT * FROM ducklake.hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10;
# ----
# <FILE>:duckdb/benchmark/clickbench/answers/q23.csv
``` 

Query 24 has a segfault
```
# query I
# SELECT * FROM (SELECT * FROM (SELECT SearchPhrase FROM ducklake.hits WHERE SearchPhrase <> '' ORDER BY EventTime LIMIT 10) LIMIT 4) ORDER BY SearchPhrase
# ----
# <FILE>:duckdb/benchmark/clickbench/answers/q24.csv
```

Query 31 has a `TProtocolException: Invalid data` error.
```
# Invalid Error: TProtocolException: Invalid data
# query I
# SELECT MIN(c), MAX(c), COUNT(*) FROM (SELECT WatchID, ClientIP, COUNT(*) AS c, SUM(IsRefresh), AVG(ResolutionWidth) FROM ducklake.hits GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10)
# ----
# <FILE>:duckdb/benchmark/clickbench/answers/q32.csv
```

Best way to run this test is to `wget https://datasets.clickhouse.com/hits_compatible/hits.parquet` and change the hardcoded paths in:

```
statement ok
CREATE TABLE hits AS
SELECT *
    REPLACE (make_date(EventDate) AS EventDate, toDateTime(EventTime) AS EventTime)
FROM read_parquet('/Users/holanda/Downloads/hits.parquet', binary_as_string=True);

# Not yet supported
statement ok
DROP MACRO toDateTime;

statement ok
ATTACH 'ducklake:ducklake_clickbench.db' AS ducklake (DATA_PATH '/Users/holanda/Documents/Projects/ducklake/clickbench/')
```

I think after it all passes and is ready to go to CI it can be replaced directly on the `CREATE TABLE` with an httpfs requirement.