### PR TITLE
Test other DBMSs with Ducklake

### DIFF
--- a/scripts/change_db.py
+++ b/scripts/change_db.py
@@ -52,10 +52,9 @@ def process_file(file_path):
     if dbms == "sqlite":
         lines = [line.replace("ducklake:__TEST_DIR__", "ducklake:sqlite:__TEST_DIR__") for line in lines]
     elif dbms == "postgres":
-        lines = [re.sub(r"'ducklake:__TEST_DIR__[^']*'", "'ducklake:postgres:dbname=postgresducklake'",line)for line in lines]
+        lines = [re.sub(r"'ducklake:__TEST_DIR__[^']*'", "'ducklake:postgres:dbname=ducklakedb'",line)for line in lines]
     elif dbms == "mysql":
-        print(f"Nop")
-        sys.exit(1)
+        lines = [re.sub(r"'ducklake:__TEST_DIR__[^']*'", "'ducklake:mysql:db=ducklakedb'",line)for line in lines]
 
     with open(file_path, 'w', encoding='utf-8') as f:
         f.writelines(lines)
@@ -74,16 +73,22 @@ def collect_test_files(root_folder):
 test_files = collect_test_files(folder_to_process)
 
 if dbms == "postgres":
-        subprocess.run("dropdb --if-exists postgresducklake", shell=True, capture_output=True, text=True)
+        subprocess.run("dropdb --if-exists ducklakedb", shell=True, capture_output=True, text=True)
+elif dbms == "mysql":
+        subprocess.run(" mysql -u root -e \"DROP DATABASE ducklakedb\"", shell=True, capture_output=True, text=True)
 
 for test_file in test_files:
     process_file(test_file)
     print(f"Running {test_file}")
     if dbms == "postgres":
-        subprocess.run("createdb postgresducklake", shell=True, capture_output=True, text=True)
+        subprocess.run("createdb ducklakedb", shell=True, capture_output=True, text=True)
+    elif dbms == "mysql":
+        subprocess.run(" mysql -u root -e \"CREATE DATABASE ducklakedb\"", shell=True, capture_output=True, text=True)
     result = subprocess.run(f"{release_folder}/unittest {test_file}", shell=True, capture_output=True, text=True)
     if dbms == "postgres":
-        subprocess.run("dropdb --if-exists postgresducklake", shell=True, capture_output=True, text=True)
+        subprocess.run("dropdb --if-exists ducklakedb", shell=True, capture_output=True, text=True)
+    elif dbms == "mysql":
+        subprocess.run(" mysql -u root -e \"DROP DATABASE ducklakedb\"", shell=True, capture_output=True, text=True)
     print(result.stdout)
     if result.stderr:
         print("Errors:")


### PR DESCRIPTION
This script is semi-ghetto, but it allows us to rewrite our existing ducklake tests to run with either sqlite, postgres or mysql.

To call it you just need to specify where the dbms extension is and what dbms you are calling:
e.g.,
`python3 scripts/change_db.py /Users/holanda/Documents/Projects/ducklake/duckdb/build/release/extension/postgres_scanner/postgres_scanner.duckdb_extension postgres
`

It then alters all tests to use that database, and run each test one by one, so it can also cleanup the database between tests.

It assumes a release build of ducklake.

After running tests for one of the systems you must restore the changed files, e.g.,
`git restore test ...`