### PR TITLE
Add support for forwarding parameters to the metadata catalog

### DIFF
--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -25,6 +25,7 @@ struct DuckLakeOptions {
 	DuckLakeEncryption encryption = DuckLakeEncryption::AUTOMATIC;
 	idx_t data_inlining_row_limit = 0;
 	unique_ptr<BoundAtClause> at_clause;
+	unordered_map<string, Value> metadata_parameters;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -31,6 +31,9 @@ string DuckLakeInitializer::GetAttachOptions() {
 			throw InternalException("Unsupported access mode in DuckLake attach");
 		}
 	}
+	for (auto &option : options.metadata_parameters) {
+		attach_options.push_back(option.first + " " + option.second.ToSQLString());
+	}
 
 	if (attach_options.empty()) {
 		return string();

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -38,6 +38,9 @@ static unique_ptr<Catalog> DuckLakeAttach(StorageExtensionInfo *storage_info, Cl
 			}
 			options.at_clause =
 			    make_uniq<BoundAtClause>("timestamp", entry.second.DefaultCastAs(LogicalType::TIMESTAMP_TZ));
+		} else if (StringUtil::StartsWith(lcase, "meta_")) {
+			auto parameter_name = lcase.substr(5);
+			options.metadata_parameters[parameter_name] = entry.second;
 		} else if (lcase == "readonly" || lcase == "read_only" || lcase == "readwrite" || lcase == "read_write" ||
 		           lcase == "type" || lcase == "default_table") {
 			// built-in options

--- a/test/sql/general/metadata_parameters.test
+++ b/test/sql/general/metadata_parameters.test
@@ -1,0 +1,23 @@
+# name: test/sql/general/metadata_parameters.test
+# description: Test attach with metadata parameters
+# group: [general]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_metadata_parameters.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_metadata_parameters', META_TYPE 'DUCKDB')
+
+statement ok
+CREATE TABLE ducklake.tbl AS FROM range(1000) t(i);
+
+query I
+SELECT COUNT(*) FROM ducklake.tbl
+----
+1000
+
+statement error
+ATTACH 'ducklake:__TEST_DIR__/ducklake_metadata_parametersxx.db' AS s (DATA_PATH '__TEST_DIR__/ducklake_metadata_parameters', META_TYPE 'DUCKDBXX')
+----
+duckdbxx


### PR DESCRIPTION
All parameters starting with `META_` are forwarded, e.g.:

```sql
-- forwards TYPE 'sqlite' to the metadata catalog
ATTACH 'ducklake:file.db' (META_TYPE 'sqlite');
```