### PR TITLE
Fail cleanly when GetEntry fails, plus autoloading of parquet

### DIFF
--- a/test/sql/general/missing_parquet.test
+++ b/test/sql/general/missing_parquet.test
@@ -1,0 +1,23 @@
+# name: test/sql/general/missing_parquet.test
+# description: Test with missing parquet extension
+# group: [general]
+
+require ducklake
+
+require no_extension_autoloading "EXPECTED This is meant to test missing parquet extension"
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_missing_parquet.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_missing_parquet')
+
+statement ok
+SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
+
+statement error
+CREATE TABLE ducklake.tbl AS FROM range(1000) t(i);
+----
+Missing Extension Error: We could not load, due to configuration or else, an extension that offers the copy functon for "parquet", try to explicitly load the relevant extension
+
+require parquet
+
+statement ok
+CREATE TABLE ducklake.tbl AS FROM range(1000) t(i);


### PR DESCRIPTION
Most clients do ship `parquet` already, but still worth sorting out autoloading also in the insert path.