### PR TITLE
Add description, unsure on text

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -11,6 +11,8 @@
 namespace duckdb {
 
 static void LoadInternal(DatabaseInstance &instance) {
+	ExtensionUtil::RegisterExtension(instance, "ducklake", {"Adds support for DuckLake, SQL as a Lakehouse Format"});
+
 	auto &config = DBConfig::GetConfig(instance);
 	config.storage_extensions["ducklake"] = make_uniq<DuckLakeStorageExtension>();
 


### PR DESCRIPTION
Due to current duckdb limitations, this shows up only after LOAD This is minor since it would be eventually handled duckdb side, but this allows to have it in some capacity already for 1.3.0