### PR TITLE
Publish extension in core-nightly bucket

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -27,3 +27,14 @@ jobs:
       duckdb_version: v1.3.0
       ci_tools_version: main
       extension_name: ducklake
+
+  duckdb-stable-deploy:
+    name: Deploy extension binaries
+    needs: duckdb-stable-build
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
+    secrets: inherit
+    with:
+      extension_name: ducklake
+      duckdb_version: v1.3.0
+      ci_tools_version: main
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
After this, in released 1.3.0, it should be possible to do:
```
FORCE INSTALL ducklake FROM core_nightly;
```