### PR TITLE
Make db name unique in test

### DIFF
--- a/test/sql/data_inlining/data_inlining_transaction_local_delete.test
+++ b/test/sql/data_inlining/data_inlining_transaction_local_delete.test
@@ -7,7 +7,7 @@ require ducklake
 require parquet
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_delete.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_delete_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_delete_local.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_delete_local_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
 
 statement ok
 CREATE TABLE ducklake.test(i INTEGER, j INTEGER)


### PR DESCRIPTION
This test fails when running all tests on a windows machine since the db name is used in a previous test.