### PR TITLE
Fix `GetCopyFunction` for motherduck

### DIFF
--- a/src/include/storage/ducklake_scan.hpp
+++ b/src/include/storage/ducklake_scan.hpp
@@ -25,7 +25,7 @@ public:
 
 	static unique_ptr<FunctionData> BindDuckLakeScan(ClientContext &context, TableFunction &function);
 
-	static CopyFunctionCatalogEntry &GetCopyFunction(DatabaseInstance &db, const string &name);
+	static CopyFunctionCatalogEntry &GetCopyFunction(ClientContext &context, const string &name);
 };
 
 enum class DuckLakeScanType { SCAN_TABLE, SCAN_INSERTIONS, SCAN_DELETIONS };

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -238,7 +238,7 @@ void DuckLakeDelete::FlushDelete(DuckLakeTransaction &transaction, ClientContext
 	}
 
 	// get the actual copy function and bind it
-	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(*context.db, "parquet");
+	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(context, "parquet");
 
 	CopyFunctionBindInput bind_input(*info);
 

--- a/test/sql/general/missing_parquet.test
+++ b/test/sql/general/missing_parquet.test
@@ -15,7 +15,7 @@ SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
 statement error
 CREATE TABLE ducklake.tbl AS FROM range(1000) t(i);
 ----
-Missing Extension Error: We could not load, due to configuration or else, an extension that offers the copy functon for "parquet", try to explicitly load the relevant extension
+Missing Extension Error: Could not load the copy function for "parquet". Try explicitly loading the "parquet" extension
 
 require parquet
 


### PR DESCRIPTION
For some reason the current way does not work for MotherDuck. This makes some minor adjustments to the copy function retrieval which makes it MotherDuck compatible.

PS: I would normally not open this PR without understanding why it is not working within MotherDuck, but I'm unfortunately kind of running out of time. I hope this is OK with you.