### PR TITLE
Add initialization for bool field in DuckLakeColumnInfo

### DIFF
--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -42,7 +42,7 @@ struct DuckLakeColumnInfo {
 	string type;
 	Value initial_default;
 	Value default_value;
-	bool nulls_allowed;
+	bool nulls_allowed {};
 	vector<DuckLakeColumnInfo> children;
 	vector<DuckLakeTag> tags;
 };


### PR DESCRIPTION
This should be trivial, remove some run-time assertion when run with relassert.