### PR TITLE
More lenient error checking

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1217,7 +1217,8 @@ void DuckLakeTransaction::FlushChanges() {
 				CleanupFiles();
 				throw;
 			}
-			bool is_primary_key_error = StringUtil::Contains(error.Message(), "primary key constraint");
+			bool is_primary_key_error =
+			    StringUtil::Contains(error.Message(), "primary key") || StringUtil::Contains(error.Message(), "unique");
 			bool finished_retrying = i + 1 >= max_retry_count;
 			if (!is_primary_key_error || finished_retrying) {
 				// we abort after the max retry count


### PR DESCRIPTION
This makes us correctly detect primary key violations also for Postgres