### PR TITLE
Rename schema_snapshot in inlined tables to schema_version

### DIFF
--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -49,7 +49,7 @@ struct DuckLakeColumnInfo {
 
 struct DuckLakeInlinedTableInfo {
 	string table_name;
-	idx_t schema_snapshot;
+	idx_t schema_version;
 };
 
 struct DuckLakeTableInfo {

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -322,7 +322,7 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) {
 		auto &inlined_data_table = inlined_data_tables[inlined_data_index];
 		extended_info->options["table_name"] = inlined_data_table.table_name;
 		extended_info->options["inlined_data"] = Value::BOOLEAN(true);
-		extended_info->options["schema_snapshot"] = Value::BIGINT(inlined_data_table.schema_snapshot);
+		extended_info->options["schema_version"] = Value::BIGINT(inlined_data_table.schema_version);
 	} else {
 		extended_info->options["file_size"] = Value::UBIGINT(file.file_size_bytes);
 		extended_info->options["footer_size"] = Value::UBIGINT(file.footer_size);

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -173,18 +173,18 @@ shared_ptr<BaseFileReader> DuckLakeMultiFileReader::TryCreateInlinedDataReader(c
 		auto columns = DuckLakeMultiFileReader::ColumnsFromFieldData(read_info.table.GetFieldData(), true);
 		return make_shared_ptr<DuckLakeInlinedDataReader>(read_info, file, transaction_local_data, std::move(columns));
 	}
-	optional_idx schema_snapshot;
-	auto version_entry = file.extended_info->options.find("schema_snapshot");
+	optional_idx schema_version;
+	auto version_entry = file.extended_info->options.find("schema_version");
 	if (version_entry != file.extended_info->options.end()) {
-		schema_snapshot = version_entry->second.GetValue<idx_t>();
+		schema_version = version_entry->second.GetValue<idx_t>();
 	}
 	reference<DuckLakeTableEntry> schema_table = read_info.table;
-	if (schema_snapshot.IsValid()) {
+	if (schema_version.IsValid()) {
 		// read the table at the specified version
 		auto transaction = read_info.GetTransaction();
 		auto &catalog = transaction->GetCatalog();
 
-		DuckLakeSnapshot snapshot(0, schema_snapshot.GetIndex(), 0, 0);
+		DuckLakeSnapshot snapshot(0, schema_version.GetIndex(), 0, 0);
 		auto entry = catalog.GetEntryById(*transaction, snapshot, read_info.table.GetTableId());
 		schema_table = entry->Cast<DuckLakeTableEntry>();
 	}


### PR DESCRIPTION
This was changed at some point to not be a snapshot id but a schema version, this name reflects that