### PR TITLE
Fix #69: when a table is dropped, also drop any partitioning info associated with that table

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -722,6 +722,7 @@ void DuckLakeMetadataManager::DropSchemas(DuckLakeSnapshot commit_snapshot, set<
 
 void DuckLakeMetadataManager::DropTables(DuckLakeSnapshot commit_snapshot, set<TableIndex> ids) {
 	FlushDrop(commit_snapshot, "ducklake_table", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_partition_info", "table_id", ids);
 }
 
 void DuckLakeMetadataManager::DropViews(DuckLakeSnapshot commit_snapshot, set<TableIndex> ids) {

--- a/test/sql/partitioning/basic_partitioning.test
+++ b/test/sql/partitioning/basic_partitioning.test
@@ -158,3 +158,11 @@ query I
 SELECT COUNT(*) FROM partition_tbl2 WHERE part_key=0
 ----
 5000
+
+statement ok
+DROP TABLE partitioned_tbl
+
+query I
+SELECT COUNT(*) FROM partition_tbl2 WHERE part_key=0
+----
+5000


### PR DESCRIPTION
Fixes #69 