### PR TITLE
Make footer size optional

### DIFF
--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -215,7 +215,7 @@ struct DuckLakeFileData {
 	string path;
 	string encryption_key;
 	idx_t file_size_bytes = 0;
-	idx_t footer_size = 0;
+	optional_idx footer_size;
 };
 
 enum class DuckLakeDataType {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -376,7 +376,10 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(T &row, idx_t &col_idx, b
 
 	data.path = FromRelativePath(path);
 	data.file_size_bytes = row.template GetValue<idx_t>(col_idx++);
-	data.footer_size = row.template GetValue<idx_t>(col_idx++);
+	if (!row.IsNull(col_idx)) {
+		data.footer_size = row.template GetValue<idx_t>(col_idx);
+	}
+	col_idx++;
 	if (is_encrypted) {
 		if (row.IsNull(col_idx)) {
 			throw InvalidInputException("Database is encrypted, but file %s does not have an encryption key",

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -325,7 +325,9 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) {
 		extended_info->options["schema_version"] = Value::BIGINT(inlined_data_table.schema_version);
 	} else {
 		extended_info->options["file_size"] = Value::UBIGINT(file.file_size_bytes);
-		extended_info->options["footer_size"] = Value::UBIGINT(file.footer_size);
+		if (file.footer_size.IsValid()) {
+			extended_info->options["footer_size"] = Value::UBIGINT(file.footer_size.GetIndex());
+		}
 		extended_info->options["row_id_start"] = Value::UBIGINT(files[i].row_id_start);
 		Value snapshot_id;
 		if (files[i].snapshot_id.IsValid()) {


### PR DESCRIPTION
If `footer_size` is not set we can fallback to default Parquet reader behavior w.r.t. footer size