### PR TITLE
Fix #108: correctly support dry_run in ducklake_expire_snapshots

### DIFF
--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -101,6 +101,7 @@ DuckLakeExpireSnapshotsFunction::DuckLakeExpireSnapshotsFunction()
                     DuckLakeExpireSnapshotsBind, DuckLakeExpireSnapshotsInit) {
 	named_parameters["older_than"] = LogicalType::TIMESTAMP_TZ;
 	named_parameters["versions"] = LogicalType::LIST(LogicalType::UBIGINT);
+	named_parameters["dry_run"] = LogicalType::BOOLEAN;
 }
 
 } // namespace duckdb

--- a/test/sql/compaction/expire_snapshots.test
+++ b/test/sql/compaction/expire_snapshots.test
@@ -27,6 +27,13 @@ statement ok
 DROP TABLE ducklake.test
 
 # explicitly expire snapshot 2
+# dry run
+query I
+SELECT snapshot_id FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [2])
+----
+2
+
+# actually expire
 statement ok
 CALL ducklake_expire_snapshots('ducklake', versions => [2])
 


### PR DESCRIPTION
Fixes #108 