### PR TITLE
Fix #109: SQLite doesn't like timestamp tz, use string literals which get cast to the correct type instead

### DIFF
--- a/src/functions/ducklake_cleanup_old_files.cpp
+++ b/src/functions/ducklake_cleanup_old_files.cpp
@@ -40,7 +40,7 @@ static unique_ptr<FunctionData> DuckLakeCleanupBind(ClientContext &context, Tabl
 	string filter;
 	if (has_timestamp) {
 		auto ts = Timestamp::ToString(timestamp_t(from_timestamp.value));
-		filter = StringUtil::Format("WHERE schedule_start < TIMESTAMP '%s' AT TIME ZONE 'UTC'", ts);
+		filter = StringUtil::Format("WHERE schedule_start < '%s'", ts);
 	}
 	auto &transaction = DuckLakeTransaction::Get(context, catalog);
 	auto &metadata_manager = transaction.GetMetadataManager();

--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -48,7 +48,7 @@ static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &conte
 	filter = "snapshot_id != (SELECT MAX(snapshot_id) FROM {METADATA_CATALOG}.ducklake_snapshot) AND ";
 	if (has_timestamp) {
 		auto ts = Timestamp::ToString(timestamp_t(from_timestamp.value));
-		filter += StringUtil::Format("snapshot_time < TIMESTAMP '%s' AT TIME ZONE 'UTC'", ts);
+		filter += StringUtil::Format("snapshot_time < '%s'", ts);
 	} else {
 		filter += StringUtil::Format("snapshot_id IN (%s)", snapshot_list);
 	}

--- a/test/sql/compaction/expire_snapshots.test
+++ b/test/sql/compaction/expire_snapshots.test
@@ -60,9 +60,13 @@ SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_expire_snapshots_files/*')
 ----
 0
 
-# let's delete snapshots 1/3
-statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [1, 3])
+# let's delete all remaining snapshots (except for the last one)
+query I
+SELECT snapshot_id FROM ducklake_expire_snapshots('ducklake', older_than => NOW()) ORDER BY ALL
+----
+0
+1
+3
 
 # all traces of the table are gone
 foreach tbl ducklake_table ducklake_column ducklake_table_stats ducklake_table_column_stats


### PR DESCRIPTION
Fixes #109