### PR TITLE
Publish to nightly versioned bucket

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -38,3 +38,4 @@ jobs:
       duckdb_version: v1.3.0
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This will make so:
- extension will be available (and not overridden) like:
```
FORCE INSTALL ducklake FROM core_nigthly VERSION 'abc01234';
```
- extension will be saved (no need to rebuild to get / test specific binaries)