### PR TITLE
Add scoped settings (per-schema and per-table)

### DIFF
--- a/src/functions/ducklake_merge_adjacent_files.cpp
+++ b/src/functions/ducklake_merge_adjacent_files.cpp
@@ -259,6 +259,8 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	auto &columns = table.GetColumns();
 
 	DuckLakeCopyInput copy_input(context, table);
+	// merge_adjacent_files does not use partitioning information - instead we always merge within partitions
+	copy_input.partition_data = nullptr;
 	copy_input.virtual_columns = InsertVirtualColumns::WRITE_SNAPSHOT_ID;
 
 	auto copy_options = DuckLakeInsert::GetCopyOptions(context, copy_input);

--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -14,8 +14,11 @@
 #include "common/ducklake_encryption.hpp"
 #include "duckdb/planner/tableref/bound_at_clause.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "common/index.hpp"
 
 namespace duckdb {
+
+using option_map_t = unordered_map<string, string>;
 
 struct DuckLakeOptions {
 	string metadata_database;
@@ -27,7 +30,9 @@ struct DuckLakeOptions {
 	idx_t data_inlining_row_limit = 0;
 	unique_ptr<BoundAtClause> at_clause;
 	unordered_map<string, Value> metadata_parameters;
-	unordered_map<string, string> config_options;
+	option_map_t config_options;
+	map<SchemaIndex, option_map_t> schema_options;
+	map<TableIndex, option_map_t> table_options;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -19,6 +19,7 @@ namespace duckdb {
 class ColumnList;
 class DuckLakeFieldData;
 struct DuckLakeFileListEntry;
+struct DuckLakeConfigOption;
 struct DeleteFileMap;
 class LogicalGet;
 
@@ -51,8 +52,8 @@ public:
 	string &Separator() {
 		return separator;
 	}
-	void SetConfigOption(string option, string value);
-	bool TryGetConfigOption(const string &option, string &result) const;
+	void SetConfigOption(const DuckLakeConfigOption &option);
+	bool TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id, TableIndex table_id) const;
 
 	optional_ptr<BoundAtClause> CatalogSnapshot() const;
 

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -25,8 +25,20 @@ struct DuckLakeTag {
 	string value;
 };
 
+struct DuckLakeSchemaSetting {
+	SchemaIndex schema_id;
+	DuckLakeTag tag;
+};
+
+struct DuckLakeTableSetting {
+	TableIndex table_id;
+	DuckLakeTag tag;
+};
+
 struct DuckLakeMetadata {
 	vector<DuckLakeTag> tags;
+	vector<DuckLakeSchemaSetting> schema_settings;
+	vector<DuckLakeTableSetting> table_settings;
 };
 
 struct DuckLakeSchemaInfo {
@@ -312,6 +324,14 @@ struct DuckLakeTableSizeInfo {
 struct DuckLakePath {
 	string path;
 	bool path_is_relative;
+};
+
+struct DuckLakeConfigOption {
+	DuckLakeTag option;
+	//! schema_id, if scoped to a schema
+	SchemaIndex schema_id;
+	//! table_id, if scoped to a table
+	TableIndex table_id;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -100,7 +100,7 @@ public:
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());
 	virtual void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
 	virtual vector<DuckLakeTableSizeInfo> GetTableSizes(DuckLakeSnapshot snapshot);
-	virtual void SetConfigOption(const string &option, const string &value);
+	virtual void SetConfigOption(const DuckLakeConfigOption &option);
 	virtual string GetPathForSchema(SchemaIndex schema_id);
 	virtual string GetPathForTable(TableIndex table_id);
 

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -101,7 +101,7 @@ public:
 	static bool IsTransactionLocal(idx_t id) {
 		return id >= DuckLakeConstants::TRANSACTION_LOCAL_ID_START;
 	}
-	void SetConfigOption(string option, string value);
+	void SetConfigOption(const DuckLakeConfigOption &option);
 
 	string GetDefaultSchemaName();
 

--- a/src/storage/ducklake_default_functions.cpp
+++ b/src/storage/ducklake_default_functions.cpp
@@ -7,7 +7,7 @@ namespace duckdb {
 // clang-format off
 static const DefaultTableMacro ducklake_table_macros[] = {
 	{DEFAULT_SCHEMA, "merge_adjacent_files", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_merge_adjacent_files({CATALOG})"},
-	{DEFAULT_SCHEMA, "set_option", {"option", "value", nullptr}, {{nullptr, nullptr}},  "FROM ducklake_set_option({CATALOG}, option, value)"},
+	{DEFAULT_SCHEMA, "set_option", {"option", "value", nullptr}, {{"table_name", "NULL"}, {"schema", "NULL"}, {nullptr, nullptr}},  "FROM ducklake_set_option({CATALOG}, option, value, table_name => table_name, schema => schema)"},
 	{DEFAULT_SCHEMA, "snapshots", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_snapshots({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_info", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_info({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_changes", {"table_name", "start_snapshot", "end_snapshot", nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_changes({CATALOG}, {SCHEMA}, table_name, start_snapshot, end_snapshot)"},

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -165,6 +165,12 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 		}
 		options.config_options.emplace(tag.key, tag.value);
 	}
+	for (auto &entry : metadata.schema_settings) {
+		options.schema_options[entry.schema_id].emplace(entry.tag.key, entry.tag.value);
+	}
+	for (auto &entry : metadata.table_settings) {
+		options.table_options[entry.table_id].emplace(entry.tag.key, entry.tag.value);
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -265,46 +265,65 @@ DuckLakeCopyOptions::DuckLakeCopyOptions(unique_ptr<CopyInfo> info_p, CopyFuncti
     : info(std::move(info_p)), copy_function(std::move(copy_function_p)) {
 }
 
-DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(DuckLakeCatalog &catalog, ClientContext &context,
-                                                   const ColumnList &columns,
-                                                   optional_ptr<DuckLakePartition> partition_data,
-                                                   optional_ptr<DuckLakeFieldData> field_data, const string &data_path,
-                                                   string encryption_key, InsertVirtualColumns virtual_columns) {
+DuckLakeCopyInput::DuckLakeCopyInput(ClientContext &context, DuckLakeTableEntry &table)
+    : catalog(table.ParentCatalog().Cast<DuckLakeCatalog>()), columns(table.GetColumns()), data_path(table.DataPath()) {
+	partition_data = table.GetPartitionData();
+	optional_idx partition_id;
+	if (partition_data) {
+		partition_id = partition_data->partition_id;
+	}
+	field_data = table.GetFieldData();
+	schema_id = table.ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId();
+	table_id = table.GetTableId();
+	encryption_key = catalog.GenerateEncryptionKey(context);
+}
+
+DuckLakeCopyInput::DuckLakeCopyInput(ClientContext &context, DuckLakeSchemaEntry &schema, const ColumnList &columns,
+                                     const string &data_path_p)
+    : catalog(schema.ParentCatalog().Cast<DuckLakeCatalog>()), columns(columns), data_path(data_path_p) {
+	schema_id = schema.GetSchemaId();
+	encryption_key = catalog.GenerateEncryptionKey(context);
+}
+
+DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckLakeCopyInput &copy_input) {
 	auto info = make_uniq<CopyInfo>();
-	info->file_path = data_path;
+	auto &catalog = copy_input.catalog;
+	info->file_path = copy_input.data_path;
 	info->format = "parquet";
 	info->is_from = false;
 	// generate the field ids to be written by the parquet writer
 	shared_ptr<DuckLakeFieldData> generated_ids;
-	if (!field_data) {
+	if (!copy_input.field_data) {
 		// CTAS - generate new ids from columns
-		generated_ids = DuckLakeFieldData::FromColumns(columns);
+		generated_ids = DuckLakeFieldData::FromColumns(copy_input.columns);
 	}
-	auto &field_ids = field_data ? *field_data : *generated_ids;
+	auto &field_ids = copy_input.field_data ? *copy_input.field_data : *generated_ids;
 	vector<Value> field_input;
-	field_input.push_back(WrittenFieldIds(field_ids, virtual_columns));
+	field_input.push_back(WrittenFieldIds(field_ids, copy_input.virtual_columns));
 	info->options["field_ids"] = std::move(field_input);
-	if (!encryption_key.empty()) {
+	if (!copy_input.encryption_key.empty()) {
 		child_list_t<Value> values;
-		values.emplace_back("footer_key_value", Value::BLOB_RAW(encryption_key));
+		values.emplace_back("footer_key_value", Value::BLOB_RAW(copy_input.encryption_key));
 		vector<Value> encryption_input;
 		encryption_input.push_back(Value::STRUCT(std::move(values)));
 		info->options["encryption_config"] = std::move(encryption_input);
 	}
+	auto &schema_id = copy_input.schema_id;
+	auto &table_id = copy_input.table_id;
 	string parquet_compression;
-	if (catalog.TryGetConfigOption("parquet_compression", parquet_compression)) {
+	if (catalog.TryGetConfigOption("parquet_compression", parquet_compression, schema_id, table_id)) {
 		info->options["compression"].emplace_back(parquet_compression);
 	}
 	string parquet_version;
-	if (catalog.TryGetConfigOption("parquet_version", parquet_version)) {
+	if (catalog.TryGetConfigOption("parquet_version", parquet_version, schema_id, table_id)) {
 		info->options["parquet_version"].emplace_back(parquet_version);
 	}
 	string parquet_compression_level;
-	if (catalog.TryGetConfigOption("parquet_compression_level", parquet_compression_level)) {
+	if (catalog.TryGetConfigOption("parquet_compression_level", parquet_compression_level, schema_id, table_id)) {
 		info->options["compression_level"].emplace_back(parquet_compression_level);
 	}
 	string row_group_size;
-	if (catalog.TryGetConfigOption("row_group_size", row_group_size)) {
+	if (catalog.TryGetConfigOption("row_group_size", row_group_size, schema_id, table_id)) {
 		info->options["row_group_size"].emplace_back(row_group_size);
 	}
 
@@ -312,10 +331,10 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(DuckLakeCatalog &catalog, Cli
 	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(context, "parquet");
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	if (!fs.IsRemoteFile(data_path)) {
+	if (!fs.IsRemoteFile(copy_input.data_path)) {
 		// create data path if it does not yet exist
 		try {
-			fs.CreateDirectoriesRecursive(data_path);
+			fs.CreateDirectoriesRecursive(copy_input.data_path);
 		} catch (...) {
 		}
 	}
@@ -323,13 +342,13 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(DuckLakeCatalog &catalog, Cli
 	// Bind Copy Function
 	CopyFunctionBindInput bind_input(*info);
 
-	auto names_to_write = columns.GetColumnNames();
-	auto types_to_write = columns.GetColumnTypes();
-	if (WriteRowId(virtual_columns)) {
+	auto names_to_write = copy_input.columns.GetColumnNames();
+	auto types_to_write = copy_input.columns.GetColumnTypes();
+	if (WriteRowId(copy_input.virtual_columns)) {
 		names_to_write.push_back("_ducklake_internal_row_id");
 		types_to_write.push_back(LogicalType::BIGINT);
 	}
-	if (WriteSnapshotId(virtual_columns)) {
+	if (WriteSnapshotId(copy_input.virtual_columns)) {
 		names_to_write.push_back("_ducklake_internal_snapshot_id");
 		types_to_write.push_back(LogicalType::BIGINT);
 	}
@@ -340,20 +359,20 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(DuckLakeCatalog &catalog, Cli
 	result.bind_data = std::move(function_data);
 
 	result.use_tmp_file = false;
-	if (partition_data) {
+	if (copy_input.partition_data) {
 		vector<idx_t> partition_columns;
-		for (auto &field : partition_data->fields) {
+		for (auto &field : copy_input.partition_data->fields) {
 			partition_columns.push_back(field.column_id);
 		}
 		result.filename_pattern.SetFilenamePattern("ducklake-{uuidv7}");
-		result.file_path = data_path;
+		result.file_path = copy_input.data_path;
 		result.partition_output = true;
 		result.partition_columns = std::move(partition_columns);
 		result.write_empty_file = true;
 	} else {
 		auto current_write_uuid = DuckLakeTransaction::GenerateUUIDv7();
 		string file_name = "ducklake-" + current_write_uuid + ".parquet";
-		result.file_path = DuckLakeUtil::JoinPath(fs, data_path, file_name);
+		result.file_path = DuckLakeUtil::JoinPath(fs, copy_input.data_path, file_name);
 		result.partition_output = false;
 		result.write_empty_file = false;
 	}
@@ -369,15 +388,11 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(DuckLakeCatalog &catalog, Cli
 	return result;
 }
 
-PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(DuckLakeCatalog &catalog, ClientContext &context,
-                                                    const ColumnList &columns, PhysicalPlanGenerator &planner,
-                                                    optional_ptr<DuckLakePartition> partition_data,
-                                                    optional_ptr<DuckLakeFieldData> field_data,
-                                                    optional_ptr<PhysicalOperator> plan, const string &data_path,
-                                                    string encryption_key, InsertVirtualColumns virtual_columns) {
-	bool is_encrypted = !encryption_key.empty();
-	auto copy_options = GetCopyOptions(catalog, context, columns, partition_data, field_data, data_path,
-	                                   std::move(encryption_key), virtual_columns);
+PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                    DuckLakeCopyInput &copy_input,
+                                                    optional_ptr<PhysicalOperator> plan) {
+	bool is_encrypted = !copy_input.encryption_key.empty();
+	auto copy_options = GetCopyOptions(context, copy_input);
 
 	auto copy_return_types = GetCopyFunctionReturnLogicalTypes(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
 	auto &physical_copy = planner
@@ -408,21 +423,6 @@ PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(DuckLakeCatalog &catalog, Cl
 	}
 
 	return physical_copy;
-}
-
-PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(ClientContext &context, PhysicalPlanGenerator &planner,
-                                                    DuckLakeTableEntry &table, optional_ptr<PhysicalOperator> plan,
-                                                    string encryption_key, InsertVirtualColumns virtual_columns) {
-	auto &columns = table.GetColumns();
-	auto partition_data = table.GetPartitionData();
-	optional_idx partition_id;
-	if (partition_data) {
-		partition_id = partition_data->partition_id;
-	}
-	auto &field_data = table.GetFieldData();
-	auto &catalog = table.ParentCatalog().Cast<DuckLakeCatalog>();
-	return PlanCopyForInsert(catalog, context, columns, planner, partition_data, field_data, plan, table.DataPath(),
-	                         std::move(encryption_key), virtual_columns);
 }
 
 PhysicalOperator &DuckLakeInsert::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
@@ -463,15 +463,15 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 	if (!op.column_index_map.empty()) {
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
-	string encryption_key = GenerateEncryptionKey(context);
 	auto &ducklake_table = op.table.Cast<DuckLakeTableEntry>();
 	optional_ptr<DuckLakeInlineData> inline_data;
 	if (DataInliningRowLimit() > 0) {
 		plan = planner.Make<DuckLakeInlineData>(*plan, DataInliningRowLimit());
 		inline_data = plan->Cast<DuckLakeInlineData>();
 	}
-	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, ducklake_table, plan, encryption_key);
-	auto &insert = DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(encryption_key));
+	DuckLakeCopyInput copy_input(context, ducklake_table);
+	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
+	auto &insert = DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
 	if (inline_data) {
 		inline_data->insert = insert.Cast<DuckLakeInsert>();
 	}
@@ -484,7 +484,6 @@ PhysicalOperator &DuckLakeCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	auto &create_info = op.info->Base();
 	auto &columns = create_info.columns;
 	// FIXME: if table already exists and we are doing CREATE IF NOT EXISTS - skip
-	string encryption_key = GenerateEncryptionKey(context);
 	reference<PhysicalOperator> root = plan;
 	optional_ptr<DuckLakeInlineData> inline_data;
 	if (DataInliningRowLimit() > 0) {
@@ -499,11 +498,11 @@ PhysicalOperator &DuckLakeCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	auto table_uuid = duck_transaction.GenerateUUID();
 	auto table_data_path =
 	    duck_schema.DataPath() + DuckLakeCatalog::GeneratePathFromName(table_uuid, create_info.table);
-	auto &catalog = op.schema.ParentCatalog().Cast<DuckLakeCatalog>();
-	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(catalog, context, columns, planner, nullptr, nullptr,
-	                                                        root.get(), table_data_path, encryption_key);
+
+	DuckLakeCopyInput copy_input(context, duck_schema, columns, table_data_path);
+	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
 	auto &insert = planner.Make<DuckLakeInsert>(op.types, op.schema, std::move(op.info), std::move(table_uuid),
-	                                            std::move(table_data_path), std::move(encryption_key));
+	                                            std::move(table_data_path), std::move(copy_input.encryption_key));
 	if (inline_data) {
 		inline_data->insert = insert.Cast<DuckLakeInsert>();
 	}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -500,7 +500,7 @@ PhysicalOperator &DuckLakeCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	    duck_schema.DataPath() + DuckLakeCatalog::GeneratePathFromName(table_uuid, create_info.table);
 
 	DuckLakeCopyInput copy_input(context, duck_schema, columns, table_data_path);
-	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
+	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, root.get());
 	auto &insert = planner.Make<DuckLakeInsert>(op.types, op.schema, std::move(op.info), std::move(table_uuid),
 	                                            std::move(table_data_path), std::move(copy_input.encryption_key));
 	if (inline_data) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -37,7 +37,7 @@ void DuckLakeMetadataManager::InitializeDuckLake(bool has_explicit_schema, DuckL
 	string data_path = StorePath(base_data_path);
 	string encryption_str = encryption == DuckLakeEncryption::ENCRYPTED ? "true" : "false";
 	initialize_query += StringUtil::Format(R"(
-CREATE TABLE {METADATA_CATALOG}.ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL);
+CREATE TABLE {METADATA_CATALOG}.ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT);
 CREATE TABLE {METADATA_CATALOG}.ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY, snapshot_time TIMESTAMPTZ, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT);
 CREATE TABLE {METADATA_CATALOG}.ducklake_snapshot_changes(snapshot_id BIGINT PRIMARY KEY, changes_made VARCHAR);
 CREATE TABLE {METADATA_CATALOG}.ducklake_schema(schema_id BIGINT PRIMARY KEY, schema_uuid UUID, begin_snapshot BIGINT, end_snapshot BIGINT, schema_name VARCHAR, path VARCHAR, path_is_relative BOOLEAN);
@@ -56,9 +56,11 @@ CREATE TABLE {METADATA_CATALOG}.ducklake_partition_column(partition_id BIGINT, t
 CREATE TABLE {METADATA_CATALOG}.ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR);
 CREATE TABLE {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion(data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, schedule_start TIMESTAMPTZ);
 CREATE TABLE {METADATA_CATALOG}.ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT);
+CREATE TABLE {METADATA_CATALOG}.ducklake_schema_settings(schema_id BIGINT, key VARCHAR NOT NULL, value VARCHAR NOT NULL);
+CREATE TABLE {METADATA_CATALOG}.ducklake_table_settings(table_id BIGINT, key VARCHAR NOT NULL, value VARCHAR NOT NULL);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot VALUES (0, NOW(), 0, 1, 0);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot_changes VALUES (0, 'created_schema:"main"');
-INSERT INTO {METADATA_CATALOG}.ducklake_metadata VALUES ('version', '0.2'), ('created_by', 'DuckDB %s'), ('data_path', %s), ('encrypted', '%s');
+INSERT INTO {METADATA_CATALOG}.ducklake_metadata (key, value) VALUES ('version', '0.2'), ('created_by', 'DuckDB %s'), ('data_path', %s), ('encrypted', '%s');
 INSERT INTO {METADATA_CATALOG}.ducklake_schema VALUES (0, UUID(), 0, NULL, 'main', 'main/', true);
 	)",
 	                                       DuckDB::SourceID(), SQLString(data_path), encryption_str);
@@ -78,6 +80,8 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_schema ADD COLUMN path VARCHAR DEFAULT '
 ALTER TABLE {METADATA_CATALOG}.ducklake_schema ADD COLUMN path_is_relative BOOLEAN DEFAULT TRUE;
 ALTER TABLE {METADATA_CATALOG}.ducklake_table ADD COLUMN path VARCHAR DEFAULT '';
 ALTER TABLE {METADATA_CATALOG}.ducklake_table ADD COLUMN path_is_relative BOOLEAN DEFAULT TRUE;
+ALTER TABLE {METADATA_CATALOG}.ducklake_metadata ADD COLUMN scope VARCHAR;
+ALTER TABLE {METADATA_CATALOG}.ducklake_metadata ADD COLUMN scope_id BIGINT;
 	)";
 	auto result = transaction.Query(migrate_query);
 	if (result->HasError()) {
@@ -86,17 +90,42 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_table ADD COLUMN path_is_relative BOOLEA
 }
 
 DuckLakeMetadata DuckLakeMetadataManager::LoadDuckLake() {
-	auto result = transaction.Query("SELECT key, value FROM {METADATA_CATALOG}.ducklake_metadata");
+	auto result = transaction.Query(R"(
+SELECT key, value, scope, scope_id FROM {METADATA_CATALOG}.ducklake_metadata
+)");
 	if (result->HasError()) {
 		auto &error_obj = result->GetErrorObject();
-		error_obj.Throw("Failed to load existing DuckLake");
+		error_obj.Throw("Failed to load existing DuckLake: ");
 	}
 	DuckLakeMetadata metadata;
 	for (auto &row : *result) {
 		DuckLakeTag tag;
 		tag.key = row.GetValue<string>(0);
 		tag.value = row.GetValue<string>(1);
-		metadata.tags.push_back(std::move(tag));
+		if (row.IsNull(2)) {
+			// scope is NULL: global tag
+			// global tag
+			metadata.tags.push_back(std::move(tag));
+			continue;
+		}
+		auto scope = row.GetValue<string>(2);
+		if (scope == "schema") {
+			// schema-level setting
+			DuckLakeSchemaSetting schema_setting;
+			schema_setting.schema_id = SchemaIndex(row.GetValue<idx_t>(3));
+			schema_setting.tag = std::move(tag);
+			metadata.schema_settings.push_back(std::move(schema_setting));
+			continue;
+		}
+		if (scope == "table") {
+			// table-level setting
+			DuckLakeTableSetting table_setting;
+			table_setting.table_id = TableIndex(row.GetValue<idx_t>(3));
+			table_setting.tag = std::move(tag);
+			metadata.table_settings.push_back(std::move(table_setting));
+			continue;
+		}
+		throw InvalidInputException("Unsupported setting scope %s - only schema/table are supported", scope);
 	}
 	return metadata;
 }
@@ -2132,28 +2161,46 @@ WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_s
 	return table_sizes;
 }
 
-void DuckLakeMetadataManager::SetConfigOption(const string &option, const string &value) {
+void DuckLakeMetadataManager::SetConfigOption(const DuckLakeConfigOption &option) {
 	// check if the option already exists
+	auto &option_key = option.option.key;
+	auto &option_value = option.option.value;
+	string scope;
+	string scope_id;
+	string scope_filter;
+	if (option.table_id.IsValid()) {
+		scope = "'table'";
+		scope_id = to_string(option.table_id.index);
+		scope_filter = StringUtil::Format("scope = 'table' AND scope_id = %d", option.table_id.index);
+	} else if (option.schema_id.IsValid()) {
+		scope = "'schema'";
+		scope_id = to_string(option.schema_id.index);
+		scope_filter = StringUtil::Format("scope = 'schema' AND scope_id = %d", option.schema_id.index);
+	} else {
+		scope = "NULL";
+		scope_id = "NULL";
+		scope_filter = "scope IS NULL";
+	}
 	auto result = transaction.Query(StringUtil::Format(R"(
 SELECT COUNT(*)
 FROM {METADATA_CATALOG}.ducklake_metadata
-WHERE key = %s
+WHERE key = %s AND %s
 )",
-	                                                   SQLString(option)));
+	                                                   SQLString(option_key), scope_filter));
 
 	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
 	if (count == 0) {
 		// option does not yet exist - insert the value
 		result = transaction.Query(StringUtil::Format(R"(
-INSERT INTO {METADATA_CATALOG}.ducklake_metadata VALUES (%s, %s)
+INSERT INTO {METADATA_CATALOG}.ducklake_metadata VALUES (%s, %s, %s, %s)
 )",
-		                                              SQLString(option), SQLString(value)));
+		                                              SQLString(option_key), SQLString(option_value), scope, scope_id));
 	} else {
 		// option already exists - update it
 		result = transaction.Query(StringUtil::Format(R"(
-UPDATE {METADATA_CATALOG}.ducklake_metadata SET value=%s WHERE key=%s
+UPDATE {METADATA_CATALOG}.ducklake_metadata SET value=%s WHERE key=%s AND %s
 )",
-		                                              SQLString(value), SQLString(option)));
+		                                              SQLString(option_value), SQLString(option_key), scope_filter));
 	}
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to insert config option in DuckLake: ");

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1267,11 +1267,11 @@ void DuckLakeTransaction::FlushChanges() {
 	}
 }
 
-void DuckLakeTransaction::SetConfigOption(string option, string value) {
+void DuckLakeTransaction::SetConfigOption(const DuckLakeConfigOption &option) {
 	// write the config option to the metadata
-	metadata_manager->SetConfigOption(option, value);
+	metadata_manager->SetConfigOption(option);
 	// set the option in the catalog
-	ducklake_catalog.SetConfigOption(std::move(option), std::move(value));
+	ducklake_catalog.SetConfigOption(option);
 }
 
 void DuckLakeTransaction::DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots) {

--- a/test/sql/settings/per_table_settings.test
+++ b/test/sql/settings/per_table_settings.test
@@ -1,0 +1,108 @@
+# name: test/sql/settings/per_table_settings.test
+# description: Test per-table settings
+# group: [settings]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_per_table_settings.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_per_table_settings_files');
+
+# test different settings per schema/table
+statement ok
+CREATE TABLE ducklake.t1(str VARCHAR)
+
+statement ok
+CREATE TABLE ducklake.t2(str VARCHAR)
+
+statement ok
+CREATE SCHEMA ducklake.s1;
+
+statement ok
+CREATE TABLE ducklake.s1.t1(str VARCHAR);
+
+statement ok
+CREATE TABLE ducklake.s1.t2(str VARCHAR);
+
+# global default -> uncompressed
+statement ok
+CALL ducklake.set_option('parquet_compression', 'uncompressed')
+
+# t1 -> zstd
+statement ok
+CALL ducklake.set_option('parquet_compression', 'zstd', table_name => 't1')
+
+# schema s1 -> lz4
+statement ok
+CALL ducklake.set_option('parquet_compression', 'lz4', schema => 's1')
+
+# s1.t1 -> gzip
+statement ok
+CALL ducklake.set_option('parquet_compression', 'gzip', schema => 's1', table_name => 't1')
+
+# non-existent schema/table
+statement error
+CALL ducklake.set_option('parquet_compression', 'gzip', table_name => 'nonexistent_table')
+----
+nonexistent_table
+
+statement error
+CALL ducklake.set_option('parquet_compression', 'gzip', schema => 'nonexistent_schema')
+----
+nonexistent_schema
+
+loop i 0 2
+
+# t1 uses zstd (table-specific setting)
+query I
+INSERT INTO ducklake.t1 SELECT 'hello world' || i str FROM range(1000) t(i)
+----
+1000
+
+query I
+SELECT DISTINCT compression FROM parquet_metadata('__TEST_DIR__/ducklake_per_table_settings_files/main/t1/**') ORDER BY ALL
+----
+ZSTD
+
+# t2 uses uncompressed (global setting)
+query I
+INSERT INTO ducklake.t2 SELECT 'hello world' || i str FROM range(1000) t(i)
+----
+1000
+
+query I
+SELECT DISTINCT compression FROM parquet_metadata('__TEST_DIR__/ducklake_per_table_settings_files/main/t2/**') ORDER BY ALL
+----
+UNCOMPRESSED
+
+# s1.t1 uses gzip (table-specific setting)
+query I
+INSERT INTO ducklake.s1.t1 SELECT 'hello world' || i str FROM range(1000) t(i)
+----
+1000
+
+query I
+SELECT DISTINCT compression FROM parquet_metadata('__TEST_DIR__/ducklake_per_table_settings_files/s1/t1/**') ORDER BY ALL
+----
+GZIP
+
+# s1.t2 uses lz4 (schema-specific setting)
+query I
+INSERT INTO ducklake.s1.t2 SELECT 'hello world' || i str FROM range(1000) t(i)
+----
+1000
+
+query I
+SELECT DISTINCT compression FROM parquet_metadata('__TEST_DIR__/ducklake_per_table_settings_files/s1/t2/**') ORDER BY ALL
+----
+LZ4_RAW
+
+# all these options are persisted - restart and do it again
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_per_table_settings.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_per_table_settings_files');
+
+endloop


### PR DESCRIPTION
This PR adds support for scoped settings. The `ducklake_metadata` table is expanded with two new columns, `scope` and `scope_id`:

```
CREATE TABLE ducklake_metadata(key VARCHAR NOT NULL, value VARCHAR NOT NULL, scope VARCHAR, scope_id BIGINT);
```

* `scope` is the scope of the setting (`NULL` for global, `'schema'` for a specific schema, `'table'` for a specific table
* `scope_id` is the identifier of the schema or table (if `scope` is set to `schema` or `table`) - this is `NULL` for global settings

Scoped settings can be set using the `set_option` function:

```sql
-- set a global option
CALL ducklake.set_option('parquet_compression', 'zstd');
-- set an option for a specific schema
CALL ducklake.set_option('parquet_compression', 'zstd', schema => 'my_schema');
-- set an option for a specific table
CALL ducklake.set_option('parquet_compression', 'zstd', table_name => 'my_table');
```

The "most specific" setting is chosen, in order:

| Priority | Setting Scope |
|---------:|---------------|
| 1        | Table         |
| 2        | Schema        |
| 3        | Global        |
| 4        | Default       |

That is to say:
* If a table-specific setting is set, it is always used for that table
* If a schema-specific setting is set, it is used for all tables in that schema **unless** they have table-specific settings
* If a global setting is set, it is used for all tables that have neither a table-specific nor a schema-specific setting
* If no setting is set, the default setting is used

All options introduced in https://github.com/duckdb/ducklake/pull/86 can be set in this way.