### PR TITLE
Fix #120, Fix #125: use filename instead of file index as row-id during late materialization

### DIFF
--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -60,6 +60,13 @@ virtual_column_map_t DuckLakeVirtualColumns(ClientContext &context, optional_ptr
 	return result;
 }
 
+vector<column_t> DuckLakeGetRowIdColumn(ClientContext &context, optional_ptr<FunctionData> bind_data) {
+	vector<column_t> result;
+	result.emplace_back(MultiFileReader::COLUMN_IDENTIFIER_FILENAME);
+	result.emplace_back(MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER);
+	return result;
+}
+
 TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &instance) {
 	// Parquet extension needs to be loaded for this to make sense
 	ExtensionHelper::AutoLoadExtension(instance, "parquet");
@@ -75,6 +82,7 @@ TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &insta
 	function.statistics = DuckLakeStatistics;
 	function.get_bind_info = DuckLakeBindInfo;
 	function.get_virtual_columns = DuckLakeVirtualColumns;
+	function.get_row_id_columns = DuckLakeGetRowIdColumn;
 
 	// Unset all of these: they are either broken, very inefficient.
 	// TODO: implement/fix these

--- a/test/sql/issues/late_materialization.test
+++ b/test/sql/issues/late_materialization.test
@@ -1,0 +1,42 @@
+# name: test/sql/issues/late_materialization.test
+# description: Test late materialization
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_late_materialization.db' AS ducklake;
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE my_table(id INTEGER, value VARCHAR);
+
+statement ok
+INSERT INTO my_table VALUES (1, 'hello');
+
+statement ok
+INSERT INTO my_table VALUES (2, 'world');
+
+statement ok
+INSERT INTO my_table VALUES (3, 'this');
+
+statement ok
+INSERT INTO my_table VALUES (4, 'is');
+
+statement ok
+INSERT INTO my_table VALUES (5, 'a');
+
+statement ok
+INSERT INTO my_table VALUES (6, 'test');
+
+query II
+SELECT * FROM my_table WHERE id > 3 ORDER BY value DESC LIMIT 1
+----
+6	test


### PR DESCRIPTION
Fixes #120 
Fixes #125 

This PR changes DuckLake scans to use the `filename` column, instead of the `file_index` column, to uniquely identify rows when performing late materialization. Using the `file_index` causes problems when combining filters that prune the files scanned together with the late materialization optimization.

The reason for that is that when late materialization is triggered, we are effectively scanning the table twice - once with the filter and once without the filter. The filter is then pushed into the file list in one of these scans - which causes the `file_index` to be inconsistent across these two scans. When matching the rows that we are supposed to scan, we then fetch them from the wrong files, causing wrong results. Using the `filename` column instead of the file index resolves the issue.