### PR TITLE
Fix for running COUNT(*) with inlined data

### DIFF
--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -80,6 +80,10 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			}
 			columns_to_read.push_back("row_id");
 		}
+		if (columns_to_read.empty()) {
+			// COUNT(*) - read row-id column
+			columns_to_read.push_back("row_id");
+		}
 		switch (read_info.scan_type) {
 		case DuckLakeScanType::SCAN_TABLE:
 			data = metadata_manager.ReadInlinedData(read_info.snapshot, table_name, columns_to_read);

--- a/test/sql/data_inlining/basic_data_inlining.test
+++ b/test/sql/data_inlining/basic_data_inlining.test
@@ -30,6 +30,11 @@ SELECT * FROM ducklake.test
 1	2
 NULL	3
 
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+2
+
 query II
 SELECT j, i FROM ducklake.test
 ----


### PR DESCRIPTION
Fixes the issue when running `COUNT(*)` described in #139