### PR TITLE
Fix #147: Actually bump version in metadata during upgrade

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -82,6 +82,7 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_table ADD COLUMN path VARCHAR DEFAULT ''
 ALTER TABLE {METADATA_CATALOG}.ducklake_table ADD COLUMN path_is_relative BOOLEAN DEFAULT TRUE;
 ALTER TABLE {METADATA_CATALOG}.ducklake_metadata ADD COLUMN scope VARCHAR;
 ALTER TABLE {METADATA_CATALOG}.ducklake_metadata ADD COLUMN scope_id BIGINT;
+UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.2' WHERE key = 'version';
 	)";
 	auto result = transaction.Query(migrate_query);
 	if (result->HasError()) {

--- a/test/sql/migration/v01.test
+++ b/test/sql/migration/v01.test
@@ -23,3 +23,10 @@ query I
 SELECT COUNT(*) FROM glob('__TEST_DIR__/ducklake_migrate_v01/*.parquet')
 ----
 1
+
+# re-attach after migration
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/v01.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_v01')


### PR DESCRIPTION
Fixes #147

Fixes an issue with migration from v0.1 -> v0.2. Otherwise we have bumped the catalog tables to v0.2, but left the version at v0.1, which causes the migration to happen again on re-connect (which will fail because the columns already exist).