### PR TITLE
Fix #160 - correctly propagate row_group_size to the Parquet writer, and add support for row_group_size_bytes

### DIFF
--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -12,13 +12,14 @@ struct DuckLakeOptionMetadata {
 	const char *description;
 };
 
-using ducklake_option_array = std::array<DuckLakeOptionMetadata, 8>;
+using ducklake_option_array = std::array<DuckLakeOptionMetadata, 9>;
 
 static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
     {{"parquet_compression", "Compression algorithm for Parquet files (uncompressed, snappy, gzip, zstd, brotli, lz4)"},
      {"parquet_version", "Parquet format version (1 or 2)"},
      {"parquet_compression_level", "Compression level for Parquet files"},
      {"parquet_row_group_size", "Number of rows per row group in Parquet files"},
+     {"parquet_row_group_size_bytes", "Number of bytes per row group in Parquet files"},
      {"version", "DuckLake format version"},
      {"created_by", "DuckLake creator information"},
      {"data_path", "Path to data files"},

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -57,6 +57,12 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 			throw NotImplementedException("Row group size cannot be 0");
 		}
 		value = to_string(row_group_size);
+	} else if (option == "parquet_row_group_size_bytes") {
+		auto row_group_size_bytes = DBConfig::ParseMemoryLimit(val.ToString());
+		if (row_group_size_bytes == 0) {
+			throw NotImplementedException("Row group size bytes cannot be 0");
+		}
+		value = to_string(row_group_size_bytes);
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -323,8 +323,12 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 		info->options["compression_level"].emplace_back(parquet_compression_level);
 	}
 	string row_group_size;
-	if (catalog.TryGetConfigOption("row_group_size", row_group_size, schema_id, table_id)) {
+	if (catalog.TryGetConfigOption("parquet_row_group_size", row_group_size, schema_id, table_id)) {
 		info->options["row_group_size"].emplace_back(row_group_size);
+	}
+	string row_group_size_bytes;
+	if (catalog.TryGetConfigOption("parquet_row_group_size_bytes", row_group_size_bytes, schema_id, table_id)) {
+		info->options["row_group_size_bytes"].emplace_back(row_group_size_bytes + " bytes");
 	}
 
 	// Get Parquet Copy function

--- a/test/sql/settings/parquet_compression.test
+++ b/test/sql/settings/parquet_compression.test
@@ -33,7 +33,7 @@ ZSTD	DELTA_LENGTH_BYTE_ARRAY
 
 # we have two row groups (of up to 64K rows)
 query I
-SELECT COUNT(*) FROM parquet_metadata('__TEST_DIR__/ducklake_parquet_compression/**') ORDER BY ALL
+SELECT COUNT(DISTINCT row_group_id) FROM parquet_metadata('__TEST_DIR__/ducklake_parquet_compression/**') ORDER BY ALL
 ----
 2
 

--- a/test/sql/settings/parquet_row_group_size_bytes.test
+++ b/test/sql/settings/parquet_row_group_size_bytes.test
@@ -1,0 +1,33 @@
+# name: test/sql/settings/parquet_row_group_size_bytes.test
+# description: Test parquet row group size bytes
+# group: [settings]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_parquet_row_group_size_bytes.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_parquet_row_group_size_bytes')
+
+statement ok
+CALL ducklake.set_option('parquet_row_group_size_bytes', '10KB')
+
+statement ok
+SET threads=1
+
+# FIXME: this should not be necessary
+statement ok
+SET preserve_insertion_order=false;
+
+statement ok
+CREATE TABLE ducklake.tbl AS SELECT i, 'hello world' || i str FROM range(100000) t(i)
+
+query I
+SELECT COUNT(DISTINCT row_group_id)>10 FROM parquet_metadata('__TEST_DIR__/ducklake_parquet_row_group_size_bytes/**')
+----
+true
+
+query II
+SELECT value, scope FROM ducklake.options() WHERE option_name='parquet_row_group_size_bytes'
+----
+10000	GLOBAL


### PR DESCRIPTION
Fixes #160 

This PR fixes an issue with the `parquet_row_group_size` parameter not being used correctly - and adds support for the `parquet_row_group_size_bytes` option.