### PR TITLE
Add support for a dedicated PostgresMetadataManager, that queries the Postgres catalog directly for certain operations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(common)
 add_subdirectory(functions)
+add_subdirectory(metadata_manager)
 add_subdirectory(storage)
 
 add_library(ducklake_library OBJECT ducklake_extension.cpp)

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// metadata_manager/postgres_metadata_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "storage/ducklake_metadata_manager.hpp"
+
+namespace duckdb {
+
+class PostgresMetadataManager : public DuckLakeMetadataManager {
+public:
+	PostgresMetadataManager(DuckLakeTransaction &transaction);
+
+protected:
+	string GetLatestSnapshotQuery() const override;
+};
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -47,6 +47,9 @@ public:
 	const string &DataPath() const {
 		return options.data_path;
 	}
+	const string &MetadataType() const {
+		return metadata_type;
+	}
 	idx_t DataInliningRowLimit() const {
 		return options.data_inlining_row_limit;
 	}
@@ -141,6 +144,8 @@ private:
 	string separator = "/";
 	//! A unique tracker for catalog changes in uncommitted transactions.
 	atomic<idx_t> last_uncommitted_catalog_version;
+	//! The metadata server type
+	string metadata_type;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -37,6 +37,8 @@ public:
 	DuckLakeMetadataManager(DuckLakeTransaction &transaction);
 	virtual ~DuckLakeMetadataManager();
 
+	static unique_ptr<DuckLakeMetadataManager> Create(DuckLakeTransaction &transaction);
+
 	DuckLakeMetadataManager &Get(DuckLakeTransaction &transaction);
 
 	//! Initialize a new DuckLake
@@ -111,6 +113,9 @@ public:
 
 	string LoadPath(string path);
 	string StorePath(string path);
+
+protected:
+	virtual string GetLatestSnapshotQuery() const;
 
 protected:
 	string GetInlinedTableQuery(const DuckLakeTableInfo &table, const string &table_name);

--- a/src/metadata_manager/CMakeLists.txt
+++ b/src/metadata_manager/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(ducklake_metadata_manager OBJECT postgres_metadata_manager.cpp)
+set(ALL_OBJECT_FILES
+    ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_metadata_manager>
+    PARENT_SCOPE)

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -1,0 +1,19 @@
+#include "metadata_manager/postgres_metadata_manager.hpp"
+
+namespace duckdb {
+
+PostgresMetadataManager::PostgresMetadataManager(DuckLakeTransaction &transaction)
+    : DuckLakeMetadataManager(transaction) {
+}
+
+string PostgresMetadataManager::GetLatestSnapshotQuery() const {
+	return R"(
+	SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL},
+		'SELECT snapshot_id, schema_version, next_catalog_id, next_file_id
+		 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot WHERE snapshot_id = (
+		     SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot
+		 );')
+	)";
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -19,7 +19,7 @@ DuckLakeTransaction::DuckLakeTransaction(DuckLakeCatalog &ducklake_catalog, Tran
                                          ClientContext &context)
     : Transaction(manager, context), ducklake_catalog(ducklake_catalog), db(*context.db),
       local_catalog_id(DuckLakeConstants::TRANSACTION_LOCAL_ID_START), catalog_version(0) {
-	metadata_manager = make_uniq<DuckLakeMetadataManager>(*this);
+	metadata_manager = DuckLakeMetadataManager::Create(*this);
 }
 
 DuckLakeTransaction::~DuckLakeTransaction() {
@@ -1362,6 +1362,7 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	auto catalog_identifier = DuckLakeUtil::SQLIdentifierToString(ducklake_catalog.MetadataDatabaseName());
 	auto catalog_literal = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataDatabaseName());
 	auto schema_identifier = DuckLakeUtil::SQLIdentifierToString(ducklake_catalog.MetadataSchemaName());
+	auto schema_identifier_escaped = StringUtil::Replace(schema_identifier, "'", "''");
 	auto schema_literal = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataSchemaName());
 	auto metadata_path = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataPath());
 	auto data_path = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.DataPath());
@@ -1370,6 +1371,7 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	query = StringUtil::Replace(query, "{METADATA_CATALOG_NAME_IDENTIFIER}", catalog_identifier);
 	query = StringUtil::Replace(query, "{METADATA_SCHEMA_NAME_LITERAL}", schema_literal);
 	query = StringUtil::Replace(query, "{METADATA_CATALOG}", catalog_identifier + "." + schema_identifier);
+	query = StringUtil::Replace(query, "{METADATA_SCHEMA_ESCAPED}", schema_identifier_escaped);
 	query = StringUtil::Replace(query, "{METADATA_PATH}", metadata_path);
 	query = StringUtil::Replace(query, "{DATA_PATH}", data_path);
 	return connection.Query(query);


### PR DESCRIPTION
Fixes https://github.com/duckdb/ducklake/issues/98

DuckLake uses DuckDB's connectors to connect to different catalog servers. While these connectors support pushdown of basic filters, they don't automatically detect pushdown of more complex queries. This PR adds initial support for manually pushing down queries into the catalog servers through a dedicated metadata manager class for Postgres - the `PostgresMetadataManager`.

Currently this only implements a dedicated query for fetching the most recent snapshot. By pushing down this query we turn it from two full scans of the `ducklake_snapshot` table into a single index look-up. In the future we plan to push down more queries explicitly into the various metadata catalogs. 