### PR TITLE
Add support for the `target_file_size` option - defaulting to 512MB - which controls the target merge threshold and automatically splits up inserts into multiple files

### DIFF
--- a/src/functions/ducklake_merge_adjacent_files.cpp
+++ b/src/functions/ducklake_merge_adjacent_files.cpp
@@ -284,7 +284,8 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	auto copy = make_uniq<LogicalCopyToFile>(std::move(copy_options.copy_function), std::move(copy_options.bind_data),
 	                                         std::move(copy_options.info));
 
-	copy->file_path = std::move(copy_options.file_path);
+	auto &fs = FileSystem::GetFileSystem(context);
+	copy->file_path = copy_options.filename_pattern.CreateFilename(fs, copy_options.file_path, "parquet", 0);
 	copy->use_tmp_file = copy_options.use_tmp_file;
 	copy->filename_pattern = std::move(copy_options.filename_pattern);
 	copy->file_extension = std::move(copy_options.file_extension);
@@ -296,13 +297,13 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 
 	copy->partition_output = copy_options.partition_output;
 	copy->write_partition_columns = copy_options.write_partition_columns;
-	// FIXME: disabled because of issue, should be re-disabled for DuckDB v1.3.1
-	copy->write_empty_file = true;
+	copy->write_empty_file = false;
 	copy->partition_columns = std::move(copy_options.partition_columns);
 	copy->names = std::move(copy_options.names);
 	copy->expected_types = std::move(copy_options.expected_types);
 	copy->preserve_order = PreserveOrderType::PRESERVE_ORDER;
 	copy->file_size_bytes = optional_idx();
+	copy->rotate = false;
 
 	copy->children.push_back(std::move(ducklake_scan));
 

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -57,6 +57,9 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 			throw NotImplementedException("Row group size cannot be 0");
 		}
 		value = to_string(row_group_size);
+	} else if (option == "target_file_size") {
+		auto target_file_size_bytes = DBConfig::ParseMemoryLimit(val.ToString());
+		value = to_string(target_file_size_bytes);
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -25,6 +25,10 @@ class LogicalGet;
 
 class DuckLakeCatalog : public Catalog {
 public:
+	// default target file size: 512MB
+	static constexpr const idx_t DEFAULT_TARGET_FILE_SIZE = 1 << 29;
+
+public:
 	DuckLakeCatalog(AttachedDatabase &db_p, DuckLakeOptions options);
 	~DuckLakeCatalog();
 
@@ -54,6 +58,7 @@ public:
 	}
 	void SetConfigOption(const DuckLakeConfigOption &option);
 	bool TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id, TableIndex table_id) const;
+	bool TryGetConfigOption(const string &option, string &result, DuckLakeTableEntry &table) const;
 
 	optional_ptr<BoundAtClause> CatalogSnapshot() const;
 

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -538,4 +538,11 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, S
 	return true;
 }
 
+bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, DuckLakeTableEntry &table) const {
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	auto schema_id = schema.GetSchemaId();
+	auto table_id = table.GetTableId();
+	return TryGetConfigOption(option, result, schema_id, table_id);
+}
+
 } // namespace duckdb

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -380,7 +380,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 		result.write_empty_file = true;
 		result.rotate = false;
 	} else {
-		result.filename_pattern.SetFilenamePattern("ducklake-{uuidv7}.parquet");
+		result.filename_pattern.SetFilenamePattern("ducklake-{uuidv7}");
 		result.file_path = copy_input.data_path;
 		result.partition_output = false;
 		result.write_empty_file = false;

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -326,6 +326,11 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	if (catalog.TryGetConfigOption("row_group_size", row_group_size, schema_id, table_id)) {
 		info->options["row_group_size"].emplace_back(row_group_size);
 	}
+	idx_t target_file_size = DuckLakeCatalog::DEFAULT_TARGET_FILE_SIZE;
+	string target_file_size_str;
+	if (catalog.TryGetConfigOption("target_file_size", target_file_size_str, schema_id, table_id)) {
+		target_file_size = Value(target_file_size_str).DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
+	}
 
 	// Get Parquet Copy function
 	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(context, "parquet");
@@ -369,18 +374,20 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 		result.partition_output = true;
 		result.partition_columns = std::move(partition_columns);
 		result.write_empty_file = true;
+		result.rotate = false;
 	} else {
-		auto current_write_uuid = DuckLakeTransaction::GenerateUUIDv7();
-		string file_name = "ducklake-" + current_write_uuid + ".parquet";
-		result.file_path = DuckLakeUtil::JoinPath(fs, copy_input.data_path, file_name);
+		result.filename_pattern.SetFilenamePattern("ducklake-{uuidv7}.parquet");
+		result.file_path = copy_input.data_path;
 		result.partition_output = false;
 		result.write_empty_file = false;
+		// file_size_bytes is currently only supported for unpartitioned writes
+		result.file_size_bytes = target_file_size;
+		result.rotate = true;
 	}
 
 	result.file_extension = "parquet";
 	result.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 	result.per_thread_output = false;
-	result.rotate = false;
 	result.return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
 	result.write_partition_columns = true;
 	result.names = names_to_write;

--- a/test/sql/insert/insert_file_size.test
+++ b/test/sql/insert/insert_file_size.test
@@ -1,0 +1,27 @@
+# name: test/sql/insert/insert_file_size.test
+# description: test ducklake split up insert across files
+# group: [insert]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_insert_file_size.db' AS ducklake
+
+statement ok
+CREATE TABLE ducklake.test(id INTEGER, s VARCHAR);
+
+statement ok
+CALL ducklake.set_option('target_file_size', '10KB')
+
+query I
+INSERT INTO ducklake.test SELECT i, concat('thisisalongstring', i) FROM range(500000) t(i)
+----
+500000
+
+# we should be splitting this up into multiple files
+query I
+SELECT COUNT(*) > 1 FROM glob('__TEST_DIR__/ducklake_insert_file_size.db.files/main/test/*.parquet')
+----
+true


### PR DESCRIPTION
This PR adds support for the `target_file_size` option - which defaults to 512MB.

* When inserting into a table without partitioning specified, the `file_size_bytes` option is used with the `target_file_size` as parameter to split up large inserts into multiple files
* When running `merge_adjacent_files`, the `target_file_size` is used to control the desired file size for merging

The option can be set using the `set_option` method, and can be set on the global, schema and table level.

```sql
CALL ducklake.set_option('target_file_size', '10KB')
```