### PR TITLE
Minor api change for `pg_duckdb` + `ducklake` integration

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -49,7 +49,7 @@ static unique_ptr<FunctionData> DuckLakeAddDataFilesBind(ClientContext &context,
 
 	names.emplace_back("filename");
 	return_types.emplace_back(LogicalType::VARCHAR);
-	return result;
+	return std::move(result);
 }
 
 struct DuckLakeAddDataFilesState : public GlobalTableFunctionState {

--- a/src/functions/ducklake_list_files.cpp
+++ b/src/functions/ducklake_list_files.cpp
@@ -1,4 +1,5 @@
 #include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_transaction.hpp"
 #include "common/ducklake_util.hpp"
 #include "storage/ducklake_transaction_changes.hpp"

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -41,9 +41,9 @@ public:
 	~DuckLakeTransaction() override;
 
 public:
-	void Start();
-	void Commit();
-	void Rollback();
+	virtual void Start();
+	virtual void Commit();
+	virtual void Rollback();
 
 	DuckLakeCatalog &GetCatalog() {
 		return ducklake_catalog;
@@ -124,6 +124,11 @@ public:
 	//! If there are no uncommitted changes, this is the schema version of the snapshot.
 	//! Otherwise, it is an id that is incremented whenever the schema changes (not stored between restarts)
 	idx_t GetCatalogVersion();
+
+protected:
+	void SetMetadataManager(unique_ptr<DuckLakeMetadataManager> metadata_manager) {
+		this->metadata_manager = std::move(metadata_manager);
+	}
 
 private:
 	void CleanupFiles();

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -40,7 +40,7 @@ DuckLakeMultiFileReader::~DuckLakeMultiFileReader() {
 unique_ptr<MultiFileReader> DuckLakeMultiFileReader::Copy() const {
 	auto result = make_uniq<DuckLakeMultiFileReader>(read_info);
 	result->transaction_local_data = transaction_local_data;
-	return result;
+	return std::move(result);
 }
 
 unique_ptr<MultiFileReader> DuckLakeMultiFileReader::CreateInstance(const TableFunction &table_function) {


### PR DESCRIPTION
Minor api changes for integrating `ducklake` into `pg_duckdb`, check out the pg_duckdb [pull request](https://github.com/duckdb/pg_duckdb/pull/830).