### PR TITLE
Add support for using secrets to manage DuckLake options and credentials

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -8,6 +8,7 @@
 #include "storage/ducklake_storage.hpp"
 #include "functions/ducklake_table_functions.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "storage/ducklake_secret.hpp"
 
 namespace duckdb {
 
@@ -52,6 +53,13 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	DuckLakeAddDataFilesFunction add_files;
 	ExtensionUtil::RegisterFunction(instance, add_files);
+
+	// secrets
+	auto secret_type = DuckLakeSecret::GetSecretType();
+	ExtensionUtil::RegisterSecretType(instance, secret_type);
+
+	auto ducklake_secret_function = DuckLakeSecret::GetFunction();
+	ExtensionUtil::RegisterFunction(instance, ducklake_secret_function);
 }
 
 void DucklakeExtension::Load(DuckDB &db) {

--- a/src/include/storage/ducklake_secret.hpp
+++ b/src/include/storage/ducklake_secret.hpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_secret.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+
+namespace duckdb {
+
+class DuckLakeSecret {
+public:
+	static constexpr const char *DEFAULT_SECRET = "__default_ducklake";
+
+public:
+	static unique_ptr<BaseSecret> CreateDuckLakeSecretFunction(ClientContext &context, CreateSecretInput &input);
+	static unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_name);
+
+	static bool PathIsSecret(const string &path);
+
+	static SecretType GetSecretType();
+	static CreateSecretFunction GetFunction();
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   ducklake_storage.cpp
   ducklake_delete.cpp
   ducklake_multi_file_reader.cpp
+  ducklake_secret.cpp
   ducklake_stats.cpp
   ducklake_table_entry.cpp
   ducklake_initializer.cpp

--- a/src/storage/ducklake_secret.cpp
+++ b/src/storage/ducklake_secret.cpp
@@ -43,7 +43,7 @@ CreateSecretFunction DuckLakeSecret::GetFunction() {
 	function.named_parameters["metadata_schema"] = LogicalType::VARCHAR;
 	function.named_parameters["metadata_catalog"] = LogicalType::VARCHAR;
 	function.named_parameters["metadata_path"] = LogicalType::VARCHAR;
-	function.named_parameters["metadata_parameters"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::ANY);
+	function.named_parameters["metadata_parameters"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	function.named_parameters["encrypted"] = LogicalType::BOOLEAN;
 	return function;
 }

--- a/src/storage/ducklake_secret.cpp
+++ b/src/storage/ducklake_secret.cpp
@@ -1,0 +1,65 @@
+#include "storage/ducklake_secret.hpp"
+
+namespace duckdb {
+
+unique_ptr<BaseSecret> DuckLakeSecret::CreateDuckLakeSecretFunction(ClientContext &context, CreateSecretInput &input) {
+	// apply any overridden settings
+	vector<string> prefix_paths;
+	auto result = make_uniq<KeyValueSecret>(prefix_paths, "ducklake", "config", input.name);
+	if (input.options.find("metadata_path") == input.options.end()) {
+		throw InvalidInputException("metadata_path must be defined when creating a DuckLake secret");
+	}
+	for (const auto &named_param : input.options) {
+		result->secret_map[named_param.first] = std::move(named_param.second);
+	}
+	return std::move(result);
+}
+
+bool DuckLakeSecret::PathIsSecret(const string &path) {
+	// secret names can be alphanumeric and have underscores
+	for (auto c : path) {
+		if (StringUtil::CharacterIsAlphaNumeric(c)) {
+			continue;
+		}
+		if (c == '_') {
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+SecretType DuckLakeSecret::GetSecretType() {
+	SecretType secret_type;
+	secret_type.name = "ducklake";
+	secret_type.deserializer = KeyValueSecret::Deserialize<KeyValueSecret>;
+	secret_type.default_provider = "config";
+	return secret_type;
+}
+
+CreateSecretFunction DuckLakeSecret::GetFunction() {
+	CreateSecretFunction function = {"ducklake", "config", CreateDuckLakeSecretFunction};
+	function.named_parameters["data_path"] = LogicalType::VARCHAR;
+	function.named_parameters["metadata_schema"] = LogicalType::VARCHAR;
+	function.named_parameters["metadata_catalog"] = LogicalType::VARCHAR;
+	function.named_parameters["metadata_path"] = LogicalType::VARCHAR;
+	function.named_parameters["metadata_parameters"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::ANY);
+	function.named_parameters["encrypted"] = LogicalType::BOOLEAN;
+	return function;
+}
+
+unique_ptr<SecretEntry> DuckLakeSecret::GetSecret(ClientContext &context, const string &secret_name) {
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	// FIXME: this should be adjusted once the `GetSecretByName` API supports this use case
+	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "memory");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "local_file");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	return nullptr;
+}
+} // namespace duckdb

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -17,6 +17,13 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 		options.metadata_database = value.ToString();
 	} else if (lcase == "metadata_path") {
 		options.metadata_path = value.ToString();
+	} else if (lcase == "metadata_parameters") {
+		auto &children = MapValue::GetChildren(value);
+		for (auto &child : children) {
+			auto &key_value = StructValue::GetChildren(child);
+			auto &parameter_name = StringValue::Get(key_value[0]);
+			options.metadata_parameters[parameter_name] = key_value[1];
+		}
 	} else if (lcase == "encrypted") {
 		if (value.GetValue<bool>()) {
 			options.encryption = DuckLakeEncryption::ENCRYPTED;
@@ -61,8 +68,8 @@ static unique_ptr<Catalog> DuckLakeAttach(StorageExtensionInfo *storage_info, Cl
 		secret = DuckLakeSecret::GetSecret(context, info.path);
 		if (!secret) {
 			throw InvalidInputException(
-			    "Secret %s was not found - if this was meant to be a path, use duckdb:%s instead", info.path,
-			    info.path);
+			    "Secret \"%s\" was not found - if this was meant to be a path to a DuckDB file, use duckdb:%s instead",
+			    info.path, info.path);
 		}
 	} else {
 		// otherwise set the remainder of the path as the metadata path

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -80,3 +80,26 @@ FROM ducklake.test
 1
 2
 3
+
+statement ok
+DETACH ducklake
+
+# metadata parameters
+statement ok
+CREATE SECRET metadata_parameters123 (
+	TYPE DUCKLAKE,
+	METADATA_PATH '__TEST_DIR__/metadata_named.db',
+	DATA_PATH '__TEST_DIR__/my_data_path_named',
+	METADATA_PARAMETERS MAP {'TYPE': 'DUCKDBXX'}
+);
+
+statement error
+ATTACH 'ducklake:metadata_parameters123' AS ducklake
+----
+duckdbxx
+
+# unknown secret name
+statement error
+ATTACH 'ducklake:unknown_secret' AS ducklake
+----
+Secret "unknown_secret" was not found

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -1,0 +1,82 @@
+# name: test/sql/secrets/ducklake_secrets.test
+# description: Test DuckLake connections with secrets
+# group: [secrets]
+
+require ducklake
+
+require parquet
+
+# default secret
+statement ok
+CREATE SECRET (
+	TYPE DUCKLAKE,
+	METADATA_PATH '__TEST_DIR__/metadata.db',
+	DATA_PATH '__TEST_DIR__/my_data_path'
+);
+
+statement ok
+ATTACH 'ducklake:' AS ducklake
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1), (2), (3);
+
+# verify we are using the correct path
+query I
+SELECT COUNT(*) FROM glob('__TEST_DIR__/my_data_path/**/*.parquet')
+----
+1
+
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:' AS ducklake
+
+query I
+FROM ducklake.test
+----
+1
+2
+3
+
+statement ok
+DETACH ducklake
+
+# named secrets
+statement ok
+CREATE SECRET my_ducklake (
+	TYPE DUCKLAKE,
+	METADATA_PATH '__TEST_DIR__/metadata_named.db',
+	DATA_PATH '__TEST_DIR__/my_data_path_named'
+);
+
+statement ok
+ATTACH 'ducklake:my_ducklake' AS ducklake
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1), (2), (3);
+
+# verify we are using the correct path
+query I
+SELECT COUNT(*) FROM glob('__TEST_DIR__/my_data_path_named/**/*.parquet')
+----
+1
+
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:my_ducklake' AS ducklake
+
+query I
+FROM ducklake.test
+----
+1
+2
+3


### PR DESCRIPTION
This PR adds support for using secrets to manage DuckLake connectivity. For example:

##### Unnamed Secret
```sql
CREATE SECRET (
	TYPE DUCKLAKE,
	METADATA_PATH 'metadata.db',
	DATA_PATH 's3://my-s3-path/'
);

-- empty connection string means we use the unnamed secret
ATTACH 'ducklake:' AS my_ducklake;
```
##### Named Secret

```sql
CREATE SECRET my_secret (
	TYPE DUCKLAKE,
	METADATA_PATH 'metadata.db',
	DATA_PATH 's3://my-s3-path/'
);
-- secret name in connection string means we use a named secret
ATTACH 'ducklake:my_secret' AS my_ducklake;
```

We automatically disambiguate between file names and secret names in the connection string:

* The provided name is treated as a secret
* If the provided name contains any symbol aside from alphanumeric symbols and underscores, it is treated as a path, i.e. `file.ducklake` is treated as a path, as is `my_path/file`
* The `duckdb:` prefix can be used to force a path, e.g. `ducklake:duckdb:this_is_a_path_to_a_file`

### Supported Parameters

|      Parameter      |                                Description                                |                Default                |
|---------------------|---------------------------------------------------------------------------|---------------------------------------|
| metadata_path       | Metadata connection string (e.g. `file.duckdb`, or `postgres:dbname=...`) |                                       |
| data_path           | Path to the data directory                                                |                                       |
| metadata_schema     | Schema to use in the metadata catalog                                     | main                                  |
| metadata_catalog    | Name of the attached metadata catalog                                     | `__ducklake_metadata_[attached_name]` |
| metadata_parameters | Map of key-value parameters to pass to the metadata catalog               | {}                                    |
| encrypted           | Whether or not the database is encrypted                                  | false                                 |