### PR TITLE
Allow data inlining to be set as a setting, and persist whether or not data inlining is enabled

### DIFF
--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -66,6 +66,9 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 	} else if (option == "target_file_size") {
 		auto target_file_size_bytes = DBConfig::ParseMemoryLimit(val.ToString());
 		value = to_string(target_file_size_bytes);
+	} else if (option == "data_inlining_row_limit") {
+		auto data_inlining_row_limit = val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
+		value = to_string(data_inlining_row_limit);
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -27,7 +27,6 @@ struct DuckLakeOptions {
 	string data_path;
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	DuckLakeEncryption encryption = DuckLakeEncryption::AUTOMATIC;
-	idx_t data_inlining_row_limit = 0;
 	unique_ptr<BoundAtClause> at_clause;
 	unordered_map<string, Value> metadata_parameters;
 	option_map_t config_options;

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -55,14 +55,20 @@ public:
 	const string &MetadataType() const {
 		return metadata_type;
 	}
-	idx_t DataInliningRowLimit() const {
-		return options.data_inlining_row_limit;
-	}
+	idx_t DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const;
 	string &Separator() {
 		return separator;
 	}
 	void SetConfigOption(const DuckLakeConfigOption &option);
 	bool TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id, TableIndex table_id) const;
+	template <class T>
+	T GetConfigOption(const string &option, SchemaIndex schema_id, TableIndex table_id, T default_value) const {
+		string value_str;
+		if (TryGetConfigOption(option, value_str, schema_id, table_id)) {
+			return Value(value_str).GetValue<T>();
+		}
+		return default_value;
+	}
 	bool TryGetConfigOption(const string &option, string &result, DuckLakeTableEntry &table) const;
 
 	optional_ptr<BoundAtClause> CatalogSnapshot() const;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -117,7 +117,7 @@ struct DuckLakeFileInfo {
 struct DuckLakeInlinedDataInfo {
 	TableIndex table_id;
 	idx_t row_id_start;
-	unique_ptr<DuckLakeInlinedData> data;
+	optional_ptr<DuckLakeInlinedData> data;
 };
 
 struct DuckLakeDeletedInlinedDataInfo {

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -72,10 +72,15 @@ public:
 	virtual void WriteNewTags(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeTagInfo> &new_tags);
 	virtual void WriteNewColumnTags(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeColumnTagInfo> &new_tags);
 	virtual void WriteNewDataFiles(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeFileInfo> &new_files);
-	virtual void WriteNewInlinedData(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeInlinedDataInfo> &new_data);
+	virtual void WriteNewInlinedData(DuckLakeSnapshot &commit_snapshot,
+	                                 const vector<DuckLakeInlinedDataInfo> &new_data);
 	virtual void WriteNewInlinedDeletes(DuckLakeSnapshot commit_snapshot,
 	                                    const vector<DuckLakeDeletedInlinedDataInfo> &new_deletes);
 	virtual void WriteNewInlinedTables(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeTableInfo> &tables);
+	virtual string GetInlinedTableQueries(DuckLakeSnapshot commit_snapshot, const DuckLakeTableInfo &table,
+	                                      string &inlined_tables, string &inlined_table_queries);
+	virtual void ExecuteInlinedTableQueries(DuckLakeSnapshot commit_snapshot, string &inlined_tables,
+	                                        const string &inlined_table_queries);
 	virtual void DropDataFiles(DuckLakeSnapshot commit_snapshot, const set<DataFileIndex> &dropped_files);
 	virtual void DropDeleteFiles(DuckLakeSnapshot commit_snapshot, const set<DataFileIndex> &dropped_files);
 	virtual void WriteNewDeleteFiles(DuckLakeSnapshot commit_snapshot,

--- a/src/include/storage/ducklake_table_entry.hpp
+++ b/src/include/storage/ducklake_table_entry.hpp
@@ -81,6 +81,9 @@ public:
 	//! Gets the top-level not-null fields
 	case_insensitive_set_t GetNotNullFields() const;
 
+	DuckLakeTableInfo GetTableInfo() const;
+	vector<DuckLakeColumnInfo> GetTableColumns() const;
+
 public:
 	unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
 

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -140,7 +140,6 @@ private:
 	               unordered_set<idx_t> &dropped_entries);
 	vector<DuckLakeSchemaInfo> GetNewSchemas(DuckLakeSnapshot &commit_snapshot);
 	NewTableInfo GetNewTables(DuckLakeSnapshot &commit_snapshot, TransactionChangeInformation &transaction_changes);
-	vector<DuckLakeColumnInfo> GetTableColumns(DuckLakeTableEntry &table);
 	DuckLakePartitionInfo GetNewPartitionKey(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &tabletable_id);
 	DuckLakeTableInfo GetNewTable(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table);
 	DuckLakeViewInfo GetNewView(DuckLakeSnapshot &commit_snapshot, DuckLakeViewEntry &view);

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -664,4 +664,8 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 	return TryGetConfigOption(option, result, schema_id, table_id);
 }
 
+idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
+	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 0);
+}
+
 } // namespace duckdb

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -64,7 +64,7 @@ void DuckLakeInitializer::Initialize() {
 		// if the schema is not explicitly set by the user - set it to the default schema in the catalog
 		options.metadata_schema = transaction.GetDefaultSchemaName();
 	}
-	if (options.data_inlining_row_limit > 0) {
+	if (catalog.DataInliningRowLimit(SchemaIndex(), TableIndex()) > 0) {
 		auto &metadata_catalog = Catalog::GetCatalog(*transaction.GetConnection().context, options.metadata_database);
 		if (!metadata_catalog.IsDuckCatalog()) {
 			throw NotImplementedException("Data inlining is currently only supported on DuckDB catalogs");

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -31,7 +31,7 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 			options.encryption = DuckLakeEncryption::UNENCRYPTED;
 		}
 	} else if (lcase == "data_inlining_row_limit") {
-		options.data_inlining_row_limit = value.GetValue<idx_t>();
+		options.config_options["data_inlining_row_limit"] = value.DefaultCastAs(LogicalType::UBIGINT).ToString();
 	} else if (lcase == "snapshot_version") {
 		if (options.at_clause) {
 			throw InvalidInputException("Cannot specify both VERSION and TIMESTAMP");

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1055,7 +1055,7 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(DuckLakeSnapshot &commit_snapsh
 		new_global_stats.emplace(table_id, std::move(new_globals));
 
 		// add the file to the to-be-written inlined data list
-		new_inlined_data.data = std::move(entry.second);
+		new_inlined_data.data = entry.second.get();
 		result.new_inlined_data.push_back(std::move(new_inlined_data));
 	}
 	if (!new_inlined_data.empty() && new_data_files.empty()) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -579,12 +579,11 @@ DuckLakePartitionInfo DuckLakeTransaction::GetNewPartitionKey(DuckLakeSnapshot &
 	return partition_key;
 }
 
-vector<DuckLakeColumnInfo> DuckLakeTransaction::GetTableColumns(DuckLakeTableEntry &table) {
+vector<DuckLakeColumnInfo> DuckLakeTableEntry::GetTableColumns() const {
 	vector<DuckLakeColumnInfo> result;
-	auto not_null_fields = table.GetNotNullFields();
-	for (auto &col : table.GetColumns().Logical()) {
-		auto col_info =
-		    DuckLakeTableEntry::ConvertColumn(col.GetName(), col.GetType(), table.GetFieldId(col.Physical()));
+	auto not_null_fields = GetNotNullFields();
+	for (auto &col : GetColumns().Logical()) {
+		auto col_info = DuckLakeTableEntry::ConvertColumn(col.GetName(), col.GetType(), GetFieldId(col.Physical()));
 		if (not_null_fields.count(col.GetName())) {
 			// no null values allowed in this field
 			col_info.nulls_allowed = false;
@@ -594,10 +593,20 @@ vector<DuckLakeColumnInfo> DuckLakeTransaction::GetTableColumns(DuckLakeTableEnt
 	return result;
 }
 
-DuckLakeTableInfo DuckLakeTransaction::GetNewTable(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table) {
-	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+DuckLakeTableInfo DuckLakeTableEntry::GetTableInfo() const {
+	auto &schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
 	DuckLakeTableInfo table_entry;
-	auto original_id = table.GetTableId();
+	table_entry.id = GetTableId();
+	table_entry.uuid = GetTableUUID();
+	table_entry.schema_id = schema.GetSchemaId();
+	table_entry.name = name;
+	table_entry.path = DataPath();
+	return table_entry;
+}
+
+DuckLakeTableInfo DuckLakeTransaction::GetNewTable(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table) {
+	auto table_entry = table.GetTableInfo();
+	auto original_id = table_entry.id;
 	bool is_new_table;
 	if (original_id.IsTransactionLocal()) {
 		table_entry.id = TableIndex(commit_snapshot.next_catalog_id++);
@@ -608,13 +617,9 @@ DuckLakeTableInfo DuckLakeTransaction::GetNewTable(DuckLakeSnapshot &commit_snap
 		table_entry.id = original_id;
 		is_new_table = false;
 	}
-	table_entry.uuid = table.GetTableUUID();
-	table_entry.schema_id = schema.GetSchemaId();
-	table_entry.name = table.name;
-	table_entry.path = table.DataPath();
 	if (is_new_table) {
 		// if this is a new table - write the columns
-		table_entry.columns = GetTableColumns(table);
+		table_entry.columns = table.GetTableColumns();
 
 		// if we have written any data to this table - move them to the new (correct) table id as well
 		auto data_file_entry = new_data_files.find(original_id);
@@ -785,7 +790,7 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeSnapshot &commit_snapshot, Duc
 		DuckLakeTableInfo table_entry;
 		table_entry.id = table.GetTableId();
 		table_entry.uuid = table.GetTableUUID();
-		table_entry.columns = GetTableColumns(table);
+		table_entry.columns = table.GetTableColumns();
 		result.new_inlined_data_tables.push_back(std::move(table_entry));
 	}
 }

--- a/test/sql/concurrent/concurrent_insert_data_inlining.test
+++ b/test/sql/concurrent/concurrent_insert_data_inlining.test
@@ -1,0 +1,40 @@
+# name: test/sql/concurrent/concurrent_insert_data_inlining.test
+# description: test concurrent insert with data inlining
+# group: [concurrent]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_concurrent_insert_inline.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_concurrent_insert_inline_files')
+
+statement ok
+CREATE TABLE ducklake.tbl(key INTEGER);
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+
+concurrentloop i 0 2
+
+query I
+INSERT INTO ducklake.tbl VALUES (${i})
+----
+1
+
+endloop
+
+query II
+SELECT COUNT(*), SUM(key) FROM ducklake.tbl
+----
+2	1
+
+query I
+SELECT COUNT(*) FROM glob('__TEST_DIR__/ducklake_concurrent_insert_inline_files/**')
+----
+0
+
+query I
+SELECT stats(key) FROM ducklake.tbl LIMIT 1
+----
+<REGEX>:.*Min: 0, Max: 1.*

--- a/test/sql/data_inlining/data_inlining_option.test
+++ b/test/sql/data_inlining/data_inlining_option.test
@@ -51,3 +51,8 @@ query I
 SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_setting_files/**')
 ----
 0
+
+query III
+SELECT option_name, description IS NOT NULL, value FROM ducklake.options() WHERE option_name = 'data_inlining_row_limit'
+----
+data_inlining_row_limit	true	10

--- a/test/sql/data_inlining/data_inlining_option.test
+++ b/test/sql/data_inlining/data_inlining_option.test
@@ -1,0 +1,53 @@
+# name: test/sql/data_inlining/data_inlining_option.test
+# description: test setting data inlining as an option
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_setting.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_setting_files', METADATA_CATALOG 'ducklake_metadata')
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER, j INTEGER);
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 2), (NULL, 3);
+
+query II
+SELECT * FROM ducklake.test
+----
+1	2
+NULL	3
+
+# all data is inlined - so we have no files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_setting_files/**')
+----
+0
+
+statement ok
+DETACH ducklake;
+
+# the option is persisted across restarts
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_setting.db' AS ducklake
+
+statement ok
+INSERT INTO ducklake.test VALUES (5, 5);
+
+query II
+SELECT * FROM ducklake.test
+----
+1	2
+NULL	3
+5	5
+
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_setting_files/**')
+----
+0

--- a/test/sql/data_inlining/data_inlining_option_transaction_local.test
+++ b/test/sql/data_inlining/data_inlining_option_transaction_local.test
@@ -1,0 +1,64 @@
+# name: test/sql/data_inlining/data_inlining_option_transaction_local.test
+# description: test setting data inlining as an option when we have transaction local changes
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_setting.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_setting_files', METADATA_CATALOG 'ducklake_metadata')
+
+# transaction local ctable
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+
+statement ok
+INSERT INTO ducklake.test VALUES (42);
+
+statement ok
+COMMIT
+
+query I
+SELECT * FROM ducklake.test
+----
+42
+
+# disable inlining again
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+# now perform a transaction local alter
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test ADD COLUMN j INTEGER
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 2), (NULL, 3);
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM ducklake.test
+----
+42	NULL
+1	2
+NULL	3
+
+# all data is inlined - so we have no files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_setting_files/**')
+----
+0

--- a/test/sql/data_inlining/data_inlining_option_transaction_local.test
+++ b/test/sql/data_inlining/data_inlining_option_transaction_local.test
@@ -7,7 +7,7 @@ require ducklake
 require parquet
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_setting.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_setting_files', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_setting_tl.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_setting_tl_files', METADATA_CATALOG 'ducklake_metadata')
 
 # transaction local ctable
 statement ok


### PR DESCRIPTION
This PR makes `data_inlining_row_limit` a setting that can be configured using `set_option`, e.g.:

```sql
CALL ducklake.set_option('data_inlining_row_limit', 10);
```

Like other options the option can be set globally, per-schema or per-table. The options are persisted in the DuckLake.

Since the option can now be toggled on or off at any point now, we need to deal with the fact that the inlined data tables might not have been created yet when we are writing inlined changes to a table. We deal with this by, in `WriteNewInlinedData`, creating the inlined tables if they do not exist.

