### PR TITLE
Eagerly load secrets when starting DuckLake - and throw error when default secret is not available

### DIFF
--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -51,6 +51,8 @@ string DuckLakeInitializer::GetAttachOptions() {
 
 void DuckLakeInitializer::Initialize() {
 	auto &transaction = DuckLakeTransaction::Get(context, catalog);
+	// explicitly load all secrets - work-around to secret initialization bug
+	transaction.Query("FROM duckdb_secrets()");
 	// attach the metadata database
 	auto result =
 	    transaction.Query("ATTACH {METADATA_PATH} AS {METADATA_CATALOG_NAME_IDENTIFIER}" + GetAttachOptions());

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -63,6 +63,10 @@ static unique_ptr<Catalog> DuckLakeAttach(StorageExtensionInfo *storage_info, Cl
 	if (info.path.empty()) {
 		// no path specified - load the default secret
 		secret = DuckLakeSecret::GetSecret(context, DuckLakeSecret::DEFAULT_SECRET);
+		if (!secret) {
+			throw InvalidInputException(
+			    "Default secret was not found - either specify a path to attach to directly, or create the secret");
+		}
 	} else if (DuckLakeSecret::PathIsSecret(info.path)) {
 		// if the path is a plain name - load the secret name
 		secret = DuckLakeSecret::GetSecret(context, info.path);

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -6,6 +6,12 @@ require ducklake
 
 require parquet
 
+# no secret available
+statement error
+ATTACH 'ducklake:' AS ducklake
+----
+Default secret was not found
+
 # default secret
 statement ok
 CREATE SECRET (


### PR DESCRIPTION
Ports https://github.com/duckdb/ducklake/pull/186 to main for now

This works around an upstream bug in instantiating secrets which gets triggered by the way that DuckLake is setup, to be fixed separately upstream.