### PR TITLE
Add jittery exponential back-off for retries

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -18,8 +18,13 @@ static void LoadInternal(DatabaseInstance &instance) {
 	auto &config = DBConfig::GetConfig(instance);
 	config.storage_extensions["ducklake"] = make_uniq<DuckLakeStorageExtension>();
 
-	config.AddExtensionOption("ducklake_max_retry_count", "The maximum amount of retry attempts for a ducklake transaction",
-	                          LogicalType::UBIGINT, Value::UBIGINT(5));
+	config.AddExtensionOption("ducklake_max_retry_count",
+	                          "The maximum amount of retry attempts for a ducklake transaction", LogicalType::UBIGINT,
+	                          Value::UBIGINT(10));
+	config.AddExtensionOption("ducklake_retry_wait_ms", "Time between retries", LogicalType::UBIGINT,
+	                          Value::UBIGINT(100));
+	config.AddExtensionOption("ducklake_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
+	                          LogicalType::DOUBLE, Value::DOUBLE(1.5));
 
 	DuckLakeSnapshotsFunction snapshots;
 	ExtensionUtil::RegisterFunction(instance, snapshots);

--- a/test/sql/concurrent/concurrent_insert_conflict.test
+++ b/test/sql/concurrent/concurrent_insert_conflict.test
@@ -13,6 +13,12 @@ statement ok
 ATTACH 'ducklake:__TEST_DIR__/ducklake_concurrent_insert.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_concurrent_insert_files')
 
 statement ok
+SET ducklake_retry_wait_ms=100
+
+statement ok
+SET ducklake_retry_backoff=2.0
+
+statement ok
 CREATE TABLE ducklake.tbl(key INTEGER);
 
 concurrentloop i 0 2

--- a/test/sql/settings/max_retry_count.test
+++ b/test/sql/settings/max_retry_count.test
@@ -1,4 +1,4 @@
-# name: test/sql/settings/max_retry_count.test  
+# name: test/sql/settings/max_retry_count.test
 # description: Test ducklake_max_retry_count configuration reading and usage
 # group: [settings]
 
@@ -16,7 +16,7 @@ USE ducklake
 query I
 SELECT current_setting('ducklake_max_retry_count')
 ----
-5
+10
 
 # Test 2: Set to custom value and verify
 statement ok
@@ -65,7 +65,7 @@ RESET ducklake_max_retry_count;
 query I
 SELECT current_setting('ducklake_max_retry_count')
 ----
-5
+10
 
 # Verify all data was inserted correctly
 query II


### PR DESCRIPTION
Fixes #233 

This PR adds a sleep between retries. The sleep duration uses jittery exponential back-off.
The base sleep duration is `100 * 1.5 ^ R` milliseconds where R is the retry number (starting at 0).
Randomly, we will sleep between `0.5 - 1.0` the base sleep duration. For 10 retries, that means we will use the following sleeps:

```
50ms - 100ms
75ms - 150ms
112ms - 225ms
168ms - 337ms
253ms - 506ms
379ms - 759ms
569ms - 1139ms
854ms - 1708ms
1281ms - 2562ms
1922ms - 3844ms
```

This PR also increases the default setting for retries to 10. 

The sleep duration is configurable using `ducklake_retry_wait_ms` (default 100) and `ducklake_retry_backoff` (default 1.5).