### PR TITLE
Fix #94: allow complex update statements, but only if the same row is not updated multiple times

### DIFF
--- a/src/include/storage/ducklake_delete.hpp
+++ b/src/include/storage/ducklake_delete.hpp
@@ -60,7 +60,7 @@ private:
 class DuckLakeDelete : public PhysicalOperator {
 public:
 	DuckLakeDelete(DuckLakeTableEntry &table, PhysicalOperator &child, shared_ptr<DuckLakeDeleteMap> delete_map,
-	               vector<idx_t> row_id_indexes, string encryption_key);
+	               vector<idx_t> row_id_indexes, string encryption_key, bool allow_duplicates);
 
 	//! The table to delete from
 	DuckLakeTableEntry &table;
@@ -70,6 +70,8 @@ public:
 	vector<idx_t> row_id_indexes;
 	//! The encryption key used to encrypt the written files
 	string encryption_key;
+	//! Whether or not we allow duplicate deletes
+	bool allow_duplicates;
 
 public:
 	// // Source interface
@@ -81,7 +83,8 @@ public:
 
 	static PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner,
 	                                    DuckLakeTableEntry &table, PhysicalOperator &child_plan,
-	                                    vector<idx_t> row_id_indexes, string encryption_key);
+	                                    vector<idx_t> row_id_indexes, string encryption_key,
+	                                    bool allow_duplicates = true);
 
 public:
 	// Sink interface

--- a/test/sql/update/update_join_duplicates.test
+++ b/test/sql/update/update_join_duplicates.test
@@ -13,22 +13,32 @@ statement ok
 CREATE TABLE ducklake.test AS SELECT i id FROM range(5) t(i);
 
 statement ok
+CREATE TEMPORARY TABLE updated_rows AS FROM range(0, 10, 2) t(update_id) UNION ALL FROM range(0, 10, 2);
+
+# duplicate row-id updates are not yet supported
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.test FROM range(5, 10)
+
+statement error
+UPDATE ducklake.test SET id=id+1000 FROM updated_rows WHERE id=updated_rows.update_id
+----
+The same row was updated multiple times
+
+statement ok
+ROLLBACK
+
+# we can update through a join if we filter out the duplciate row ids
+statement ok
 BEGIN
 
 statement ok
 INSERT INTO ducklake.test FROM range(5, 10)
 
 statement ok
-CREATE TEMPORARY TABLE updated_rows AS FROM range(0, 10, 2) t(update_id) UNION ALL FROM range(0, 10, 2);
-
-# not supported yet
-# FIXME: should be fixed
-statement error
-UPDATE ducklake.test SET id=id+1000 FROM updated_rows WHERE id=updated_rows.update_id
-----
-not yet supported
-
-mode skip
+UPDATE ducklake.test SET id=id+1000 FROM (SELECT DISTINCT update_id FROM updated_rows) updated_rows WHERE id=updated_rows.update_id
 
 query III
 SELECT COUNT(*), SUM(id), AVG(id) FROM ducklake.test


### PR DESCRIPTION
Partially implements #94 

We explicitly disabled support for complex update statements because we did not handle the case where the same row was updated multiple times (i.e. when the join results in duplicate results). Instead of disabling these types of update statements altogether - we now detect whether or not there are duplicate row ids being updated. If so, we throw the error. This should allow most complex update statements to work as you generally don't want to update the same row multiple times in the same statement anyway. 