### PR TITLE
Allow compaction of non-adjacent files using `ducklake_merge_adjacent_files`

### DIFF
--- a/src/include/storage/ducklake_compaction.hpp
+++ b/src/include/storage/ducklake_compaction.hpp
@@ -22,13 +22,15 @@ class DuckLakeCompaction : public PhysicalOperator {
 public:
 	DuckLakeCompaction(const vector<LogicalType> &types, DuckLakeTableEntry &table,
 	                   vector<DuckLakeCompactionFileEntry> source_files_p, string encryption_key,
-	                   optional_idx partition_id, vector<string> partition_values, PhysicalOperator &child);
+	                   optional_idx partition_id, vector<string> partition_values, optional_idx row_id_start,
+	                   PhysicalOperator &child);
 
 	DuckLakeTableEntry &table;
 	vector<DuckLakeCompactionFileEntry> source_files;
 	string encryption_key;
 	optional_idx partition_id;
 	vector<string> partition_values;
+	optional_idx row_id_start;
 
 public:
 	// // Source interface

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -243,7 +243,7 @@ enum class DuckLakeDataType {
 struct DuckLakeFileListEntry {
 	DuckLakeFileData file;
 	DuckLakeFileData delete_file;
-	idx_t row_id_start;
+	optional_idx row_id_start;
 	optional_idx snapshot_id;
 	optional_idx max_row_count;
 	MappingIndex mapping_id;
@@ -255,7 +255,7 @@ struct DuckLakeDeleteScanEntry {
 	DuckLakeFileData delete_file;
 	DuckLakeFileData previous_delete_file;
 	idx_t row_count;
-	idx_t row_id_start;
+	optional_idx row_id_start;
 	MappingIndex mapping_id;
 	optional_idx snapshot_id;
 };
@@ -265,7 +265,7 @@ struct DuckLakeFileListExtendedEntry {
 	DataFileIndex delete_file_id;
 	DuckLakeFileData file;
 	DuckLakeFileData delete_file;
-	idx_t row_id_start;
+	optional_idx row_id_start;
 	optional_idx snapshot_id;
 	idx_t row_count;
 	idx_t delete_count = 0;
@@ -288,7 +288,7 @@ struct DuckLakeFileScheduledForCleanup {
 };
 
 struct DuckLakeCompactionFileData : public DuckLakeCompactionBaseFileData {
-	idx_t row_id_start;
+	optional_idx row_id_start;
 	MappingIndex mapping_id;
 	optional_idx partition_id;
 	vector<string> partition_values;
@@ -306,7 +306,7 @@ struct DuckLakeCompactionFileEntry {
 struct DuckLakeCompactionEntry {
 	vector<DuckLakeCompactionFileEntry> source_files;
 	DuckLakeDataFile written_file;
-	idx_t row_id_start;
+	optional_idx row_id_start;
 };
 
 struct DuckLakeCompactedFileInfo {

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -145,7 +145,7 @@ private:
 	DuckLakeViewInfo GetNewView(DuckLakeSnapshot &commit_snapshot, DuckLakeViewEntry &view);
 	void FlushNewPartitionKey(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table);
 	DuckLakeFileInfo GetNewDataFile(DuckLakeDataFile &file, DuckLakeSnapshot &commit_snapshot, TableIndex table_id,
-	                                idx_t row_id_start);
+	                                optional_idx row_id_start);
 	NewDataInfo GetNewDataFiles(DuckLakeSnapshot &commit_snapshot);
 	vector<DuckLakeDeleteFileInfo> GetNewDeleteFiles(DuckLakeSnapshot &commit_snapshot,
 	                                                 set<DataFileIndex> &overwritten_delete_files);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -568,7 +568,10 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 		DuckLakeFileListEntry file_entry;
 		idx_t col_idx = 0;
 		file_entry.file = ReadDataFile(table, row, col_idx, IsEncrypted());
-		file_entry.row_id_start = row.GetValue<idx_t>(col_idx++);
+		if (!row.IsNull(col_idx)) {
+			file_entry.row_id_start = row.GetValue<idx_t>(col_idx);
+		}
+		col_idx++;
 		file_entry.snapshot_id = row.GetValue<idx_t>(col_idx++);
 		if (!row.IsNull(col_idx)) {
 			auto partial_file_info = row.GetValue<string>(col_idx);
@@ -610,7 +613,10 @@ WHERE data.table_id=%d AND data.begin_snapshot >= %d AND data.begin_snapshot <= 
 		DuckLakeFileListEntry file_entry;
 		idx_t col_idx = 0;
 		file_entry.file = ReadDataFile(table, row, col_idx, IsEncrypted());
-		file_entry.row_id_start = row.GetValue<idx_t>(col_idx++);
+		if (!row.IsNull(col_idx)) {
+			file_entry.row_id_start = row.GetValue<idx_t>(col_idx);
+		}
+		col_idx++;
 		file_entry.snapshot_id = row.GetValue<idx_t>(col_idx++);
 		if (!row.IsNull(col_idx)) {
 			auto partial_file_info = row.GetValue<string>(col_idx);
@@ -687,7 +693,10 @@ USING (data_file_id), (
 		DuckLakeDeleteScanEntry entry;
 		idx_t col_idx = 0;
 		entry.file = ReadDataFile(table, row, col_idx, IsEncrypted());
-		entry.row_id_start = row.GetValue<idx_t>(col_idx++);
+		if (!row.IsNull(col_idx)) {
+			entry.row_id_start = row.GetValue<idx_t>(col_idx);
+		}
+		col_idx++;
 		entry.row_count = row.GetValue<idx_t>(col_idx++);
 		if (!row.IsNull(col_idx)) {
 			entry.mapping_id = MappingIndex(row.GetValue<idx_t>(col_idx));
@@ -736,7 +745,10 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 		file_entry.row_count = row.GetValue<idx_t>(2);
 		idx_t col_idx = 3;
 		file_entry.file = ReadDataFile(table, row, col_idx, IsEncrypted());
-		file_entry.row_id_start = row.GetValue<idx_t>(col_idx++);
+		if (!row.IsNull(col_idx)) {
+			file_entry.row_id_start = row.GetValue<idx_t>(col_idx);
+		}
+		col_idx++;
 		file_entry.delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
 		files.push_back(std::move(file_entry));
 	}
@@ -767,7 +779,7 @@ LEFT JOIN (
    GROUP BY data_file_id
 ) partition_info USING (data_file_id)
 WHERE data.table_id=%d
-ORDER BY data.row_id_start, data.data_file_id, del.begin_snapshot
+ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
 		)",
 	                                select_list, table_id.index, table_id.index);
 	auto result = transaction.Query(query);
@@ -781,7 +793,10 @@ ORDER BY data.row_id_start, data.data_file_id, del.begin_snapshot
 		// parse the data file
 		new_entry.file.id = DataFileIndex(row.GetValue<idx_t>(col_idx++));
 		new_entry.file.row_count = row.GetValue<idx_t>(col_idx++);
-		new_entry.file.row_id_start = row.GetValue<idx_t>(col_idx++);
+		if (!row.IsNull(col_idx)) {
+			new_entry.file.row_id_start = row.GetValue<idx_t>(col_idx);
+		}
+		col_idx++;
 		new_entry.file.begin_snapshot = row.GetValue<idx_t>(col_idx++);
 		new_entry.file.end_snapshot = row.IsNull(col_idx) ? optional_idx() : row.GetValue<idx_t>(col_idx);
 		col_idx++;

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -314,7 +314,9 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) {
 		// scanning transaction local data
 		extended_info->options["transaction_local_data"] = Value::BOOLEAN(true);
 		extended_info->options["inlined_data"] = Value::BOOLEAN(true);
-		extended_info->options["row_id_start"] = Value::BIGINT(NumericCast<int64_t>(file_entry.row_id_start));
+		if (file_entry.row_id_start.IsValid()) {
+			extended_info->options["row_id_start"] = Value::UBIGINT(file_entry.row_id_start.GetIndex());
+		}
 		extended_info->options["snapshot_id"] = Value(LogicalType::BIGINT);
 		if (file_entry.mapping_id.IsValid()) {
 			extended_info->options["mapping_id"] = Value::UBIGINT(file_entry.mapping_id.index);
@@ -332,7 +334,9 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) {
 		if (file.footer_size.IsValid()) {
 			extended_info->options["footer_size"] = Value::UBIGINT(file.footer_size.GetIndex());
 		}
-		extended_info->options["row_id_start"] = Value::UBIGINT(files[i].row_id_start);
+		if (files[i].row_id_start.IsValid()) {
+			extended_info->options["row_id_start"] = Value::UBIGINT(files[i].row_id_start.GetIndex());
+		}
 		Value snapshot_id;
 		if (files[i].snapshot_id.IsValid()) {
 			snapshot_id = Value::BIGINT(NumericCast<int64_t>(files[i].snapshot_id.GetIndex()));

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -303,10 +303,13 @@ unique_ptr<Expression> DuckLakeMultiFileReader::GetVirtualColumnExpression(
 		if (!reader_data.file_to_be_opened.extended_info) {
 			throw InternalException("Extended info not found for reading row id column");
 		}
+
 		auto &options = reader_data.file_to_be_opened.extended_info->options;
 		auto entry = options.find("row_id_start");
 		if (entry == options.end()) {
-			throw InternalException("row_id_start not found for reading row id column");
+			throw InvalidInputException("File \"%s\" does not have row_id_start defined, and the file does not have a "
+			                            "row_id column written either - row id could not be read",
+			                            reader_data.file_to_be_opened.path);
 		}
 		auto row_id_expr = make_uniq<BoundConstantExpression>(entry->second);
 		auto file_row_number = make_uniq<BoundReferenceExpression>(type, local_idx.GetIndex());

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -923,7 +923,7 @@ void DuckLakeTransaction::UpdateGlobalTableStats(TableIndex table_id, const Duck
 }
 
 DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(DuckLakeDataFile &file, DuckLakeSnapshot &commit_snapshot,
-                                                     TableIndex table_id, idx_t row_id_start) {
+                                                     TableIndex table_id, optional_idx row_id_start) {
 	DuckLakeFileInfo data_file;
 	data_file.id = DataFileIndex(commit_snapshot.next_file_id++);
 	data_file.table_id = table_id;

--- a/test/sql/compaction/compaction_partitioned_non_adjacent.test
+++ b/test/sql/compaction/compaction_partitioned_non_adjacent.test
@@ -74,7 +74,7 @@ SELECT * FROM ducklake.partitioned AT (VERSION => 3)
 ----
 1	10
 
-query II
+query II rowsort
 SELECT * FROM ducklake.partitioned AT (VERSION => 4)
 ----
 1	10
@@ -87,3 +87,60 @@ SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 4	1	2	100
 5	2	1	20
 6	3	2	200
+
+# insert and compact again
+statement ok
+INSERT INTO ducklake.partitioned VALUES (1, 30);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (2, 300);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (1, 40);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (2, 400);
+
+query IIII
+SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+----
+3	0	1	10
+4	1	2	100
+5	2	1	20
+6	3	2	200
+8	4	1	30
+9	5	2	300
+10	6	1	40
+11	7	2	400
+
+# we're back up to 6 files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
+----
+6
+
+# compact + cleanup
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake');
+
+# cleanup
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+# back down to 2 files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
+----
+2
+
+query IIII
+SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+----
+3	0	1	10
+4	1	2	100
+5	2	1	20
+6	3	2	200
+8	4	1	30
+9	5	2	300
+10	6	1	40
+11	7	2	400

--- a/test/sql/compaction/compaction_partitioned_non_adjacent.test
+++ b/test/sql/compaction/compaction_partitioned_non_adjacent.test
@@ -1,0 +1,89 @@
+# name: test/sql/compaction/compaction_partitioned_non_adjacent.test
+# description: test compaction of partitioned tables
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_partitioned_compact_non_adjacent.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files', METADATA_CATALOG 'ducklake_metadata')
+
+statement ok
+CREATE TABLE ducklake.partitioned(part_key INTEGER, value INTEGER);
+
+statement ok
+ALTER TABLE ducklake.partitioned SET PARTITIONED BY (part_key);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (1, 10);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (2, 100);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (1, 20);
+
+statement ok
+INSERT INTO ducklake.partitioned VALUES (2, 200);
+
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
+----
+4
+
+query IIII
+SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+----
+3	0	1	10
+4	1	2	100
+5	2	1	20
+6	3	2	200
+
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake');
+
+# we gain two files here
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
+----
+6
+
+# cleanup
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+# two files left
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
+----
+2
+
+# verify we have written partition info correctly
+query II
+SELECT partition_id, partition_value
+FROM ducklake_metadata.ducklake_data_file
+JOIN ducklake_metadata.ducklake_file_partition_value USING (data_file_id)
+ORDER BY ALL
+----
+2	1
+2	2
+
+query II
+SELECT * FROM ducklake.partitioned AT (VERSION => 3)
+----
+1	10
+
+query II
+SELECT * FROM ducklake.partitioned AT (VERSION => 4)
+----
+1	10
+2	100
+
+query IIII
+SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+----
+3	0	1	10
+4	1	2	100
+5	2	1	20
+6	3	2	200

--- a/test/sql/compaction/mix_large_small_insertions.test
+++ b/test/sql/compaction/mix_large_small_insertions.test
@@ -1,0 +1,86 @@
+# name: test/sql/compaction/mix_large_small_insertions.test
+# description: test ducklake mix of small and large insertions
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_compaction_mix.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_compaction_mix_files', METADATA_CATALOG 'metadata')
+
+# set target file size very small
+statement ok
+CALL ducklake.set_option('target_file_size', '2KB');
+
+# snapshot 1
+statement ok
+CREATE TABLE ducklake.tbl(id INTEGER, str VARCHAR);
+
+# perform a mix of large and small insertions
+
+# snapshot 2
+statement ok
+INSERT INTO ducklake.tbl VALUES (1, 'hello');
+
+# snapshot 3
+statement ok
+INSERT INTO ducklake.tbl SELECT 100000 + i, concat('thisisastring', i) FROM range(10000) t(i)
+
+# snapshot 4
+statement ok
+INSERT INTO ducklake.tbl VALUES (2, 'world');
+
+# snapshot 5
+statement ok
+INSERT INTO ducklake.tbl VALUES (3, 'and');
+
+# snapshot 6
+statement ok
+INSERT INTO ducklake.tbl SELECT 200000 + i, concat('thisisalsoastring', i) FROM range(10000) t(i)
+
+# snapshot 7
+statement ok
+INSERT INTO ducklake.tbl VALUES (3, 'my');
+
+# snapshot 8
+statement ok
+INSERT INTO ducklake.tbl VALUES (3, 'friends');
+
+query IIII
+SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (3, 6) ORDER BY ALL
+----
+0	2	1	hello
+10001	4	2	world
+10002	5	3	and
+20003	7	3	my
+20004	8	3	friends
+
+# we should have 7 files now
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_compaction_mix_files/**/*.parquet')
+----
+7
+
+# now compact and cleanup
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake');
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+# now we should have 3 files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_compaction_mix_files/**/*.parquet')
+----
+3
+
+# all row-ids and snapshots are still intact
+query IIII
+SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (3, 6) ORDER BY ALL
+----
+0	2	1	hello
+10001	4	2	world
+10002	5	3	and
+20003	7	3	my
+20004	8	3	friends


### PR DESCRIPTION
This makes the function a bit of a misnomer, but oh well :)

This PR allows `ducklake_merge_adjacent_files` to merge files that are non-adjacent, i.e. that have row-ids that are disjoint. 

Previously compaction operations would be limited to merging files with adjacent row-ids. This works well when we have standard sequential inserts, but can be limiting in particular with non-temporal partitioning where files might be spread across partitions in non-adjacent ways. For example, we might first insert into `partition 1`, then insert into `partition 2`, then insert into `partition 1` again. 

By writing the row ids to the file instead of relying on `row_id_start`, we can compact together files that are non-adjacent as well without loss of information: the row identifiers will be written to the file on compaction, and read from the file during reads. This PR also enables the `row_id_start` to be set to `NULL` in the metadata layer - signaling the row ids should be read from the file instead. 

Support for reading and writing row-ids to files already existed as part of the `UPDATE` infrastructure - so this PR is not a very big lift. 