### PR TITLE
Add `CREATE_IF_NOT_EXISTS` attach option (which defaults to true)

### DIFF
--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -27,6 +27,7 @@ struct DuckLakeOptions {
 	string data_path;
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	DuckLakeEncryption encryption = DuckLakeEncryption::AUTOMATIC;
+	bool create_if_not_exists = true;
 	unique_ptr<BoundAtClause> at_clause;
 	unordered_map<string, Value> metadata_parameters;
 	option_map_t config_options;

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -84,6 +84,9 @@ void DuckLakeInitializer::Initialize() {
 	}
 	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
 	if (count == 0) {
+		if (!options.create_if_not_exists) {
+			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a new DuckLake is explicitly disabled", options.metadata_path);
+		}
 		InitializeNewDuckLake(transaction, has_explicit_schema);
 	} else {
 		LoadExistingDuckLake(transaction);

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -45,6 +45,8 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 	} else if (StringUtil::StartsWith(lcase, "meta_")) {
 		auto parameter_name = lcase.substr(5);
 		options.metadata_parameters[parameter_name] = value;
+	} else if (lcase == "create_if_not_exists") {
+		options.create_if_not_exists = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "readonly" || lcase == "read_only" || lcase == "readwrite" || lcase == "read_write" ||
 	           lcase == "type" || lcase == "default_table") {
 		// built-in options for ATTACH

--- a/test/sql/initialize/ducklake_create_new.test
+++ b/test/sql/initialize/ducklake_create_new.test
@@ -1,0 +1,24 @@
+# name: test/sql/initialize/ducklake_create_new.test
+# description: test ducklake extension
+# group: [sql]
+
+require ducklake
+
+require parquet
+
+# when CREATE_IF_NOT_EXISTS is specified we cannot connect to a non-existent ducklake
+statement error
+ATTACH 'ducklake:__TEST_DIR__/ducklake_non_existent.db' AS ducklake (CREATE_IF_NOT_EXISTS false)
+----
+creating a new DuckLake is explicitly disabled
+
+# create a new one
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_existent.db' AS ducklake (CREATE_IF_NOT_EXISTS true)
+
+statement ok
+DETACH ducklake;
+
+# we can attach to an existing ducklake
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_existent.db' AS ducklake (CREATE_IF_NOT_EXISTS false)


### PR DESCRIPTION
Usage:

```sql
ATTACH 'ducklake:new_ducklake.db' (CREATE_IF_NOT_EXISTS false);
-- Existing DuckLake at metadata catalog "new_ducklake.db" does not exist - and creating a new DuckLake is explicitly disabled
```