### PR TITLE
Add support for adding hive partitioned files using `ducklake_add_data_files`

### DIFF
--- a/src/common/ducklake_name_map.cpp
+++ b/src/common/ducklake_name_map.cpp
@@ -41,6 +41,9 @@ bool DuckLakeNameMapEntry::IsCompatibleWith(const DuckLakeNameMapEntry &other) c
 	if (target_field_id != other.target_field_id) {
 		return false;
 	}
+	if (hive_partition != other.hive_partition) {
+		return false;
+	}
 	return ListIsCompatible(child_entries, other.child_entries);
 }
 

--- a/src/include/common/ducklake_name_map.hpp
+++ b/src/include/common/ducklake_name_map.hpp
@@ -23,6 +23,7 @@ namespace duckdb {
 struct DuckLakeNameMapEntry {
 	string source_name;
 	FieldIndex target_field_id;
+	bool hive_partition = false;
 	vector<unique_ptr<DuckLakeNameMapEntry>> child_entries;
 
 	hash_t GetHash() const;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -343,6 +343,7 @@ struct DuckLakeNameMapColumnInfo {
 	idx_t column_id;
 	string source_name;
 	FieldIndex target_field_id;
+	bool hive_partition = false;
 	optional_idx parent_column;
 };
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -115,6 +115,7 @@ public:
 	virtual string GetPathForTable(TableIndex table_id);
 
 	virtual void MigrateV01();
+	virtual void MigrateV02();
 
 	string LoadPath(string path);
 	string StorePath(string path);

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -380,6 +380,7 @@ unique_ptr<DuckLakeNameMap> ConvertNameMap(DuckLakeColumnMappingInfo column_mapp
 		auto map_entry = make_uniq<DuckLakeNameMapEntry>();
 		map_entry->source_name = std::move(col.source_name);
 		map_entry->target_field_id = col.target_field_id;
+		map_entry->hive_partition = col.hive_partition;
 		// add the column id -> entry mapping
 		column_id_map.emplace(col.column_id, *map_entry);
 		if (!col.parent_column.IsValid()) {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -153,10 +153,10 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 			}
 			if (version == "0.2") {
 				metadata_manager.MigrateV02();
-				version = "0.3-dev";
+				version = "0.3-dev1";
 			}
-			if (version != "0.3-dev") {
-				throw NotImplementedException("Only DuckLake versions 0.1, 0.2 and 0.3-dev are supported");
+			if (version != "0.3-dev1") {
+				throw NotImplementedException("Only DuckLake versions 0.1, 0.2 and 0.3-dev1 are supported");
 			}
 		}
 		if (tag.key == "data_path") {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -85,7 +85,9 @@ void DuckLakeInitializer::Initialize() {
 	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
 	if (count == 0) {
 		if (!options.create_if_not_exists) {
-			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a new DuckLake is explicitly disabled", options.metadata_path);
+			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a "
+			                            "new DuckLake is explicitly disabled",
+			                            options.metadata_path);
 		}
 		InitializeNewDuckLake(transaction, has_explicit_schema);
 	} else {
@@ -149,8 +151,12 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 				metadata_manager.MigrateV01();
 				version = "0.2";
 			}
-			if (version != "0.2") {
-				throw NotImplementedException("Only DuckLake versions 0.1 and 0.2 are supported");
+			if (version == "0.2") {
+				metadata_manager.MigrateV02();
+				version = "0.3-dev";
+			}
+			if (version != "0.3-dev") {
+				throw NotImplementedException("Only DuckLake versions 0.1, 0.2 and 0.3-dev are supported");
 			}
 		}
 		if (tag.key == "data_path") {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -69,7 +69,7 @@ CREATE TABLE {METADATA_CATALOG}.ducklake_file_partition_value(data_file_id BIGIN
 CREATE TABLE {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion(data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, schedule_start TIMESTAMPTZ);
 CREATE TABLE {METADATA_CATALOG}.ducklake_inlined_data_tables(table_id BIGINT, table_name VARCHAR, schema_version BIGINT);
 CREATE TABLE {METADATA_CATALOG}.ducklake_column_mapping(mapping_id BIGINT, table_id BIGINT, type VARCHAR);
-CREATE TABLE {METADATA_CATALOG}.ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT);
+CREATE TABLE {METADATA_CATALOG}.ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot VALUES (0, NOW(), 0, 1, 0);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot_changes VALUES (0, 'created_schema:"main"');
 INSERT INTO {METADATA_CATALOG}.ducklake_metadata (key, value) VALUES ('version', '0.2'), ('created_by', 'DuckDB %s'), ('data_path', %s), ('encrypted', '%s');
@@ -103,6 +103,16 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.2' WHERE key = 'versi
 	auto result = transaction.Query(migrate_query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to migrate DuckLake from v0.1 to v0.2:");
+	}
+}
+
+void DuckLakeMetadataManager::MigrateV02() {
+	string migrate_query = R"(
+ALTER TABLE {METADATA_CATALOG}.ducklake_name_mapping ADD COLUMN is_partition BOOLEAN DEFAULT false;
+	)";
+	auto result = transaction.Query(migrate_query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to migrate DuckLake from v0.2 to v0.3:");
 	}
 }
 
@@ -1539,7 +1549,7 @@ vector<DuckLakeColumnMappingInfo> DuckLakeMetadataManager::GetColumnMappings(opt
 		filter = "WHERE mapping_id >= " + to_string(start_from.GetIndex());
 	}
 	auto result = transaction.Query(StringUtil::Format(R"(
-SELECT mapping_id, table_id, type, column_id, source_name, target_field_id, parent_column
+SELECT mapping_id, table_id, type, column_id, source_name, target_field_id, parent_column, is_partition
 FROM {METADATA_CATALOG}.ducklake_column_mapping
 JOIN {METADATA_CATALOG}.ducklake_name_mapping USING (mapping_id)
 %s
@@ -1564,6 +1574,7 @@ ORDER BY mapping_id, parent_column NULLS FIRST
 		if (!row.IsNull(6)) {
 			name_map_column.parent_column = row.GetValue<idx_t>(6);
 		}
+		name_map_column.hive_partition = row.GetValue<bool>(7);
 		mapping_info.map_columns.push_back(std::move(name_map_column));
 	}
 	return column_maps;
@@ -1586,9 +1597,11 @@ void DuckLakeMetadataManager::WriteNewColumnMappings(DuckLakeSnapshot commit_sna
 			}
 			string parent_column =
 			    name_map_column.parent_column.IsValid() ? to_string(name_map_column.parent_column.GetIndex()) : "NULL";
-			name_map_insert_query += StringUtil::Format(
-			    "(%d, %d, %s, %d, %s)", column_mapping.mapping_id.index, name_map_column.column_id,
-			    SQLString(name_map_column.source_name), name_map_column.target_field_id.index, parent_column);
+			string is_partition = name_map_column.hive_partition ? "true" : "false";
+			name_map_insert_query +=
+			    StringUtil::Format("(%d, %d, %s, %d, %s, %s)", column_mapping.mapping_id.index,
+			                       name_map_column.column_id, SQLString(name_map_column.source_name),
+			                       name_map_column.target_field_id.index, parent_column, is_partition);
 		}
 	}
 	column_mapping_insert_query =

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -72,7 +72,7 @@ CREATE TABLE {METADATA_CATALOG}.ducklake_column_mapping(mapping_id BIGINT, table
 CREATE TABLE {METADATA_CATALOG}.ducklake_name_mapping(mapping_id BIGINT, column_id BIGINT, source_name VARCHAR, target_field_id BIGINT, parent_column BIGINT, is_partition BOOLEAN);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot VALUES (0, NOW(), 0, 1, 0);
 INSERT INTO {METADATA_CATALOG}.ducklake_snapshot_changes VALUES (0, 'created_schema:"main"');
-INSERT INTO {METADATA_CATALOG}.ducklake_metadata (key, value) VALUES ('version', '0.2'), ('created_by', 'DuckDB %s'), ('data_path', %s), ('encrypted', '%s');
+INSERT INTO {METADATA_CATALOG}.ducklake_metadata (key, value) VALUES ('version', '0.3-dev1'), ('created_by', 'DuckDB %s'), ('data_path', %s), ('encrypted', '%s');
 INSERT INTO {METADATA_CATALOG}.ducklake_schema VALUES (0, UUID(), 0, NULL, 'main', 'main/', true);
 	)",
 	                                       DuckDB::SourceID(), SQLString(data_path), encryption_str);
@@ -109,6 +109,7 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.2' WHERE key = 'versi
 void DuckLakeMetadataManager::MigrateV02() {
 	string migrate_query = R"(
 ALTER TABLE {METADATA_CATALOG}.ducklake_name_mapping ADD COLUMN is_partition BOOLEAN DEFAULT false;
+UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.3-dev1' WHERE key = 'version';
 	)";
 	auto result = transaction.Query(migrate_query);
 	if (result->HasError()) {

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -220,43 +220,62 @@ shared_ptr<BaseFileReader> DuckLakeMultiFileReader::CreateReader(ClientContext &
 	return MultiFileReader::CreateReader(context, file, options, file_options, interface);
 }
 
-vector<MultiFileColumnDefinition> MapColumns(const vector<MultiFileColumnDefinition> &global_map,
+vector<MultiFileColumnDefinition> MapColumns(MultiFileReaderData &reader_data,
+                                             const vector<MultiFileColumnDefinition> &global_map,
                                              const vector<unique_ptr<DuckLakeNameMapEntry>> &column_maps) {
-	vector<MultiFileColumnDefinition> result;
-
 	// create a map of field id -> column map index for the mapping at this level
 	unordered_map<idx_t, idx_t> field_id_map;
 	for (idx_t column_map_idx = 0; column_map_idx < column_maps.size(); column_map_idx++) {
 		auto &column_map = *column_maps[column_map_idx];
 		field_id_map.emplace(column_map.target_field_id.index, column_map_idx);
 	}
-	// iterate over the global columns
-	// note: we make a copy of the column here on purpose - we override it to generate the new column map
-	for (auto global_column : global_map) {
-		auto field_id = global_column.identifier.GetValue<idx_t>();
+	map<string, string> partitions;
+
+	// make a copy of the global column map
+	auto result = global_map;
+	// now perform the actual remapping for the file
+	for (auto &result_col : result) {
+		auto field_id = result_col.identifier.GetValue<idx_t>();
 		// look up the field id
 		auto entry = field_id_map.find(field_id);
 		if (entry == field_id_map.end()) {
 			// field-id not found - this means the column is not present in the file
 			// replace the identifier with a stub name to ensure it is omitted
-			global_column.identifier = Value("__ducklake_unknown_identifier");
-		} else {
-			// field-id found - add the name-based mapping at this level
-			auto &column_map = column_maps[entry->second];
-			global_column.identifier = Value(column_map->source_name);
-			// recursively process any child nodes
-			if (!column_map->child_entries.empty()) {
-				global_column.children = MapColumns(global_column.children, column_map->child_entries);
-			}
+			result_col.identifier = Value("__ducklake_unknown_identifier");
+			continue;
 		}
-		result.push_back(std::move(global_column));
+		// field-id found - add the name-based mapping at this level
+		auto &column_map = column_maps[entry->second];
+		if (column_map->hive_partition) {
+			// this column is read from a hive partition - replace the identifier with a stub name
+			result_col.identifier = Value("__ducklake_unknown_identifier");
+			// replace the default value with the actual partition value
+			if (partitions.empty()) {
+				partitions = HivePartitioning::Parse(reader_data.reader->file.path);
+			}
+			auto entry = partitions.find(column_map->source_name);
+			if (entry == partitions.end()) {
+				throw InvalidInputException("Column \"%s\" should have been read from hive partitions - but it was not "
+				                            "found in filename \"%s\"",
+				                            column_map->source_name, reader_data.reader->file.path);
+			}
+			Value partition_val(entry->second);
+			result_col.default_expression = make_uniq<ConstantExpression>(partition_val.DefaultCastAs(result_col.type));
+			continue;
+		}
+		result_col.identifier = Value(column_map->source_name);
+		// recursively process any child nodes
+		if (!column_map->child_entries.empty()) {
+			result_col.children = MapColumns(reader_data, result_col.children, column_map->child_entries);
+		}
 	}
 	return result;
 }
 
-vector<MultiFileColumnDefinition> CreateNewMapping(const vector<MultiFileColumnDefinition> &global_map,
+vector<MultiFileColumnDefinition> CreateNewMapping(MultiFileReaderData &reader_data,
+                                                   const vector<MultiFileColumnDefinition> &global_map,
                                                    const DuckLakeNameMap &name_map) {
-	return MapColumns(global_map, name_map.column_maps);
+	return MapColumns(reader_data, global_map, name_map.column_maps);
 }
 
 ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
@@ -271,7 +290,7 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 			auto transaction = read_info.transaction.lock();
 			auto &mapping = transaction->GetMappingById(mapping_id);
 			// use the mapping to generate a new set of global columns for this file
-			auto mapped_columns = CreateNewMapping(global_columns, mapping);
+			auto mapped_columns = CreateNewMapping(reader_data, global_columns, mapping);
 			return MultiFileReader::CreateMapping(context, reader_data, mapped_columns, global_column_ids, filters,
 			                                      multi_file_list, bind_data, virtual_columns,
 			                                      MultiFileColumnMappingMode::BY_NAME);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1109,6 +1109,7 @@ void ConvertNameMapColumn(const DuckLakeNameMapEntry &name_map_entry, MappingInd
 	column_info.column_id = column_id;
 	column_info.source_name = name_map_entry.source_name;
 	column_info.target_field_id = name_map_entry.target_field_id;
+	column_info.hive_partition = name_map_entry.hive_partition;
 	column_info.parent_column = parent_idx;
 	result.map_columns.push_back(std::move(column_info));
 

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -1,0 +1,58 @@
+# name: test/sql/add_files/add_files_hive.test
+# description: test ducklake adding hive-partitioned files directly
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_add_files_hive.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_add_files_hive/', METADATA_CATALOG 'metadata');
+
+statement ok
+CREATE TABLE partitioned_tbl(part_key INT, part_key2 INT, val VARCHAR);
+
+statement ok
+INSERT INTO partitioned_tbl VALUES (1, 10, 'hello'), (2, 10, 'world'), (2, 20, 'abc')
+
+statement ok
+COPY partitioned_tbl TO '__TEST_DIR__/ducklake_add_files_hive/' (FORMAT PARQUET, PARTITION_BY(part_key, part_key2));
+
+statement ok
+CREATE TABLE ducklake.test(part_key INT, part_key2 INT, val VARCHAR);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/**/*.parquet', hive_partitioning => true)
+
+query III
+SELECT part_key, part_key2, val FROM ducklake.test ORDER BY ALL
+----
+1	10	hello
+2	10	world
+2	20	abc
+
+# rename the hive partition
+statement ok
+ALTER TABLE ducklake.test RENAME part_key TO new_part_key
+
+query III
+SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
+----
+1	10	hello
+2	10	world
+2	20	abc
+
+# add new values post-rename
+statement ok
+COPY (FROM (VALUES (1, 10, 'new value')) t(new_part_key, part_key2, val)) TO '__TEST_DIR__/ducklake_add_files_hive/' (FORMAT PARQUET, PARTITION_BY(new_part_key, part_key2), APPEND);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/new_part_key=*/**/*.parquet', hive_partitioning => true)
+
+query III
+SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
+----
+1	10	hello
+1	10	new value
+2	10	world
+2	20	abc

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -37,6 +37,12 @@ SELECT part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 2	10	world
 2	20	abc
 
+# test pushdown into stats
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE part_key=1
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
 # rename the hive partition
 statement ok
 ALTER TABLE ducklake.test RENAME part_key TO new_part_key
@@ -55,6 +61,24 @@ COPY (FROM (VALUES (1, 10, 'new value')) t(new_part_key, part_key2, val)) TO '__
 # hive partitioning is automatically detected by default
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/new_part_key=*/**/*.parquet')
+
+query III
+SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
+----
+1	10	hello
+1	10	new value
+2	10	world
+2	20	abc
+
+# test pushdown into stats
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE new_part_key=1
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+
+# type promotion
+statement ok
+ALTER TABLE ducklake.test ALTER new_part_key SET TYPE BIGINT
 
 query III
 SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -21,6 +21,12 @@ COPY partitioned_tbl TO '__TEST_DIR__/ducklake_add_files_hive/' (FORMAT PARQUET,
 statement ok
 CREATE TABLE ducklake.test(part_key INT, part_key2 INT, val VARCHAR);
 
+# we need the hive partition columns
+statement error
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/**/*.parquet', hive_partitioning => false)
+----
+allow_missing
+
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/**/*.parquet', hive_partitioning => true)
 
@@ -46,8 +52,9 @@ SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 statement ok
 COPY (FROM (VALUES (1, 10, 'new value')) t(new_part_key, part_key2, val)) TO '__TEST_DIR__/ducklake_add_files_hive/' (FORMAT PARQUET, PARTITION_BY(new_part_key, part_key2), APPEND);
 
+# hive partitioning is automatically detected by default
 statement ok
-CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/new_part_key=*/**/*.parquet', hive_partitioning => true)
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive/new_part_key=*/**/*.parquet')
 
 query III
 SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL

--- a/test/sql/add_files/add_files_hive_mismatch.test
+++ b/test/sql/add_files/add_files_hive_mismatch.test
@@ -39,3 +39,20 @@ FROM ducklake.test ORDER BY ALL
 p1	10	hello
 p2	10	world
 p2	20	abc
+
+# add non-hive partitioned file
+
+# now add non-hive partitioned column
+statement ok
+COPY (SELECT 'p1' part_key, 10 part_key2, 'non_partitioned' val) TO '__TEST_DIR__/ducklake_add_files_hive_mismatch/non_partitioned_file.parquet'
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive_mismatch/non_partitioned_file.parquet')
+
+query III
+FROM ducklake.test ORDER BY ALL
+----
+p1	10	hello
+p1	10	non_partitioned
+p2	10	world
+p2	20	abc

--- a/test/sql/add_files/add_files_hive_mismatch.test
+++ b/test/sql/add_files/add_files_hive_mismatch.test
@@ -1,0 +1,41 @@
+# name: test/sql/add_files/add_files_hive_mismatch.test
+# description: test ducklake adding hive-partitioned files with type mismatch
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_add_files_hive_mismatch.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_add_files_hive_mismatch/', METADATA_CATALOG 'metadata');
+
+statement ok
+CREATE TABLE partitioned_tbl(part_key VARCHAR, part_key2 INT, val VARCHAR);
+
+statement ok
+INSERT INTO partitioned_tbl VALUES ('p1', 10, 'hello'), ('p2', 10, 'world'), ('p2', 20, 'abc')
+
+statement ok
+COPY partitioned_tbl TO '__TEST_DIR__/ducklake_add_files_hive_mismatch/' (FORMAT PARQUET, PARTITION_BY(part_key, part_key2));
+
+statement ok
+CREATE TABLE ducklake.test(part_key INT, part_key2 INT, val VARCHAR);
+
+# value "p1" cannot be cast to integer
+statement error
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive_mismatch/**/*.parquet', hive_partitioning => true)
+----
+cannot be cast to the column type
+
+statement ok
+CREATE OR REPLACE TABLE ducklake.test(part_key VARCHAR, part_key2 INT, val VARCHAR);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/ducklake_add_files_hive_mismatch/**/*.parquet', hive_partitioning => true)
+
+query III
+FROM ducklake.test ORDER BY ALL
+----
+p1	10	hello
+p2	10	world
+p2	20	abc

--- a/test/sql/initialize/ducklake_create_new.test
+++ b/test/sql/initialize/ducklake_create_new.test
@@ -1,6 +1,6 @@
 # name: test/sql/initialize/ducklake_create_new.test
 # description: test ducklake extension
-# group: [sql]
+# group: [initialize]
 
 require ducklake
 


### PR DESCRIPTION
Follow-up from https://github.com/duckdb/ducklake/pull/175

This PR adds support for adding hive partitioned files using `ducklake_add_data_files`. Hive partitioned files are "special" because they have columns that are not present in the files themselves but only in the file path (e.g. `date=1992-01-01/file.parquet`).

This PR solves that by adding a new field - `is_partition` - to the columns in `ducklake_name_mapping`. When this field is set to `true`, the column is not read from the file but instead read from the file name. 

Whether or not files are hive partitioned is automatically detected by `ducklake_add_data_files` by default. It can be disabled using `hive_partitioning => false`, e.g.:

```sql
-- explicitly disable hive partitioning
CALL ducklake_add_data_files('ducklake', 'test', 'files/**/*.parquet', hive_partitioning => false);
```

This PR moves the DuckLake version to `v0.3-dev1` and adds migration from `v0.2 -> v0.3` - as such we will not merge this (yet) and this will likely only land together with DuckDB v1.4.