### PR TITLE
Add support for flushing inlined data using the `ducklake_flush_inlined_data` function

### DIFF
--- a/src/common/ducklake_data_file.cpp
+++ b/src/common/ducklake_data_file.cpp
@@ -16,6 +16,7 @@ DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 	encryption_key = other.encryption_key;
 	mapping_id = other.mapping_id;
 	begin_snapshot = other.begin_snapshot;
+	max_partial_file_snapshot = other.max_partial_file_snapshot;
 }
 
 DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
@@ -32,6 +33,7 @@ DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
 	encryption_key = other.encryption_key;
 	mapping_id = other.mapping_id;
 	begin_snapshot = other.begin_snapshot;
+	max_partial_file_snapshot = other.max_partial_file_snapshot;
 	return *this;
 }
 

--- a/src/common/ducklake_data_file.cpp
+++ b/src/common/ducklake_data_file.cpp
@@ -15,6 +15,7 @@ DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 	partition_values = other.partition_values;
 	encryption_key = other.encryption_key;
 	mapping_id = other.mapping_id;
+	begin_snapshot = other.begin_snapshot;
 }
 
 DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
@@ -30,6 +31,7 @@ DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
 	partition_values = other.partition_values;
 	encryption_key = other.encryption_key;
 	mapping_id = other.mapping_id;
+	begin_snapshot = other.begin_snapshot;
 	return *this;
 }
 

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -47,6 +47,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	DuckLakeExpireSnapshotsFunction expire_snapshots;
 	ExtensionUtil::RegisterFunction(instance, expire_snapshots);
 
+	DuckLakeFlushInlinedDataFunction flush_inlined_data;
+	ExtensionUtil::RegisterFunction(instance, flush_inlined_data);
+
 	DuckLakeSetOptionFunction set_options;
 	ExtensionUtil::RegisterFunction(instance, set_options);
 

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
   ducklake_add_data_files.cpp
   ducklake_cleanup_old_files.cpp
   ducklake_expire_snapshots.cpp
+  ducklake_flush_inlined_data.cpp
   ducklake_list_files.cpp
   ducklake_snapshots.cpp
   ducklake_merge_adjacent_files.cpp

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -1,0 +1,267 @@
+#include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_transaction.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_schema_entry.hpp"
+#include "storage/ducklake_table_entry.hpp"
+#include "storage/ducklake_insert.hpp"
+#include "storage/ducklake_multi_file_reader.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
+#include "duckdb/planner/operator/logical_extension_operator.hpp"
+#include "duckdb/planner/operator/logical_set_operation.hpp"
+#include "storage/ducklake_compaction.hpp"
+#include "duckdb/common/multi_file/multi_file_function.hpp"
+#include "storage/ducklake_multi_file_list.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
+#include "duckdb/planner/operator/logical_empty_result.hpp"
+#include "storage/ducklake_flush_data.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Flush Data Operator
+//===--------------------------------------------------------------------===//
+DuckLakeFlushData::DuckLakeFlushData(const vector<LogicalType> &types, DuckLakeTableEntry &table,
+                                     DuckLakeInlinedTableInfo inlined_table_p, string encryption_key_p,
+                                     optional_idx partition_id, PhysicalOperator &child)
+    : PhysicalOperator(PhysicalOperatorType::EXTENSION, types, 0), table(table),
+      inlined_table(std::move(inlined_table_p)), encryption_key(std::move(encryption_key_p)),
+      partition_id(partition_id) {
+	children.push_back(child);
+}
+
+//===--------------------------------------------------------------------===//
+// GetData
+//===--------------------------------------------------------------------===//
+SourceResultType DuckLakeFlushData::GetData(ExecutionContext &context, DataChunk &chunk,
+                                            OperatorSourceInput &input) const {
+	return SourceResultType::FINISHED;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+unique_ptr<GlobalSinkState> DuckLakeFlushData::GetGlobalSinkState(ClientContext &context) const {
+	return make_uniq<DuckLakeInsertGlobalState>(table);
+}
+
+SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
+	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id);
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+//===--------------------------------------------------------------------===//
+// Finalize
+//===--------------------------------------------------------------------===//
+SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                             OperatorSinkFinalizeInput &input) const {
+	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
+
+	// add the files to the transaction
+	auto &transaction = DuckLakeTransaction::Get(context, global_state.table.catalog);
+	transaction.AppendFiles(global_state.table.GetTableId(), std::move(global_state.written_files));
+
+	// delete the inlined data
+	transaction.DeleteInlinedData(inlined_table);
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
+// Helpers
+//===--------------------------------------------------------------------===//
+string DuckLakeFlushData::GetName() const {
+	return "DUCKLAKE_FLUSH_DATA";
+}
+
+//===--------------------------------------------------------------------===//
+// Logical Operator
+//===--------------------------------------------------------------------===//
+class DuckLakeLogicalFlush : public LogicalExtensionOperator {
+public:
+	DuckLakeLogicalFlush(idx_t table_index, DuckLakeTableEntry &table, DuckLakeInlinedTableInfo inlined_table_p,
+	                     string encryption_key_p, optional_idx partition_id_p)
+	    : table_index(table_index), table(table), inlined_table(std::move(inlined_table_p)),
+	      encryption_key(std::move(encryption_key_p)), partition_id(partition_id_p) {
+	}
+
+	idx_t table_index;
+	DuckLakeTableEntry &table;
+	DuckLakeInlinedTableInfo inlined_table;
+	string encryption_key;
+	optional_idx partition_id;
+
+public:
+	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override {
+		auto &child = planner.CreatePlan(*children[0]);
+		return planner.Make<DuckLakeFlushData>(types, table, std::move(inlined_table), std::move(encryption_key),
+		                                       partition_id, child);
+	}
+
+	string GetExtensionName() const override {
+		return "ducklake";
+	}
+	vector<ColumnBinding> GetColumnBindings() override {
+		vector<ColumnBinding> result;
+		result.emplace_back(table_index, 0);
+		return result;
+	}
+
+	void ResolveTypes() override {
+		types = {LogicalType::BOOLEAN};
+	}
+};
+
+////===--------------------------------------------------------------------===//
+//// Compaction Command Generator
+////===--------------------------------------------------------------------===//
+class DuckLakeDataFlusher {
+public:
+	DuckLakeDataFlusher(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
+	                    Binder &binder, TableIndex table_id, const DuckLakeInlinedTableInfo &inlined_table);
+
+	unique_ptr<LogicalOperator> GenerateFlushCommand();
+
+private:
+	ClientContext &context;
+	DuckLakeCatalog &catalog;
+	DuckLakeTransaction &transaction;
+	Binder &binder;
+	TableIndex table_id;
+	const DuckLakeInlinedTableInfo &inlined_table;
+};
+
+DuckLakeDataFlusher::DuckLakeDataFlusher(ClientContext &context, DuckLakeCatalog &catalog,
+                                         DuckLakeTransaction &transaction, Binder &binder, TableIndex table_id,
+                                         const DuckLakeInlinedTableInfo &inlined_table_p)
+    : context(context), catalog(catalog), transaction(transaction), binder(binder), table_id(table_id),
+      inlined_table(inlined_table_p) {
+}
+
+unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
+	// get the table entry at the specified snapshot
+	DuckLakeSnapshot snapshot(0, inlined_table.schema_version, 0, 0);
+
+	auto entry = catalog.GetEntryById(transaction, snapshot, table_id);
+	if (!entry) {
+		throw InternalException("DuckLakeCompactor: failed to find table entry for given snapshot id");
+	}
+	auto &table = entry->Cast<DuckLakeTableEntry>();
+
+	auto table_idx = binder.GenerateTableIndex();
+	unique_ptr<FunctionData> bind_data;
+	EntryLookupInfo info(CatalogType::TABLE_ENTRY, table.name);
+	auto scan_function = table.GetScanFunction(context, bind_data, info);
+
+	auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
+	auto &read_info = scan_function.function_info->Cast<DuckLakeFunctionInfo>();
+	multi_file_bind_data.file_list = make_uniq<DuckLakeMultiFileList>(read_info, inlined_table);
+
+	optional_idx partition_id;
+	auto partition_data = table.GetPartitionData();
+	if (partition_data) {
+		partition_id = partition_data->partition_id;
+	}
+
+	// generate the LogicalGet
+	auto &columns = table.GetColumns();
+
+	DuckLakeCopyInput copy_input(context, table);
+	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID;
+
+	auto copy_options = DuckLakeInsert::GetCopyOptions(context, copy_input);
+
+	auto virtual_columns = table.GetVirtualColumns();
+	auto ducklake_scan =
+	    make_uniq<LogicalGet>(table_idx, std::move(scan_function), std::move(bind_data), copy_options.expected_types,
+	                          copy_options.names, std::move(virtual_columns));
+	auto &column_ids = ducklake_scan->GetMutableColumnIds();
+	for (idx_t i = 0; i < columns.PhysicalColumnCount(); i++) {
+		column_ids.emplace_back(i);
+	}
+	column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+	column_ids.emplace_back(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID);
+
+	// generate the LogicalCopyToFile
+	auto copy = make_uniq<LogicalCopyToFile>(std::move(copy_options.copy_function), std::move(copy_options.bind_data),
+	                                         std::move(copy_options.info));
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	copy->file_path = copy_options.filename_pattern.CreateFilename(fs, copy_options.file_path, "parquet", 0);
+	copy->use_tmp_file = copy_options.use_tmp_file;
+	copy->filename_pattern = std::move(copy_options.filename_pattern);
+	copy->file_extension = std::move(copy_options.file_extension);
+	copy->overwrite_mode = copy_options.overwrite_mode;
+	copy->per_thread_output = copy_options.per_thread_output;
+	copy->file_size_bytes = copy_options.file_size_bytes;
+	copy->rotate = copy_options.rotate;
+	copy->return_type = copy_options.return_type;
+
+	copy->partition_output = copy_options.partition_output;
+	copy->write_partition_columns = copy_options.write_partition_columns;
+	copy->write_empty_file = false;
+	copy->partition_columns = std::move(copy_options.partition_columns);
+	copy->names = std::move(copy_options.names);
+	copy->expected_types = std::move(copy_options.expected_types);
+	copy->preserve_order = PreserveOrderType::PRESERVE_ORDER;
+	copy->file_size_bytes = optional_idx();
+	copy->rotate = false;
+
+	copy->children.push_back(std::move(ducklake_scan));
+
+	// followed by the compaction operator (that writes the results back to the
+	auto compaction = make_uniq<DuckLakeLogicalFlush>(binder.GenerateTableIndex(), table, inlined_table,
+	                                                  std::move(copy_input.encryption_key), partition_id);
+	compaction->children.push_back(std::move(copy));
+	return std::move(compaction);
+}
+
+//===--------------------------------------------------------------------===//
+// Function
+//===--------------------------------------------------------------------===//
+unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context, TableFunctionBindInput &input,
+                                                 idx_t bind_index, vector<string> &return_names) {
+	// gather a list of files to compact
+	auto &catalog = BaseMetadataFunction::GetCatalog(context, input.inputs[0]);
+	auto &ducklake_catalog = catalog.Cast<DuckLakeCatalog>();
+	auto &transaction = DuckLakeTransaction::Get(context, ducklake_catalog);
+
+	// try to compact all tables
+	vector<unique_ptr<LogicalOperator>> flushes;
+	auto schemas = ducklake_catalog.GetSchemas(context);
+	for (auto &schema : schemas) {
+		schema.get().Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
+			auto &table = entry.Cast<DuckLakeTableEntry>();
+			auto &inlined_tables = table.GetInlinedDataTables();
+			for (auto &inlined_table : inlined_tables) {
+				auto &table = entry.Cast<DuckLakeTableEntry>();
+				DuckLakeDataFlusher compactor(context, ducklake_catalog, transaction, *input.binder, table.GetTableId(),
+				                              inlined_table);
+				flushes.push_back(compactor.GenerateFlushCommand());
+			}
+		});
+	}
+	return_names.push_back("Success");
+	if (flushes.empty()) {
+		// nothing to write - generate empty result
+		vector<ColumnBinding> bindings;
+		vector<LogicalType> return_types;
+		bindings.emplace_back(bind_index, 0);
+		return_types.emplace_back(LogicalType::BOOLEAN);
+		return make_uniq<LogicalEmptyResult>(std::move(return_types), std::move(bindings));
+	}
+	if (flushes.size() == 1) {
+		flushes[0]->Cast<DuckLakeLogicalFlush>().table_index = bind_index;
+		return std::move(flushes[0]);
+	}
+	auto union_op = input.binder->UnionOperators(std::move(flushes));
+	union_op->Cast<LogicalSetOperation>().table_index = bind_index;
+	return union_op;
+}
+
+DuckLakeFlushInlinedDataFunction::DuckLakeFlushInlinedDataFunction()
+    : TableFunction("ducklake_flush_inlined_data", {LogicalType::VARCHAR}, nullptr, nullptr, nullptr) {
+	bind_operator = FlushInlinedDataBind;
+}
+
+} // namespace duckdb

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -47,7 +47,7 @@ unique_ptr<GlobalSinkState> DuckLakeFlushData::GetGlobalSinkState(ClientContext 
 
 SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
-	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id);
+	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id, true);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 

--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -45,6 +45,7 @@ struct DuckLakeDataFile {
 	vector<DuckLakeFilePartition> partition_values;
 	string encryption_key;
 	MappingIndex mapping_id;
+	optional_idx begin_snapshot;
 };
 
 } // namespace duckdb

--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -46,6 +46,7 @@ struct DuckLakeDataFile {
 	string encryption_key;
 	MappingIndex mapping_id;
 	optional_idx begin_snapshot;
+	optional_idx max_partial_file_snapshot;
 };
 
 } // namespace duckdb

--- a/src/include/functions/ducklake_table_functions.hpp
+++ b/src/include/functions/ducklake_table_functions.hpp
@@ -70,6 +70,11 @@ public:
 	DuckLakeExpireSnapshotsFunction();
 };
 
+class DuckLakeFlushInlinedDataFunction : public TableFunction {
+public:
+	DuckLakeFlushInlinedDataFunction();
+};
+
 class DuckLakeSetOptionFunction : public TableFunction {
 public:
 	DuckLakeSetOptionFunction();

--- a/src/include/storage/ducklake_flush_data.hpp
+++ b/src/include/storage/ducklake_flush_data.hpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_flush_data.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
+
+#include "duckdb/execution/physical_operator.hpp"
+#include "duckdb/common/index_vector.hpp"
+#include "storage/ducklake_stats.hpp"
+#include "storage/ducklake_metadata_info.hpp"
+
+namespace duckdb {
+class DuckLakeTableEntry;
+
+class DuckLakeFlushData : public PhysicalOperator {
+public:
+	DuckLakeFlushData(const vector<LogicalType> &types, DuckLakeTableEntry &table,
+	                  DuckLakeInlinedTableInfo inlined_table, string encryption_key, optional_idx partition_id,
+	                  PhysicalOperator &child);
+
+	DuckLakeTableEntry &table;
+	DuckLakeInlinedTableInfo inlined_table;
+	string encryption_key;
+	optional_idx partition_id;
+
+public:
+	// // Source interface
+	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
+
+	bool IsSource() const override {
+		return true;
+	}
+
+public:
+	// Sink interface
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          OperatorSinkFinalizeInput &input) const override;
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	bool ParallelSink() const override {
+		return false;
+	}
+
+	string GetName() const override;
+};
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -16,11 +16,7 @@ namespace duckdb {
 class DuckLakeFieldData;
 struct DuckLakeFunctionInfo;
 
-enum class InlinedVirtualColumn {
-	NONE,
-	COLUMN_ROW_ID,
-	COLUMN_EMPTY
-};
+enum class InlinedVirtualColumn { NONE, COLUMN_ROW_ID, COLUMN_EMPTY };
 
 class DuckLakeInlinedDataReader : public BaseFileReader {
 public:

--- a/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -16,6 +16,12 @@ namespace duckdb {
 class DuckLakeFieldData;
 struct DuckLakeFunctionInfo;
 
+enum class InlinedVirtualColumn {
+	NONE,
+	COLUMN_ROW_ID,
+	COLUMN_EMPTY
+};
+
 class DuckLakeInlinedDataReader : public BaseFileReader {
 public:
 	//! Initialize an inlined data reader over a set of data stored within a table in the metadata catalog
@@ -41,7 +47,7 @@ private:
 	string table_name;
 	shared_ptr<DuckLakeInlinedData> data;
 	bool initialized_scan = false;
-	vector<bool> is_virtual;
+	vector<InlinedVirtualColumn> virtual_columns;
 	int64_t file_row_number = 0;
 	vector<column_t> scan_column_ids;
 	ColumnDataScanState state;

--- a/src/include/storage/ducklake_insert.hpp
+++ b/src/include/storage/ducklake_insert.hpp
@@ -120,6 +120,9 @@ struct DuckLakeCopyOptions {
 	vector<idx_t> partition_columns;
 	vector<string> names;
 	vector<LogicalType> expected_types;
+
+	//! Set of projection columns to execute prior to inserting (if any)
+	vector<unique_ptr<Expression>> projection_list;
 };
 
 struct DuckLakeCopyInput {
@@ -136,6 +139,7 @@ struct DuckLakeCopyInput {
 	SchemaIndex schema_id;
 	TableIndex table_id;
 	InsertVirtualColumns virtual_columns = InsertVirtualColumns::NONE;
+	optional_idx get_table_index;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_insert.hpp
+++ b/src/include/storage/ducklake_insert.hpp
@@ -75,7 +75,7 @@ public:
 	static PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
 	                                    DuckLakeTableEntry &table, string encryption_key);
 	static void AddWrittenFiles(DuckLakeInsertGlobalState &gstate, DataChunk &chunk, const string &encryption_key,
-	                            optional_idx partition_id);
+	                            optional_idx partition_id, bool set_snapshot_id = false);
 
 public:
 	// Sink interface

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -107,6 +107,7 @@ struct DuckLakeFileInfo {
 	optional_idx row_id_start;
 	optional_idx partition_id;
 	optional_idx begin_snapshot;
+	optional_idx max_partial_file_snapshot;
 	string encryption_key;
 	MappingIndex mapping_id;
 	vector<DuckLakeColumnStatsInfo> column_stats;
@@ -246,6 +247,7 @@ struct DuckLakeFileListEntry {
 	optional_idx row_id_start;
 	optional_idx snapshot_id;
 	optional_idx max_row_count;
+	optional_idx snapshot_filter;
 	MappingIndex mapping_id;
 	DuckLakeDataType data_type = DuckLakeDataType::DATA_FILE;
 };

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -106,6 +106,7 @@ public:
 	                                                                 DuckLakeSnapshot end_snapshot,
 	                                                                 const string &inlined_table_name,
 	                                                                 const vector<string> &columns_to_read);
+	virtual void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);
 
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());
 	virtual void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);

--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -24,9 +24,10 @@ class DuckLakeMultiFileList : public MultiFileList {
 	    "__ducklake_inlined_transaction_local_data";
 
 public:
-	explicit DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeDataFile> transaction_local_files,
-	                               shared_ptr<DuckLakeInlinedData> transaction_local_data, string filter = string());
-	explicit DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeFileListEntry> files_to_scan);
+	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeDataFile> transaction_local_files,
+	                      shared_ptr<DuckLakeInlinedData> transaction_local_data, string filter = string());
+	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeFileListEntry> files_to_scan);
+	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, const DuckLakeInlinedTableInfo &inlined_table);
 
 	unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
 	                                                MultiFilePushdownInfo &info,
@@ -72,6 +73,8 @@ private:
 	vector<DuckLakeDataFile> transaction_local_files;
 	//! Inlined transaction-local data
 	shared_ptr<DuckLakeInlinedData> transaction_local_data;
+	//! Inlined data tables
+	vector<DuckLakeInlinedTableInfo> inlined_data_tables;
 	//! The set of delete scans, only used when scanning deleted tuples using ducklake_table_deletions
 	vector<DuckLakeDeleteScanEntry> delete_scans;
 	//! The filter to apply

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -98,6 +98,7 @@ public:
 	void DropFile(TableIndex table_id, DataFileIndex data_file_id, string path);
 
 	void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
+	void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);
 
 	bool SchemaChangesMade();
 	bool ChangesMade();

--- a/src/include/storage/ducklake_transaction_changes.hpp
+++ b/src/include/storage/ducklake_transaction_changes.hpp
@@ -27,6 +27,9 @@ struct SnapshotChangeInformation {
 	set<TableIndex> inserted_tables;
 	set<TableIndex> tables_deleted_from;
 	set<TableIndex> tables_compacted;
+	set<TableIndex> tables_inserted_inlined;
+	set<TableIndex> tables_deleted_inlined;
+	set<TableIndex> tables_flushed_inlined;
 
 	static SnapshotChangeInformation ParseChangesMade(const string &changes_made);
 };

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -85,7 +85,9 @@ void DuckLakeInitializer::Initialize() {
 	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
 	if (count == 0) {
 		if (!options.create_if_not_exists) {
-			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a new DuckLake is explicitly disabled", options.metadata_path);
+			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a "
+			                            "new DuckLake is explicitly disabled",
+			                            options.metadata_path);
 		}
 		InitializeNewDuckLake(transaction, has_explicit_schema);
 	} else {

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -76,13 +76,15 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			// set-up the scan to emit the row-id column, but to ignore it in the final result
 			for (idx_t i = 0; i < columns_to_read.size(); i++) {
 				scan_column_ids.push_back(i);
-				is_virtual.push_back(false);
+				virtual_columns.push_back(InlinedVirtualColumn::NONE);
 			}
 			columns_to_read.push_back("row_id");
+			virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_EMPTY);
 		}
 		if (columns_to_read.empty()) {
-			// COUNT(*) - read row-id column
+			// COUNT(*) - read row_id but don't emit
 			columns_to_read.push_back("row_id");
+			virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_EMPTY);
 		}
 		switch (read_info.scan_type) {
 		case DuckLakeScanType::SCAN_TABLE:
@@ -99,10 +101,11 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 		default:
 			throw InternalException("Unknown DuckLake scan type");
 		}
-		if (deletion_filter) {
+		if (!virtual_columns.empty()) {
 			auto scan_types = data->data->Types();
 			scan_chunk.Initialize(context, scan_types);
-
+		}
+		if (deletion_filter) {
 			// map the deleted row-ids to the deleted ordinals to obtain the correct deleted rows
 			auto &filter = reinterpret_cast<DuckLakeDeleteFilter &>(*deletion_filter);
 			vector<idx_t> deleted_ordinals;
@@ -133,12 +136,12 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			auto &column_id = column_indexes[i];
 			auto col_id = column_id.GetPrimaryIndex();
 			if (col_id >= types.size()) {
-				is_virtual.push_back(true);
+				virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_ROW_ID);
 				continue;
 			}
 			scan_types.push_back(types[col_id]);
 			scan_column_ids.push_back(col_id);
-			is_virtual.push_back(false);
+			virtual_columns.emplace_back(InlinedVirtualColumn::NONE);
 		}
 		if (!scan_types.empty()) {
 			scan_types.push_back(types[0]);
@@ -153,21 +156,28 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 
 void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
                                      LocalTableFunctionState &local_state, DataChunk &chunk) {
-	if (!is_virtual.empty()) {
+	if (!virtual_columns.empty()) {
 		scan_chunk.Reset();
 		data->data->Scan(state, scan_chunk);
 
 		idx_t source_idx = 0;
-		for (idx_t c = 0; c < is_virtual.size(); c++) {
-			if (is_virtual[c]) {
+		for (idx_t c = 0; c < virtual_columns.size(); c++) {
+			switch(virtual_columns[c]) {
+			case InlinedVirtualColumn::NONE: {
+				auto column_id = source_idx++;
+				chunk.data[c].Reference(scan_chunk.data[column_id]);
+				break;
+			}
+			case InlinedVirtualColumn::COLUMN_ROW_ID: {
 				auto row_id_data = FlatVector::GetData<int64_t>(chunk.data[c]);
 				for (idx_t r = 0; r < scan_chunk.size(); r++) {
 					row_id_data[r] = NumericCast<int64_t>(file_row_number + r);
 				}
 				continue;
 			}
-			auto column_id = source_idx++;
-			chunk.data[c].Reference(scan_chunk.data[column_id]);
+			case InlinedVirtualColumn::COLUMN_EMPTY:
+				break;
+			}
 		}
 		chunk.SetCardinality(scan_chunk.size());
 	} else {

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -162,7 +162,7 @@ void DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableFunction
 
 		idx_t source_idx = 0;
 		for (idx_t c = 0; c < virtual_columns.size(); c++) {
-			switch(virtual_columns[c]) {
+			switch (virtual_columns[c]) {
 			case InlinedVirtualColumn::NONE: {
 				auto column_id = source_idx++;
 				chunk.data[c].Reference(scan_chunk.data[column_id]);

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -123,6 +123,9 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 					if (snapshot_stats.has_min) {
 						data_file.begin_snapshot = StringUtil::ToUnsigned(snapshot_stats.min);
 					}
+					if (snapshot_stats.has_max) {
+						data_file.max_partial_file_snapshot = StringUtil::ToUnsigned(snapshot_stats.max);
+					}
 				}
 				continue;
 			}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2284,6 +2284,17 @@ WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
 	}
 }
 
+void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table) {
+	auto result = transaction.Query(StringUtil::Format(R"(
+		DELETE FROM {METADATA_CATALOG}.%s
+)",
+	                                                   SQLIdentifier(inlined_table.table_name)));
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to delete inlined data in DuckLake from table " +
+		                               inlined_table.table_name + ": ");
+	}
+}
+
 vector<DuckLakeTableSizeInfo> DuckLakeMetadataManager::GetTableSizes(DuckLakeSnapshot snapshot) {
 	vector<DuckLakeTableSizeInfo> table_sizes;
 	auto result = transaction.Query(snapshot, R"(

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -537,6 +537,20 @@ idx_t GetMaxRowCount(DuckLakeSnapshot snapshot, const string &partial_file_info_
 	return max_row_count;
 }
 
+void ParsePartialFileInfo(DuckLakeSnapshot snapshot, const string &partial_file_info_str,
+                          DuckLakeFileListEntry &file_entry) {
+	if (StringUtil::StartsWith(partial_file_info_str, "partial_max:")) {
+		auto max_partial_file_snapshot = StringUtil::ToUnsigned(partial_file_info_str.substr(12));
+		if (max_partial_file_snapshot <= snapshot.snapshot_id) {
+			// all snapshot ids are included for this snapshot - skip reading partial file info
+			return;
+		}
+		file_entry.snapshot_filter = snapshot.snapshot_id;
+	} else {
+		file_entry.max_row_count = GetMaxRowCount(snapshot, partial_file_info_str);
+	}
+}
+
 vector<DuckLakeFileListEntry>
 DuckLakeMetadataManager::GetFilesForTable(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot, const string &filter) {
 	auto table_id = table.GetTableId();
@@ -575,7 +589,7 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 		file_entry.snapshot_id = row.GetValue<idx_t>(col_idx++);
 		if (!row.IsNull(col_idx)) {
 			auto partial_file_info = row.GetValue<string>(col_idx);
-			file_entry.max_row_count = GetMaxRowCount(snapshot, partial_file_info);
+			ParsePartialFileInfo(snapshot, partial_file_info, file_entry);
 		}
 		col_idx++;
 		if (!row.IsNull(col_idx)) {
@@ -620,7 +634,7 @@ WHERE data.table_id=%d AND data.begin_snapshot >= %d AND data.begin_snapshot <= 
 		file_entry.snapshot_id = row.GetValue<idx_t>(col_idx++);
 		if (!row.IsNull(col_idx)) {
 			auto partial_file_info = row.GetValue<string>(col_idx);
-			file_entry.max_row_count = GetMaxRowCount(end_snapshot, partial_file_info);
+			ParsePartialFileInfo(end_snapshot, partial_file_info, file_entry);
 		}
 		col_idx++;
 		if (!row.IsNull(col_idx)) {
@@ -1452,7 +1466,12 @@ void DuckLakeMetadataManager::WriteNewDataFiles(DuckLakeSnapshot commit_snapshot
 		    file.encryption_key.empty() ? "NULL" : "'" + Blob::ToBase64(string_t(file.encryption_key)) + "'";
 		string partial_file_info = "NULL";
 		if (!file.partial_file_info.empty()) {
+			if (file.max_partial_file_snapshot.IsValid()) {
+				throw InternalException("Either partial_file_info or max_partial_file_snapshot can be set - not both");
+			}
 			partial_file_info = "'" + PartialFileInfoToString(file.partial_file_info) + "'";
+		} else if (file.max_partial_file_snapshot.IsValid()) {
+			partial_file_info = "'partial_max:" + to_string(file.max_partial_file_snapshot.GetIndex()) + "'";
 		}
 		string footer_size = file.footer_size.IsValid() ? to_string(file.footer_size.GetIndex()) : "NULL";
 		string mapping = file.mapping_id.IsValid() ? to_string(file.mapping_id.index) : "NULL";

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1541,6 +1541,9 @@ void DuckLakeMetadataManager::DropDeleteFiles(DuckLakeSnapshot commit_snapshot,
 
 void DuckLakeMetadataManager::WriteNewDeleteFiles(DuckLakeSnapshot commit_snapshot,
                                                   const vector<DuckLakeDeleteFileInfo> &new_files) {
+	if (new_files.empty()) {
+		return;
+	}
 	string delete_file_insert_query;
 	for (auto &file : new_files) {
 		if (!delete_file_insert_query.empty()) {
@@ -2056,6 +2059,9 @@ idx_t DuckLakeMetadataManager::GetNextColumnId(TableIndex table_id) {
 }
 
 void DuckLakeMetadataManager::WriteCompactions(const vector<DuckLakeCompactedFileInfo> &compactions) {
+	if (compactions.empty()) {
+		return;
+	}
 	string deleted_file_ids;
 	string scheduled_deletions;
 	for (auto &compaction : compactions) {

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -35,6 +35,17 @@ DuckLakeMultiFileList::DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info,
       files(std::move(files_to_scan)), read_file_list(true) {
 }
 
+DuckLakeMultiFileList::DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info,
+                                             const DuckLakeInlinedTableInfo &inlined_table)
+    : MultiFileList(vector<OpenFileInfo> {}, FileGlobOptions::ALLOW_EMPTY), read_info(read_info), read_file_list(true) {
+	DuckLakeFileListEntry file_entry;
+	file_entry.file.path = inlined_table.table_name;
+	file_entry.row_id_start = 0;
+	file_entry.data_type = DuckLakeDataType::INLINED_DATA;
+	files.push_back(std::move(file_entry));
+	inlined_data_tables.push_back(inlined_table);
+}
+
 unique_ptr<MultiFileList> DuckLakeMultiFileList::ComplexFilterPushdown(ClientContext &context,
                                                                        const MultiFileOptions &options,
                                                                        MultiFilePushdownInfo &info,
@@ -305,7 +316,6 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) {
 	auto &file = file_entry.file;
 	OpenFileInfo result(file.path);
 	auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
-	auto &inlined_data_tables = read_info.table.GetInlinedDataTables();
 	idx_t inlined_data_file_start = files.size() - inlined_data_tables.size();
 	if (transaction_local_data) {
 		inlined_data_file_start--;
@@ -434,7 +444,7 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 		transaction_row_start += file.row_count;
 		result.push_back(std::move(file_entry));
 	}
-	auto &inlined_data_tables = read_info.table.GetInlinedDataTables();
+	inlined_data_tables = read_info.table.GetInlinedDataTables();
 	for (auto &table : inlined_data_tables) {
 		DuckLakeFileListExtendedEntry file_entry;
 		file_entry.file.path = table.table_name;
@@ -502,7 +512,7 @@ void DuckLakeMultiFileList::GetFilesForTable() {
 		transaction_row_start += file.row_count;
 		files.emplace_back(std::move(file_entry));
 	}
-	auto &inlined_data_tables = read_info.table.GetInlinedDataTables();
+	inlined_data_tables = read_info.table.GetInlinedDataTables();
 	for (auto &table : inlined_data_tables) {
 		DuckLakeFileListEntry file_entry;
 		file_entry.file.path = table.table_name;
@@ -529,7 +539,7 @@ void DuckLakeMultiFileList::GetTableInsertions() {
 	auto &metadata_manager = transaction.GetMetadataManager();
 	files = metadata_manager.GetTableInsertions(read_info.table, *read_info.start_snapshot, read_info.snapshot);
 	// add inlined data tables as sources (if any)
-	auto &inlined_data_tables = read_info.table.GetInlinedDataTables();
+	inlined_data_tables = read_info.table.GetInlinedDataTables();
 	for (auto &table : inlined_data_tables) {
 		DuckLakeFileListEntry file_entry;
 		file_entry.file.path = table.table_name;
@@ -556,7 +566,7 @@ void DuckLakeMultiFileList::GetTableDeletions() {
 		files.emplace_back(std::move(file_entry));
 	}
 	// add inlined data tables as sources (if any)
-	auto &inlined_data_tables = read_info.table.GetInlinedDataTables();
+	inlined_data_tables = read_info.table.GetInlinedDataTables();
 	for (auto &table : inlined_data_tables) {
 		DuckLakeFileListEntry file_entry;
 		file_entry.file.path = table.table_name;

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -24,6 +24,7 @@
 #include "storage/ducklake_delete.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "storage/ducklake_inlined_data_reader.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
 
 namespace duckdb {
 
@@ -151,8 +152,49 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			reader.deletion_filter = std::move(delete_filter);
 		}
 	}
-	return MultiFileReader::InitializeReader(reader_data, bind_data, global_columns, global_column_ids, table_filters,
-	                                         context, gstate);
+	auto result = MultiFileReader::InitializeReader(reader_data, bind_data, global_columns, global_column_ids,
+	                                                table_filters, context, gstate);
+	if (file_entry.snapshot_filter.IsValid()) {
+		// we have a snapshot filter - add it to the filter list
+		// find the column we need to filter on
+		auto &reader = *reader_data.reader;
+		optional_idx snapshot_col;
+		auto snapshot_filter_constant = Value::UBIGINT(file_entry.snapshot_filter.GetIndex());
+		for (idx_t col_idx = 0; col_idx < reader.columns.size(); col_idx++) {
+			auto &col = reader.columns[col_idx];
+			if (col.identifier.type() == LogicalTypeId::INTEGER &&
+			    IntegerValue::Get(col.identifier) == LAST_UPDATED_SEQUENCE_NUMBER_ID) {
+				snapshot_col = col_idx;
+				snapshot_filter_constant = snapshot_filter_constant.DefaultCastAs(col.type);
+				break;
+			}
+		}
+		if (!snapshot_col.IsValid()) {
+			throw InvalidInputException("Snapshot filter was specified but snapshot column was not present in file");
+		}
+		idx_t snapshot_col_id = snapshot_col.GetIndex();
+		// check if the column is currently projected
+		optional_idx snapshot_local_id;
+		for (idx_t i = 0; i < reader.column_ids.size(); i++) {
+			if (reader.column_indexes[i].GetPrimaryIndex() == snapshot_col_id) {
+				snapshot_local_id = i;
+				break;
+			}
+		}
+		if (!snapshot_local_id.IsValid()) {
+			snapshot_local_id = reader.column_indexes.size();
+			reader.column_indexes.emplace_back(snapshot_col_id);
+			reader.column_ids.emplace_back(snapshot_col_id);
+		}
+		if (!reader.filters) {
+			reader.filters = make_uniq<TableFilterSet>();
+		}
+		ColumnIndex snapshot_col_idx(snapshot_local_id.GetIndex());
+		auto snapshot_filter =
+		    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(snapshot_filter_constant));
+		reader.filters->PushFilter(snapshot_col_idx, std::move(snapshot_filter));
+	}
+	return result;
 }
 
 shared_ptr<BaseFileReader> DuckLakeMultiFileReader::TryCreateInlinedDataReader(const OpenFileInfo &file) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1414,6 +1414,11 @@ void DuckLakeTransaction::DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &sn
 	metadata_manager.DeleteSnapshots(snapshots);
 }
 
+void DuckLakeTransaction::DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table) {
+	auto &metadata_manager = GetMetadataManager();
+	metadata_manager.DeleteInlinedData(inlined_table);
+}
+
 unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	auto &connection = GetConnection();
 	auto catalog_identifier = DuckLakeUtil::SQLIdentifierToString(ducklake_catalog.MetadataDatabaseName());

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -936,6 +936,7 @@ DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(DuckLakeDataFile &file, Duc
 	data_file.row_id_start = row_id_start;
 	data_file.mapping_id = file.mapping_id;
 	data_file.begin_snapshot = file.begin_snapshot;
+	data_file.max_partial_file_snapshot = file.max_partial_file_snapshot;
 	// gather the column statistics for this file
 	for (auto &column_stats_entry : file.column_stats) {
 		DuckLakeColumnStatsInfo column_stats;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -436,6 +436,22 @@ void DuckLakeTransaction::CheckForConflicts(const TransactionChangeInformation &
 			                           table_id.index);
 		}
 	}
+	for (auto &table_id : changes.tables_inserted_inlined) {
+		auto dropped_entry = other_changes.dropped_tables.find(table_id);
+		if (dropped_entry != other_changes.dropped_tables.end()) {
+			// trying to insert into a table that was dropped
+			throw TransactionException("Transaction conflict - attempting to insert into table with id %d"
+			                           " - but this table has been dropped by another transaction",
+			                           table_id.index);
+		}
+		auto alter_entry = other_changes.altered_tables.find(table_id);
+		if (alter_entry != other_changes.altered_tables.end()) {
+			// trying to insert into a table that was dropped
+			throw TransactionException("Transaction conflict - attempting to insert into table with id %d"
+			                           " - but this table has been altered by another transaction",
+			                           table_id.index);
+		}
+	}
 	for (auto &table_id : changes.tables_deleted_from) {
 		auto dropped_entry = other_changes.dropped_tables.find(table_id);
 		if (dropped_entry != other_changes.dropped_tables.end()) {
@@ -463,6 +479,66 @@ void DuckLakeTransaction::CheckForConflicts(const TransactionChangeInformation &
 			// trying to delete from a table that was compacted from
 			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
 			                           " - but this table has been compacted from by another transaction",
+			                           table_id.index);
+		}
+	}
+	for (auto &table_id : changes.tables_deleted_inlined) {
+		auto dropped_entry = other_changes.dropped_tables.find(table_id);
+		if (dropped_entry != other_changes.dropped_tables.end()) {
+			// trying to delete from a table that was dropped
+			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
+			                           " - but this table has been dropped by another transaction",
+			                           table_id.index);
+		}
+		auto alter_entry = other_changes.altered_tables.find(table_id);
+		if (alter_entry != other_changes.altered_tables.end()) {
+			// trying to delete from a table that was altered
+			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
+			                           " - but this table has been altered by another transaction",
+			                           table_id.index);
+		}
+		auto delete_entry = other_changes.tables_deleted_inlined.find(table_id);
+		if (delete_entry != other_changes.tables_deleted_inlined.end()) {
+			// trying to delete from a table that was deleted from
+			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
+			                           " - but this table has been deleted from by another transaction",
+			                           table_id.index);
+		}
+		auto flush_entry = other_changes.tables_flushed_inlined.find(table_id);
+		if (flush_entry != other_changes.tables_flushed_inlined.end()) {
+			// trying to delete from a table that was flushed
+			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
+			                           " - but this inlined data has been flushed by another transaction",
+			                           table_id.index);
+		}
+		auto compact_entry = other_changes.tables_compacted.find(table_id);
+		if (compact_entry != other_changes.tables_compacted.end()) {
+			// trying to delete from a table that was compacted from
+			throw TransactionException("Transaction conflict - attempting to delete from table with id %d"
+			                           " - but this table has been compacted from by another transaction",
+			                           table_id.index);
+		}
+	}
+	for (auto &table_id : changes.tables_flushed_inlined) {
+		auto dropped_entry = other_changes.dropped_tables.find(table_id);
+		if (dropped_entry != other_changes.dropped_tables.end()) {
+			// trying to delete from a table that was dropped
+			throw TransactionException("Transaction conflict - attempting to flush inline data from table with id %d"
+			                           " - but this table has been dropped by another transaction",
+			                           table_id.index);
+		}
+		auto delete_entry = other_changes.tables_deleted_inlined.find(table_id);
+		if (delete_entry != other_changes.tables_deleted_inlined.end()) {
+			// trying to delete from a table that was deleted from
+			throw TransactionException("Transaction conflict - attempting to flush inline data from table with id %d"
+			                           " - but this table has been deleted from by another transaction",
+			                           table_id.index);
+		}
+		auto flush_entry = other_changes.tables_flushed_inlined.find(table_id);
+		if (flush_entry != other_changes.tables_flushed_inlined.end()) {
+			// trying to delete from a table that was flushed
+			throw TransactionException("Transaction conflict - attempting to flush inline data from table with id %d"
+			                           " - but this inlined data has been flushed by another transaction",
 			                           table_id.index);
 		}
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -935,6 +935,7 @@ DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(DuckLakeDataFile &file, Duc
 	data_file.encryption_key = file.encryption_key;
 	data_file.row_id_start = row_id_start;
 	data_file.mapping_id = file.mapping_id;
+	data_file.begin_snapshot = file.begin_snapshot;
 	// gather the column statistics for this file
 	for (auto &column_stats_entry : file.column_stats) {
 		DuckLakeColumnStatsInfo column_stats;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -702,6 +702,7 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeSnapshot &commit_snapshot, Duc
 			result.new_partition_keys.push_back(std::move(partition_key));
 
 			transaction_changes.altered_tables.insert(table_id);
+			column_schema_change = true;
 			break;
 		}
 		case LocalChangeType::SET_COMMENT: {

--- a/src/storage/ducklake_transaction_changes.cpp
+++ b/src/storage/ducklake_transaction_changes.cpp
@@ -12,6 +12,9 @@ enum class ChangeType {
 	DROPPED_VIEW,
 	INSERTED_INTO_TABLE,
 	DELETED_FROM_TABLE,
+	INSERTED_INTO_TABLE_INLINED,
+	DELETED_FROM_TABLE_INLINED,
+	FLUSHED_INLINE_DATA_FOR_TABLE,
 	ALTERED_TABLE,
 	ALTERED_VIEW,
 	COMPACTED_TABLE
@@ -52,6 +55,12 @@ ChangeType ParseChangeType(const string &changes_made, idx_t &pos) {
 		return ChangeType::DELETED_FROM_TABLE;
 	} else if (StringUtil::CIEquals(change_type_str, "compacted_table")) {
 		return ChangeType::COMPACTED_TABLE;
+	} else if (StringUtil::CIEquals(change_type_str, "inlined_insert")) {
+		return ChangeType::INSERTED_INTO_TABLE_INLINED;
+	} else if (StringUtil::CIEquals(change_type_str, "inlined_delete")) {
+		return ChangeType::DELETED_FROM_TABLE_INLINED;
+	} else if (StringUtil::CIEquals(change_type_str, "flushed_inlined")) {
+		return ChangeType::FLUSHED_INLINE_DATA_FOR_TABLE;
 	} else {
 		throw InvalidInputException("Unsupported change type %s", change_type_str);
 	}
@@ -145,6 +154,15 @@ SnapshotChangeInformation SnapshotChangeInformation::ParseChangesMade(const stri
 			break;
 		case ChangeType::COMPACTED_TABLE:
 			result.tables_compacted.insert(TableIndex(StringUtil::ToUnsigned(entry.change_value)));
+			break;
+		case ChangeType::INSERTED_INTO_TABLE_INLINED:
+			result.tables_inserted_inlined.insert(TableIndex(StringUtil::ToUnsigned(entry.change_value)));
+			break;
+		case ChangeType::DELETED_FROM_TABLE_INLINED:
+			result.tables_deleted_inlined.insert(TableIndex(StringUtil::ToUnsigned(entry.change_value)));
+			break;
+		case ChangeType::FLUSHED_INLINE_DATA_FOR_TABLE:
+			result.tables_flushed_inlined.insert(TableIndex(StringUtil::ToUnsigned(entry.change_value)));
 			break;
 		default:
 			throw InternalException("Unsupported change type in ParseChangesMade");

--- a/test/sql/data_inlining/data_inlining_encryption.test
+++ b/test/sql/data_inlining/data_inlining_encryption.test
@@ -1,0 +1,46 @@
+# name: test/sql/data_inlining/data_inlining_encryption.test
+# description: Test ducklake data inlining with encryption
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_encryption.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_encryption_files', ENCRYPTED, DATA_INLINING_ROW_LIMIT 10000)
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
+
+query II
+SELECT COUNT(*), SUM(id) FROM ducklake.test
+----
+1000	499500
+
+# data is inlined
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
+----
+0
+
+# we can flush the data
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# now we have a file
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
+----
+1
+
+# that file is encrypted
+statement error
+SELECT * FROM '__TEST_DIR__/ducklake_inlining_encryption_files/main/test/*.parquet'
+----
+encrypted
+
+# but we can read it
+query II
+SELECT COUNT(*), SUM(id) FROM ducklake.test
+----
+1000	499500

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -63,6 +63,11 @@ BEGIN
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
+query II
+SELECT snapshot_id, changes FROM ducklake.snapshots() ORDER BY snapshot_id
+----
+
+
 query I
 SELECT COUNT(*) FROM ducklake.test
 ----

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -46,9 +46,29 @@ SELECT rowid, snapshot_id, * FROM ducklake.test AT (version => 4) ORDER BY ALL
 1	3	1
 2	4	2
 
+statement ok
+BEGIN
+
 # flush inlined data
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+query III
+SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
+----
+0	2	0
+1	3	1
+2	4	2
+3	5	3
+4	6	4
+5	7	5
+6	8	6
+7	9	7
+8	10	8
+9	11	9
+
+statement ok
+COMMIT
 
 # we now have one file
 query I

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -56,6 +56,13 @@ SELECT rowid, snapshot_id, * FROM ducklake.test AT (version => 4) ORDER BY ALL
 1	3	1
 2	4	2
 
+query IIII
+FROM ducklake.table_changes('test', 3, 5) ORDER BY ALL
+----
+3	1	insert	1
+4	2	insert	2
+5	3	insert	3
+
 statement ok
 BEGIN
 
@@ -97,6 +104,11 @@ SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_flush_data/**')
 ----
 1
 
+# flushing inlined data has no changes
+query IIII
+FROM ducklake.table_changes('test', 11, 12) ORDER BY ALL
+----
+
 query III
 SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
 ----
@@ -117,6 +129,27 @@ SELECT * FROM ducklake.test AT (version => 4) ORDER BY ALL
 0
 1
 2
+
+# we can still access other change feeds
+query IIII
+FROM ducklake.table_changes('test', 2, 5) ORDER BY ALL
+----
+2	0	insert	0
+3	1	insert	1
+4	2	insert	2
+5	3	insert	3
+
+# FIXME: this does not work correctly
+mode skip
+
+query IIII
+FROM ducklake.table_changes('test', 3, 5) ORDER BY ALL
+----
+3	1	insert	1
+4	2	insert	2
+5	3	insert	3
+
+mode unskip
 
 query III
 SELECT rowid, snapshot_id, * FROM ducklake.test AT (version => 4) ORDER BY ALL

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -39,12 +39,12 @@ SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
 8	10	8
 9	11	9
 
-query I
-SELECT * FROM ducklake.test AT (version => 4) ORDER BY ALL
+query III
+SELECT rowid, snapshot_id, * FROM ducklake.test AT (version => 4) ORDER BY ALL
 ----
-0
-1
-2
+0	2	0
+1	3	1
+2	4	2
 
 # flush inlined data
 statement ok
@@ -70,10 +70,16 @@ SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
 8	10	8
 9	11	9
 
-# FIXME: need to "backdate" the snapshot version
 query I
 SELECT * FROM ducklake.test AT (version => 4) ORDER BY ALL
 ----
 0
 1
 2
+
+query III
+SELECT rowid, snapshot_id, * FROM ducklake.test AT (version => 4) ORDER BY ALL
+----
+0	2	0
+1	3	1
+2	4	2

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -63,11 +63,6 @@ BEGIN
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query II
-SELECT snapshot_id, changes FROM ducklake.snapshots() ORDER BY snapshot_id
-----
-
-
 query I
 SELECT COUNT(*) FROM ducklake.test
 ----
@@ -89,6 +84,12 @@ SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
 
 statement ok
 COMMIT
+
+query II
+SELECT snapshot_id, changes FROM ducklake.snapshots() WHERE snapshot_id IN (2, 12) ORDER BY snapshot_id
+----
+2	{inlined_insert=[1]}
+12	{flushed_inlined=[1]}
 
 # we now have one file
 query I

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -1,0 +1,79 @@
+# name: test/sql/data_inlining/data_inlining_flush.test
+# description: test flushing inlined data to disk
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_flush.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_flush_data', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+loop i 0 10
+
+statement ok
+INSERT INTO ducklake.test VALUES (${i})
+
+endloop
+
+# all data is inlined
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_files/**')
+----
+0
+
+query III
+SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
+----
+0	2	0
+1	3	1
+2	4	2
+3	5	3
+4	6	4
+5	7	5
+6	8	6
+7	9	7
+8	10	8
+9	11	9
+
+query I
+SELECT * FROM ducklake.test AT (version => 4) ORDER BY ALL
+----
+0
+1
+2
+
+# flush inlined data
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# we now have one file
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_flush_data/**')
+----
+1
+
+query III
+SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
+----
+0	2	0
+1	3	1
+2	4	2
+3	5	3
+4	6	4
+5	7	5
+6	8	6
+7	9	7
+8	10	8
+9	11	9
+
+# FIXME: need to "backdate" the snapshot version
+query I
+SELECT * FROM ducklake.test AT (version => 4) ORDER BY ALL
+----
+0
+1
+2

--- a/test/sql/data_inlining/data_inlining_flush.test
+++ b/test/sql/data_inlining/data_inlining_flush.test
@@ -12,6 +12,11 @@ ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_flush.db' AS ducklake (DATA_PATH
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+0
+
 loop i 0 10
 
 statement ok
@@ -24,6 +29,11 @@ query I
 SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_files/**')
 ----
 0
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+10
 
 query III
 SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL
@@ -52,6 +62,11 @@ BEGIN
 # flush inlined data
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+10
 
 query III
 SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY ALL

--- a/test/sql/data_inlining/data_inlining_partitions.test
+++ b/test/sql/data_inlining/data_inlining_partitions.test
@@ -28,7 +28,7 @@ endloop
 
 # all data is inlined
 query I
-SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/**')
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/main/partitioned_tbl/**')
 ----
 0
 
@@ -54,7 +54,7 @@ CALL ducklake_flush_inlined_data('ducklake')
 
 # we now have 14 files
 query I
-SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/**')
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/main/partitioned_tbl/**')
 ----
 14
 

--- a/test/sql/data_inlining/data_inlining_partitions.test
+++ b/test/sql/data_inlining/data_inlining_partitions.test
@@ -1,0 +1,95 @@
+# name: test/sql/data_inlining/data_inlining_partitions.test
+# description: Test data inlining with partitions
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+# partitioning based on a column
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_partitions.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_partitions', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 1000)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE partitioned_tbl(id INTEGER, ts TIMESTAMP, values VARCHAR);
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (year(ts), month(ts));
+
+loop i 0 10
+
+statement ok
+INSERT INTO partitioned_tbl SELECT i, TIMESTAMP '2020-01-01' + interval (i) hours, concat('thisisastring_', i) FROM range(1000 * ${i}, 1000 * (${i} + 1)) t(i)
+
+endloop
+
+# all data is inlined
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/**')
+----
+0
+
+query IIII
+SELECT year(ts), COUNT(*), MIN(values), MAX(values) FROM partitioned_tbl GROUP BY year(ts)
+----
+2020	8784	thisisastring_0	thisisastring_999
+2021	1216	thisisastring_8784	thisisastring_9999
+
+query IIII
+SELECT year(ts), COUNT(*), MIN(values), MAX(values) FROM partitioned_tbl AT (version => 4) GROUP BY year(ts)
+----
+2020	2000	thisisastring_0	thisisastring_999
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE year(ts) = 2021
+----
+1216
+
+# flush the inlined data
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# we now have 14 files
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_partitions/**')
+----
+14
+
+query IIII
+SELECT year(ts), COUNT(*), MIN(values), MAX(values) FROM partitioned_tbl GROUP BY year(ts)
+----
+2020	8784	thisisastring_0	thisisastring_999
+2021	1216	thisisastring_8784	thisisastring_9999
+
+query IIII
+SELECT year(ts), COUNT(*), MIN(values), MAX(values) FROM partitioned_tbl AT (version => 4) GROUP BY year(ts)
+----
+2020	2000	thisisastring_0	thisisastring_999
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE year(ts) = 2021
+----
+1216
+
+# verify the result data is partitioned
+query II
+SELECT regexp_extract(path, '.*year=([0-9]+)[/\\].*', 1)::INT AS year_part, regexp_extract(path, '.*month=([0-9]+)[/\\].*', 1)::INT AS month_part
+FROM glob('__TEST_DIR__/ducklake_inlining_partitions/**') t(path) ORDER BY ALL
+----
+2020	1
+2020	2
+2020	3
+2020	4
+2020	5
+2020	6
+2020	7
+2020	8
+2020	9
+2020	10
+2020	11
+2020	12
+2021	1
+2021	2

--- a/test/sql/initialize/ducklake_create_new.test
+++ b/test/sql/initialize/ducklake_create_new.test
@@ -1,6 +1,6 @@
 # name: test/sql/initialize/ducklake_create_new.test
 # description: test ducklake extension
-# group: [sql]
+# group: [initialize]
 
 require ducklake
 

--- a/test/sql/transaction/transaction_conflict_inlining.test
+++ b/test/sql/transaction/transaction_conflict_inlining.test
@@ -10,19 +10,58 @@ statement ok
 ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_encryption.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_encryption_files', ENCRYPTED, DATA_INLINING_ROW_LIMIT 10000)
 
 statement ok
-CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
+SET immediate_transaction_mode=true
 
-# two transactions try to flush the inlined data
+# statement ok
+# CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
+#
+# # two transactions try to flush the inlined data
+# statement ok con1
+# BEGIN
+#
+# statement ok con1
+# CALL ducklake_flush_inlined_data('ducklake')
+#
+# query I
+# SELECT COUNT(*) FROM ducklake.test
+# ----
+# 1000
+#
+# statement ok con1
+# COMMIT
+#
+#
+# statement ok
+# DROP TABLE ducklake.test
+
+# one transaction flushes inlined data, the other updates it
+statement ok
+CREATE TABLE ducklake.test2(id INTEGER);
+
+statement ok
+INSERT INTO ducklake.test2 FROM range(1000);
+
 statement ok con1
 BEGIN
 
-statement ok con1
-CALL ducklake_flush_inlined_data('ducklake')
+statement ok con2
+BEGIN
 
-query I
-SELECT COUNT(*) FROM ducklake.test
-----
-1000
+statement ok con1
+UPDATE ducklake.test2 SET id=id+1000
+
+statement ok con2
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok con1
 COMMIT
+
+statement error con2
+COMMIT
+----
+zxcv
+
+query I
+SELECT COUNT(*) FROM ducklake.test2
+----
+1000

--- a/test/sql/transaction/transaction_conflict_inlining.test
+++ b/test/sql/transaction/transaction_conflict_inlining.test
@@ -1,6 +1,6 @@
-# name: test/sql/transaction/transaction_conflict_inlining_flush.test
+# name: test/sql/transaction/transaction_conflict_inlining.test
 # description: Test ducklake transaction conflicts with data inlining
-# group: [data_inlining]
+# group: [transaction]
 
 require ducklake
 
@@ -12,35 +12,17 @@ ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_encryption.db' AS ducklake (DATA
 statement ok
 CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
 
-query II
-SELECT COUNT(*), SUM(id) FROM ducklake.test
-----
-1000	499500
+# two transactions try to flush the inlined data
+statement ok con1
+BEGIN
 
-# data is inlined
-query I
-SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
-----
-0
-
-# we can flush the data
-statement ok
+statement ok con1
 CALL ducklake_flush_inlined_data('ducklake')
 
-# now we have a file
 query I
-SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
+SELECT COUNT(*) FROM ducklake.test
 ----
-1
+1000
 
-# that file is encrypted
-statement error
-SELECT * FROM '__TEST_DIR__/ducklake_inlining_encryption_files/main/test/*.parquet'
-----
-encrypted
-
-# but we can read it
-query II
-SELECT COUNT(*), SUM(id) FROM ducklake.test
-----
-1000	499500
+statement ok con1
+COMMIT

--- a/test/sql/transaction/transaction_conflict_inlining.test
+++ b/test/sql/transaction/transaction_conflict_inlining.test
@@ -1,0 +1,46 @@
+# name: test/sql/transaction/transaction_conflict_inlining_flush.test
+# description: Test ducklake transaction conflicts with data inlining
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_encryption.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_inlining_encryption_files', ENCRYPTED, DATA_INLINING_ROW_LIMIT 10000)
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
+
+query II
+SELECT COUNT(*), SUM(id) FROM ducklake.test
+----
+1000	499500
+
+# data is inlined
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
+----
+0
+
+# we can flush the data
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# now we have a file
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_inlining_encryption_files/main/test/**')
+----
+1
+
+# that file is encrypted
+statement error
+SELECT * FROM '__TEST_DIR__/ducklake_inlining_encryption_files/main/test/*.parquet'
+----
+encrypted
+
+# but we can read it
+query II
+SELECT COUNT(*), SUM(id) FROM ducklake.test
+----
+1000	499500

--- a/test/sql/transaction/transaction_conflict_inlining.test
+++ b/test/sql/transaction/transaction_conflict_inlining.test
@@ -12,29 +12,34 @@ ATTACH 'ducklake:__TEST_DIR__/ducklake_inlining_encryption.db' AS ducklake (DATA
 statement ok
 SET immediate_transaction_mode=true
 
-# statement ok
-# CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
-#
-# # two transactions try to flush the inlined data
-# statement ok con1
-# BEGIN
-#
-# statement ok con1
-# CALL ducklake_flush_inlined_data('ducklake')
-#
-# query I
-# SELECT COUNT(*) FROM ducklake.test
-# ----
-# 1000
-#
-# statement ok con1
-# COMMIT
-#
-#
-# statement ok
-# DROP TABLE ducklake.test
+statement ok
+CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
 
-# one transaction flushes inlined data, the other updates it
+# two transactions try to flush the inlined data
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement error con2
+CALL ducklake_flush_inlined_data('ducklake')
+----
+Conflict
+
+statement ok con1
+COMMIT
+
+statement ok con2
+COMMIT
+
+statement ok
+DROP TABLE ducklake.test
+
+# one transaction updates inlined data; the other flushes it
 statement ok
 CREATE TABLE ducklake.test2(id INTEGER);
 
@@ -59,9 +64,34 @@ COMMIT
 statement error con2
 COMMIT
 ----
-zxcv
+conflict
 
-query I
-SELECT COUNT(*) FROM ducklake.test2
+statement ok
+DROP TABLE ducklake.test2
+
+# one transaction flushes inlined data; the other updates it
+statement ok
+CREATE TABLE ducklake.test3(id INTEGER);
+
+statement ok
+INSERT INTO ducklake.test3 FROM range(1000);
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok con2
+UPDATE ducklake.test3 SET id=id+1000
+
+statement ok con1
+COMMIT
+
+statement error con2
+COMMIT
 ----
-1000
+conflict

--- a/test/sql/transaction/transaction_conflicts_delete.test
+++ b/test/sql/transaction/transaction_conflicts_delete.test
@@ -89,7 +89,7 @@ COMMIT
 statement error con2
 COMMIT
 ----
-has been dropped by another transaction
+another transaction has dropped it
 
 statement ok
 CREATE TABLE ducklake.test AS FROM range(1000) t(i)
@@ -115,4 +115,4 @@ COMMIT
 statement error con2
 COMMIT
 ----
-has been altered by another transaction
+another transaction has altered it

--- a/test/sql/transaction/transaction_conflicts_view.test
+++ b/test/sql/transaction/transaction_conflicts_view.test
@@ -115,7 +115,7 @@ COMMIT
 statement error con2
 COMMIT
 ----
-altered by another transaction
+another transaction has altered it
 
 query I
 SELECT comment FROM duckdb_views WHERE view_name='comment_view'


### PR DESCRIPTION
This PR adds support for flushing inlined data using the `ducklake_flush_inlined_data` function.

This function can be called to explicitly flush inlined data from any table that has inlined data to a set of Parquet files, e.g.:

```sql
ATTACH 'ducklake:inlined_test.db' AS inlined_test (DATA_PATH 'inlined_files/');


CALL inlined_test.set_option('data_inlining_row_limit', 10);
CREATE TABLE inlined_test.inlined_tbl(i INTEGER);
INSERT INTO inlined_test.inlined_tbl VALUES (1);
INSERT INTO inlined_test.inlined_tbl VALUES (2);
INSERT INTO inlined_test.inlined_tbl VALUES (3);

-- this data is all inlined
SELECT COUNT(*) FROM glob('inlined_files/**');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│      0       │
└──────────────┘

-- flush inlined data
CALL ducklake_flush_inlined_data('inlined_test');


-- now we have a file
SELECT COUNT(*) FROM glob('inlined_files/**');
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│      1       │
└──────────────┘

-- all operations keep working "as usual"
FROM inlined_test.inlined_tbl AT (VERSION => 3);
┌───────┐
│   i   │
│ int32 │
├───────┤
│     1 │
│     2 │
└───────┘
```

Flushing inlined data writes the rows, together with the snapshot and row ids of the written rows, to the Parquet files. This effectively makes the operation "invisible" similar to regular compaction - all operations should keep on working as expected, including operations like time travel, change data feeds, etc. 