### PR TITLE
Add `lz4_raw` parquet compression as one of the supported compression algorithms

### DIFF
--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -16,7 +16,7 @@ using ducklake_option_array = std::array<DuckLakeOptionMetadata, 11>;
 
 static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
     {{"data_inlining_row_limit", "Maximum amount of rows to inline in a single insert"},
-     {"parquet_compression", "Compression algorithm for Parquet files (uncompressed, snappy, gzip, zstd, brotli, lz4)"},
+     {"parquet_compression", "Compression algorithm for Parquet files (uncompressed, snappy, gzip, zstd, brotli, lz4, lz4_raw)"},
      {"parquet_version", "Parquet format version (1 or 2)"},
      {"parquet_compression_level", "Compression level for Parquet files"},
      {"parquet_row_group_size", "Number of rows per row group in Parquet files"},

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -28,7 +28,7 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 	// read the option
 	if (option == "parquet_compression") {
 		auto codec = val.DefaultCastAs(LogicalType::VARCHAR).GetValue<string>();
-		vector<string> supported_algorithms {"uncompressed", "snappy", "gzip", "zstd", "brotli", "lz4"};
+		vector<string> supported_algorithms {"uncompressed", "snappy", "gzip", "zstd", "brotli", "lz4", "lz4_raw"};
 		bool found = false;
 		for (auto &algorithm : supported_algorithms) {
 			if (StringUtil::CIEquals(algorithm, codec)) {


### PR DESCRIPTION
lz4_raw is part of both the [parquet spec](https://parquet.apache.org/docs/file-format/data-pages/compression/) and also [available in duckdb](https://github.com/duckdb/duckdb/blob/4b9b91aa88dfaed7244b0965bb127642cfd07c18/extension/parquet/parquet_extension.cpp#L318)