### PR TITLE
Fix #284: correctly set table id of newly written files when resolving conflicts between separate transactions

### DIFF
--- a/src/include/storage/ducklake_catalog_set.hpp
+++ b/src/include/storage/ducklake_catalog_set.hpp
@@ -34,8 +34,6 @@ public:
 	optional_ptr<CatalogEntry> GetEntryById(SchemaIndex index);
 	optional_ptr<CatalogEntry> GetEntryById(TableIndex index);
 	void AddEntry(DuckLakeSchemaEntry &schema, TableIndex id, unique_ptr<CatalogEntry> entry);
-	void RemapEntry(SchemaIndex old_index, SchemaIndex new_index, DuckLakeSchemaEntry &schema);
-	void RemapEntry(TableIndex old_index, TableIndex new_index, DuckLakeTableEntry &table);
 
 	template <class T>
 	optional_ptr<T> GetEntry(const string &name) {

--- a/src/include/storage/ducklake_schema_entry.hpp
+++ b/src/include/storage/ducklake_schema_entry.hpp
@@ -27,9 +27,6 @@ public:
 	const string &GetSchemaUUID() const {
 		return schema_uuid;
 	}
-	void SetSchemaId(SchemaIndex new_schema_id) {
-		schema_id = new_schema_id;
-	}
 	const string &DataPath() const {
 		return data_path;
 	}

--- a/src/include/storage/ducklake_table_entry.hpp
+++ b/src/include/storage/ducklake_table_entry.hpp
@@ -44,9 +44,6 @@ public:
 	const string &GetTableUUID() const {
 		return table_uuid;
 	}
-	void SetTableId(TableIndex new_table_id) {
-		table_id = new_table_id;
-	}
 	bool IsTransactionLocal() const {
 		return local_change.type != LocalChangeType::NONE;
 	}

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -34,6 +34,7 @@ struct NewTableInfo;
 struct NewNameMapInfo;
 struct CompactionInformation;
 struct DuckLakePath;
+struct DuckLakeCommitState;
 
 class DuckLakeTransaction : public Transaction, public enable_shared_from_this<DuckLakeTransaction> {
 public:
@@ -84,13 +85,13 @@ public:
 
 	MappingIndex AddNameMap(unique_ptr<DuckLakeNameMap> name_map);
 	const DuckLakeNameMap &GetMappingById(MappingIndex mapping_id);
-	NewNameMapInfo GetNewNameMaps(DuckLakeSnapshot &commit_snapshot);
+	NewNameMapInfo GetNewNameMaps(DuckLakeCommitState &commit_state);
 
 	void AppendInlinedData(TableIndex table_id, unique_ptr<DuckLakeInlinedData> collection);
 	void AddNewInlinedDeletes(TableIndex table_id, const string &table_name, set<idx_t> new_deletes);
 	void DeleteFromLocalInlinedData(TableIndex table_id, set<idx_t> new_deletes);
 	optional_ptr<DuckLakeInlinedDataDeletes> GetInlinedDeletes(TableIndex table_id, const string &table_name);
-	vector<DuckLakeDeletedInlinedDataInfo> GetNewInlinedDeletes(DuckLakeSnapshot &commit_snapshot);
+	vector<DuckLakeDeletedInlinedDataInfo> GetNewInlinedDeletes(DuckLakeCommitState &commit_state);
 
 	void DropSchema(DuckLakeSchemaEntry &schema);
 	void DropTable(DuckLakeTableEntry &table);
@@ -134,31 +135,31 @@ private:
 	void CleanupFiles();
 	void FlushChanges();
 	void FlushSettingChanges();
-	void CommitChanges(DuckLakeSnapshot &commit_snapshot, TransactionChangeInformation &transaction_changes);
+	void CommitChanges(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
 	void CommitCompaction(DuckLakeSnapshot &commit_snapshot, TransactionChangeInformation &transaction_changes);
 	void FlushDrop(DuckLakeSnapshot commit_snapshot, const string &metadata_table_name, const string &id_name,
 	               unordered_set<idx_t> &dropped_entries);
-	vector<DuckLakeSchemaInfo> GetNewSchemas(DuckLakeSnapshot &commit_snapshot);
-	NewTableInfo GetNewTables(DuckLakeSnapshot &commit_snapshot, TransactionChangeInformation &transaction_changes);
-	DuckLakePartitionInfo GetNewPartitionKey(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &tabletable_id);
-	DuckLakeTableInfo GetNewTable(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table);
-	DuckLakeViewInfo GetNewView(DuckLakeSnapshot &commit_snapshot, DuckLakeViewEntry &view);
+	vector<DuckLakeSchemaInfo> GetNewSchemas(DuckLakeCommitState &commit_state);
+	NewTableInfo GetNewTables(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
+	DuckLakePartitionInfo GetNewPartitionKey(DuckLakeCommitState &commit_state, DuckLakeTableEntry &tabletable_id);
+	DuckLakeTableInfo GetNewTable(DuckLakeCommitState &commit_state, DuckLakeTableEntry &table);
+	DuckLakeViewInfo GetNewView(DuckLakeCommitState &commit_state, DuckLakeViewEntry &view);
 	void FlushNewPartitionKey(DuckLakeSnapshot &commit_snapshot, DuckLakeTableEntry &table);
 	DuckLakeFileInfo GetNewDataFile(DuckLakeDataFile &file, DuckLakeSnapshot &commit_snapshot, TableIndex table_id,
 	                                optional_idx row_id_start);
-	NewDataInfo GetNewDataFiles(DuckLakeSnapshot &commit_snapshot);
-	vector<DuckLakeDeleteFileInfo> GetNewDeleteFiles(DuckLakeSnapshot &commit_snapshot,
+	NewDataInfo GetNewDataFiles(DuckLakeCommitState &commit_state);
+	vector<DuckLakeDeleteFileInfo> GetNewDeleteFiles(DuckLakeCommitState &commit_state,
 	                                                 set<DataFileIndex> &overwritten_delete_files);
 	void UpdateGlobalTableStats(TableIndex table_id, const DuckLakeNewGlobalStats &new_stats);
 	void CheckForConflicts(DuckLakeSnapshot transaction_snapshot, const TransactionChangeInformation &changes);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes);
-	void WriteSnapshotChanges(DuckLakeSnapshot commit_snapshot, TransactionChangeInformation &changes);
+	void WriteSnapshotChanges(DuckLakeCommitState &commit_state, TransactionChangeInformation &changes);
 	//! Return the set of changes made by this transaction
 	TransactionChangeInformation GetTransactionChanges();
-	void GetNewTableInfo(DuckLakeSnapshot &commit_snapshot, DuckLakeCatalogSet &catalog_set,
+	void GetNewTableInfo(DuckLakeCommitState &commit_state, DuckLakeCatalogSet &catalog_set,
 	                     reference<CatalogEntry> table_entry, NewTableInfo &result,
 	                     TransactionChangeInformation &transaction_changes);
-	void GetNewViewInfo(DuckLakeSnapshot &commit_snapshot, DuckLakeCatalogSet &catalog_set,
+	void GetNewViewInfo(DuckLakeCommitState &commit_state, DuckLakeCatalogSet &catalog_set,
 	                    reference<CatalogEntry> table_entry, NewTableInfo &result,
 	                    TransactionChangeInformation &transaction_changes);
 	CompactionInformation GetCompactionChanges(DuckLakeSnapshot &commit_snapshot);

--- a/src/include/storage/ducklake_view_entry.hpp
+++ b/src/include/storage/ducklake_view_entry.hpp
@@ -29,9 +29,6 @@ public:
 	const string &GetViewUUID() const {
 		return view_uuid;
 	}
-	void SetViewId(TableIndex new_view_id) {
-		view_id = new_view_id;
-	}
 	bool IsTransactionLocal() const {
 		return local_change.type != LocalChangeType::NONE;
 	}

--- a/src/storage/ducklake_catalog_set.cpp
+++ b/src/storage/ducklake_catalog_set.cpp
@@ -63,14 +63,4 @@ void DuckLakeCatalogSet::AddEntry(DuckLakeSchemaEntry &schema, TableIndex id, un
 	schema.AddEntry(catalog_type, std::move(entry));
 }
 
-void DuckLakeCatalogSet::RemapEntry(SchemaIndex old_index, SchemaIndex new_index, DuckLakeSchemaEntry &schema) {
-	schema_entry_map.erase(old_index);
-	schema_entry_map.insert(make_pair(new_index, reference<DuckLakeSchemaEntry>(schema)));
-}
-
-void DuckLakeCatalogSet::RemapEntry(TableIndex old_index, TableIndex new_index, DuckLakeTableEntry &table) {
-	table_entry_map.erase(old_index);
-	table_entry_map.insert(make_pair(new_index, reference<CatalogEntry>(table)));
-}
-
 } // namespace duckdb

--- a/test/sql/transaction/concurrent_table_creation.test
+++ b/test/sql/transaction/concurrent_table_creation.test
@@ -1,0 +1,42 @@
+# name: test/sql/transaction/concurrent_table_creation.test
+# description: Test concurrent table creation with files
+# group: [transaction]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_conflicts.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_conflicts_files', METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+SET immediate_transaction_mode=true
+
+# two transactions try to create a table with different names and data: no conflict
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CREATE TABLE ducklake.test AS SELECT 42 i
+
+statement ok con2
+CREATE TABLE ducklake.test2 AS SELECT 'hello world' s
+
+statement ok con1
+COMMIT
+
+statement ok con2
+COMMIT
+
+query I
+FROM ducklake.test
+----
+42
+
+query I
+FROM ducklake.test2
+----
+hello world


### PR DESCRIPTION
Fixes #284 

While writing a new table to DuckLake, we pick a table id for that table during the commit stage, and then try to commit. If we need to retry, the table id of that table will change. In the retry code, there was an issue where we would update the table id of the table in the retry correctly - but would leave any data associated with that transaction-local table stuck on the first table id picked. If two transactions performed a `CREATE TABLE AS` that would conflict this could cause data files from one table to erroneously point to the other table.

This PR fixes this issue by, instead of modifying the table id of the table in-place with the new table-id, constructing a map of `transaction_local_id -> final_id` and then clearing that map upon retry. 