### PR TITLE
Set `end_snapshot` on all metadata entries when dropping table

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -59,7 +59,7 @@ public:
 	virtual vector<DuckLakeFileScheduledForCleanup> GetFilesScheduledForCleanup(const string &filter);
 	virtual void RemoveFilesScheduledForCleanup(const vector<DuckLakeFileScheduledForCleanup> &cleaned_up_files);
 	virtual void DropSchemas(DuckLakeSnapshot commit_snapshot, const set<SchemaIndex> &ids);
-	virtual void DropTables(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids);
+	virtual void DropTables(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids, bool renamed);
 	virtual void DropViews(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids);
 	virtual void WriteNewSchemas(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeSchemaInfo> &new_schemas);
 	virtual void WriteNewTables(DuckLakeSnapshot commit_snapshot, const vector<DuckLakeTableInfo> &new_tables);

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -193,6 +193,7 @@ private:
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_tables;
 	set<TableIndex> dropped_tables;
 	set<TableIndex> renamed_tables;
+	set<TableIndex> intersected_renamed_dropped;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
 	set<TableIndex> tables_deleted_from;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -193,7 +193,7 @@ private:
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_tables;
 	set<TableIndex> dropped_tables;
 	set<TableIndex> renamed_tables;
-	set<TableIndex> intersected_renamed_dropped;
+	set<TableIndex> real_dropped_tables;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
 	set<TableIndex> tables_deleted_from;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -193,7 +193,6 @@ private:
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_tables;
 	set<TableIndex> dropped_tables;
 	set<TableIndex> renamed_tables;
-	set<TableIndex> real_dropped_tables;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
 	set<TableIndex> tables_deleted_from;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -192,6 +192,7 @@ private:
 	//! New tables added by this transaction
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_tables;
 	set<TableIndex> dropped_tables;
+	set<TableIndex> renamed_tables;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
 	set<TableIndex> tables_deleted_from;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -886,6 +886,11 @@ void DuckLakeMetadataManager::DropSchemas(DuckLakeSnapshot commit_snapshot, cons
 void DuckLakeMetadataManager::DropTables(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids) {
 	FlushDrop(commit_snapshot, "ducklake_table", "table_id", ids);
 	FlushDrop(commit_snapshot, "ducklake_partition_info", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_column", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_column_tag", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_data_file", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_delete_file", "table_id", ids);
+	FlushDrop(commit_snapshot, "ducklake_tag", "object_id", ids);
 }
 
 void DuckLakeMetadataManager::DropViews(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -894,14 +894,16 @@ void DuckLakeMetadataManager::DropSchemas(DuckLakeSnapshot commit_snapshot, cons
 	FlushDrop(commit_snapshot, "ducklake_schema", "schema_id", ids);
 }
 
-void DuckLakeMetadataManager::DropTables(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids) {
+void DuckLakeMetadataManager::DropTables(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids, bool renamed) {
 	FlushDrop(commit_snapshot, "ducklake_table", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_partition_info", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_column", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_column_tag", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_data_file", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_delete_file", "table_id", ids);
-	FlushDrop(commit_snapshot, "ducklake_tag", "object_id", ids);
+	if (renamed == false) {
+		FlushDrop(commit_snapshot, "ducklake_partition_info", "table_id", ids);
+		FlushDrop(commit_snapshot, "ducklake_column", "table_id", ids);
+		FlushDrop(commit_snapshot, "ducklake_column_tag", "table_id", ids);
+		FlushDrop(commit_snapshot, "ducklake_data_file", "table_id", ids);
+		FlushDrop(commit_snapshot, "ducklake_delete_file", "table_id", ids);
+		FlushDrop(commit_snapshot, "ducklake_tag", "object_id", ids);
+	}	
 }
 
 void DuckLakeMetadataManager::DropViews(DuckLakeSnapshot commit_snapshot, const set<TableIndex> &ids) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1156,22 +1156,16 @@ struct CompactionInformation {
 void DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
                                         TransactionChangeInformation &transaction_changes) {
 	auto &commit_snapshot = commit_state.commit_snapshot;
-
-	for (const auto &val : dropped_tables) {
-	    if (renamed_tables.find(val) == renamed_tables.end()) {
-	        real_dropped_tables.insert(val);
-	    }
-	}
 	
 	// drop entries
 	if (!dropped_tables.empty()) {
-		if (!renamed_tables.empty()){
-			metadata_manager->DropTables(commit_snapshot, dropped_tables, true);
-		} 
-		if (!real_dropped_tables.empty()) {
-			metadata_manager->DropTables(commit_snapshot, dropped_tables, false);
-		}
+		metadata_manager->DropTables(commit_snapshot, dropped_tables, true);
 	}
+
+	if (!renamed_tables.empty()){
+		metadata_manager->DropTables(commit_snapshot, renamed_tables, true);
+	} 
+
 	if (!dropped_views.empty()) {
 		metadata_manager->DropViews(commit_snapshot, dropped_views);
 	}
@@ -1874,7 +1868,6 @@ void DuckLakeTransaction::AlterEntryInternal(DuckLakeTableEntry &table, unique_p
 		} else {
 			// table is not transaction local - add to drop list
 			auto table_id = table.GetTableId();
-			dropped_tables.insert(table_id);
 			renamed_tables.insert(table_id);
 		}
 		break;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1159,7 +1159,7 @@ void DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 	
 	// drop entries
 	if (!dropped_tables.empty()) {
-		metadata_manager->DropTables(commit_snapshot, dropped_tables, true);
+		metadata_manager->DropTables(commit_snapshot, dropped_tables, false);
 	}
 
 	if (!renamed_tables.empty()){

--- a/test/sql/partitioning/basic_partitioning.test
+++ b/test/sql/partitioning/basic_partitioning.test
@@ -22,6 +22,18 @@ ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
 statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(10000) t(i)
 
+statement ok
+ALTER TABLE partitioned_tbl RENAME TO partitioned_tbl_renamed
+
+# check if rename causes partition info to get dropped
+query I
+SELECT COUNT(*) FROM ducklake_metadata.ducklake_partition_info WHERE end_snapshot IS NOT NULL
+----
+0
+
+statement ok
+ALTER TABLE partitioned_tbl_renamed RENAME TO partitioned_tbl
+
 query I
 SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=0
 ----


### PR DESCRIPTION
To prevent issues similar to https://github.com/duckdb/ducklake/issues/69 , especially when working with other engines. Also fixes issue where table renames causes partition info to be dropped. 