### PR TITLE
Implement `migrate_if_required` Option

### DIFF
--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -28,6 +28,7 @@ struct DuckLakeOptions {
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	DuckLakeEncryption encryption = DuckLakeEncryption::AUTOMATIC;
 	bool create_if_not_exists = true;
+	bool migrate_if_required = true;
 	unique_ptr<BoundAtClause> at_clause;
 	unordered_map<string, Value> metadata_parameters;
 	option_map_t config_options;

--- a/src/include/storage/ducklake_initializer.hpp
+++ b/src/include/storage/ducklake_initializer.hpp
@@ -24,7 +24,7 @@ public:
 
 private:
 	void InitializeNewDuckLake(DuckLakeTransaction &transaction, bool has_explicit_schema);
-	void LoadExistingDuckLake(DuckLakeTransaction &transaction);
+	void LoadExistingDuckLake(DuckLakeTransaction &transaction, bool migrate_if_required);
 	void InitializeDataPath();
 	string GetAttachOptions();
 	void CheckAndAutoloadedRequiredExtension(const string &pattern);

--- a/src/include/storage/ducklake_initializer.hpp
+++ b/src/include/storage/ducklake_initializer.hpp
@@ -24,7 +24,7 @@ public:
 
 private:
 	void InitializeNewDuckLake(DuckLakeTransaction &transaction, bool has_explicit_schema);
-	void LoadExistingDuckLake(DuckLakeTransaction &transaction, bool migrate_if_required);
+	void LoadExistingDuckLake(DuckLakeTransaction &transaction);
 	void InitializeDataPath();
 	string GetAttachOptions();
 	void CheckAndAutoloadedRequiredExtension(const string &pattern);

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -92,7 +92,7 @@ void DuckLakeInitializer::Initialize() {
 		}
 		InitializeNewDuckLake(transaction, has_explicit_schema);
 	} else {
-		LoadExistingDuckLake(transaction, options.migrate_if_required);
+		LoadExistingDuckLake(transaction);
 	}
 	if (options.at_clause) {
 		// if the user specified a snapshot try to load it to trigger an error if it does not exist
@@ -141,14 +141,14 @@ void DuckLakeInitializer::InitializeNewDuckLake(DuckLakeTransaction &transaction
 	}
 }
 
-void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction, bool migrate_if_required) {
+void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction) {
 	// load the data path from the existing duck lake
 	auto &metadata_manager = transaction.GetMetadataManager();
 	auto metadata = metadata_manager.LoadDuckLake();
 	for (auto &tag : metadata.tags) {
 		if (tag.key == "version") {
 			string version = tag.value;
-			if (version != "0.3-dev1" && !migrate_if_required) {
+			if (version != "0.3-dev1" && !options.migrate_if_required) {
 				// Throw when Loading the Ducklake if a Migration is required and migrate_if_required option is false
 				throw InvalidInputException(
 				    "DuckLake Extension requires a DuckLake Catalog version of 0.3-dev1 or higher, current version is %s "

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -47,6 +47,8 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 		options.metadata_parameters[parameter_name] = value;
 	} else if (lcase == "create_if_not_exists") {
 		options.create_if_not_exists = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
+	} else if (lcase == "migrate_if_required") {
+		options.migrate_if_required = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "readonly" || lcase == "read_only" || lcase == "readwrite" || lcase == "read_write" ||
 	           lcase == "type" || lcase == "default_table") {
 		// built-in options for ATTACH


### PR DESCRIPTION
Closes #304 

This throws on Attach if the Ducklake Extension requires Migrations and the `MIGRATE_IF_REQUIRED` Flag is False (default True).

This is critical for us as we have a Master Ducklake Metadata Catalog which we want to ensure is tightly managed and hence should not Invisibly Migrate. Particularly as we may have many different clients accessing this Catalog.

Not sold on the option name (perhaps `migrate_automatically` is clearer...) or implementation (particularly hardcoding so many version strings) so open to suggestions...