### PR TITLE
added ducklake label to the internal forwarding bot

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Create or label issue
         run: |
           if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
-            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/ducklake/issues/${{ github.event.issue.number || github.event.discussion.number }}"
+            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --label "ducklake" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/ducklake/issues/${{ github.event.issue.number || github.event.discussion.number }}"
           else
             gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --remove-label "$UNLABEL" --add-label "$LABEL"
           fi


### PR DESCRIPTION
This PR just adds the label `ducklake` to the internal mirroring repository that we use for issue tracking