### PR TITLE
Add support for `MERGE INTO` to DuckLake

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -88,6 +88,8 @@ public:
 	                             PhysicalOperator &plan) override;
 	PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
 	                             PhysicalOperator &plan) override;
+	PhysicalOperator &PlanMergeInto(ClientContext &context, PhysicalPlanGenerator &planner, LogicalMergeInto &op,
+	                                PhysicalOperator &plan) override;
 	unique_ptr<LogicalOperator> BindCreateIndex(Binder &binder, CreateStatement &stmt, TableCatalogEntry &table,
 	                                            unique_ptr<LogicalOperator> plan) override;
 

--- a/src/include/storage/ducklake_update.hpp
+++ b/src/include/storage/ducklake_update.hpp
@@ -28,6 +28,8 @@ public:
 	PhysicalOperator &delete_op;
 	//! The (final) insert operator that registers inserted data
 	PhysicalOperator &insert_op;
+	//! The row-id-index
+	idx_t row_id_index;
 
 public:
 	// // Source interface

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   ducklake_inline_data.cpp
   ducklake_inlined_data_reader.cpp
   ducklake_insert.cpp
+  ducklake_merge_into.cpp
   ducklake_schema_entry.cpp
   ducklake_transaction_manager.cpp
   ducklake_catalog_set.cpp

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -163,6 +163,8 @@ unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog &catal
 		update.columns = std::move(action.columns);
 		update.update_is_del_and_insert = action.update_is_del_and_insert;
 		result->op = catalog.PlanUpdate(context, planner, update, child_plan);
+		auto &dl_update = result->op->Cast<DuckLakeUpdate>();
+		dl_update.row_id_index = child_plan.types.size() - 1;
 		break;
 	}
 	case MergeActionType::MERGE_DELETE: {

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -1,0 +1,234 @@
+#include "storage/ducklake_catalog.hpp"
+#include "duckdb/execution/operator/persistent/physical_merge_into.hpp"
+#include "duckdb/planner/operator/logical_merge_into.hpp"
+#include "storage/ducklake_update.hpp"
+#include "storage/ducklake_delete.hpp"
+#include "storage/ducklake_insert.hpp"
+#include "duckdb/planner/operator/logical_update.hpp"
+#include "duckdb/planner/operator/logical_dummy_scan.hpp"
+#include "duckdb/planner/operator/logical_delete.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/parallel/thread_context.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Merge Insert
+//===--------------------------------------------------------------------===//
+class DuckLakeMergeInsert : public PhysicalOperator {
+public:
+	DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, PhysicalOperator &insert,
+	                    PhysicalOperator &copy);
+
+	//! The copy operator that writes to the file
+	PhysicalOperator &copy;
+	//! The final insert operator
+	PhysicalOperator &insert;
+
+public:
+	// // Source interface
+	SourceResultType GetData(ExecutionContext &context, DataChunk &chunk, OperatorSourceInput &input) const override;
+
+	bool IsSource() const override {
+		return true;
+	}
+
+public:
+	// Sink interface
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          OperatorSinkFinalizeInput &input) const override;
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
+
+	bool IsSink() const override {
+		return true;
+	}
+
+	bool ParallelSink() const override {
+		return true;
+	}
+};
+
+DuckLakeMergeInsert::DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
+                                         PhysicalOperator &insert, PhysicalOperator &copy)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), copy(copy), insert(insert) {
+}
+
+SourceResultType DuckLakeMergeInsert::GetData(ExecutionContext &context, DataChunk &chunk,
+                                              OperatorSourceInput &input) const {
+	return SourceResultType::FINISHED;
+}
+
+//===--------------------------------------------------------------------===//
+// Sink
+//===--------------------------------------------------------------------===//
+SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	OperatorSinkInput sink_input {*copy.sink_state, input.local_state, input.interrupt_state};
+	return copy.Sink(context, chunk, sink_input);
+}
+
+SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
+	OperatorSinkCombineInput combine_input {*copy.sink_state, input.local_state, input.interrupt_state};
+	return copy.Combine(context, combine_input);
+}
+
+SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                               OperatorSinkFinalizeInput &input) const {
+	OperatorSinkFinalizeInput copy_finalize {*copy.sink_state, input.interrupt_state};
+	auto finalize_result = copy.Finalize(pipeline, event, context, copy_finalize);
+	if (finalize_result == SinkFinalizeType::BLOCKED) {
+		return SinkFinalizeType::BLOCKED;
+	}
+
+	// now scan the copy
+	DataChunk chunk;
+	chunk.Initialize(context, copy.types);
+
+	ThreadContext thread(context);
+	ExecutionContext exec_context(context, thread, nullptr);
+
+	auto copy_global = copy.GetGlobalSourceState(context);
+	auto copy_local = copy.GetLocalSourceState(exec_context, *copy_global);
+	OperatorSourceInput source_input {*copy_global, *copy_local, input.interrupt_state};
+
+	auto insert_global = insert.GetGlobalSinkState(context);
+	auto insert_local = insert.GetLocalSinkState(exec_context);
+	OperatorSinkInput sink_input {*insert_global, *insert_local, input.interrupt_state};
+	SourceResultType source_res = SourceResultType::HAVE_MORE_OUTPUT;
+	while (source_res == SourceResultType::HAVE_MORE_OUTPUT) {
+		chunk.Reset();
+		source_res = copy.GetData(exec_context, chunk, source_input);
+		if (chunk.size() == 0) {
+			continue;
+		}
+		if (source_res == SourceResultType::BLOCKED) {
+			throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
+		}
+
+		auto sink_result = insert.Sink(exec_context, chunk, sink_input);
+		if (sink_result != SinkResultType::NEED_MORE_INPUT) {
+			throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
+		}
+	}
+	OperatorSinkCombineInput combine_input {*insert_global, *insert_local, input.interrupt_state};
+	auto combine_res = insert.Combine(exec_context, combine_input);
+	if (combine_res == SinkCombineResultType::BLOCKED) {
+		throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
+	}
+	OperatorSinkFinalizeInput finalize_input {*insert_global, input.interrupt_state};
+	auto finalize_res = insert.Finalize(pipeline, event, context, finalize_input);
+	if (finalize_res == SinkFinalizeType::BLOCKED) {
+		throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
+	}
+	return SinkFinalizeType::READY;
+}
+
+unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContext &context) const {
+	copy.sink_state = copy.GetGlobalSinkState(context);
+	return make_uniq<GlobalSinkState>();
+}
+
+unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionContext &context) const {
+	return copy.GetLocalSinkState(context);
+}
+
+//===--------------------------------------------------------------------===//
+// Plan Merge Into
+//===--------------------------------------------------------------------===//
+unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog &catalog, ClientContext &context,
+                                                          LogicalMergeInto &op, PhysicalPlanGenerator &planner,
+                                                          BoundMergeIntoAction &action, PhysicalOperator &child_plan) {
+	auto result = make_uniq<MergeIntoOperator>();
+
+	result->action_type = action.action_type;
+	result->condition = std::move(action.condition);
+	vector<unique_ptr<BoundConstraint>> bound_constraints;
+	for (auto &constraint : op.bound_constraints) {
+		bound_constraints.push_back(constraint->Copy());
+	}
+	auto return_types = op.types;
+
+	switch (action.action_type) {
+	case MergeActionType::MERGE_UPDATE: {
+		LogicalUpdate update(op.table);
+		for (auto &def : op.bound_defaults) {
+			update.bound_defaults.push_back(def->Copy());
+		}
+		update.bound_constraints = std::move(bound_constraints);
+		update.expressions = std::move(action.expressions);
+		update.columns = std::move(action.columns);
+		update.update_is_del_and_insert = action.update_is_del_and_insert;
+		result->op = catalog.PlanUpdate(context, planner, update, child_plan);
+		break;
+	}
+	case MergeActionType::MERGE_DELETE: {
+		LogicalDelete delete_op(op.table, 0);
+		delete_op.expressions.push_back(nullptr);
+
+		vector<LogicalType> row_id_types {LogicalType::VARCHAR, LogicalType::UBIGINT, LogicalType::BIGINT};
+		for (idx_t i = 0; i < 3; i++) {
+			auto ref = make_uniq<BoundReferenceExpression>(row_id_types[i], op.row_id_start + i + 1);
+			delete_op.expressions.push_back(std::move(ref));
+		}
+		delete_op.bound_constraints = std::move(bound_constraints);
+		result->op = catalog.PlanDelete(context, planner, delete_op, child_plan);
+		break;
+	}
+	case MergeActionType::MERGE_INSERT: {
+		LogicalInsert insert_op(op.table, 0);
+		insert_op.bound_constraints = std::move(bound_constraints);
+		for (auto &def : op.bound_defaults) {
+			insert_op.bound_defaults.push_back(def->Copy());
+		}
+		result->expressions = std::move(action.expressions);
+		auto &insert = catalog.PlanInsert(context, planner, insert_op, child_plan);
+		auto &copy = insert.children[0].get();
+		result->op = planner.Make<DuckLakeMergeInsert>(insert.types, insert, copy);
+		break;
+	}
+	case MergeActionType::MERGE_ERROR:
+		result->expressions = std::move(action.expressions);
+		break;
+	case MergeActionType::MERGE_DO_NOTHING:
+		break;
+	default:
+		throw InternalException("Unsupported merge action");
+	}
+	return result;
+}
+
+PhysicalOperator &DuckLakeCatalog::PlanMergeInto(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                 LogicalMergeInto &op, PhysicalOperator &plan) {
+	if (op.return_chunk) {
+		throw NotImplementedException("RETURNING is not implemented for DuckLake yet");
+	}
+	map<MergeActionCondition, vector<unique_ptr<MergeIntoOperator>>> actions;
+
+	// plan the merge into clauses
+	idx_t update_delete_count = 0;
+	for (auto &entry : op.actions) {
+		vector<unique_ptr<MergeIntoOperator>> planned_actions;
+		for (auto &action : entry.second) {
+			if (action->action_type == MergeActionType::MERGE_UPDATE ||
+			    action->action_type == MergeActionType::MERGE_DELETE) {
+				update_delete_count++;
+				if (update_delete_count > 1) {
+					throw NotImplementedException(
+					    "MERGE INTO with DuckLake only supports a single UPDATE/DELETE action currently");
+				}
+			}
+			planned_actions.push_back(DuckLakePlanMergeIntoAction(*this, context, op, planner, *action, plan));
+		}
+		actions.emplace(entry.first, std::move(planned_actions));
+	}
+
+	auto &result = planner.Make<PhysicalMergeInto>(op.types, std::move(actions), op.row_id_start, op.source_marker,
+	                                               true, op.return_chunk);
+	result.children.push_back(plan);
+	return result;
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -76,7 +76,7 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		insert_chunk.data[columns[i].index].Reference(chunk.data[i]);
 	}
 	idx_t row_id_index = columns.size();
-	insert_chunk.data[row_id_index].Reference(chunk.data[chunk.ColumnCount() - 1]);
+	insert_chunk.data[row_id_index].Reference(chunk.data[row_id_index]);
 
 	OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 	copy_op.Sink(context, insert_chunk, copy_input);

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -76,7 +76,7 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		insert_chunk.data[columns[i].index].Reference(chunk.data[i]);
 	}
 	idx_t row_id_index = columns.size();
-	insert_chunk.data[row_id_index].Reference(chunk.data[row_id_index]);
+	insert_chunk.data[row_id_index].Reference(chunk.data[chunk.ColumnCount() - 1]);
 
 	OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 	copy_op.Sink(context, insert_chunk, copy_input);

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -15,6 +15,7 @@ DuckLakeUpdate::DuckLakeUpdate(PhysicalPlan &physical_plan, DuckLakeTableEntry &
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, 1), table(table),
       columns(std::move(columns_p)), copy_op(copy_op), delete_op(delete_op), insert_op(insert_op) {
 	children.push_back(child);
+	row_id_index = columns.size();
 }
 
 //===--------------------------------------------------------------------===//
@@ -75,8 +76,7 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	for (idx_t i = 0; i < columns.size(); i++) {
 		insert_chunk.data[columns[i].index].Reference(chunk.data[i]);
 	}
-	idx_t row_id_index = columns.size();
-	insert_chunk.data[row_id_index].Reference(chunk.data[row_id_index]);
+	insert_chunk.data[columns.size()].Reference(chunk.data[row_id_index]);
 
 	OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 	copy_op.Sink(context, insert_chunk, copy_input);

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -24,7 +24,8 @@
     "The same row was updated multiple times - this is not (yet) supported in DuckLake",
     "Failed to convert DuckDB type to DuckLake - unsupported type",
     "Collations are not supported in DuckLake storage",
-    "Cascade Drop not supported in DuckLake"
+    "Cascade Drop not supported in DuckLake",
+    "CHECK constraints are not supported in DuckLake"
   ],
   "skip_tests": [
     {

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -9,7 +9,22 @@
     "ducklake"
   ],
   "skip_error_messages": [
-    "MERGE INTO with DuckLake only supports a single UPDATE/DELETE action currently"
+    "MERGE INTO with DuckLake only supports a single UPDATE/DELETE action currently",
+    "dbgen is only supported for DuckDB database files",
+    "PRIMARY KEY/UNIQUE constraints are not supported in DuckLake",
+    "RETURNING is not implemented for DuckLake yet",
+    "SET DEFAULT is not yet supported for updates of a DuckLake table",
+    "DuckLake does not support indexes",
+    "DuckLake does not support generated columns",
+    "RETURNING clause",
+    "DuckLake does not support sequences",
+    "DuckLake does not support functions",
+    "DuckLake does not support user-defined types",
+    "Parquet files do not support negative intervals",
+    "The same row was updated multiple times - this is not (yet) supported in DuckLake",
+    "Failed to convert DuckDB type to DuckLake - unsupported type",
+    "Collations are not supported in DuckLake storage",
+    "Cascade Drop not supported in DuckLake"
   ],
   "skip_tests": [
     {

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -1,0 +1,37 @@
+{
+  "description": "Run on DuckLake database as storage.",
+  "on_init": "ATTACH 'ducklake:{TEST_DIR}/{BASE_TEST_NAME}__ducklake.db' AS dl;",
+  "on_new_connection": "USE dl;",
+  "skip_compiled": "true",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "parquet",
+    "ducklake"
+  ],
+  "skip_error_messages": [
+    "MERGE INTO with DuckLake only supports a single UPDATE/DELETE action currently"
+  ],
+  "skip_tests": [
+    {
+      "reason": "Contains explicit use of the memory catalog.",
+      "paths": [
+        "test/sql/show_select/test_describe_all.test",
+        "test/sql/catalog/function/attached_macro.test",
+        "test/sql/catalog/test_temporary.test",
+        "test/sql/pragma/test_show_tables_temp_views.test",
+        "test/sql/pg_catalog/system_functions.test",
+        "test/sql/pg_catalog/sqlalchemy.test",
+        "test/sql/attach/attach_table_info.test",
+        "test/sql/attach/attach_defaults.test",
+        "test/sql/attach/attach_did_you_mean.test",
+        "test/sql/attach/attach_default_table.test",
+        "test/sql/attach/attach_show_all_tables.test",
+        "test/sql/attach/attach_issue7711.test",
+        "test/sql/attach/attach_issue_7660.test",
+        "test/sql/attach/show_databases.test",
+        "test/sql/attach/attach_views.test",
+        "test/sql/copy_database/copy_table_with_sequence.test"
+      ]
+    }
+  ]
+}

--- a/test/sql/merge/merge_into_tpch.test_slow
+++ b/test/sql/merge/merge_into_tpch.test_slow
@@ -1,0 +1,58 @@
+# name: test/sql/merge/merge_into_tpch.test_slow
+# description: Test merge into with TPC-H SF1
+# group: [merge]
+
+require ducklake
+
+require parquet
+
+require tpch
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_merge_into_tpch.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_merge_into_tpch_files', METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+CALL dbgen(sf=1);
+
+statement ok
+CREATE TABLE ducklake.random_lineitem AS FROM lineitem LIMIT 0
+
+# create lineitem but with a random subset of the rows
+statement ok
+MERGE INTO ducklake.random_lineitem USING lineitem USING (l_orderkey, l_linenumber)
+WHEN NOT MATCHED AND random() < 0.2 THEN INSERT
+
+# insert a bunch of rows with unchanged values
+statement ok
+MERGE INTO ducklake.random_lineitem USING (SELECT * REPLACE (l_orderkey + 10000000 AS l_orderkey) FROM lineitem) USING (l_orderkey, l_linenumber)
+WHEN MATCHED THEN ERROR
+WHEN NOT MATCHED AND random() < 0.2 THEN INSERT
+
+# randomly update a bunch of rows
+statement ok
+MERGE INTO ducklake.random_lineitem USING lineitem USING (l_orderkey, l_linenumber)
+WHEN MATCHED AND random() < 0.1 THEN UPDATE SET l_discount = random()
+
+# run two merges that should fully equalize the tables
+statement ok
+MERGE INTO ducklake.random_lineitem USING lineitem USING (l_orderkey, l_linenumber)
+WHEN MATCHED THEN UPDATE
+
+statement ok
+MERGE INTO ducklake.random_lineitem USING lineitem USING (l_orderkey, l_linenumber)
+WHEN NOT MATCHED BY TARGET THEN INSERT
+WHEN NOT MATCHED BY SOURCE THEN DELETE
+
+# both tables should now be identical - despite all the random stuff we did
+query IIIIIIIIIIIIIIII
+FROM lineitem EXCEPT FROM ducklake.random_lineitem
+----
+
+query IIIIIIIIIIIIIIII
+FROM ducklake.random_lineitem EXCEPT FROM lineitem
+----
+
+statement ok
+DROP TABLE ducklake.random_lineitem
+
+endloop

--- a/test/sql/settings/parquet_compression.test
+++ b/test/sql/settings/parquet_compression.test
@@ -52,7 +52,6 @@ SELECT DISTINCT compression, encodings FROM parquet_metadata('__TEST_DIR__/duckl
 ----
 ZSTD	DELTA_BINARY_PACKED
 ZSTD	DELTA_LENGTH_BYTE_ARRAY
-ZSTD	RLE_DICTIONARY
 
 # unknown settings
 statement error


### PR DESCRIPTION
This PR adds support for `MERGE INTO` into DuckLake - see https://github.com/duckdb/duckdb/pull/18135

There is an extra restriction over the regular `MERGE INTO`, which is that it can only contain a single `UPDATE` or `DELETE` operator, e.g. this is allowed:

```sql
MERGE INTO item USING buy ON (item.item_name = buy.item_name)
WHEN MATCHED THEN UPDATE SET count = item.count + buy.count
WHEN NOT MATCHED THEN INSERT;
```

But this is not:

```sql
MERGE INTO item USING sell ON (item.item_name = sell.item_name)
WHEN MATCHED AND sell.count >= item.count THEN DELETE
WHEN MATCHED THEN UPDATE SET count = item.count - sell.count;
-- MERGE INTO with DuckLake only supports a single UPDATE/DELETE action currently
```

#### Testing

For testing, we rely on the base tests in DuckLake together with the included test-config:

```bash
build/reldebug/test/unittest --test-config test/configs/attach_ducklake.json --test-dir duckdb "test/sql/merge/*"
```

This is not (yet) run in CI - and needs more work to get there. This is worth working on separately of the `MERGE INTO` support. CC @pdet 