### PR TITLE
Get information on the last committed snapshot

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -67,6 +67,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	DuckLakeCurrentSnapshotFunction current_snapshot;
 	loader.RegisterFunction(current_snapshot);
 
+	DuckLakeLastCommittedSnapshotFunction last_committed;
+	loader.RegisterFunction(last_committed);
+
 	// secrets
 	auto secret_type = DuckLakeSecret::GetSecretType();
 	loader.RegisterSecretType(secret_type);

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
   ducklake_expire_snapshots.cpp
   ducklake_flush_inlined_data.cpp
   ducklake_current_snapshot.cpp
+  ducklake_last_committed_snapshot.cpp
   ducklake_list_files.cpp
   ducklake_merge_adjacent_files.cpp
   ducklake_set_commit_message.cpp

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -51,7 +51,7 @@ static unique_ptr<FunctionData> DuckLakeAddDataFilesBind(ClientContext &context,
 		} else if (lower == "hive_partitioning") {
 			result->hive_partitioning =
 			    BooleanValue::Get(entry.second) ? HivePartitioningType::YES : HivePartitioningType::NO;
-		}  else if (lower != "schema") {
+		} else if (lower != "schema") {
 			throw InternalException("Unknown named parameter %s for add_files", entry.first);
 		}
 	}

--- a/src/functions/ducklake_last_committed_snapshot.cpp
+++ b/src/functions/ducklake_last_committed_snapshot.cpp
@@ -1,0 +1,33 @@
+#include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_table_entry.hpp"
+#include "storage/ducklake_transaction.hpp"
+#include "common/ducklake_util.hpp"
+#include "storage/ducklake_transaction_changes.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "duckdb/common/optional_idx.hpp"
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> DuckLakeLastCommittedSnapshotBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                  vector<LogicalType> &return_types,
+                                                                  vector<string> &names) {
+	auto &catalog = BaseMetadataFunction::GetCatalog(context, input.inputs[0]);
+	auto &transaction = DuckLakeTransaction::Get(context, catalog);
+	auto &duck_catalog = transaction.GetCatalog();
+	names.emplace_back("id");
+	return_types.emplace_back(LogicalType::UBIGINT);
+
+	// generate the result
+	auto result = make_uniq<MetadataBindData>();
+	vector<Value> row_values;
+	row_values.push_back(duck_catalog.GetLastCommitedSnapshotId());
+	result->rows.push_back(std::move(row_values));
+	return std::move(result);
+}
+
+DuckLakeLastCommittedSnapshotFunction::DuckLakeLastCommittedSnapshotFunction()
+    : BaseMetadataFunction("ducklake_last_committed_snapshot", DuckLakeLastCommittedSnapshotBind) {
+}
+
+} // namespace duckdb

--- a/src/include/functions/ducklake_table_functions.hpp
+++ b/src/include/functions/ducklake_table_functions.hpp
@@ -90,6 +90,11 @@ public:
 	DuckLakeOptionsFunction();
 };
 
+class DuckLakeLastCommittedSnapshotFunction : public BaseMetadataFunction {
+public:
+	DuckLakeLastCommittedSnapshotFunction();
+};
+
 class DuckLakeListFilesFunction : public BaseMetadataFunction {
 public:
 	DuckLakeListFilesFunction();

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -140,6 +140,25 @@ public:
 		return ++last_uncommitted_catalog_version;
 	}
 
+	void IncreaseCommitedSnapshotId() {
+		if (!last_committed_snapshot.IsValid()) {
+			last_committed_snapshot = 0;
+		} else {
+			last_committed_snapshot = last_committed_snapshot.GetIndex() + 1;
+		}
+	}
+
+	void SetCommitedSnapshotId(idx_t value) {
+		last_committed_snapshot = value;
+	}
+
+	Value GetLastCommitedSnapshotId() const {
+		if (last_committed_snapshot.IsValid()) {
+			return Value::UBIGINT(last_committed_snapshot.GetIndex());
+		}
+		return Value();
+	}
+
 	optional_ptr<const DuckLakeNameMap> TryGetMappingById(DuckLakeTransaction &transaction, MappingIndex mapping_id);
 	MappingIndex TryGetCompatibleNameMap(DuckLakeTransaction &transaction, const DuckLakeNameMap &name_map);
 
@@ -176,6 +195,8 @@ private:
 	string metadata_type;
 	//! Whether or not the catalog is initialized
 	bool initialized = false;
+	//! The id of the last committed snapshot, set at FlushChanges on a successful commit
+	optional_idx last_committed_snapshot;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_default_functions.cpp
+++ b/src/storage/ducklake_default_functions.cpp
@@ -11,6 +11,7 @@ static const DefaultTableMacro ducklake_table_macros[] = {
 	{DEFAULT_SCHEMA, "set_commit_message", {"author", "commit_message", nullptr}, {{"extra_info", "NULL"},{nullptr, nullptr}},  "FROM ducklake_set_commit_message({CATALOG}, author, commit_message, extra_info => extra_info)"},
 	{DEFAULT_SCHEMA, "options", {nullptr}, {{nullptr, nullptr}}, "FROM ducklake_options({CATALOG})"},
 	{DEFAULT_SCHEMA, "current_snapshot", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_current_snapshot({CATALOG})"},
+{DEFAULT_SCHEMA, "last_committed_snapshot", {nullptr}, {{nullptr, nullptr}}, "FROM ducklake_last_committed_snapshot({CATALOG})"},
 	{DEFAULT_SCHEMA, "snapshots", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_snapshots({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_info", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_info({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_changes", {"table_name", "start_snapshot", "end_snapshot", nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_changes({CATALOG}, {SCHEMA}, table_name, start_snapshot, end_snapshot)"},

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1361,7 +1361,7 @@ void DuckLakeTransaction::FlushChanges() {
 			if (!can_retry || !retry_on_error || finished_retrying) {
 				// we abort after the max retry count
 				CleanupFiles();
-				// Add additional information on number of retries and suggest to increase it
+				// Add additional information on the number of retries and suggest to increase it
 				std::ostringstream error_message;
 				error_message << "Failed to commit DuckLake transaction." << '\n';
 				if (finished_retrying) {
@@ -1373,7 +1373,6 @@ void DuckLakeTransaction::FlushChanges() {
 				error.Throw(error_message.str());
 			}
 
-			//
 #ifndef DUCKDB_NO_THREADS
 			RandomEngine random;
 			// random multiplier between 0.5 - 1.0
@@ -1388,6 +1387,8 @@ void DuckLakeTransaction::FlushChanges() {
 			snapshot.reset();
 		}
 	}
+	// If we got here, this snapshot was successful
+	ducklake_catalog.IncreaseCommitedSnapshotId();
 }
 
 void DuckLakeTransaction::SetConfigOption(const DuckLakeConfigOption &option) {

--- a/test/sql/snapshot_info/ducklake_last_commit.test
+++ b/test/sql/snapshot_info/ducklake_last_commit.test
@@ -1,0 +1,104 @@
+# name: test/sql/snapshot_info/ducklake_last_commit.test
+# description: test that the ducklake_last_commit_snapshot returns last committed snapshot id
+# group: [snapshot_info]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_last_snapshot_commit.db' AS ducklake;
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+NULL
+
+# Snapshot 1
+statement ok
+CREATE TABLE ducklake.integer(i INTEGER);
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+0
+
+# Start a few transactions
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con3
+BEGIN TRANSACTION
+
+# Each transaction does somethins
+statement ok con1
+CREATE TABLE ducklake.integers_2(i INTEGER)
+
+statement ok con1
+INSERT into ducklake.integers_2 values (0);
+
+statement ok con2
+INSERT into ducklake.integer values (0);
+
+statement ok con3
+INSERT into ducklake.integer  values (1);
+
+# Snapshot still 1
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+0
+
+# Check commited snapshot from within a transaction
+query I con1
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+0
+
+statement ok con1
+COMMIT
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+1
+
+statement ok con2
+ROLLBACK
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+1
+
+statement ok con3
+COMMIT
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+2
+
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_last_snapshot_commit.db' AS ducklake;
+
+statement ok
+USE ducklake;
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+2
+
+# Try out the macro
+query I
+FROM last_committed_snapshot()
+----
+2
+


### PR DESCRIPTION
This PR implements the `ducklake_last_committed_snapshot(catalog)` and `last_committed_snapshot` macro.

@Mytherin can you double-check the logic when loading an existing ducklake? 