### PR TITLE
merge_adjacent_files() on expired snapshots

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -51,7 +51,7 @@ static unique_ptr<FunctionData> DuckLakeAddDataFilesBind(ClientContext &context,
 		} else if (lower == "hive_partitioning") {
 			result->hive_partitioning =
 			    BooleanValue::Get(entry.second) ? HivePartitioningType::YES : HivePartitioningType::NO;
-		}  else if (lower != "schema") {
+		} else if (lower != "schema") {
 			throw InternalException("Unknown named parameter %s for add_files", entry.first);
 		}
 	}

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -108,6 +108,7 @@ public:
 	                                                                 const string &inlined_table_name,
 	                                                                 const vector<string> &columns_to_read);
 	virtual void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);
+	virtual void InsertNewSchema(const DuckLakeSnapshot &snapshot);
 
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());
 	virtual void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -804,7 +804,6 @@ SELECT %s,
 FROM {METADATA_CATALOG}.ducklake_data_file data
 JOIN snapshot_ranges sr
   ON data.begin_snapshot BETWEEN sr.min_snapshot_id AND sr.max_snapshot_id
-LEFT JOIN {METADATA_CATALOG}.ducklake_snapshot snapshot ON (data.begin_snapshot = snapshot.snapshot_id)
 LEFT JOIN (
 	SELECT *
     FROM {METADATA_CATALOG}.ducklake_delete_file

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -114,6 +114,7 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_snapshot_changes ADD COLUMN author VARCH
 ALTER TABLE {METADATA_CATALOG}.ducklake_snapshot_changes ADD COLUMN commit_message VARCHAR DEFAULT NULL;
 ALTER TABLE {METADATA_CATALOG}.ducklake_snapshot_changes ADD COLUMN commit_extra_info VARCHAR DEFAULT NULL;
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.3-dev1' WHERE key = 'version';
+CREATE TABLE {METADATA_CATALOG}.ducklake_schema_versions(begin_snapshot BIGINT, schema_version BIGINT);
 INSERT INTO {METADATA_CATALOG}.ducklake_schema_versions SELECT MIN(snapshot_id), schema_version FROM {METADATA_CATALOG}.ducklake_snapshot GROUP BY schema_version ORDER BY schema_version;
 	)";
 	auto result = transaction.Query(migrate_query);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1345,8 +1345,13 @@ void DuckLakeTransaction::FlushChanges() {
 			metadata_manager->InsertSnapshot(commit_snapshot);
 
 			WriteSnapshotChanges(commit_state, transaction_changes);
+			if (SchemaChangesMade()) {
+				// Insert our new schema in our table that tracks schema changes
+				metadata_manager->InsertNewSchema(commit_snapshot);
+			}
 			connection->Commit();
 			catalog_version = commit_snapshot.schema_version;
+
 			// finished writing
 			break;
 		} catch (std::exception &ex) {

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -55,3 +55,74 @@ FROM example
 ----
 foo	bar
 baz	qux
+
+# Add a few schema changes
+statement ok
+INSERT INTO example (key, value) VALUES ('a', 'b');
+
+statement ok
+ALTER TABLE example ADD COLUMN j INTEGER
+
+statement ok
+INSERT INTO example VALUES ('c', 'd', 1);
+
+statement ok
+INSERT INTO example VALUES ('e', 'f', 2);
+
+statement ok
+ALTER TABLE example DROP COLUMN key
+
+statement ok
+INSERT INTO example VALUES ('k', 3);
+
+statement ok
+INSERT INTO example VALUES ('f', 9);
+
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+6
+
+query II
+SELECT snapshot_id, changes FROM snapshots();
+----
+0	{schemas_created=[main]}
+1	{tables_created=[main.example]}
+3	{tables_inserted_into=[1]}
+4	{}
+5	{tables_inserted_into=[1]}
+6	{tables_altered=[1]}
+7	{tables_inserted_into=[1]}
+8	{tables_inserted_into=[1]}
+9	{tables_altered=[1]}
+10	{tables_inserted_into=[1]}
+11	{tables_inserted_into=[1]}
+
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', versions => [5,6,7,8]);
+
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+6
+
+statement ok
+CALL ducklake.merge_adjacent_files();
+
+# Because of the drops we can only merge 9-10
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+5
+
+query II
+FROM example
+----
+bar	NULL
+qux	NULL
+b	NULL
+d	1
+f	2
+k	3
+f	9

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -1,0 +1,51 @@
+# name: test/sql/compaction/merge_files_expired_snapshots.test
+# description: test ducklake merges files from expired snapshots if they also belong to current snapshot
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_merge_expire_snapshots_schema.db' AS ducklake
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE example (key VARCHAR, value VARCHAR);
+
+statement ok
+INSERT INTO example (key, value) VALUES ('foo', 'bar');
+
+statement ok
+INSERT INTO example (key, value) VALUES ('baz', 'qux');
+
+query II
+SELECT snapshot_id, changes FROM snapshots();
+----
+0	{schemas_created=[main]}
+1	{tables_created=[main.example]}
+2	{tables_inserted_into=[1]}
+3	{tables_inserted_into=[1]}
+
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+2
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', versions => [2]);
+
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+2
+
+statement ok
+CALL ducklake.merge_adjacent_files();
+
+query I
+SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
+----
+1

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -49,3 +49,9 @@ query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 ----
 1
+
+query II
+FROM example
+----
+foo	bar
+baz	qux

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -35,7 +35,7 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 2
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [2]);
+CALL ducklake_expire_snapshots('ducklake', versions => [1,2]);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
@@ -87,7 +87,6 @@ query II
 SELECT snapshot_id, changes FROM snapshots();
 ----
 0	{schemas_created=[main]}
-1	{tables_created=[main.example]}
 3	{tables_inserted_into=[1]}
 4	{}
 5	{tables_inserted_into=[1]}
@@ -110,19 +109,19 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 statement ok
 CALL ducklake.merge_adjacent_files();
 
-# Because of the drops we can only merge 9-10
+# We altered the schema twice, hence we can have 3 files, as there are only 3 different schemas.
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 ----
-5
+3
 
 query II
-FROM example
+FROM example ORDER BY ALL
 ----
-bar	NULL
-qux	NULL
 b	NULL
+bar	NULL
 d	1
 f	2
-k	3
 f	9
+k	3
+qux	NULL


### PR DESCRIPTION
This PR changes the compaction query to also be able to compact files from expired snapshots, as long as they fit within the same schema version.

Fix: https://github.com/duckdb/ducklake/issues/336