### PR TITLE
Backporting ducklake_last_committed_snapshot to v1.3.2

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -67,6 +67,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	DuckLakeCurrentSnapshotFunction current_snapshot;
 	ExtensionUtil::RegisterFunction(instance, current_snapshot);
 
+	DuckLakeLastCommittedSnapshotFunction last_committed;
+	ExtensionUtil::RegisterFunction(instance, last_committed);
+
 	// secrets
 	auto secret_type = DuckLakeSecret::GetSecretType();
 	ExtensionUtil::RegisterSecretType(instance, secret_type);

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   ducklake_merge_adjacent_files.cpp
   ducklake_set_commit_message.cpp
   ducklake_current_snapshot.cpp
+  ducklake_last_committed_snapshot.cpp
   ducklake_set_option.cpp
   ducklake_options.cpp
   ducklake_table_changes.cpp

--- a/src/functions/ducklake_last_committed_snapshot.cpp
+++ b/src/functions/ducklake_last_committed_snapshot.cpp
@@ -1,0 +1,33 @@
+#include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_table_entry.hpp"
+#include "storage/ducklake_transaction.hpp"
+#include "common/ducklake_util.hpp"
+#include "storage/ducklake_transaction_changes.hpp"
+#include "duckdb/planner/tableref/bound_at_clause.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "duckdb/common/optional_idx.hpp"
+
+namespace duckdb {
+
+static unique_ptr<FunctionData> DuckLakeLastCommittedSnapshotBind(ClientContext &context, TableFunctionBindInput &input,
+                                                                  vector<LogicalType> &return_types,
+                                                                  vector<string> &names) {
+	auto &catalog = BaseMetadataFunction::GetCatalog(context, input.inputs[0]);
+	auto &transaction = DuckLakeTransaction::Get(context, catalog);
+	auto &duck_catalog = transaction.GetCatalog();
+	names.emplace_back("id");
+	return_types.emplace_back(LogicalType::UBIGINT);
+
+	// generate the result
+	auto result = make_uniq<MetadataBindData>();
+	vector<Value> row_values;
+	row_values.push_back(duck_catalog.GetLastCommittedSnapshotId());
+	result->rows.push_back(std::move(row_values));
+	return std::move(result);
+}
+
+DuckLakeLastCommittedSnapshotFunction::DuckLakeLastCommittedSnapshotFunction()
+    : BaseMetadataFunction("ducklake_last_committed_snapshot", DuckLakeLastCommittedSnapshotBind) {
+}
+
+} // namespace duckdb

--- a/src/include/common/ducklake_snapshot.hpp
+++ b/src/include/common/ducklake_snapshot.hpp
@@ -18,6 +18,10 @@ struct DuckLakeSnapshot {
 	      next_file_id(next_file_id) {
 	}
 
+	DuckLakeSnapshot()
+	    : snapshot_id(DConstants::INVALID_INDEX), schema_version(DConstants::INVALID_INDEX),
+	      next_catalog_id(DConstants::INVALID_INDEX), next_file_id(DConstants::INVALID_INDEX) {
+	}
 	idx_t snapshot_id;
 	idx_t schema_version;
 	idx_t next_catalog_id;

--- a/src/include/functions/ducklake_table_functions.hpp
+++ b/src/include/functions/ducklake_table_functions.hpp
@@ -90,6 +90,11 @@ public:
 	DuckLakeCurrentSnapshotFunction();
 };
 
+class DuckLakeLastCommittedSnapshotFunction : public BaseMetadataFunction {
+public:
+	DuckLakeLastCommittedSnapshotFunction();
+};
+
 class DuckLakeListFilesFunction : public BaseMetadataFunction {
 public:
 	DuckLakeListFilesFunction();

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -128,6 +128,19 @@ public:
 		return ++last_uncommitted_catalog_version;
 	}
 
+	void SetCommittedSnapshotId(idx_t value) {
+		lock_guard<mutex> guard(commit_lock);
+		last_committed_snapshot = value;
+	}
+
+	Value GetLastCommittedSnapshotId() const {
+		lock_guard<mutex> guard(commit_lock);
+		if (last_committed_snapshot.IsValid()) {
+			return Value::UBIGINT(last_committed_snapshot.GetIndex());
+		}
+		return Value();
+	}
+
 	optional_ptr<const DuckLakeNameMap> TryGetMappingById(DuckLakeTransaction &transaction, MappingIndex mapping_id);
 	MappingIndex TryGetCompatibleNameMap(DuckLakeTransaction &transaction, const DuckLakeNameMap &name_map);
 
@@ -164,6 +177,9 @@ private:
 	string metadata_type;
 	//! Whether or not the catalog is initialized
 	bool initialized = false;
+	//! The id of the last committed snapshot, set at FlushChanges on a successful commit
+	mutable mutex commit_lock;
+	optional_idx last_committed_snapshot;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_default_functions.cpp
+++ b/src/storage/ducklake_default_functions.cpp
@@ -11,6 +11,7 @@ static const DefaultTableMacro ducklake_table_macros[] = {
 	{DEFAULT_SCHEMA, "options", {nullptr}, {{nullptr, nullptr}}, "FROM ducklake_options({CATALOG})"},
 {DEFAULT_SCHEMA, "set_commit_message", {"author", "commit_message", nullptr}, {{"extra_info", "NULL"},{nullptr, nullptr}}, "FROM ducklake_set_commit_message({CATALOG}, author, commit_message, extra_info => extra_info)"},	{DEFAULT_SCHEMA, "snapshots", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_snapshots({CATALOG})"},
 {DEFAULT_SCHEMA, "current_snapshot", {nullptr}, {{nullptr, nullptr}}, "FROM ducklake_current_snapshot({CATALOG})"},
+	{DEFAULT_SCHEMA, "last_committed_snapshot", {nullptr}, {{nullptr, nullptr}}, "FROM ducklake_last_committed_snapshot({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_info", {nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_info({CATALOG})"},
 	{DEFAULT_SCHEMA, "table_changes", {"table_name", "start_snapshot", "end_snapshot", nullptr}, {{nullptr, nullptr}},  "FROM ducklake_table_changes({CATALOG}, {SCHEMA}, table_name, start_snapshot, end_snapshot)"},
 	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1368,8 +1368,9 @@ void DuckLakeTransaction::FlushChanges() {
 
 	auto transaction_snapshot = GetSnapshot();
 	auto transaction_changes = GetTransactionChanges();
+	DuckLakeSnapshot commit_snapshot;
 	for (idx_t i = 0; i < max_retry_count + 1; i++) {
-		auto commit_snapshot = GetSnapshot();
+		commit_snapshot = GetSnapshot();
 		commit_snapshot.snapshot_id++;
 		if (SchemaChangesMade()) {
 			// we changed the schema - need to get a new schema version
@@ -1432,6 +1433,8 @@ void DuckLakeTransaction::FlushChanges() {
 			snapshot.reset();
 		}
 	}
+	// If we got here, this snapshot was successful
+	ducklake_catalog.SetCommittedSnapshotId(commit_snapshot.snapshot_id);
 }
 
 void DuckLakeTransaction::SetConfigOption(const DuckLakeConfigOption &option) {

--- a/test/sql/snapshot_info/ducklake_last_commit.test
+++ b/test/sql/snapshot_info/ducklake_last_commit.test
@@ -1,0 +1,104 @@
+# name: test/sql/snapshot_info/ducklake_last_commit.test
+# description: test that the ducklake_last_commit_snapshot returns last committed snapshot id
+# group: [snapshot_info]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_last_snapshot_commit.db' AS ducklake;
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+NULL
+
+# Snapshot 1
+statement ok
+CREATE TABLE ducklake.integer(i INTEGER);
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+1
+
+# Start a few transactions
+statement ok con1
+BEGIN TRANSACTION
+
+statement ok con2
+BEGIN TRANSACTION
+
+statement ok con3
+BEGIN TRANSACTION
+
+# Each transaction does somethins
+statement ok con1
+CREATE TABLE ducklake.integers_2(i INTEGER)
+
+statement ok con1
+INSERT into ducklake.integers_2 values (0);
+
+statement ok con2
+INSERT into ducklake.integer values (0);
+
+statement ok con3
+INSERT into ducklake.integer  values (1);
+
+# Snapshot still 1
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+1
+
+# Check commited snapshot from within a transaction
+query I con1
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+1
+
+statement ok con1
+COMMIT
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+2
+
+statement ok con2
+ROLLBACK
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+2
+
+statement ok con3
+COMMIT
+
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+3
+
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_last_snapshot_commit.db' AS ducklake;
+
+statement ok
+USE ducklake;
+
+# Last snapshot is reset for the transaction
+query I
+FROM ducklake_last_committed_snapshot('ducklake')
+----
+NULL
+
+# Try out the macro
+query I
+FROM last_committed_snapshot()
+----
+NULL


### PR DESCRIPTION
cc @krishan-la and @vcanaran 

With this PR `ducklake_last_committed_snapshot` will be available on the nightly build, the `current_commit` already is!