### PR TITLE
Fix test/sql/catalog/test_schema.test

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -133,6 +133,10 @@ public:
 	string GenerateUUID() const;
 	static string GenerateUUIDv7();
 
+	const set<TableIndex> &GetDroppedTables() {
+		return dropped_tables;
+	}
+
 	//! Returns the current version of the catalog:
 	//! If there are no uncommitted changes, this is the schema version of the snapshot.
 	//! Otherwise, it is an id that is incremented whenever the schema changes (not stored between restarts)

--- a/src/include/storage/ducklake_transaction_manager.hpp
+++ b/src/include/storage/ducklake_transaction_manager.hpp
@@ -28,6 +28,7 @@ private:
 	DuckLakeCatalog &ducklake_catalog;
 	mutex transaction_lock;
 	reference_map_t<Transaction, shared_ptr<DuckLakeTransaction>> transactions;
+	bool get_snapshot = true;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -312,7 +312,11 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 		// get a list of all dependents
 		vector<reference<CatalogEntry>> dependents;
 		for (auto &entry : tables.GetEntries()) {
-			dependents.push_back(*entry.second);
+			const auto &dropped_tables = transaction.GetDroppedTables();
+			const auto &ducklake_table = entry.second->Cast<DuckLakeTableEntry>();
+			if (dropped_tables.find(ducklake_table.GetTableId()) == dropped_tables.end()) {
+				dependents.push_back(*entry.second);
+			}
 		}
 		if (dependents.empty()) {
 			return;
@@ -320,7 +324,9 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 		string error_string = "Cannot drop schema \"" + name + "\" because there are entries that depend on it\n";
 		for (auto &dependent : dependents) {
 			auto &dep = dependent.get();
-			error_string += StringUtil::Format("%s %s depends on %s.\n", CatalogTypeToString(dep.type), dep.name, name);
+			error_string += StringUtil::Format("%s \"%s\" depends on %s \"%s\".\n",
+			                                   StringUtil::Lower(CatalogTypeToString(dep.type)), dep.name,
+			                                   StringUtil::Lower(CatalogTypeToString(type)), name);
 		}
 		error_string += "Use DROP...CASCADE to drop all dependents.";
 		throw CatalogException(error_string);

--- a/src/storage/ducklake_transaction_manager.cpp
+++ b/src/storage/ducklake_transaction_manager.cpp
@@ -1,5 +1,7 @@
 #include "storage/ducklake_transaction_manager.hpp"
 
+#include "duckdb/main/settings.hpp"
+
 namespace duckdb {
 
 DuckLakeTransactionManager::DuckLakeTransactionManager(AttachedDatabase &db_p, DuckLakeCatalog &ducklake_catalog)
@@ -9,6 +11,13 @@ DuckLakeTransactionManager::DuckLakeTransactionManager(AttachedDatabase &db_p, D
 Transaction &DuckLakeTransactionManager::StartTransaction(ClientContext &context) {
 	auto transaction = make_shared_ptr<DuckLakeTransaction>(ducklake_catalog, *this, context);
 	transaction->Start();
+	if (DBConfig::GetSetting<ImmediateTransactionModeSetting>(context) && get_snapshot) {
+		lock_guard<mutex> l(transaction_lock);
+		get_snapshot = false;
+		// no snapshot loaded yet for this transaction - load it
+		transaction->GetSnapshot();
+		get_snapshot = true;
+	}
 	auto &result = *transaction;
 	lock_guard<mutex> l(transaction_lock);
 	transactions[result] = std::move(transaction);

--- a/src/storage/ducklake_transaction_manager.cpp
+++ b/src/storage/ducklake_transaction_manager.cpp
@@ -12,7 +12,6 @@ Transaction &DuckLakeTransactionManager::StartTransaction(ClientContext &context
 	auto transaction = make_shared_ptr<DuckLakeTransaction>(ducklake_catalog, *this, context);
 	transaction->Start();
 	if (DBConfig::GetSetting<ImmediateTransactionModeSetting>(context) && get_snapshot) {
-		lock_guard<mutex> l(transaction_lock);
 		get_snapshot = false;
 		// no snapshot loaded yet for this transaction - load it
 		transaction->GetSnapshot();


### PR DESCRIPTION
This PR has 3 fixes for a DuckDB test that is throwing an internal error.

1. Not add dropped elements to dependent
2. Make error message of dependents match duckdb
3. Get snapshot of transaction if Immediate Transaction Mode is set.

@Mytherin, I reckon that 3. is not the correct fix for it, I think you recommended starting a transaction there? But I'm not exactly sure what you meant.