### PR TITLE
Add support for per thread output

### DIFF
--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -12,7 +12,7 @@ struct DuckLakeOptionMetadata {
 	const char *description;
 };
 
-using ducklake_option_array = std::array<DuckLakeOptionMetadata, 14>;
+using ducklake_option_array = std::array<DuckLakeOptionMetadata, 15>;
 
 static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
     {{"data_inlining_row_limit", "Maximum amount of rows to inline in a single insert"},
@@ -30,7 +30,8 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
      {"require_commit_message", "If an explicit commit message is required for a snapshot commit."},
      {"rewrite_delete_threshold", "A threshold that determines the minimum amount of data that must be "
                                   "removed from a file before a rewrite is warranted. From 0 - 1."},
-     {"encrypted", "Whether or not to encrypt Parquet files written to the data path"}}};
+     {"encrypted", "Whether or not to encrypt Parquet files written to the data path"},
+     {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -79,6 +79,8 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		value = to_string(val.GetValue<double>());
 	} else if (option == "hive_file_pattern") {
 		value = val.GetValue<bool>() ? "true" : "false";
+	} else if (option == "per_thread_output") {
+		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -511,6 +511,11 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	if (catalog.TryGetConfigOption("parquet_row_group_size_bytes", row_group_size_bytes, schema_id, table_id)) {
 		info->options["row_group_size_bytes"].emplace_back(row_group_size_bytes + " bytes");
 	}
+	string per_thread_output_str;
+	bool per_thread_output = false;
+	if (catalog.TryGetConfigOption("per_thread_output", per_thread_output_str, schema_id, table_id)) {
+		per_thread_output = per_thread_output_str == "true";
+	}
 	idx_t target_file_size = catalog.GetConfigOption<idx_t>("target_file_size", schema_id, table_id,
 	                                                        DuckLakeCatalog::DEFAULT_TARGET_FILE_SIZE);
 
@@ -563,7 +568,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	StripTrailingSeparator(fs, result.file_path);
 	result.file_extension = "parquet";
 	result.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
-	result.per_thread_output = false;
+	result.per_thread_output = per_thread_output;
 	result.write_partition_columns = true;
 	result.return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;
 	result.names = names_to_write;

--- a/test/sql/settings/per_thread_output.test
+++ b/test/sql/settings/per_thread_output.test
@@ -1,0 +1,44 @@
+# name: test/sql/settings/per_thread_output.test
+# description: Test per thread output option
+# group: [settings]
+
+require ducklake
+
+require parquet
+
+statement ok
+SET preserve_insertion_order=false;
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/per_thread.db' AS ducklake (DATA_PATH '__TEST_DIR__/per_thread_data')
+
+statement ok
+CALL ducklake.set_option('per_thread_output', 'true')
+
+# Setup some parquet files to read from
+statement ok
+CREATE TABLE ducklake.tbl_base AS (SELECT i AS col_a FROM range(0,1000000) tbl(i))
+
+# Now create a new files reading from those
+statement ok
+CREATE TABLE ducklake.tbl_actual AS (FROM ducklake.tbl_base)
+
+# Verify that multiple files were created
+query I
+SELECT COUNT(*) > 1 FROM ducklake_list_files('ducklake', 'tbl_actual')
+----
+true
+
+# Now set to off and repeat
+statement ok
+CALL ducklake.set_option('per_thread_output', 'false')
+
+statement ok
+CREATE TABLE ducklake.tbl_no_thread_output AS (FROM ducklake.tbl_base)
+
+# Verify that a single file was created
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'tbl_no_thread_output')
+----
+1
+


### PR DESCRIPTION
Some of my usecases see very significant performance improvements when using `PER_THREAD_OUTPUT`, I wanted to migrate to using ducklake rather than just naively partitioned parquet files, but being > 4 times slower for writes wasn't acceptable.

This tries to add that option to ducklake, for my test I had to create a sample table to read from which was a bit funky but I found just using a `range` led to single threaded execution.

Renaming the option or allowing it to be more tied to the individual insertion both seem reasonable to me, but I wasn't sure what name you would prefer (either with the parquet prefix like the parquet specific ones, or without like the hive_partitioning one), or any other way of configuring options.