### PR TITLE
Properly handle stats for nested columns in ducklake_add_data_files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -187,14 +187,14 @@ FROM parquet_schema(%s)
 		if (!row.IsNull(8)) {
 			column->logical_type = row.GetValue<string>(8);
 		}
-		
+
 		// Only assign column_id to leaf columns (those without children)
 		if (child_count == 0) {
 			column->column_id = column_id++;
 		} else {
 			column->column_id = DConstants::INVALID_INDEX; // Mark as non-leaf
 		}
-		
+
 		auto &column_ref = *column;
 
 		if (current_column.empty()) {
@@ -204,7 +204,7 @@ FROM parquet_schema(%s)
 			// add as child to last column
 			current_column.back().get().child_columns.push_back(std::move(column));
 		}
-		
+
 		// Only add leaf columns to column_id_map (those that will have statistics)
 		if (column_ref.column_id != DConstants::INVALID_INDEX) {
 			file->column_id_map.emplace(column_ref.column_id, column_ref);

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -4,6 +4,7 @@
 #include "storage/ducklake_transaction_changes.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_insert.hpp"
+#include "duckdb/common/constants.hpp"
 
 namespace duckdb {
 
@@ -169,7 +170,6 @@ FROM parquet_schema(%s)
 			throw InvalidInputException("child_counts provided by parquet_schema are unaligned");
 		}
 		auto column = make_uniq<ParquetColumn>();
-		column->column_id = column_id++;
 		column->name = row.GetValue<string>(1);
 		column->type = row.GetValue<string>(2);
 		if (!row.IsNull(4)) {
@@ -187,6 +187,14 @@ FROM parquet_schema(%s)
 		if (!row.IsNull(8)) {
 			column->logical_type = row.GetValue<string>(8);
 		}
+		
+		// Only assign column_id to leaf columns (those without children)
+		if (child_count == 0) {
+			column->column_id = column_id++;
+		} else {
+			column->column_id = DConstants::INVALID_INDEX; // Mark as non-leaf
+		}
+		
 		auto &column_ref = *column;
 
 		if (current_column.empty()) {
@@ -196,8 +204,11 @@ FROM parquet_schema(%s)
 			// add as child to last column
 			current_column.back().get().child_columns.push_back(std::move(column));
 		}
-		// add to column id map
-		file->column_id_map.emplace(column_ref.column_id, column_ref);
+		
+		// Only add leaf columns to column_id_map (those that will have statistics)
+		if (column_ref.column_id != DConstants::INVALID_INDEX) {
+			file->column_id_map.emplace(column_ref.column_id, column_ref);
+		}
 
 		// reduce the child count by one
 		child_counts.back()--;

--- a/test/sql/add_files/add_files_complex_nested_stats_mre.test
+++ b/test/sql/add_files/add_files_complex_nested_stats_mre.test
@@ -7,7 +7,7 @@ require ducklake
 require parquet
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/stats_mre.db' AS ducklake (DATA_PATH '__TEST_DIR__/stats_data');
+ATTACH 'ducklake:__TEST_DIR__/stats_mre.db' AS ducklake (DATA_PATH '__TEST_DIR__/stats_data', METADATA_CATALOG 'metadata');
 
 # Schema that reproduces the original error: array + struct array + other types
 statement ok
@@ -34,5 +34,42 @@ COPY (SELECT
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_table', '__TEST_DIR__/file1.parquet')
 
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_file_column_statistics ORDER BY data_file_id, column_id
+----
+2	1.0	2.0
+5	status	status
+6	active	active
+7	100	100
+
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats ORDER BY column_id
+----
+2	1.0	2.0
+5	status	status
+6	active	active
+7	100	100
+
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_table', '__TEST_DIR__/file2.parquet')
+
+query IIII
+SELECT data_file_id, column_id, min_value, max_value FROM metadata.ducklake_file_column_statistics ORDER BY data_file_id, column_id
+----
+1	2	1.0	2.0
+1	5	status	status
+1	6	active	active
+1	7	100	100
+2	2	3.0	5.0
+2	5	state	type
+2	6	running	test
+2	7	200	200
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats ORDER BY column_id
+----
+2	1.0	5.0
+5	state	type
+6	active	test
+7	100	200

--- a/test/sql/add_files/add_files_complex_nested_stats_mre.test
+++ b/test/sql/add_files/add_files_complex_nested_stats_mre.test
@@ -1,0 +1,38 @@
+# name: test/sql/add_files/add_files_complex_nested_stats_mre.test
+# description: MRE for statistics mismatch with array and struct array columns
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/stats_mre.db' AS ducklake (DATA_PATH '__TEST_DIR__/stats_data');
+
+# Schema that reproduces the original error: array + struct array + other types
+statement ok
+CREATE TABLE ducklake.test_table(
+    data_array DOUBLE[],
+    diagnostics STRUCT("key" VARCHAR, "value" VARCHAR)[],
+    seq_num UINTEGER
+);
+
+statement ok
+COPY (SELECT 
+    [1.0::DOUBLE, 2.0] as data_array,
+    [{'key': 'status', 'value': 'active'}] as diagnostics,
+    100::UINTEGER as seq_num
+) TO '__TEST_DIR__/file1.parquet';
+
+statement ok
+COPY (SELECT 
+    [3.0::DOUBLE, 4.0, 5.0] as data_array,
+    [{'key': 'type', 'value': 'test'}, {'key': 'state', 'value': 'running'}] as diagnostics,
+    200::UINTEGER as seq_num
+) TO '__TEST_DIR__/file2.parquet';
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_table', '__TEST_DIR__/file1.parquet')
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_table', '__TEST_DIR__/file2.parquet')


### PR DESCRIPTION
Fixes #400

The bug was a column ID mapping mismatch where the code assigned sequential IDs to all schema elements (including nested containers), but parquet_metadata() only returns statistics for leaf columns, causing statistics to be incorrectly assigned to the wrong columns.

 The fix ensures only leaf columns (those without children) receive column IDs and get added to the column_id_map, so statistics are properly matched to their corresponding data columns.

In addition to this simple test, I've run it on my datasets which contain lots of nested files and it is no longer crashing where it previously was

You should note that ducklake does assign column_ids to non leaf columns

Here's some more context:
Create the sample parquet:
```sql
COPY (SELECT 
      [1.0::DOUBLE, 2.0] as data_array,
      [{'key': 'status', 'value': 'active'}] as diagnostics,
      100::UINTEGER as seq_num
  ) TO 'file1.parquet';
```
Queries used by ducklake:
### Parquet Schema:
```sql
SELECT file_name, name, type, num_children, converted_type, scale, precision, field_id, logical_type
FROM parquet_schema('file1.parquet')
```
Output:
```
┌───────────────┬───────────────┬────────────┬──────────────┬────────────────┬───────┬───────────┬──────────┬──────────────┐
│   file_name   │     name      │    type    │ num_children │ converted_type │ scale │ precision │ field_id │ logical_type │
│    varchar    │    varchar    │  varchar   │    int64     │    varchar     │ int64 │   int64   │  int64   │   varchar    │
├───────────────┼───────────────┼────────────┼──────────────┼────────────────┼───────┼───────────┼──────────┼──────────────┤
│ file1.parquet │ duckdb_schema │ NULL       │            3 │ NULL           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ data_array    │ NULL       │            1 │ LIST           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ list          │ NULL       │            1 │ NULL           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ element       │ DOUBLE     │         NULL │ NULL           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ diagnostics   │ NULL       │            1 │ LIST           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ list          │ NULL       │            1 │ NULL           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ element       │ NULL       │            2 │ NULL           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ key           │ BYTE_ARRAY │         NULL │ UTF8           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ value         │ BYTE_ARRAY │         NULL │ UTF8           │  NULL │      NULL │     NULL │ NULL         │
│ file1.parquet │ seq_num       │ INT32      │         NULL │ UINT_32        │  NULL │      NULL │     NULL │ NULL         │
├───────────────┴───────────────┴────────────┴──────────────┴────────────────┴───────┴───────────┴──────────┴──────────────┤
│ 10 rows                                                                                                        9 columns │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
### Parquet Metadata:
```sql
SELECT file_name, column_id, num_values, coalesce(stats_min, stats_min_value), 
       coalesce(stats_max, stats_max_value), stats_null_count, total_compressed_size
FROM parquet_metadata('file1.parquet')
```
Output:
```
┌───────────────┬───────────┬────────────┬──────────────────────────────────────┬──────────────────────────────────────┬──────────────────┬───────────────────────┐
│   file_name   │ column_id │ num_values │ COALESCE(stats_min, stats_min_value) │ COALESCE(stats_max, stats_max_value) │ stats_null_count │ total_compressed_size │
│    varchar    │   int64   │   int64    │               varchar                │               varchar                │      int64       │         int64         │
├───────────────┼───────────┼────────────┼──────────────────────────────────────┼──────────────────────────────────────┼──────────────────┼───────────────────────┤
│ file1.parquet │         0 │          2 │ 1.0                                  │ 2.0                                  │             NULL │                    75 │
│ file1.parquet │         1 │          1 │ status                               │ status                               │             NULL │                    59 │
│ file1.parquet │         2 │          1 │ active                               │ active                               │             NULL │                    59 │
│ file1.parquet │         3 │          1 │ 100                                  │ 100                                  │                0 │                    47 │
└───────────────┴───────────┴────────────┴──────────────────────────────────────┴──────────────────────────────────────┴──────────────────┴───────────────────────┘
```

### Ducklake column id assignment (which differs from parquet_metadata)
```sql
SELECT column_id, table_id, column_order, column_name, column_type, parent_column FROM metadata.ducklake_column;
```
Output:
```
┌───────────┬──────────┬──────────────┬─────────────┬─────────────┬───────────────┐
│ column_id │ table_id │ column_order │ column_name │ column_type │ parent_column │
│   int64   │  int64   │    int64     │   varchar   │   varchar   │     int64     │
├───────────┼──────────┼──────────────┼─────────────┼─────────────┼───────────────┤
│         1 │        1 │            1 │ data_array  │ list        │          NULL │
│         2 │        1 │            2 │ element     │ float64     │             1 │
│         3 │        1 │            3 │ diagnostics │ list        │          NULL │
│         4 │        1 │            4 │ element     │ struct      │             3 │
│         5 │        1 │            5 │ key         │ varchar     │             4 │
│         6 │        1 │            6 │ value       │ varchar     │             4 │
│         7 │        1 │            7 │ seq_num     │ uint32      │          NULL │
└───────────┴──────────┴──────────────┴─────────────┴─────────────┴───────────────┘
```
