### PR TITLE
 Fix view aliases getting cleared out every time

### DIFF
--- a/src/storage/ducklake_view_entry.cpp
+++ b/src/storage/ducklake_view_entry.cpp
@@ -101,7 +101,6 @@ void DuckLakeViewEntry::Bind(ClientContext &context) {
 	const auto create_view_sql = "CREATE VIEW mock_view_name_lake as " + query_sql;
 	const auto view_info = CreateViewInfo::FromCreateView(context, schema, create_view_sql);
 	// Fill aliases, types and names
-	aliases = view_info->aliases;
 	types = view_info->types;
 	names = view_info->names;
 }

--- a/src/storage/ducklake_view_entry.cpp
+++ b/src/storage/ducklake_view_entry.cpp
@@ -98,9 +98,20 @@ bool DuckLakeViewEntry::IsBound() const {
 void DuckLakeViewEntry::Bind(ClientContext &context) {
 	D_ASSERT(!is_bound);
 	is_bound = true;
-	const auto create_view_sql = "CREATE VIEW mock_view_name_lake as " + query_sql;
+	std::string create_view_sql = "CREATE VIEW mock_view_name_lake";
+	if (!aliases.empty()) {
+		create_view_sql += "(";
+		for (const auto &alias : aliases) {
+			create_view_sql += KeywordHelper::WriteOptionallyQuoted(alias);
+			create_view_sql += ", ";
+		}
+		create_view_sql += ")";
+	}
+
+	create_view_sql += " as " + query_sql;
 	const auto view_info = CreateViewInfo::FromCreateView(context, schema, create_view_sql);
 	// Fill aliases, types and names
+	aliases = view_info->aliases;
 	types = view_info->types;
 	names = view_info->names;
 }


### PR DESCRIPTION
The current behavior clears out the aliases every time, because the dummy view, does not contain any aliases. This fixes this by adding the aliases to the view creation. Alternatively I could also imagine not overwriting the aliases, that would also fix things for us.

---

Not having this fix will break aliased views for MotherDuck
