### PR TITLE
`ducklake_add_data_files` Simplify column stats processing

### DIFF
--- a/benchmark/ingest/add_files.benchmark.in
+++ b/benchmark/ingest/add_files.benchmark.in
@@ -1,0 +1,37 @@
+# name: ${FILE_PATH}
+# description: Benchmark adding TPCH data files using ducklake_add_data_files
+# group: [add_files_sf${sf}]
+
+argument sf 1
+argument table_name lineitem
+
+name DuckLake Add Files SF${sf}
+group tpch_add_files
+subgroup sf${sf}
+
+require ducklake
+require parquet
+require tpch
+
+load
+ATTACH ':memory:' AS mem;
+USE mem;
+CALL dbgen(sf=${sf});
+SET preserve_insertion_order=False;
+EXPORT DATABASE '${BENCHMARK_DIR}/add_files_sf${sf}_export' (
+    FORMAT PARQUET, 
+    ROW_GROUP_SIZE 2048, 
+    ROW_GROUPS_PER_FILE 100, 
+    PER_THREAD_OUTPUT,
+    OVERWRITE
+);
+ATTACH 'ducklake:${BENCHMARK_DIR}/add_files_sf${sf}_ducklake.db' AS ducklake (DATA_PATH '${BENCHMARK_DIR}/add_files_sf${sf}_ducklake_files', METADATA_CATALOG 'metadata');
+USE ducklake;
+DETACH mem;
+
+reload
+ATTACH 'ducklake:${BENCHMARK_DIR}/add_files_sf${sf}_ducklake.db' AS ducklake (METADATA_CATALOG 'metadata');
+
+run
+CREATE TABLE IF NOT EXISTS ducklake.${table_name} AS (FROM '${BENCHMARK_DIR}/add_files_sf${sf}_export/${table_name}.parquet/**/*.parquet' LIMIT 0);
+CALL ducklake_add_data_files('ducklake', '${table_name}', '${BENCHMARK_DIR}/add_files_sf${sf}_export/${table_name}.parquet/**/*.parquet');

--- a/benchmark/ingest/add_files_lineitem.benchmark
+++ b/benchmark/ingest/add_files_lineitem.benchmark
@@ -1,0 +1,6 @@
+# name: benchmark/ingest/add_files_lineitem.benchmark
+# description: Benchmark adding TPCH lineitem table files using ducklake_add_data_files
+# group: [add_files]
+
+template benchmark/ingest/add_files.benchmark.in
+table_name=lineitem

--- a/benchmark/ingest/add_files_orders.benchmark
+++ b/benchmark/ingest/add_files_orders.benchmark
@@ -1,0 +1,6 @@
+# name: benchmark/ingest/add_files_orders.benchmark
+# description: Benchmark adding TPCH orders table files using ducklake_add_data_files
+# group: [add_files]
+
+template benchmark/ingest/add_files.benchmark.in
+table_name=orders

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -284,13 +284,42 @@ FROM parquet_metadata(%s)
 				auto &name = bbox_child_types[child_idx].first;
 				auto &value = bbox_child_values[child_idx];
 				if (!value.IsNull()) {
-					stats.column_stats.push_back(GetStatsValue("bbox_" + name, value));
+					if (name == "xmax") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.xmax = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "xmin") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.xmin = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "ymax") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.ymax = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "ymin") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.ymin = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "zmax") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.zmax = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "zmin") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.zmin = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "mmax") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.mmax = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else if (name == "mmin") {
+						auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+						geo_stats.mmin = value.DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+					} else {
+						throw InternalException("Unknown bbox child name %s", name);
+					}
 				}
 			}
 		}
 		if (!row.IsNull(8)) {
 			auto list_value = row.iterator.chunk->GetValue(8, row.row);
-			stats.column_stats.push_back(GetStatsValue("geo_types", std::move(list_value)));
+			auto &geo_stats = stats.extra_stats->Cast<DuckLakeColumnGeoStats>();
+			for (const auto &child : ListValue::GetChildren(list_value)) {
+				geo_stats.geo_types.insert(StringValue::Get(child));
+			}
 		}
 
 		column.column_stats.push_back(std::move(stats));

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -120,7 +120,6 @@ private:
 	unique_ptr<DuckLakeNameMapEntry> MapHiveColumn(ParquetFileMetadata &file_metadata, const DuckLakeFieldId &field_id,
 	                                               DuckLakeDataFile &result, const Value &hive_value);
 
-	Value GetStatsValue(string name, Value val);
 	void CheckMatchingType(const LogicalType &type, ParquetColumn &column);
 
 private:
@@ -227,13 +226,6 @@ FROM parquet_schema(%s)
 		auto &filename = file->filename;
 		parquet_files.emplace(filename, std::move(file));
 	}
-}
-
-Value DuckLakeFileProcessor::GetStatsValue(string name, Value val) {
-	child_list_t<Value> children;
-	children.emplace_back("key", Value(std::move(name)));
-	children.emplace_back("value", std::move(val));
-	return Value::STRUCT(std::move(children));
 }
 
 void DuckLakeFileProcessor::ReadParquetStats(const string &glob) {


### PR DESCRIPTION
Replaces `ParquetColumnStats` with `DuckLakeColumnStats`, previously ducklake would convert from separate stats to a list of key value pairs back to separate stats, not doing that and instead just keeping as separate led to a significant speedup

On my sample query of 1280 files 680 GB which previously took 94 seconds
- Reduction by 35 seconds by switching from `ParquetColumnStats` to `DuckLakeColumnStats`
- Reduction by an additional 35 seconds possible by running with duckdb PR [parallel](https://github.com/duckdb/duckdb/pull/18854)

Works on https://github.com/duckdb/ducklake/issues/404

More speedups possible by doing the parquet file min max calculations in a duckdb native function, there's no real need to get the metadata for each row group to ducklake, doing the comparisons for min and max in a vectorized way would definitely help, also adding exporting the leaf_column_id within the `parquet_schema` function would make some logic easier over here I think)