### PR TITLE
Use the transaction snapshot unless the file snapshot id differs from it

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -300,8 +300,10 @@ unique_ptr<LogicalOperator>
 DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files) {
 	// get the table entry at the specified snapshot
 	auto snapshot_id = source_files[0].file.begin_snapshot;
-	DuckLakeSnapshot snapshot(snapshot_id, source_files[0].schema_version, 0, 0);
-
+	auto snapshot = transaction.GetSnapshot();
+	if (snapshot_id != snapshot.snapshot_id) {
+		snapshot = DuckLakeSnapshot(snapshot_id, source_files[0].schema_version, 0, 0);
+	}
 	auto entry = catalog.GetEntryById(transaction, snapshot, table_id);
 	if (!entry) {
 		throw InternalException("DuckLakeCompactor: failed to find table entry for given snapshot id");

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -471,12 +471,6 @@
       ]
     },
     {
-      "reason": "FIXME: Wrong snapshot ID when running merge_adjacent_files",
-      "paths": [
-        "test/sql/storage/compression/rle/rle_nulls_edge_case.test"
-      ]
-    },
-    {
       "reason": "Checkpoint in DuckLake doesn't produce expected result. Notice these are not ducklake bugs just tests that do not fit.",
       "paths": [
         "test/fuzzer/pedro/incomplete_checkpoint.test",

--- a/test/sql/checkpoint/many_inserts_transaction.test
+++ b/test/sql/checkpoint/many_inserts_transaction.test
@@ -1,0 +1,44 @@
+# name: test/sql/checkpoint/many_inserts_transaction.test
+# description: Test checkpoint with many inserts in one transaction
+# group: [checkpoint]
+
+require ducklake
+
+require parquet
+
+require icu
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/many_inserts_transaction.db' AS ducklake (DATA_PATH '__TEST_DIR__/many_inserts_transaction')
+
+statement ok
+use ducklake
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE integers(i INTEGER);
+
+statement ok
+INSERT INTO integers SELECT 1 FROM range(10);
+
+statement ok
+INSERT INTO integers SELECT 1;
+
+statement ok
+INSERT INTO integers SELECT 2;
+
+statement ok
+INSERT INTO integers SELECT 3;
+
+statement ok
+COMMIT;
+
+statement ok
+CHECKPOINT;
+
+query IIII
+SELECT MIN(i), MAX(i), COUNT(*), COUNT(i) FROM integers;
+----
+1	3	13	13


### PR DESCRIPTION
Fixes a small issue found by the duckdb tests and the inclusion of the checkpoint functionality.

Test:
`test/sql/storage/compression/rle/rle_nulls_edge_case.test`