### PR TITLE
[BUG] Unecessarily writing partial_file_info on merge rewrite

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1298,7 +1298,7 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeSnapshot
 						throw InternalException("Only the first compacted file can have existing partial file info");
 					}
 					new_file.partial_file_info = compacted_file.partial_files;
-				} else {
+				} else if (compaction.source_files.size() > 1) {
 					DuckLakePartialFileInfo partial_info;
 					partial_info.snapshot_id = compacted_file.file.begin_snapshot;
 					partial_info.max_row_count = row_id_limit;

--- a/test/sql/rewrite_data_files/test_rewrite_merge_adjacent.test
+++ b/test/sql/rewrite_data_files/test_rewrite_merge_adjacent.test
@@ -1,0 +1,45 @@
+# name: test/sql/rewrite_data_files/test_rewrite_merge_adjacent.test
+# description: Test calling rewrite and merge adjacent
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/test_rewrite_merge_adjacent.db' AS ducklake (DATA_PATH '__TEST_DIR__/test_rewrite_merge_adjacent', METADATA_CATALOG 'test_rewrite_merge_adjacent')
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE t (a VARCHAR, b INT);
+
+# Generates the 1st file
+statement ok
+INSERT INTO t VALUES ('text', 1);
+
+# Generates the 2nd file
+statement ok
+INSERT INTO t VALUES ('text2', 2);
+
+# Generates the 3rd file
+statement ok
+INSERT INTO t SELECT 'text' a, range b FROM range(100_000);
+
+# Deletes on the 3rd file
+statement ok
+DELETE FROM t WHERE b > 100;
+
+# Rewrites 3rd file
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 't');
+
+# Should merge everyone
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake');
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't');
+----
+1


### PR DESCRIPTION
Fix: https://github.com/duckdblabs/duckdb-internal/issues/5854
