### PR TITLE
Unify data_inlining check

### DIFF
--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -68,7 +68,8 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		auto target_file_size_bytes = DBConfig::ParseMemoryLimit(val.ToString());
 		value = to_string(target_file_size_bytes);
 	} else if (option == "data_inlining_row_limit") {
-		if (!ducklake_catalog.MetadataType().empty()) {
+		auto &metadata_catalog = Catalog::GetCatalog(context, ducklake_catalog.MetadataDatabaseName());
+		if (!metadata_catalog.IsDuckCatalog()) {
 			throw NotImplementedException("Data Inlining is currently only implemented for DuckDB as a DBMS");
 		}
 		auto data_inlining_row_limit = val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();


### PR DESCRIPTION
`DuckLakeInitializer::Initialize` checks whether the Catalog implements a DuckCatalog (`IsDuckCatalog()`); This check is a bit more permissive than checking whether the META_TYPE is empty.

In this PR we unify those checks to not run into situations where the DATA_INLINING_ROW_LIMIT can be set on startup but then not dynamically modified later.