### PR TITLE
Use Client Context FIleSystem in DuckLake transaction

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -379,7 +379,7 @@ void DuckLakeTransaction::CleanupFiles() {
 	// remove any files that were written
 	// auto &fs = FileSystem::GetFileSystem(db);
 	auto context_ref = context.lock();
-	auto &fs = FileSystem::GetFileSystem(*context_ref);
+	auto &fs = FileSystem::GetFileSystem(db);
 	for (auto &entry : table_data_changes) {
 		auto &table_changes = entry.second;
 		for (auto &file : table_changes.new_data_files) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -377,7 +377,6 @@ void DuckLakeTransaction::WriteSnapshotChanges(DuckLakeCommitState &commit_state
 
 void DuckLakeTransaction::CleanupFiles() {
 	// remove any files that were written
-	// auto &fs = FileSystem::GetFileSystem(db);
 	auto context_ref = context.lock();
 	auto &fs = FileSystem::GetFileSystem(db);
 	for (auto &entry : table_data_changes) {
@@ -1815,7 +1814,6 @@ void DuckLakeTransaction::TransactionLocalDelete(TableIndex table_id, const stri
 		if (file.file_name == data_file_path) {
 			if (file.delete_file) {
 				// this file already has a transaction-local delete file - delete it
-				// auto &fs = FileSystem::GetFileSystem(db);
 				auto context_ref = context.lock();
 				auto &fs = FileSystem::GetFileSystem(*context_ref);
 				fs.RemoveFile(file.delete_file->file_name);

--- a/test/sql/cloud/test_cloud_cases.test
+++ b/test/sql/cloud/test_cloud_cases.test
@@ -1,0 +1,60 @@
+# name: test/sql/cloud/test_cloud_cases.test
+# description: test ducklake extension
+# group: [sql]
+
+require-env CLOUD_TESTS_READY
+
+require-env AWS_KEY_ID
+
+require-env AWS_SECRET_KEY
+
+require-env AWS_REGION
+
+require ducklake
+
+require parquet
+
+require httpfs
+
+statement ok
+set s3_region='${AWS_REGION}';
+
+statement ok
+create secret foo (
+    type s3,
+    key_id '${AWS_KEY_ID}',
+    secret '${AWS_SECRET_KEY}'
+);
+
+statement ok
+attach 'ducklake:duckdb:' as lake (data_path 's3://test-ducklake-pedro/');
+
+statement ok
+use lake;
+
+statement ok
+CREATE TABLE test AS FROM range (10) t(i);
+
+statement ok
+START;
+
+statement ok
+DELETE FROM test where i = 1;
+
+statement ok
+DELETE FROM test where i = 2;
+
+statement ok
+COMMIT;
+
+statement ok
+select * from test order by all;
+----
+0
+3
+4
+5
+6
+7
+8
+9


### PR DESCRIPTION
Fixes https://github.com/duckdblabs/duckdb-internal/issues/5937

In a DuckLake transaction, there are multiple places where we attempt to remove files since their contents is invalidated by other statements within the transaction. We would use the database file system to do this. The database file system does not have access to the context, and therefore cannot access any secrets, which meant communication with s3 storage would fail. 

By using the Client Context file system, we now have access to the secrets, and can therefore delete the file. 
The test requires s3 communication, unsure if that is set up yet. 