### PR TITLE
Adds `OR` and `IN` pushdown

### DIFF
--- a/test/sql/stats/filter_pushdown.test
+++ b/test/sql/stats/filter_pushdown.test
@@ -126,3 +126,24 @@ query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d >= DATE '2011-05-29' AND k < 50000;
 ----
 analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# OR filters
+query I
+SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
+----
+2
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+
+query I
+SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i in (500, 600, 700);
+----
+3
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i IN (500, 600, 700);
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*


### PR DESCRIPTION
Fixes #470

This failure to pushdown seemed significant enough that I wanted to target v1.4, but I'm not sure if that's correct
It had a disastrous performance impact on big datasets with restrictive filters.

While OR pushdown was technically handled before, it wasn't in practice because it was wrapped in a different filter first that wasn't handled.

The key to the OR being pushed down was that it was wrapped in an OPTIONAL_FILTER, which wasn't being processed

I don't know the significance of what makes some filters optional, but actually pushing them down really helps.