### PR TITLE
Use a ColumnDataCollection for tracking deleted rows so we can track the memory usage and potentially offload to disk

### DIFF
--- a/src/include/storage/ducklake_delete.hpp
+++ b/src/include/storage/ducklake_delete.hpp
@@ -109,7 +109,7 @@ public:
 
 private:
 	void FlushDelete(DuckLakeTransaction &transaction, ClientContext &context, DuckLakeDeleteGlobalState &global_state,
-	                 const string &filename, vector<idx_t> &deleted_rows) const;
+	                 const string &filename, ColumnDataCollection &deleted_rows) const;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
Improves memory management when performing large deletes