### PR TITLE
Ensure entry type before compaction

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -538,9 +538,11 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 			auto schemas = ducklake_catalog.GetSchemas(context);
 			for (auto &cur_schema : schemas) {
 				cur_schema.get().Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
-					auto &cur_table = entry.Cast<DuckLakeTableEntry>();
-					GenerateCompaction(context, transaction, ducklake_catalog, input, cur_table, type, delete_threshold,
-					                   compactions);
+					if (entry.type == CatalogType::TABLE_ENTRY) {
+						auto &cur_table = entry.Cast<DuckLakeTableEntry>();
+						GenerateCompaction(context, transaction, ducklake_catalog, input, cur_table, type,
+						                   delete_threshold, compactions);
+					}
 				});
 			}
 			return GenerateCompactionOperator(input, bind_index, compactions);


### PR DESCRIPTION
Fixes an issue when checkpointing DuckLake that has views. Discussed in https://github.com/duckdblabs/motherduck/issues/415