### PR TITLE
feat: support merge/update on duplicate rows

### DIFF
--- a/test/sql/data_inlining/data_inlining_update.test
+++ b/test/sql/data_inlining/data_inlining_update.test
@@ -73,3 +73,25 @@ SELECT rowid, snapshot_id, * FROM ducklake.test ORDER BY rowid
 0	2	101	2
 1	1	NULL	3
 2	3	1010	20
+
+# test update with duplicate source rows on inlined data
+# 10000 duplicates spans multiple chunks, exercising the all-duplicates early return
+statement ok
+DROP TABLE ducklake.test
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT 1 as id
+
+statement ok
+CREATE TEMPORARY TABLE dup_source AS SELECT 1 as update_id FROM range(10000)
+
+# despite 10000 source matches, only 1 row should be updated (deduplication)
+query I
+UPDATE ducklake.test SET id=id+1000 FROM dup_source WHERE id=dup_source.update_id
+----
+1
+
+query I
+SELECT id FROM ducklake.test
+----
+1001

--- a/test/sql/update/update_join_duplicates.test
+++ b/test/sql/update/update_join_duplicates.test
@@ -17,27 +17,42 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/du
 statement ok
 CREATE TABLE ducklake.test AS SELECT i id FROM range(5) t(i);
 
+# Source table with duplicate update_ids (each value appears twice)
 statement ok
 CREATE TEMPORARY TABLE updated_rows AS FROM range(0, 10, 2) t(update_id) UNION ALL FROM range(0, 10, 2);
 
-# duplicate row-id updates are not yet supported
+# duplicate row-id updates now succeed with first-write-wins semantics
 statement ok
 BEGIN
 
 statement ok
 INSERT INTO ducklake.test FROM range(5, 10)
 
-statement error
+# This UPDATE has duplicates in the source - same row matched multiple times
+# With first-write-wins, only the first match is applied
+statement ok
 UPDATE ducklake.test SET id=id+1000 FROM updated_rows WHERE id=updated_rows.update_id
+
+query III
+SELECT COUNT(*), SUM(id), AVG(id) FROM ducklake.test
 ----
-The same row was updated multiple times
+10	5045	504.5
 
 statement ok
-ROLLBACK
+COMMIT
 
-# we can update through a join if we filter out the duplciate row ids
+# Verify data persists after commit
+query III
+SELECT COUNT(*), SUM(id), AVG(id) FROM ducklake.test
+----
+10	5045	504.5
+
+# Using DISTINCT still works (and gives same result)
 statement ok
-BEGIN
+DROP TABLE ducklake.test
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i id FROM range(5) t(i);
 
 statement ok
 INSERT INTO ducklake.test FROM range(5, 10)
@@ -50,12 +65,24 @@ SELECT COUNT(*), SUM(id), AVG(id) FROM ducklake.test
 ----
 10	5045	504.5
 
+# Test with many duplicates to exercise the all-duplicates early return path
+# 10000 matches for 1 row spans multiple chunks, later chunks are all duplicates
 statement ok
-COMMIT
+DROP TABLE ducklake.test
 
-query III
-SELECT COUNT(*), SUM(id), AVG(id) FROM ducklake.test
+statement ok
+CREATE TABLE ducklake.test AS SELECT 1 as id
+
+statement ok
+CREATE TEMPORARY TABLE dup_source AS SELECT 1 as update_id FROM range(10000)
+
+# despite 10000 source matches, only 1 row should be updated (deduplication)
+query I
+UPDATE ducklake.test SET id=id+1000 FROM dup_source WHERE id=dup_source.update_id
 ----
-10	5045	504.5
+1
 
-
+query I
+SELECT id FROM ducklake.test
+----
+1001


### PR DESCRIPTION
resolves https://github.com/duckdb/ducklake/discussions/645

"AI" use disclosure: this code was entirely written using Claude Code on Opus 4.5, with a lot of direction. I've run the tests, including on the `repro.sql` in the linked discussion. if this is more work than it's worth, feel free to discard and apologies! I'm not comfortable writing C++ myself but would love to see this fixed

```
> /cost
  ⎿  Total cost:            $12.72
     Total duration (API):  34m 37s
     Total duration (wall): 1h 22m 54s
     Total code changes:    344 lines added, 167 lines removed
     Usage by model:
             claude-haiku:  180.4k input, 26.7k output, 2.0m cache read, 218.9k cache write ($0.78)
          claude-opus-4-5:  11.9k input, 67.4k output, 13.5m cache read, 546.2k cache write, 3 web search ($11.93)
```

---

keeps the first row if there are duplicates on merge/update
