### PR TITLE
Use RemoveFiles (bulk delete) to clean up old files

### DIFF
--- a/src/functions/ducklake_cleanup_files.cpp
+++ b/src/functions/ducklake_cleanup_files.cpp
@@ -131,9 +131,12 @@ void DuckLakeCleanupExecute(ClientContext &context, TableFunctionInput &data_p, 
 	if (!state.executed && !data.dry_run) {
 		// delete the files
 		auto &fs = FileSystem::GetFileSystem(context);
-		for (auto &file : data.files) {
-			fs.TryRemoveFile(file.path);
+		vector<string> paths;
+		paths.reserve(data.files.size());
+		for (const auto &file : data.files) {
+			paths.push_back(file.path);
 		}
+		fs.RemoveFiles(paths);
 		if (data.type == CleanupType::OLD_FILES) {
 			// If we are removing old files, we need to remove them from the catalog
 			auto &transaction = DuckLakeTransaction::Get(context, data.catalog);


### PR DESCRIPTION
This PR is the final change to address https://github.com/duckdb/ducklake/discussions/384: take advantage of S3 bulk deletion instead of doing one delete request per file.

It requires these 2 PRs to be merged before:
- https://github.com/duckdb/duckdb/pull/20333
- https://github.com/duckdb/duckdb-httpfs/pull/181

The test `test/sql/cleanup/cleanup_old_files.test` already covers this change when run with `--test-config test/configs/minio.json` (btw I think I spotted a bug with the test configs, see https://github.com/duckdb/ducklake/issues/653).  