### PR TITLE
Throw a catalog exception when a partition key column doesn't exist

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -369,6 +369,9 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 		    expr.ToString());
 	}
 	DuckLakePartitionField field;
+	if (!table.ColumnExists(column_name)) {
+		throw CatalogException("Unexpected partition key - column \"%s\" does not exist", column_name);
+	}
 	auto &col = table.GetColumn(column_name);
 	PhysicalIndex column_index(col.StorageOid());
 	auto &field_id = table.GetFieldData().GetByRootIndex(column_index);

--- a/test/sql/partitioning/basic_partitioning.test
+++ b/test/sql/partitioning/basic_partitioning.test
@@ -16,6 +16,12 @@ USE ducklake
 statement ok
 CREATE TABLE partitioned_tbl(part_key INTEGER, values VARCHAR);
 
+# cannot partition by a nonexistent column
+statement error
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (nonexistent);
+----
+column "nonexistent" does not exist
+
 statement ok
 ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
 


### PR DESCRIPTION
I discovered that trying to partition a table by a nonexistent column will throw an `INTERNAL` error.

```sql
ATTACH 'ducklake:metadata.duckdb' AS my_ducklake (DATA_PATH 'data/');
USE my_ducklake;
CREATE TABLE test (id INT, name TEXT);
ALTER TABLE test SET PARTITIONED BY (foo);
```

```
INTERNAL Error:
Column with name "foo" does not exist

Stack Trace:

0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 52
1        duckdb::InternalException::InternalException(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 20
2        duckdb::InternalException::InternalException<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 48
3        duckdb::ColumnList::GetColumn(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const + 116
4        duckdb::GetPartitionField(duckdb::DuckLakeTableEntry&, duckdb::ParsedExpression&) + 624
5        duckdb::DuckLakeTableEntry::AlterTable(duckdb::DuckLakeTransaction&, duckdb::SetPartitionedByInfo&) + 164
6        duckdb::DuckLakeSchemaEntry::Alter(duckdb::CatalogTransaction, duckdb::AlterInfo&) + 636
7        duckdb::Catalog::Alter(duckdb::CatalogTransaction, duckdb::AlterInfo&) + 216
8        duckdb::Catalog::Alter(duckdb::ClientContext&, duckdb::AlterInfo&) + 116
9        duckdb::PhysicalAlter::GetDataInternal(duckdb::ExecutionContext&, duckdb::DataChunk&, duckdb::OperatorSourceInput&) const + 152
10       duckdb::PipelineExecutor::FetchFromSource(duckdb::DataChunk&) + 140
11       duckdb::PipelineExecutor::Execute(unsigned long long) + 268
12       duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode) + 260
13       duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode) + 288
14       duckdb::Executor::ExecuteTask(bool) + 544
15       duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult&, bool) + 60
16       duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&) + 104
17       duckdb::ClientContext::Query(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 136
18       duckdb::Connection::SendQuery(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>, duckdb::QueryParameters) + 64
19       duckdb_shell::ShellState::ExecuteStatement(duckdb::unique_ptr<duckdb::SQLStatement, std::__1::default_delete<duckdb::SQLStatement>, true>) + 272
20       duckdb_shell::ShellState::ExecuteSQL(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 548
21       duckdb_shell::ShellState::RunOneSqlLine(duckdb_shell::InputMode, char*) + 264
22       duckdb_shell::ShellState::ProcessInput(duckdb_shell::InputMode) + 1720
23       main + 3740
24       start + 7184

This error signals an assertion failure within DuckDB. This usually occurs due to unexpected conditions or errors in the program's logic.
For more information, see https://duckdb.org/docs/stable/dev/internal_errors
```

Trying to run any subsequent queries on the same database will find it in an invalid state and require a restart.

```
FATAL Error:
Failed: database has been invalidated because of a previous fatal error. The database must be restarted prior to being used again.
Original error: "Column with name "foo" does not exist"

Stack Trace:

0        duckdb::Exception::Exception(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 52
1        duckdb::FatalException::FatalException(duckdb::ExceptionType, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 12
2        duckdb::ErrorManager::InvalidatedDatabase(duckdb::ClientContext&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 72
[…]
```

This was due to the `ALTER` statement calling `table.GetColumn()` without first checking if the table column exists. I've added that check, as well as a unit test for the basic partitioning logic.
