### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/test/sql/autoloading/autoload_data_path.test
+++ b/test/sql/autoloading/autoload_data_path.test
@@ -9,6 +9,13 @@ require ducklake
 statement ok
 set allow_persistent_secrets=false;
 
+# Next two statement ensure ducklake is loadable also
+statement ok
+ATTACH 'ducklake:random_file.ducklake' AS db;
+
+statement ok
+DETACH db;
+
 # Ensure we have a clean extension directory without any preinstalled extensions
 statement ok
 set extension_directory='__TEST_DIR__/autoloading_filesystems'

--- a/test/sql/initialize/read_only_mode.test
+++ b/test/sql/initialize/read_only_mode.test
@@ -7,22 +7,22 @@ require ducklake
 require parquet
 
 statement ok
-ATTACH '__TEST_DIR__/ducklake_read_only.db' AS db1
+ATTACH '__TEST_DIR__/read_only_mode.db' AS db1
 
 statement ok
 DETACH db1;
 
 statement error
-ATTACH 'ducklake:__TEST_DIR__/ducklake_read_only.db' AS ducklake (READONLY 1, CREATE_IF_NOT_EXISTS false)
+ATTACH 'ducklake:__TEST_DIR__/read_only_mode.db' AS ducklake (READONLY 1, CREATE_IF_NOT_EXISTS false)
 ----
 creating a new DuckLake is explicitly disabled
 
 statement error
-ATTACH 'ducklake:__TEST_DIR__/ducklake_read_only.db' AS ducklake (READONLY 1)
+ATTACH 'ducklake:__TEST_DIR__/read_only_mode.db' AS ducklake (READONLY 1)
 ----
 creating a new DuckLake is explicitly disabled
 
 statement error
-ATTACH 'ducklake:__TEST_DIR__/ducklake_read_only.db' AS ducklake (READONLY 1, CREATE_IF_NOT_EXISTS true)
+ATTACH 'ducklake:__TEST_DIR__/read_only_mode.db' AS ducklake (READONLY 1, CREATE_IF_NOT_EXISTS true)
 ----
 "CREATE" on database "__ducklake_metadata_ducklake" which is attached in read-only mode!

--- a/test/sql/remove_orphans/remove_orphaned_files.test
+++ b/test/sql/remove_orphans/remove_orphaned_files.test
@@ -73,6 +73,9 @@ SELECT ends_with(path,'bla.parquet') FROM ducklake_delete_orphaned_files('duckla
 ----
 True
 
+statement ok
+LOAD icu
+
 # Check older_than filter
 query I
 SELECT count(*) FROM ducklake_delete_orphaned_files('ducklake', older_than => NOW() - INTERVAL '1 week', dry_run => true);


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:
- `avoid_test_same_db.patch`
- `more_fixes.patch`
