### PR TITLE
implicit conversion unique_ptr in return

### DIFF
--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -647,7 +647,7 @@ unique_ptr<LogicalOperator> DuckLakeInsert::InsertCasts(Binder &binder, unique_p
 	auto result = make_uniq<LogicalProjection>(binder.GenerateTableIndex(), std::move(cast_expressions));
 	result->children.push_back(std::move(plan));
 
-	return result;
+	return std::move(result);
 }
 
 PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(ClientContext &context, PhysicalPlanGenerator &planner,

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -180,7 +180,7 @@ unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionConte
 	}
 	result->cast_chunk.Initialize(context.client, copy.Cast<PhysicalCopyToFile>().expected_types);
 
-	return result;
+	return std::move(result);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -203,7 +203,7 @@ unique_ptr<MultiFileList> DuckLakeMultiFileList::Copy() {
 	result->read_file_list = read_file_list;
 	result->delete_scans = delete_scans;
 	result->inlined_data_tables = inlined_data_tables;
-	return result;
+	return std::move(result);
 }
 
 const DuckLakeFileListEntry &DuckLakeMultiFileList::GetFileEntry(idx_t file_idx) {

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -322,7 +322,7 @@ static unique_ptr<Expression> GetPartitionExpressionForUpdate(ClientContext &con
                                                               const DuckLakePartitionField &field) {
 	switch (field.transform.type) {
 	case DuckLakeTransformType::IDENTITY:
-		return column_reference;
+		return std::move(column_reference);
 	case DuckLakeTransformType::YEAR:
 		return GetFunction(context, std::move(column_reference), "year");
 	case DuckLakeTransformType::MONTH:


### PR DESCRIPTION
use `std::move` to convert `unique_ptr<Derive>` to `unique_ptr<Base>`. some strict compiler will complain implicit conversion. (clang19 -std=c++11)

see https://stackoverflow.com/questions/36752678/clang-returning-stdunique-ptr-with-type-conversion.