### PR TITLE
Add AUTOMATIC_MIGRATION option, and make automatic migration opt_in

### DIFF
--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -29,7 +29,7 @@ struct DuckLakeOptions {
 	AccessMode access_mode = AccessMode::AUTOMATIC;
 	DuckLakeEncryption encryption = DuckLakeEncryption::AUTOMATIC;
 	bool create_if_not_exists = true;
-	bool migrate_if_required = true;
+	bool automatic_migration = false;
 	unique_ptr<BoundAtClause> at_clause;
 	case_insensitive_map_t<Value> metadata_parameters;
 	option_map_t config_options;

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -142,12 +142,12 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 	for (auto &tag : metadata.tags) {
 		if (tag.key == "version") {
 			string version = tag.value;
-			if (version != "0.4-dev1" && !options.migrate_if_required) {
-				// Throw when Loading the Ducklake if a Migration is required and migrate_if_required option is false
-				throw InvalidInputException("DuckLake Extension requires a DuckLake Catalog version of 0.4-dev1 or "
-				                            "higher, current version is %s "
-				                            "and migrate_if_required is set to false",
-				                            version);
+			if (version != "0.4-dev1" && !options.automatic_migration) {
+				// Throw when Loading the DuckLake if a Migration is required and automatic_migration option is false
+				throw InvalidInputException(
+				    "DuckLake catalog version mismatch: catalog version is %s, but the extension requires version "
+				    "0.4-dev1. To automatically migrate, set AUTOMATIC_MIGRATION to TRUE when attaching.",
+				    version);
 			}
 			if (version == "0.1") {
 				metadata_manager.MigrateV01();

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -49,8 +49,8 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 		options.metadata_parameters[parameter_name] = value;
 	} else if (lcase == "create_if_not_exists") {
 		options.create_if_not_exists = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
-	} else if (lcase == "migrate_if_required") {
-		options.migrate_if_required = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
+	} else if (lcase == "automatic_migration") {
+		options.automatic_migration = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "busy_timeout") {
 		options.busy_timeout = UBigIntValue::Get(value.DefaultCastAs(LogicalType::UBIGINT));
 	} else {

--- a/test/sql/delete/delete_ignore_extra_columns.test
+++ b/test/sql/delete/delete_ignore_extra_columns.test
@@ -9,7 +9,7 @@ require parquet
 unzip data/iceberg_deletes/delete_ignore_extra_columns.db.gz __TEST_DIR__/delete_ignore_extra_columns.db
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/delete_ignore_extra_columns.db' AS ducklake (DATA_PATH 'data/iceberg_deletes/delete_ignore_extra_columns', OVERRIDE_DATA_PATH TRUE)
+ATTACH 'ducklake:__TEST_DIR__/delete_ignore_extra_columns.db' AS ducklake (DATA_PATH 'data/iceberg_deletes/delete_ignore_extra_columns', OVERRIDE_DATA_PATH TRUE, AUTOMATIC_MIGRATION TRUE)
 
 statement ok
 use ducklake

--- a/test/sql/migration/migration.test
+++ b/test/sql/migration/migration.test
@@ -12,10 +12,20 @@ unzip data/old_ducklake/v02.db.gz __TEST_DIR__/v02.db
 
 unzip data/old_ducklake/v03-dev1.db.gz __TEST_DIR__/v03-dev1.db
 
+# test that automatic_migration defaults to false and throws an error
+foreach version v01 v02 v03-dev1
+
+statement error
+ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_${version}_err', OVERRIDE_DATA_PATH TRUE)
+----
+DuckLake catalog version mismatch
+
+endloop
+
 foreach version v01 v02 v03-dev1
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_${version}', OVERRIDE_DATA_PATH TRUE)
+ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_${version}', OVERRIDE_DATA_PATH TRUE, AUTOMATIC_MIGRATION TRUE)
 
 statement ok
 INSERT INTO ducklake.test VALUES (42);
@@ -48,7 +58,7 @@ statement ok
 DETACH ducklake
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_${version}', OVERRIDE_DATA_PATH TRUE)
+ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_${version}', OVERRIDE_DATA_PATH TRUE, AUTOMATIC_MIGRATION TRUE)
 
 query I
 FROM ducklake.test

--- a/test/sql/migration/per_table_schema.test
+++ b/test/sql/migration/per_table_schema.test
@@ -9,7 +9,7 @@ require parquet
 unzip data/old_ducklake/per_table_schema.db.gz __TEST_DIR__/per_table_schema.db
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/per_table_schema.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_per_table_schema', OVERRIDE_DATA_PATH TRUE)
+ATTACH 'ducklake:__TEST_DIR__/per_table_schema.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_migrate_per_table_schema', OVERRIDE_DATA_PATH TRUE, AUTOMATIC_MIGRATION TRUE)
 
 # Turning the global to local is basically an explosion within the table snapshot range.
 query III

--- a/test/sql/migration/v01_partitioned.test
+++ b/test/sql/migration/v01_partitioned.test
@@ -13,7 +13,7 @@ unzip data/old_ducklake/v01_partitioned.db.gz ${DATA_PATH}/v01_partitioned.db
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/v01_partitioned.db
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_migrate_v01_partitioned', METADATA_CATALOG 'ducklake_metadata', OVERRIDE_DATA_PATH TRUE)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_migrate_v01_partitioned', METADATA_CATALOG 'ducklake_metadata', OVERRIDE_DATA_PATH TRUE, AUTOMATIC_MIGRATION TRUE)
 
 statement ok
 INSERT INTO ducklake.partitioned_tbl SELECT NULL, i%2, concat('thisisastring_', i) FROM range(10000) t(i)


### PR DESCRIPTION
Before this PR when connecting a new version of the DuckLake extension, an automatic migration of the catalog would be triggered. Here we add a new option to the connection, `AUTOMATIC_MIGRATION` which by default is set to false. If false it triggers an error message saying there is a catalog mismatch, and that the user needs to set `AUTOMATIC_MIGRATION True` to use the extension.

This should prevent users from accidentally migrating their catalog.

cc @guillesd 