### PR TITLE
Skip autoload test

### DIFF
--- a/test/sql/autoloading/autoload_data_path.test
+++ b/test/sql/autoloading/autoload_data_path.test
@@ -6,6 +6,8 @@ require-env LOCAL_EXTENSION_REPO
 
 require ducklake
 
+mode skip
+
 statement ok
 set allow_persistent_secrets=false;
 


### PR DESCRIPTION
Getting on the way of tesitng ducklake directly in duckdb-core, should be checked again in the future.