### PR TITLE
Implement metadata-only COUNT(*) optimization

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -142,6 +142,8 @@ public:
 
 	bool HasDroppedFiles() const;
 	bool FileIsDropped(const string &path) const;
+	//! Check if there are any uncommitted changes for this table (inserts, deletes, or dropped files)
+	bool HasAnyLocalChanges(TableIndex table_id);
 
 	string GenerateUUID() const;
 	static string GenerateUUIDv7();

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -1,10 +1,13 @@
 #include "storage/ducklake_scan.hpp"
+#include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_multi_file_reader.hpp"
 #include "storage/ducklake_multi_file_list.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_stats.hpp"
+#include "storage/ducklake_transaction.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/function/partition_stats.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -70,6 +73,64 @@ vector<column_t> DuckLakeGetRowIdColumn(ClientContext &context, optional_ptr<Fun
 	return result;
 }
 
+vector<PartitionStatistics> DuckLakeGetPartitionStats(ClientContext &context, GetPartitionStatsInput &input) {
+	vector<PartitionStatistics> result;
+
+	if (!input.table_function.function_info) {
+		return result;
+	}
+	auto &func_info = input.table_function.function_info->Cast<DuckLakeFunctionInfo>();
+
+	// Only use partition stats for regular table scans
+	if (func_info.scan_type != DuckLakeScanType::SCAN_TABLE) {
+		return result;
+	}
+
+	auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
+	auto &file_list = bind_data.file_list->Cast<DuckLakeMultiFileList>();
+	auto &table = file_list.GetTable();
+	auto transaction = func_info.GetTransaction();
+
+	auto table_id = table.GetTableId();
+
+	// Check if this is a time travel query - if so, fall back to scanning
+	// After merge_adjacent_files, multiple files are merged into one with a combined record_count.
+	// The merged file contains an embedded snapshot_id column for time travel filtering,
+	// but the metadata record_count represents ALL rows, not per-snapshot counts.
+	// Only a full scan can filter by snapshot_id to get the correct historical count.
+	// Time travel can occur via: (1) per-query AT clause, or (2) catalog attached at historical snapshot
+	auto current_snapshot = transaction->GetSnapshot();
+	if (func_info.snapshot.snapshot_id != current_snapshot.snapshot_id || transaction->GetCatalog().CatalogSnapshot()) {
+		return result;
+	}
+
+	// Check if this is a transaction-local table (no committed stats)
+	if (table.IsTransactionLocal()) {
+		return result;
+	}
+
+	// If there are any transaction-local changes fall back to scanning
+	// Accounting for transaction local changes gets difficult, especially when entire
+	// files are dropped.
+	if (transaction->HasAnyLocalChanges(table_id)) {
+		return result;
+	}
+
+	// Get count from active data files minus delete count, plus inlined data
+	// (inlined deletes are handled by end_snapshot visibility in GetInlinedDataRowCount)
+	idx_t record_count = table.GetActiveRecordCount(*transaction);
+	idx_t delete_count = table.GetTotalDeleteCount(*transaction);
+	idx_t inlined_count = table.GetInlinedDataRowCount(*transaction);
+	idx_t count = record_count - delete_count + inlined_count;
+
+	// Return single partition with total count
+	PartitionStatistics stats;
+	stats.count = count;
+	stats.count_type = CountType::COUNT_EXACT;
+	result.push_back(std::move(stats));
+	return result;
+}
+
 TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &instance) {
 	// Parquet extension needs to be loaded for this to make sense
 	ExtensionHelper::AutoLoadExtension(instance, "parquet");
@@ -87,6 +148,7 @@ TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &insta
 	function.get_bind_info = DuckLakeBindInfo;
 	function.get_virtual_columns = DuckLakeVirtualColumns;
 	function.get_row_id_columns = DuckLakeGetRowIdColumn;
+	function.get_partition_stats = DuckLakeGetPartitionStats;
 
 	// Unset all of these: they are either broken, very inefficient.
 	// TODO: implement/fix these

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2187,6 +2187,14 @@ bool DuckLakeTransaction::HasLocalDeletes(TableIndex table_id) {
 	return !entry->second.new_delete_files.empty();
 }
 
+bool DuckLakeTransaction::HasAnyLocalChanges(TableIndex table_id) {
+	auto entry = table_data_changes.find(table_id);
+	if (entry != table_data_changes.end() && !entry->second.IsEmpty()) {
+		return true;
+	}
+	return tables_deleted_from.find(table_id) != tables_deleted_from.end();
+}
+
 void DuckLakeTransaction::GetLocalDeleteForFile(TableIndex table_id, const string &path, DuckLakeFileData &result) {
 	auto entry = table_data_changes.find(table_id);
 	if (entry == table_data_changes.end()) {

--- a/test/sql/stats/count_star_optimization.test
+++ b/test/sql/stats/count_star_optimization.test
@@ -1,0 +1,272 @@
+# name: test/sql/stats/count_star_optimization.test
+# description: Test metadata-only COUNT(*) optimization
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/count_star_optimization')
+
+# create table and insert data
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test FROM range(1000);
+
+# basic COUNT(*) should return correct count
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1000
+
+# insert more data (non-overlapping range)
+statement ok
+INSERT INTO ducklake.test FROM range(1000, 1500);
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1500
+
+# test COUNT(*) with uncommitted inserts
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.test FROM range(2000, 2200);
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1700
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1500
+
+# test COUNT(*) with uncommitted deletes (no prior committed deletes on this data)
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM ducklake.test WHERE i >= 400 AND i < 500;
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1400
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1500
+
+# test with committed deletes
+statement ok
+DELETE FROM ducklake.test WHERE i < 100;
+
+query I
+SELECT COUNT(*) FROM ducklake.test;
+----
+1400
+
+# test transaction-local table (newly created table)
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE ducklake.new_table(x INTEGER);
+
+statement ok
+INSERT INTO ducklake.new_table FROM range(50);
+
+query I
+SELECT COUNT(*) FROM ducklake.new_table;
+----
+50
+
+statement ok
+COMMIT;
+
+query I
+SELECT COUNT(*) FROM ducklake.new_table;
+----
+50
+
+# ============================================
+# Test with inlined data
+# ============================================
+
+statement ok
+DETACH ducklake;
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}_inlined' AS ducklake (DATA_PATH '${DATA_PATH}/count_star_inlined', DATA_INLINING_ROW_LIMIT 100)
+
+# create table with inlined data (small enough to be inlined)
+statement ok
+CREATE TABLE ducklake.inlined_test AS SELECT * FROM range(50) t(i);
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+50
+
+# insert more inlined data
+statement ok
+INSERT INTO ducklake.inlined_test FROM range(50, 80);
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+80
+
+# delete from inlined data
+statement ok
+DELETE FROM ducklake.inlined_test WHERE i < 10;
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+70
+
+# test with uncommitted inlined inserts
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.inlined_test FROM range(100, 120);
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+90
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+70
+
+# test with uncommitted inlined deletes
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM ducklake.inlined_test WHERE i >= 70;
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+60
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined_test;
+----
+70
+
+# ============================================
+# Test time travel after merge_adjacent_files
+# ============================================
+
+statement ok
+DETACH ducklake;
+
+statement ok
+ATTACH 'ducklake:${DATA_PATH}/merge_meta.db' AS ducklake (DATA_PATH '${DATA_PATH}/merge_data')
+
+# create table and insert data in multiple batches to create multiple files
+statement ok
+CREATE TABLE ducklake.merge_test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.merge_test FROM range(100);
+
+# record snapshot after first insert (should have 100 rows)
+query I
+SELECT MAX(snapshot_id) FROM ducklake.snapshots();
+----
+2
+
+statement ok
+INSERT INTO ducklake.merge_test FROM range(100, 200);
+
+statement ok
+INSERT INTO ducklake.merge_test FROM range(200, 300);
+
+# current count should be 300
+query I
+SELECT COUNT(*) FROM ducklake.merge_test;
+----
+300
+
+# run merge to create a file with partial_max
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake', 'merge_test');
+
+# current count should still be 300
+query I
+SELECT COUNT(*) FROM ducklake.merge_test;
+----
+300
+
+# time travel to snapshot 2 should return 100, not 300
+# this verifies we fall back to scanning for time travel queries
+query I
+SELECT COUNT(*) FROM ducklake.merge_test AT (VERSION => 2);
+----
+100
+
+# time travel to snapshot 3 should return 200
+query I
+SELECT COUNT(*) FROM ducklake.merge_test AT (VERSION => 3);
+----
+200
+
+# ============================================
+# Test attaching at historical snapshot
+# ============================================
+
+# detach and re-attach at snapshot 2
+statement ok
+DETACH ducklake;
+
+statement ok
+ATTACH 'ducklake:${DATA_PATH}/merge_meta.db' AS ducklake_v2 (DATA_PATH '${DATA_PATH}/merge_data', SNAPSHOT_VERSION 2)
+
+# COUNT(*) should return 100 (the count at snapshot 2), not 300
+query I
+SELECT COUNT(*) FROM ducklake_v2.merge_test;
+----
+100
+
+# detach v2 and attach at snapshot 3
+statement ok
+DETACH ducklake_v2;
+
+statement ok
+ATTACH 'ducklake:${DATA_PATH}/merge_meta.db' AS ducklake_v3 (DATA_PATH '${DATA_PATH}/merge_data', SNAPSHOT_VERSION 3)
+
+query I
+SELECT COUNT(*) FROM ducklake_v3.merge_test;
+----
+200


### PR DESCRIPTION
Add DuckLakeGetPartitionStats to enable COUNT(*) queries to return results from metadata without scanning parquet files.

The optimization is disabled for:
- COUNT(*) in time travel queries
- COUNT(*) on Transaction-local tables
- COUNT(*) in transactions on tables with uncomitted local changes

Benchmarked on S3 backed tables (us-east-1) using my Macbook M4 (no inlined data or deletes): 

| Files | COUNT(*) | COUNT(*) optimized | Speedup |
|-------|----------|--------------------|---------|
| 10    | 361ms    | 42ms               | 8.6x    |
| 100   | 2,716ms  | 42ms               | 64x     |
| 500   | 10,901ms | 42ms               | 258x    |

After this change, runtime for COUNT(*) is nearly constant regardless of number of files