### PR TITLE
Fix ducklake_add_data_files with multiple hive-partitioned columns

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1172,8 +1172,15 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 		if (file.hive_partition_values.size() != partition_data->fields.size()) {
 			invalid_partition = true;
 		} else {
-			for (idx_t i = 0; i < partition_data->fields.size(); i++) {
-				if (file.hive_partition_values[i].field_index.index != partition_data->fields[i].field_id.index) {
+			for (auto hive_partition_value : file.hive_partition_values) {
+				bool found_field = false;
+				for (auto field : partition_data->fields) {
+					if (field.field_id.index == hive_partition_value.field_index.index) {
+						found_field = true;
+						break;
+					}
+				}
+				if (!found_field) {
 					invalid_partition = true;
 					break;
 				}

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1172,9 +1172,9 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 		if (file.hive_partition_values.size() != partition_data->fields.size()) {
 			invalid_partition = true;
 		} else {
-			for (auto hive_partition_value : file.hive_partition_values) {
+			for (const auto& hive_partition_value : file.hive_partition_values) {
 				bool found_field = false;
-				for (auto field : partition_data->fields) {
+				for (const auto& field : partition_data->fields) {
 					if (field.field_id.index == hive_partition_value.field_index.index) {
 						found_field = true;
 						break;

--- a/test/sql/add_files/add_files_hive_many_columns.test
+++ b/test/sql/add_files/add_files_hive_many_columns.test
@@ -31,3 +31,27 @@ query IIIIII
 SELECT year, month, day, collection, language, value FROM ducklake.test
 ----
 2026	1	30	abcde	eng	1
+
+query II
+SELECT column_name, partition_value
+FROM __ducklake_metadata_ducklake.ducklake_column
+NATURAL INNER JOIN __ducklake_metadata_ducklake.ducklake_partition_column
+NATURAL INNER JOIN __ducklake_metadata_ducklake.ducklake_file_partition_value
+ORDER BY column_name;
+----
+collection	abcde
+day	30
+language	eng
+month	1
+year	2026
+
+statement ok
+CREATE TABLE ducklake.test2 AS FROM '${DATA_PATH}/hive_many_columns/**/*.parquet' WITH NO DATA;
+
+statement ok
+ALTER TABLE ducklake.test2 SET PARTITIONED BY (year, month, day, collection, value);
+
+statement error
+CALL ducklake_add_data_files('ducklake', 'test2', '${DATA_PATH}/hive_many_columns/**/*.parquet');
+----
+contains an invalid partition value for the table configuration

--- a/test/sql/add_files/add_files_hive_many_columns.test
+++ b/test/sql/add_files/add_files_hive_many_columns.test
@@ -1,0 +1,33 @@
+# name: test/sql/add_files/add_files_hive_many_columns.test
+# description: test ducklake adding files with many Hive-partitioned columns
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive_many_columns');
+
+statement ok
+COPY (SELECT 2026 AS year, 1 AS month, 30 AS day, 'abcde' AS collection, 'eng' AS language, 1 AS value)
+TO '${DATA_PATH}/hive_many_columns' (FORMAT PARQUET, PARTITION_BY (year, month, day, collection, language));
+
+statement ok
+CREATE TABLE ducklake.test AS FROM '${DATA_PATH}/hive_many_columns/**/*.parquet' WITH NO DATA;
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (year, month, day, collection, language);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '${DATA_PATH}/hive_many_columns/**/*.parquet');
+
+query IIIIII
+SELECT year, month, day, collection, language, value FROM ducklake.test
+----
+2026	1	30	abcde	eng	1


### PR DESCRIPTION
I ran into an issue with the `ducklake_add_data_files` function when processing files that had multiple hive-partitioned columns.

The issue turned out to be that `DuckLakeFileProcessor::AddFileToTable` assumes that `table.GetPartitionData()` and `file.hive_partition_values` were both sorted on `field_id`. However, `file.hive_partition_values` was created by iterating over an `unordered_map` (in `DuckLakeFileProcessor::MapColumns`) and so had a different ordering. This difference was handled fine by the actual column mapping, but not in the check whether all fields were valid. I changed this check to be order-independent, and now the files get added properly.

Let me know if you agree with this change and whether you think the check is still valid now. I couldn't figure out in what scenario the fields would actually be populated to be invalid, so I did not add a test case to verify the check. If you have any suggestions there I'd be happy to add test cases as well.

## To reproduce

```sql
CREATE SECRET (
    TYPE s3,
    ENDPOINT 'a3s.fi',
    URL_STYLE 'path',
    SCOPE 's3://2006391-owi-remote-index'
);

ATTACH 'ducklake:test.ducklake' AS dl;
USE dl;

CREATE TABLE remote_index AS
FROM 's3://2006391-owi-remote-index/year=2025/month=12/day=25/collection=26eb6c02-e237-11f0-b4b1-8ebf6bb2cab9/index/representation=title/language=eng/postings_0.parquet'
WITH NO DATA;

ALTER TABLE remote_index SET PARTITIONED BY (
    year, month, day, collection, representation, language
);

CALL ducklake_add_data_files('dl', 'remote_index', 's3://2006391-owi-remote-index/year=2025/month=12/day=25/collection=26eb6c02-e237-11f0-b4b1-8ebf6bb2cab9/index/representation=title/language=eng/postings_0.parquet');
```

Before my changes, I would get the following error:
```
Invalid Input Error:
File "s3://2006391-owi-remote-index/year=2025/month=12/day=25/collection=26eb6c02-e237-11f0-b4b1-8ebf6bb2cab9/index/representation=title/language=eng/postings_0.parquet" contains an invalid partition value for the table configuration.
```

After adding the fix, the file is added and  `ducklake_file_partition_value` is populated correctly.