### PR TITLE
split GetOrphanFilesForCleanup

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -149,6 +149,7 @@ public:
 	virtual idx_t GetNetDataFileRowCount(TableIndex table_id, DuckLakeSnapshot snapshot);
 	virtual idx_t GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot);
 	virtual vector<DuckLakeFileForCleanup> GetOldFilesForCleanup(const string &filter);
+	virtual unordered_set<string> GetActiveFiles(const string &separator);
 	virtual vector<DuckLakeFileForCleanup> GetOrphanFilesForCleanup(const string &filter, const string &separator);
 	virtual vector<DuckLakeFileForCleanup> GetFilesForCleanup(const string &filter, CleanupType type,
 	                                                          const string &separator);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3937,12 +3937,8 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 	}
 	return result;
 }
-vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
-                                                                                 const string &separator) {
-	auto query = R"(SELECT filename
-FROM read_blob({DATA_PATH} || '**')
-WHERE suffix(filename, '.parquet')
-AND filename NOT IN (
+unordered_set<string> DuckLakeMetadataManager::GetActiveFiles(const string &separator) {
+	string query = R"(
 SELECT REPLACE(
            CASE
                WHEN NOT file_relative THEN file_path
@@ -3977,19 +3973,39 @@ SELECT REPLACE(
            '{SEPARATOR}'
 ) AS full_path
 FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
-)
-)" + filter;
+)";
 	query = StringUtil::Replace(query, "{SEPARATOR}", separator);
 	auto res = transaction.Query(query);
 	if (res->HasError()) {
-		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+		res->GetErrorObject().Throw("Failed to get active files from DuckLake: ");
+	}
+	unordered_set<string> result;
+	for (auto &row : *res) {
+		result.insert(row.GetValue<string>(0));
+	}
+	return result;
+}
+
+vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
+                                                                                 const string &separator) {
+	// Get active files from metadata
+	auto active_files = GetActiveFiles(separator);
+
+	// Get all files from filesystem using DuckDB's read_blob
+	auto query = "SELECT filename FROM read_blob({DATA_PATH} || '**') WHERE suffix(filename, '.parquet') " + filter;
+	auto res = transaction.Query(query);
+	if (res->HasError()) {
+		res->GetErrorObject().Throw("Failed to get files from filesystem: ");
 	}
 	auto context = transaction.context.lock();
 	vector<DuckLakeFileForCleanup> result;
 	for (auto &row : *res) {
-		DuckLakeFileForCleanup info;
-		info.path = row.GetValue<string>(0);
-		result.push_back(std::move(info));
+		auto filename = row.GetValue<string>(0);
+		if (active_files.find(filename) == active_files.end()) {
+			DuckLakeFileForCleanup info;
+			info.path = filename;
+			result.push_back(std::move(info));
+		}
 	}
 	return result;
 }


### PR DESCRIPTION
part of #731 

split `GetOrphanFilesForCleanup` into `GetActiveFiles`(on metadata db) and get all files by DuckDB's `read_blob`.