### PR TITLE
Add override for GetName() for ducklake extension operators

### DIFF
--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -229,6 +229,10 @@ public:
 		                                       partition_id, child);
 	}
 
+	string GetName() const override {
+		return "DUCKLAKE_FLUSH_DATA";
+	}
+
 	string GetExtensionName() const override {
 		return "ducklake";
 	}

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -56,6 +56,10 @@ public:
 		                                        partition_id, std::move(partition_values), row_id_start, child, type);
 	}
 
+	string GetName() const override {
+		return "DUCKLAKE_COMPACTION";
+	}
+
 	string GetExtensionName() const override {
 		return "ducklake";
 	}


### PR DESCRIPTION
Add override for GetName() for ducklake extension operators compact and flush.
The motivation is so that custom optimizer extensions can recognize these operators.
