### PR TITLE
Fix filter pushdown

### DIFF
--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -36,6 +36,10 @@ public:
 	                                                const vector<column_t> &column_ids,
 	                                                TableFilterSet &filters) const override;
 
+	unique_ptr<MultiFileList> ComplexFilterPushdown(ClientContext &context, const MultiFileOptions &options,
+	                                                MultiFilePushdownInfo &info,
+	                                                vector<unique_ptr<Expression>> &filters) const override;
+
 	vector<OpenFileInfo> GetAllFiles() const override;
 	FileExpandResult GetExpandResult() const override;
 	idx_t GetTotalFileCount() const override;
@@ -63,6 +67,7 @@ private:
 	void GetFilesForTable() const;
 	void GetTableInsertions() const;
 	void GetTableDeletions() const;
+	void AddFilterToPushdownInfo(FilterPushdownInfo &pushdown_info, column_t column_id, unique_ptr<TableFilter> filter) const;
 
 private:
 	mutable mutex file_lock;

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -48,6 +48,12 @@ EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE part_key=1
 ----
 analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
+# Offset/Limit generate more complex query plans, ensure they don't trigger unnecessary file reads.
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.test WHERE part_key = 1 OFFSET 0 LIMIT 1;
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
 # rename the hive partition
 statement ok
 ALTER TABLE ducklake.test RENAME part_key TO new_part_key


### PR DESCRIPTION
This is a continuation of: https://github.com/duckdb/duckdb/pull/20816.

Optimizations like late materialization create more complex query plans that allow certain join branches to skip filters critical to limiting the number of unnecessary files pulled from the source. I'm not sure if `Bind()` is the right place to update that config option, but I confirmed that this fixes the issue locally. I'll figure out how to write a test for this, but I just want to be sure this approach is good while I'm working on it.