### PR TITLE
Making inlining default to ducklake.

### DIFF
--- a/.github/workflows/Catalogs.yml
+++ b/.github/workflows/Catalogs.yml
@@ -57,7 +57,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-postgres' }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/ducklake' }}
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1

--- a/.github/workflows/ConfigTests.yml
+++ b/.github/workflows/ConfigTests.yml
@@ -44,7 +44,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-postgres' }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/ducklake' }}
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1

--- a/.github/workflows/Debug.yml
+++ b/.github/workflows/Debug.yml
@@ -51,7 +51,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-postgres' }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/ducklake' }}
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1

--- a/.github/workflows/NoInline.yml
+++ b/.github/workflows/NoInline.yml
@@ -44,7 +44,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@main
       with:
         key: ${{ github.job }}
-        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-postgres' }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/ducklake' }}
 
     - name: Setup vcpkg
       uses: lukka/run-vcpkg@v11.1

--- a/.github/workflows/NoInline.yml
+++ b/.github/workflows/NoInline.yml
@@ -1,0 +1,62 @@
+name: No Inline Tests
+on: [push, pull_request,repository_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ducklake-no-inline-tests:
+    name: DuckLake Tests (No Inlining)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ['linux_amd64']
+        vcpkg_version: [ '2023.04.15' ]
+        include:
+          - arch: 'linux_amd64'
+            vcpkg_triplet: 'x64-linux'
+
+    env:
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      GEN: Ninja
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    steps:
+    - name: Install required ubuntu packages
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install -y -qq build-essential cmake ninja-build ccache python3
+
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: 'true'
+
+    - name: Checkout DuckDB to version
+      run: |
+        cd duckdb
+        git checkout $(cat ../.github/duckdb-version)
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb-postgres' }}
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11.1
+      with:
+        vcpkgGitCommitId: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+
+    - name: Build extension
+      env:
+        GEN: ninja
+      run: |
+        make release
+
+    - name: Test extension (no inlining)
+      run: |
+        build/release/test/unittest --test-config test/configs/no_inline.json

--- a/src/common/ducklake_data_file.cpp
+++ b/src/common/ducklake_data_file.cpp
@@ -15,6 +15,7 @@ DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 	mapping_id = other.mapping_id;
 	begin_snapshot = other.begin_snapshot;
 	max_partial_file_snapshot = other.max_partial_file_snapshot;
+	flush_row_id_start = other.flush_row_id_start;
 	created_by_ducklake = other.created_by_ducklake;
 }
 
@@ -31,6 +32,7 @@ DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
 	mapping_id = other.mapping_id;
 	begin_snapshot = other.begin_snapshot;
 	max_partial_file_snapshot = other.max_partial_file_snapshot;
+	flush_row_id_start = other.flush_row_id_start;
 	created_by_ducklake = other.created_by_ducklake;
 	return *this;
 }

--- a/src/common/ducklake_types.cpp
+++ b/src/common/ducklake_types.cpp
@@ -42,7 +42,7 @@ static constexpr const ducklake_type_array DUCKLAKE_TYPES {{{"boolean", LogicalT
                                                             {"varchar", LogicalTypeId::VARCHAR},
                                                             {"blob", LogicalTypeId::BLOB},
                                                             {"uuid", LogicalTypeId::UUID},
-																{"geometry", LogicalTypeId::GEOMETRY},
+                                                            {"geometry", LogicalTypeId::GEOMETRY},
                                                             {"struct", LogicalTypeId::STRUCT},
                                                             {"map", LogicalTypeId::MAP},
                                                             {"list", LogicalTypeId::LIST},
@@ -160,7 +160,8 @@ void DuckLakeTypes::CheckSupportedType(const LogicalType &type) {
 	});
 
 	// Special case for now, only allow GEOMETRY as top-level type
-	if ((!IsGeoType(type) && TypeVisitor::Contains(type, IsGeoType)) || (type.id() != LogicalTypeId::GEOMETRY && TypeVisitor::Contains(type, LogicalTypeId::GEOMETRY))) {
+	if ((!IsGeoType(type) && TypeVisitor::Contains(type, IsGeoType)) ||
+	    (type.id() != LogicalTypeId::GEOMETRY && TypeVisitor::Contains(type, LogicalTypeId::GEOMETRY))) {
 		throw InvalidInputException("GEOMETRY type is only supported as a top-level type");
 	}
 }

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -1,6 +1,5 @@
 #include "common/ducklake_util.hpp"
 #include "duckdb/common/string_util.hpp"
-#include <cmath>
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "storage/ducklake_metadata_manager.hpp"
@@ -9,6 +8,8 @@
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+
+#include <cmath>
 
 namespace duckdb {
 
@@ -142,7 +143,6 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::BLOB:
-		return "'" + value.ToString() + "'::" + value_type;
 	case LogicalTypeId::GEOMETRY:
 		return "'" + value.ToString() + "'::" + value_type;
 	case LogicalTypeId::INTERVAL: {
@@ -208,8 +208,8 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 			// Stored as VARCHAR text - use ToString() which produces parseable format
 			return value.ToString();
 		}
-		auto &children = value.type().id() == LogicalTypeId::LIST ? ListValue::GetChildren(value)
-		                                                          : ArrayValue::GetChildren(value);
+		auto &children =
+		    value.type().id() == LogicalTypeId::LIST ? ListValue::GetChildren(value) : ArrayValue::GetChildren(value);
 		string ret = "[";
 		for (idx_t i = 0; i < children.size(); i++) {
 			ret += ToSQLString(metadata_manager, children[i]);
@@ -327,7 +327,8 @@ DynamicFilter *DuckLakeUtil::GetOptionalDynamicFilter(const TableFilter &filter)
 }
 
 bool DuckLakeUtil::IsInlinedSystemColumn(const string &name) {
-	return name == "row_id" || name == "begin_snapshot" || name == "end_snapshot";
+	return StringUtil::CIEquals(name, "row_id") || StringUtil::CIEquals(name, "begin_snapshot") ||
+	       StringUtil::CIEquals(name, "end_snapshot");
 }
 
 bool DuckLakeUtil::HasInlinedSystemColumnConflict(const ColumnList &columns) {

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -1,5 +1,6 @@
 #include "common/ducklake_util.hpp"
 #include "duckdb/common/string_util.hpp"
+#include <cmath>
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "storage/ducklake_metadata_manager.hpp"
@@ -158,14 +159,16 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 		ret += is_unnamed ? ")" : "}";
 		return ret;
 	}
-	case LogicalTypeId::FLOAT:
-		if (!value.FloatIsFinite(FloatValue::Get(value))) {
+	case LogicalTypeId::FLOAT: {
+		float fval = FloatValue::Get(value);
+		if (!Value::FloatIsFinite(fval) || (fval == 0.0f && std::signbit(fval))) {
 			return "'" + value.ToString() + "'::" + value_type;
 		}
 		return value.ToString();
+	}
 	case LogicalTypeId::DOUBLE: {
 		double val = DoubleValue::Get(value);
-		if (!value.DoubleIsFinite(val)) {
+		if (!Value::DoubleIsFinite(val) || (val == 0.0 && std::signbit(val))) {
 			return "'" + value.ToString() + "'::" + value_type;
 		}
 		return value.ToString();

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -116,9 +116,13 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
-	case LogicalTypeId::INTERVAL:
 	case LogicalTypeId::BLOB:
 		return "'" + value.ToString() + "'::" + value_type;
+	case LogicalTypeId::INTERVAL: {
+		auto interval = IntervalValue::Get(value);
+		return StringUtil::Format("'%d months %d days %lld microseconds'::%s", interval.months, interval.days,
+		                          interval.micros, value_type);
+	}
 	case LogicalTypeId::VARCHAR:
 	case LogicalTypeId::ENUM: {
 		auto str_val = value.ToString();

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -24,7 +24,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::DOUBLE, Value::DOUBLE(1.5), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("ducklake_default_data_inlining_row_limit",
 	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
-	                          Value::UBIGINT(1000), nullptr, SetScope::GLOBAL);
+	                          Value::UBIGINT(10), nullptr, SetScope::GLOBAL);
 
 	DuckLakeSnapshotsFunction snapshots;
 	loader.RegisterFunction(snapshots);

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -22,6 +22,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          Value::UBIGINT(100), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption("ducklake_retry_backoff", "Backoff factor for exponentially increasing retry wait time",
 	                          LogicalType::DOUBLE, Value::DOUBLE(1.5), nullptr, SetScope::GLOBAL);
+	config.AddExtensionOption("ducklake_default_data_inlining_row_limit",
+	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
+	                          Value::UBIGINT(1000), nullptr, SetScope::GLOBAL);
 
 	DuckLakeSnapshotsFunction snapshots;
 	loader.RegisterFunction(snapshots);

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -692,12 +692,12 @@ static unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context, 
 	// Pick the right sum overload
 	auto sum_func = sum_entry.functions.GetFunctionByArguments(context, {sum_args[0]->return_type});
 	FunctionBinder function_binder(context);
-	auto sum_aggregate = function_binder.BindAggregateFunction(
-	    sum_func,                    // The SUM(BIGINT) -> HUGEINT function
-	    std::move(sum_args),         // Arguments: [rows_flushed column ref]
-	    nullptr,                     // No FILTER clause (e.g., SUM(x) FILTER (WHERE ...))
-	    AggregateType::NON_DISTINCT  // Not SUM(DISTINCT ...)
-	);
+	auto sum_aggregate =
+	    function_binder.BindAggregateFunction(sum_func,            // The SUM(BIGINT) -> HUGEINT function
+	                                          std::move(sum_args), // Arguments: [rows_flushed column ref]
+	                                          nullptr,             // No FILTER clause (e.g., SUM(x) FILTER (WHERE ...))
+	                                          AggregateType::NON_DISTINCT // Not SUM(DISTINCT ...)
+	    );
 
 	// Create LogicalAggregate with GROUP BY schema_name, table_name and SUM(rows_flushed)
 	idx_t group_index = input.binder->GenerateTableIndex();
@@ -717,8 +717,8 @@ static unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context, 
 	unique_ptr<Expression> sum_col_ref = make_uniq<BoundColumnRefExpression>(aggregate->types[2], agg_bindings[2]);
 	// Note: SUM(BIGINT) returns HUGEINT. We must use the its output type for the 0 constant
 	unique_ptr<Expression> zero_const = make_uniq<BoundConstantExpression>(Value::Numeric(aggregate->types[2], 0));
-	unique_ptr<Expression> filter_expr = make_uniq<BoundComparisonExpression>(ExpressionType::COMPARE_GREATERTHAN,
-	                                                        std::move(sum_col_ref), std::move(zero_const));
+	unique_ptr<Expression> filter_expr = make_uniq<BoundComparisonExpression>(
+	    ExpressionType::COMPARE_GREATERTHAN, std::move(sum_col_ref), std::move(zero_const));
 
 	auto filter = make_uniq<LogicalFilter>(std::move(filter_expr));
 	filter->children.push_back(std::move(aggregate));

--- a/src/functions/ducklake_table_insertions.cpp
+++ b/src/functions/ducklake_table_insertions.cpp
@@ -65,9 +65,9 @@ static unique_ptr<FunctionData> DuckLakeTableChangesBind(ClientContext &context,
 
 	// Preload the file list to avoid metadata queries during parallel execution
 	// This prevents potential deadlocks between the metadata connection and DuckDB's thread pool
-	// auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
-	// auto &file_list = multi_file_bind_data.file_list->Cast<DuckLakeMultiFileList>();
-	// file_list.GetFiles();
+	auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
+	auto &file_list = multi_file_bind_data.file_list->Cast<DuckLakeMultiFileList>();
+	file_list.GetFiles();
 
 	return bind_data;
 }

--- a/src/functions/ducklake_table_insertions.cpp
+++ b/src/functions/ducklake_table_insertions.cpp
@@ -4,7 +4,9 @@
 #include "storage/ducklake_transaction_changes.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "storage/ducklake_scan.hpp"
+#include "storage/ducklake_multi_file_list.hpp"
 #include "duckdb/planner/tableref/bound_at_clause.hpp"
+#include "duckdb/common/multi_file/multi_file_function.hpp"
 
 namespace duckdb {
 
@@ -60,6 +62,13 @@ static unique_ptr<FunctionData> DuckLakeTableChangesBind(ClientContext &context,
 	function_info.start_snapshot =
 	    make_uniq<DuckLakeSnapshot>(transaction.GetSnapshot(start_at_clause, SnapshotBound::LOWER_BOUND));
 	function_info.scan_type = scan_type;
+
+	// Preload the file list to avoid metadata queries during parallel execution
+	// This prevents potential deadlocks between the metadata connection and DuckDB's thread pool
+	// auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
+	// auto &file_list = multi_file_bind_data.file_list->Cast<DuckLakeMultiFileList>();
+	// file_list.GetFiles();
+
 	return bind_data;
 }
 

--- a/src/functions/ducklake_table_insertions.cpp
+++ b/src/functions/ducklake_table_insertions.cpp
@@ -4,9 +4,7 @@
 #include "storage/ducklake_transaction_changes.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "storage/ducklake_scan.hpp"
-#include "storage/ducklake_multi_file_list.hpp"
 #include "duckdb/planner/tableref/bound_at_clause.hpp"
-#include "duckdb/common/multi_file/multi_file_function.hpp"
 
 namespace duckdb {
 
@@ -62,13 +60,6 @@ static unique_ptr<FunctionData> DuckLakeTableChangesBind(ClientContext &context,
 	function_info.start_snapshot =
 	    make_uniq<DuckLakeSnapshot>(transaction.GetSnapshot(start_at_clause, SnapshotBound::LOWER_BOUND));
 	function_info.scan_type = scan_type;
-
-	// Preload the file list to avoid metadata queries during parallel execution
-	// This prevents potential deadlocks between the metadata connection and DuckDB's thread pool
-	auto &multi_file_bind_data = bind_data->Cast<MultiFileBindData>();
-	auto &file_list = multi_file_bind_data.file_list->Cast<DuckLakeMultiFileList>();
-	file_list.GetFiles();
-
 	return bind_data;
 }
 

--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -63,6 +63,8 @@ struct DuckLakeDataFile {
 	MappingIndex mapping_id;
 	optional_idx begin_snapshot;
 	optional_idx max_partial_file_snapshot;
+	//! The row_id_start extracted from the file (for flushed files that have embedded row_ids)
+	optional_idx flush_row_id_start;
 	//! If the file was created by ducklake
 	bool created_by_ducklake = true;
 };

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -37,6 +37,9 @@ public:
 	static string JoinPath(FileSystem &fs, const string &a, const string &b);
 
 	static DynamicFilter *GetOptionalDynamicFilter(const TableFilter &filter);
+
+	//! Returns true if the given column name conflicts with inlined data system columns
+	static bool IsInlinedSystemColumn(const string &name);
 };
 
 } // namespace duckdb

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -13,10 +13,12 @@
 #include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
+class ColumnList;
 class DuckLakeMetadataManager;
 class FileSystem;
 class TableFilter;
 class DynamicFilter;
+struct DuckLakeColumnInfo;
 
 struct ParsedCatalogEntry {
 	string schema;
@@ -40,6 +42,9 @@ public:
 
 	//! Returns true if the given column name conflicts with inlined data system columns
 	static bool IsInlinedSystemColumn(const string &name);
+	//! Returns true if any column name conflicts with inlined data system columns
+	static bool HasInlinedSystemColumnConflict(const ColumnList &columns);
+	static bool HasInlinedSystemColumnConflict(const vector<DuckLakeColumnInfo> &columns);
 };
 
 } // namespace duckdb

--- a/src/include/metadata_manager/sqlite_metadata_manager.hpp
+++ b/src/include/metadata_manager/sqlite_metadata_manager.hpp
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// metadata_manager/sqlite_metadata_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "storage/ducklake_metadata_manager.hpp"
+
+namespace duckdb {
+
+class SQLiteMetadataManager : public DuckLakeMetadataManager {
+public:
+	explicit SQLiteMetadataManager(DuckLakeTransaction &transaction);
+
+	bool TypeIsNativelySupported(const LogicalType &type) override;
+};
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -42,7 +42,6 @@ private:
 	bool TryEvaluateExpression(ClientContext &context, idx_t virtual_col_idx, Vector &input_vector,
 	                           const LogicalType &input_type, Vector &output_vector);
 
-
 	mutex lock;
 	DuckLakeFunctionInfo &read_info;
 	string table_name;

--- a/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/multi_file/base_file_reader.hpp"
 #include "storage/ducklake_inlined_data.hpp"
 #include "common/ducklake_snapshot.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 
 namespace duckdb {
 class DuckLakeFieldData;
@@ -48,6 +49,8 @@ private:
 	vector<column_t> scan_column_ids;
 	ColumnDataScanState state;
 	DataChunk scan_chunk;
+	//! Expression executors for expression_map entries, keyed by column_t (from column_ids)
+	unordered_map<column_t, unique_ptr<ExpressionExecutor>> expression_executors;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_inlined_data_reader.hpp
+++ b/src/include/storage/ducklake_inlined_data_reader.hpp
@@ -39,6 +39,10 @@ public:
 	void AddVirtualColumn(column_t virtual_column_id) override;
 
 private:
+	bool TryEvaluateExpression(ClientContext &context, idx_t virtual_col_idx, Vector &input_vector,
+	                           const LogicalType &input_type, Vector &output_vector);
+
+
 	mutex lock;
 	DuckLakeFunctionInfo &read_info;
 	string table_name;

--- a/src/include/storage/ducklake_stats.hpp
+++ b/src/include/storage/ducklake_stats.hpp
@@ -14,7 +14,7 @@ namespace duckdb {
 class BaseStatistics;
 
 //! Returns true for types that require value-based (not lexicographic string) comparison for min/max stats
-static bool RequiresValueComparison(const LogicalType &type) {
+inline bool RequiresValueComparison(const LogicalType &type) {
 	if (type.IsNumeric()) {
 		return true;
 	}

--- a/src/include/storage/ducklake_stats.hpp
+++ b/src/include/storage/ducklake_stats.hpp
@@ -13,6 +13,25 @@
 namespace duckdb {
 class BaseStatistics;
 
+//! Returns true for types that require value-based (not lexicographic string) comparison for min/max stats
+static bool RequiresValueComparison(const LogicalType &type) {
+	if (type.IsNumeric()) {
+		return true;
+	}
+	switch (type.id()) {
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIME:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+		return true;
+	default:
+		return false;
+	}
+}
+
 struct DuckLakeColumnStats;
 
 struct DuckLakeColumnStats {

--- a/src/include/storage/ducklake_stats.hpp
+++ b/src/include/storage/ducklake_stats.hpp
@@ -15,21 +15,7 @@ class BaseStatistics;
 
 //! Returns true for types that require value-based (not lexicographic string) comparison for min/max stats
 inline bool RequiresValueComparison(const LogicalType &type) {
-	if (type.IsNumeric()) {
-		return true;
-	}
-	switch (type.id()) {
-	case LogicalTypeId::DATE:
-	case LogicalTypeId::TIME:
-	case LogicalTypeId::TIMESTAMP:
-	case LogicalTypeId::TIMESTAMP_TZ:
-	case LogicalTypeId::TIMESTAMP_SEC:
-	case LogicalTypeId::TIMESTAMP_MS:
-	case LogicalTypeId::TIMESTAMP_NS:
-		return true;
-	default:
-		return false;
-	}
+	return type.IsNumeric() || type.IsTemporal();
 }
 
 struct DuckLakeColumnStats;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -112,6 +112,8 @@ public:
 	void AppendInlinedData(TableIndex table_id, unique_ptr<DuckLakeInlinedData> collection);
 	void AddNewInlinedDeletes(TableIndex table_id, const string &table_name, set<idx_t> new_deletes);
 	void DeleteFromLocalInlinedData(TableIndex table_id, set<idx_t> new_deletes);
+	void AddColumnToLocalInlinedData(TableIndex table_id, const LogicalType &new_column_type,
+	                                 FieldIndex new_field_index, const Value &default_value = Value());
 	optional_ptr<DuckLakeInlinedDataDeletes> GetInlinedDeletes(TableIndex table_id, const string &table_name);
 	vector<DuckLakeDeletedInlinedDataInfo> GetNewInlinedDeletes(DuckLakeCommitState &commit_state);
 

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -188,7 +188,6 @@ protected:
 	}
 
 private:
-	Connection &GetConnectionInternal();
 	void CleanupFiles();
 	void FlushChanges();
 	void FlushSettingChanges();

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -37,6 +37,7 @@ struct NewNameMapInfo;
 struct CompactionInformation;
 struct DuckLakePath;
 struct DuckLakeCommitState;
+class DuckLakeFieldId;
 
 struct LocalTableDataChanges {
 	vector<DuckLakeDataFile> new_data_files;
@@ -114,6 +115,8 @@ public:
 	void DeleteFromLocalInlinedData(TableIndex table_id, set<idx_t> new_deletes);
 	void AddColumnToLocalInlinedData(TableIndex table_id, const LogicalType &new_column_type,
 	                                 FieldIndex new_field_index, const Value &default_value = Value());
+	void RemoveColumnFromLocalInlinedData(TableIndex table_id, LogicalIndex removed_column_index,
+	                                      const DuckLakeFieldId &field_id);
 	optional_ptr<DuckLakeInlinedDataDeletes> GetInlinedDeletes(TableIndex table_id, const string &table_name);
 	vector<DuckLakeDeletedInlinedDataInfo> GetNewInlinedDeletes(DuckLakeCommitState &commit_state);
 

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -181,6 +181,7 @@ protected:
 	}
 
 private:
+	Connection &GetConnectionInternal();
 	void CleanupFiles();
 	void FlushChanges();
 	void FlushSettingChanges();

--- a/src/metadata_manager/CMakeLists.txt
+++ b/src/metadata_manager/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(ducklake_metadata_manager OBJECT postgres_metadata_manager.cpp)
+add_library(ducklake_metadata_manager OBJECT postgres_metadata_manager.cpp
+                                             sqlite_metadata_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_metadata_manager>
     PARENT_SCOPE)

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -19,9 +19,17 @@ bool PostgresMetadataManager::TypeIsNativelySupported(const LogicalType &type) {
 	case LogicalTypeId::UBIGINT:
 	case LogicalTypeId::HUGEINT:
 	case LogicalTypeId::UHUGEINT:
+	// Postgres timestamp/date ranges are narrower than DuckDB's
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
+	// Postgres bytea input format differs from DuckDB's blob text format
+	case LogicalTypeId::BLOB:
+	// Postgres cannot store null bytes in VARCHAR/TEXT columns
+	case LogicalTypeId::VARCHAR:
 		return false;
 	default:
 		return true;
@@ -39,8 +47,21 @@ string PostgresMetadataManager::GetColumnTypeInternal(const LogicalType &column_
 		return "INTEGER";
 	case LogicalTypeId::UINTEGER:
 		return "BIGINT";
+	case LogicalTypeId::FLOAT:
+		return "REAL";
 	case LogicalTypeId::BLOB:
+	case LogicalTypeId::VARCHAR:
 		return "BYTEA";
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UHUGEINT:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_NS:
+		return "VARCHAR";
 	default:
 		return column_type.ToString();
 	}

--- a/src/metadata_manager/sqlite_metadata_manager.cpp
+++ b/src/metadata_manager/sqlite_metadata_manager.cpp
@@ -1,0 +1,21 @@
+#include "metadata_manager/sqlite_metadata_manager.hpp"
+
+namespace duckdb {
+
+SQLiteMetadataManager::SQLiteMetadataManager(DuckLakeTransaction &transaction) : DuckLakeMetadataManager(transaction) {
+}
+
+bool SQLiteMetadataManager::TypeIsNativelySupported(const LogicalType &type) {
+	switch (type.id()) {
+	// SQLite converts IEEE 754 NaN to NULL when storing double values,
+	// so FLOAT/DOUBLE must be stored as VARCHAR to preserve NaN through the round-trip
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return false;
+	default:
+		return true;
+	}
+}
+
+} // namespace duckdb

--- a/src/metadata_manager/sqlite_metadata_manager.cpp
+++ b/src/metadata_manager/sqlite_metadata_manager.cpp
@@ -11,6 +11,10 @@ SQLiteMetadataManager::SQLiteMetadataManager(DuckLakeTransaction &transaction) :
 
 bool SQLiteMetadataManager::TypeIsNativelySupported(const LogicalType &type) {
 	switch (type.id()) {
+	// Unnamed composite types are not supported.
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::LIST:
 	// SQLite converts IEEE 754 NaN to NULL when storing double values,
 	// so FLOAT/DOUBLE must be stored as VARCHAR to preserve NaN through the round-trip
 	case LogicalTypeId::FLOAT:

--- a/src/metadata_manager/sqlite_metadata_manager.cpp
+++ b/src/metadata_manager/sqlite_metadata_manager.cpp
@@ -26,6 +26,8 @@ bool SQLiteMetadataManager::TypeIsNativelySupported(const LogicalType &type) {
 
 string SQLiteMetadataManager::GetColumnTypeInternal(const LogicalType &column_type) {
 	switch (column_type.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
 	case LogicalTypeId::VARIANT:
 		return "VARCHAR";
 	default:

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -816,7 +816,7 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 }
 
 idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
-	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 1000);
+	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 10);
 }
 
 unique_ptr<LogicalOperator> DuckLakeCatalog::BindAlterAddIndex(Binder &binder, TableCatalogEntry &table_entry,

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -61,6 +61,15 @@ void DuckLakeCatalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 		con->BeginTransaction();
 		context = con->context.get();
 	}
+	// If data_inlining_row_limit wasn't explicitly set via ATTACH options,
+	// use the global DuckDB setting as the default
+	if (options.config_options.find("data_inlining_row_limit") == options.config_options.end()) {
+		Value setting_val;
+		if (context->TryGetCurrentSetting("ducklake_default_data_inlining_row_limit", setting_val)) {
+			auto limit = setting_val.GetValue<idx_t>();
+			options.config_options["data_inlining_row_limit"] = to_string(limit);
+		}
+	}
 	DuckLakeInitializer initializer(*context, *this, options);
 	initializer.Initialize();
 	db.tags["data_path"] = DataPath();
@@ -807,7 +816,7 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 }
 
 idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
-	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 0);
+	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 1000);
 }
 
 unique_ptr<LogicalOperator> DuckLakeCatalog::BindAlterAddIndex(Binder &binder, TableCatalogEntry &table_entry,

--- a/src/storage/ducklake_field_data.cpp
+++ b/src/storage/ducklake_field_data.cpp
@@ -283,7 +283,7 @@ unique_ptr<DuckLakeFieldId> DuckLakeFieldId::RenameField(const vector<string> &c
 	if (!found) {
 		throw InternalException("DuckLakeFieldId::AddField - child not found in struct path");
 	}
-	auto new_type = GetStructType(new_children);
+	auto new_type = GetNewNestedType(type, new_children);
 	return make_uniq<DuckLakeFieldId>(column_data.Copy(), Name(), std::move(new_type), std::move(new_children));
 }
 

--- a/src/storage/ducklake_inline_data.cpp
+++ b/src/storage/ducklake_inline_data.cpp
@@ -1,4 +1,5 @@
 #include "storage/ducklake_inline_data.hpp"
+#include "storage/ducklake_stats.hpp"
 
 #include "duckdb/common/type_visitor.hpp"
 #include "storage/ducklake_insert.hpp"
@@ -234,7 +235,7 @@ DuckLakeColumnStats GetVectorStats(Vector &input_vec, idx_t row_count) {
 	VectorOperations::DefaultCast(input_vec, str_vector, row_count);
 	// FIXME: we can be more efficient here by templating on other types (numerics...)
 	// FIXME: we can gather nan statistics for FLOAT/DOUBLE
-	if (type.IsNumeric()) {
+	if (RequiresValueComparison(type)) {
 		return TemplatedUpdateStats<string_t, StatsNumericFallbackOperator>(str_vector, type, row_count);
 	}
 	return TemplatedUpdateStats<string_t, StatsFallbackOperator>(str_vector, type, row_count);

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -149,9 +149,6 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			}
 			filter.delete_data->deleted_rows = std::move(deleted_ordinals);
 		}
-		for (auto &entry : expression_map) {
-			expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
-		}
 		data->data->InitializeScan(state);
 	} else {
 		// scanning from transaction-local data - we already have the data
@@ -176,11 +173,10 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			scan_column_ids.push_back(0);
 		}
 		scan_chunk.Initialize(context, scan_types);
-		// Initialize expression executors for transaction-local data
-		for (auto &entry : expression_map) {
-			expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
-		}
 		data->data->InitializeScan(state, scan_column_ids);
+	}
+	for (auto &entry : expression_map) {
+		expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
 	}
 	return true;
 }

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -190,8 +190,7 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
 					if (expr_it != expression_executors.end()) {
 						// Evaluate expressions
 						DataChunk expr_input;
-						expr_input.Initialize(Allocator::Get(context),
-						                      {scan_chunk.data[column_id].GetType()});
+						expr_input.Initialize(Allocator::Get(context), {scan_chunk.data[column_id].GetType()});
 						expr_input.Reset();
 						expr_input.data[0].Reference(scan_chunk.data[column_id]);
 						expr_input.SetCardinality(scan_chunk.size());

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -211,8 +211,8 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
 			switch (virtual_columns[c]) {
 			case InlinedVirtualColumn::NONE: {
 				auto column_id = source_idx++;
-				if (TryEvaluateExpression(context, c, scan_chunk.data[column_id],
-				                          scan_chunk.data[column_id].GetType(), chunk.data[c])) {
+				if (TryEvaluateExpression(context, c, scan_chunk.data[column_id], scan_chunk.data[column_id].GetType(),
+				                          chunk.data[c])) {
 					break;
 				}
 				if (chunk.data[c].GetType() != scan_chunk.data[column_id].GetType()) {

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -68,8 +68,10 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 				}
 			}
 			string projected_column = KeywordHelper::WriteOptionallyQuoted(columns[index].name);
-			if (!ducklake_catalog.IsDuckCatalog()) {
-				// If it's not a duckdb catalog, we add a cast.
+			auto &metadata_type = ducklake_catalog.MetadataType();
+			bool needs_cast = !metadata_type.empty() && metadata_type != "duckdb";
+			if (needs_cast) {
+				// For non-DuckDB metadata backends (e.g. SQLite), data is stored as VARCHAR - cast is required
 				if (columns[index].type.id() != LogicalTypeId::VARCHAR) {
 					projected_column = metadata_manager.CastColumnToTarget(projected_column, columns[index].type);
 				}

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -68,7 +68,9 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			string projected_column = KeywordHelper::WriteOptionallyQuoted(columns[index].name);
 			if (!ducklake_catalog.IsDuckCatalog()) {
 				// If it's not a duckdb catalog, we add a cast.
-				projected_column += "::" + columns[index].type.ToString();
+				if (columns[index].type.id() != LogicalTypeId::VARCHAR) {
+					projected_column += "::" + columns[index].type.ToString();
+				}
 			}
 			columns_to_read.push_back(projected_column);
 		}

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -31,10 +31,6 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 		}
 		initialized_scan = true;
 	}
-	if (!expression_map.empty()) {
-		throw InternalException("FIXME: support expression_map");
-	}
-
 	if (!data) {
 		// scanning data from a table - read it from the metadata catalog
 		auto transaction = read_info.GetTransaction();
@@ -92,6 +88,12 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			columns_to_read.push_back(KeywordHelper::WriteOptionallyQuoted("row_id"));
 			virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_EMPTY);
 		}
+		if (!expression_map.empty() && virtual_columns.empty()) {
+			for (idx_t i = 0; i < columns_to_read.size(); i++) {
+				scan_column_ids.push_back(i);
+				virtual_columns.push_back(InlinedVirtualColumn::NONE);
+			}
+		}
 		switch (read_info.scan_type) {
 		case DuckLakeScanType::SCAN_TABLE:
 			data = metadata_manager.ReadInlinedData(read_info.snapshot, table_name, columns_to_read);
@@ -135,6 +137,9 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			}
 			filter.delete_data->deleted_rows = std::move(deleted_ordinals);
 		}
+		for (auto &entry : expression_map) {
+			expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
+		}
 		data->data->InitializeScan(state);
 	} else {
 		// scanning from transaction-local data - we already have the data
@@ -152,12 +157,17 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			scan_column_ids.push_back(col_id);
 			virtual_columns.emplace_back(InlinedVirtualColumn::NONE);
 		}
-		if (!scan_types.empty()) {
+		if (!scan_types.empty() || !virtual_columns.empty()) {
+			// add an extra column to scan to determine the cardinality
+			// this is needed even when all columns are virtual (e.g., only rowid)
 			scan_types.push_back(types[0]);
 			scan_column_ids.push_back(0);
 		}
 		scan_chunk.Initialize(context, scan_types);
-
+		// Initialize expression executors for transaction-local data
+		for (auto &entry : expression_map) {
+			expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
+		}
 		data->data->InitializeScan(state, scan_column_ids);
 	}
 	return true;
@@ -173,6 +183,22 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
 			switch (virtual_columns[c]) {
 			case InlinedVirtualColumn::NONE: {
 				auto column_id = source_idx++;
+				// Check if this column has an expression to evaluate
+				if (!expression_map.empty() && c < column_ids.size()) {
+					auto local_id = column_ids[MultiFileLocalIndex(c)];
+					auto expr_it = expression_executors.find(local_id);
+					if (expr_it != expression_executors.end()) {
+						// Evaluate expressions
+						DataChunk expr_input;
+						expr_input.Initialize(Allocator::Get(context),
+						                      {scan_chunk.data[column_id].GetType()});
+						expr_input.Reset();
+						expr_input.data[0].Reference(scan_chunk.data[column_id]);
+						expr_input.SetCardinality(scan_chunk.size());
+						expr_it->second->ExecuteExpression(expr_input, chunk.data[c]);
+						break;
+					}
+				}
 				chunk.data[c].Reference(scan_chunk.data[column_id]);
 				break;
 			}

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -72,7 +72,7 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 			auto &metadata_type = ducklake_catalog.MetadataType();
 			bool needs_cast = !metadata_type.empty() && metadata_type != "duckdb";
 			if (needs_cast) {
-				// For non-DuckDB metadata backends (e.g. SQLite), data is stored as VARCHAR - cast is required
+				// If it's not a duckdb catalog, we add a cast.
 				if (columns[index].type.id() != LogicalTypeId::VARCHAR) {
 					projected_column = metadata_manager.CastColumnToTarget(projected_column, columns[index].type);
 				}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -28,8 +28,7 @@ namespace duckdb {
 
 static bool HasInlinedSystemColumnConflict(const ColumnList &columns) {
 	for (auto &col : columns.Logical()) {
-		auto &name = col.Name();
-		if (name == "row_id" || name == "begin_snapshot" || name == "end_snapshot") {
+		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name())) {
 			return true;
 		}
 	}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -150,6 +150,13 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 				continue;
 			}
 			if (column_names[0] == "_ducklake_internal_row_id") {
+				if (set_snapshot_id) {
+					// extract the min row_id so flushed files preserve the original row_id_start
+					auto row_id_stats = ParseColumnStats(LogicalType::BIGINT, col_stats);
+					if (row_id_stats.has_min) {
+						data_file.flush_row_id_start = StringUtil::ToUnsigned(row_id_stats.min);
+					}
+				}
 				continue;
 			}
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -973,8 +973,8 @@ string DuckLakeMetadataManager::CastValueToTarget(const Value &val, const Logica
 }
 
 string DuckLakeMetadataManager::CastStatsToTarget(const string &stats, const LogicalType &type) {
-	// we only need to cast numerics
-	if (type.IsNumeric()) {
+	// we need to cast numerics and temporals for correct comparison
+	if (RequiresValueComparison(type)) {
 		return "TRY_CAST(" + stats + " AS " + type.ToString() + ")";
 	}
 	return stats;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2026,7 +2026,7 @@ string DuckLakeMetadataManager::GetColumnType(const DuckLakeColumnInfo &col) {
 
 static bool HasInlinedSystemColumnConflict(const vector<DuckLakeColumnInfo> &columns) {
 	for (auto &col : columns) {
-		if (col.name == "row_id" || col.name == "begin_snapshot" || col.name == "end_snapshot") {
+		if (DuckLakeUtil::IsInlinedSystemColumn(col.name)) {
 			return true;
 		}
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2327,16 +2327,6 @@ WHERE table_id = %d AND schema_version=(
 			batch_query += append_query;
 		}
 	}
-	// We need to handle new tables that have created new inlined tables in the same commit
-	// Since creating or inserting data to an inline table also creates a new snapshot
-	for (auto table_id : pre_created_inlined_tables_with_data) {
-		for (auto &new_table : new_tables) {
-			if (new_table.id.index == table_id) {
-				commit_snapshot.schema_version++;
-				break;
-			}
-		}
-	}
 	return batch_query;
 }
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -9,6 +9,7 @@
 #include "storage/ducklake_table_entry.hpp"
 #include "duckdb.hpp"
 #include "metadata_manager/postgres_metadata_manager.hpp"
+#include "metadata_manager/sqlite_metadata_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
@@ -33,6 +34,9 @@ unique_ptr<DuckLakeMetadataManager> DuckLakeMetadataManager::Create(DuckLakeTran
 	auto catalog_type = catalog.MetadataType();
 	if (catalog_type == "postgres" || catalog_type == "postgres_scanner") {
 		return make_uniq<PostgresMetadataManager>(transaction);
+	}
+	if (catalog_type == "sqlite_scanner") {
+		return make_uniq<SQLiteMetadataManager>(transaction);
 	}
 	return make_uniq<DuckLakeMetadataManager>(transaction);
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1761,6 +1761,9 @@ string DuckLakeMetadataManager::GetColumnTypeInternal(const LogicalType &column_
 string DuckLakeMetadataManager::GetColumnType(const DuckLakeColumnInfo &col) {
 	auto column_type = DuckLakeTypes::FromString(col.type);
 	if (!TypeIsNativelySupported(column_type)) {
+		if (!column_type.IsNested()) {
+			return GetColumnTypeInternal(column_type);
+		}
 		return "VARCHAR";
 	}
 	switch (column_type.id()) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2071,9 +2071,11 @@ WHERE table_id = %d AND schema_version=(
 				row_id++;
 			}
 		}
-		string append_query = StringUtil::Format("INSERT INTO {METADATA_CATALOG}.%s VALUES %s;",
-		                                         SQLIdentifier(inlined_table_name), values);
-		batch_query += append_query;
+		if (!values.empty()) {
+			string append_query = StringUtil::Format("INSERT INTO {METADATA_CATALOG}.%s VALUES %s;",
+			                                         SQLIdentifier(inlined_table_name), values);
+			batch_query += append_query;
+		}
 	}
 	return batch_query;
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2034,9 +2034,6 @@ string DuckLakeMetadataManager::WriteNewTables(DuckLakeSnapshot commit_snapshot,
 		batch_query += "INSERT INTO {METADATA_CATALOG}.ducklake_column VALUES " + column_insert_sql + ";";
 	}
 
-	// write new data-inlining tables (if data-inlining is enabled)
-	batch_query += WriteNewInlinedTables(commit_snapshot, new_tables);
-
 	return batch_query;
 }
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2024,15 +2024,6 @@ string DuckLakeMetadataManager::GetColumnType(const DuckLakeColumnInfo &col) {
 	}
 }
 
-static bool HasInlinedSystemColumnConflict(const vector<DuckLakeColumnInfo> &columns) {
-	for (auto &col : columns) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.name)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 string DuckLakeMetadataManager::GetInlinedTableQuery(const DuckLakeTableInfo &table, const string &table_name) {
 	string columns;
 
@@ -2122,7 +2113,7 @@ string DuckLakeMetadataManager::WriteNewInlinedTables(DuckLakeSnapshot commit_sn
 			}
 		}
 		// FIXME: we are skipping columns that have conflicting names, we should resolve this
-		if (HasInlinedSystemColumnConflict(table_with_columns.columns)) {
+		if (DuckLakeUtil::HasInlinedSystemColumnConflict(table_with_columns.columns)) {
 			continue;
 		}
 		GetInlinedTableQueries(commit_snapshot, table_with_columns, inlined_tables, inlined_table_queries);

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -5,6 +5,8 @@
 #include "storage/ducklake_stats.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/common/multi_file/multi_file_data.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/query_profiler.hpp"
@@ -21,6 +23,66 @@ static InsertionOrderPreservingMap<string> DuckLakeFunctionToString(TableFunctio
 		result["Table"] = table_info.table_name;
 	}
 
+	return result;
+}
+
+static InsertionOrderPreservingMap<string> DuckLakeDynamicToString(TableFunctionDynamicToStringInput &input) {
+	InsertionOrderPreservingMap<string> result;
+	if (!input.global_state) {
+		return result;
+	}
+	auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
+	auto &file_list = gstate.file_list.Cast<DuckLakeMultiFileList>();
+
+	// Count different types of files
+	auto files_loaded = gstate.file_index.load();
+	auto &files = file_list.GetFiles();
+	idx_t data_files_read = 0;
+	idx_t data_files_skipped = 0;
+	idx_t inlined_tables_read = 0;
+	for (idx_t i = 0; i < files_loaded && i < files.size() && i < gstate.readers.size(); i++) {
+		bool is_skipped = gstate.readers[i]->file_state == MultiFileFileState::SKIPPED;
+		switch (files[i].data_type) {
+		case DuckLakeDataType::DATA_FILE:
+			if (is_skipped) {
+				data_files_skipped++;
+			} else {
+				data_files_read++;
+			}
+			break;
+		case DuckLakeDataType::INLINED_DATA:
+		case DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA:
+			if (!is_skipped) {
+				inlined_tables_read++;
+			}
+			break;
+		}
+	}
+
+	result.insert(make_pair("Total Files Read", std::to_string(data_files_read)));
+	if (data_files_skipped > 0) {
+		result.insert(make_pair("Total Files Skipped", std::to_string(data_files_skipped)));
+	}
+	if (inlined_tables_read > 0) {
+		result.insert(make_pair("Inlined Tables Read", std::to_string(inlined_tables_read)));
+	}
+
+	// Build filename list showing only actual data files (not inlined data tables)
+	constexpr size_t FILE_NAME_LIST_LIMIT = 5;
+	vector<std::string> file_path_names;
+	for (idx_t i = 0; i < files.size() && file_path_names.size() <= FILE_NAME_LIST_LIMIT; i++) {
+		if (files[i].data_type == DuckLakeDataType::DATA_FILE) {
+			file_path_names.push_back(files[i].file.path);
+		}
+	}
+	if (!file_path_names.empty()) {
+		if (file_path_names.size() > FILE_NAME_LIST_LIMIT) {
+			file_path_names.resize(FILE_NAME_LIST_LIMIT);
+			file_path_names.push_back("...");
+		}
+		auto list_of_files = StringUtil::Join(file_path_names, ", ");
+		result.insert(make_pair("Filename(s)", list_of_files));
+	}
 	return result;
 }
 
@@ -94,6 +156,7 @@ TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &insta
 	function.deserialize = DuckLakeScanDeserialize;
 
 	function.to_string = DuckLakeFunctionToString;
+	function.dynamic_to_string = DuckLakeDynamicToString;
 
 	function.name = "ducklake_scan";
 	return function;

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -72,7 +72,7 @@ static InsertionOrderPreservingMap<string> DuckLakeDynamicToString(TableFunction
 
 	// Build filename list showing only actual data files (not inlined data tables)
 	constexpr size_t FILE_NAME_LIST_LIMIT = 5;
-	vector<std::string> file_path_names;
+	vector<string> file_path_names;
 	for (idx_t i = 0; i < files.size() && file_path_names.size() <= FILE_NAME_LIST_LIMIT; i++) {
 		if (files[i].data_type == DuckLakeDataType::DATA_FILE) {
 			file_path_names.push_back(files[i].file.path);

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -115,8 +115,8 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 		has_min = false;
 	} else if (has_min) {
 		// both stats have a min - select the smallest
-		if (type.IsNumeric()) {
-			// for numerics we need to parse the stats
+		if (RequiresValueComparison(type)) {
+			// for numerics/temporals we need to parse the stats
 			auto current_min = Value(min).DefaultCastAs(type);
 			auto new_min = Value(new_stats.min).DefaultCastAs(type);
 			if (new_min < current_min) {
@@ -131,9 +131,9 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 	if (!new_stats.has_max) {
 		has_max = false;
 	} else if (has_max) {
-		// both stats have a min - select the smallest
-		if (type.IsNumeric()) {
-			// for numerics we need to parse the stats
+		// both stats have a max - select the largest
+		if (RequiresValueComparison(type)) {
+			// for numerics/temporals we need to parse the stats
 			auto current_max = Value(max).DefaultCastAs(type);
 			auto new_max = Value(new_stats.max).DefaultCastAs(type);
 			if (new_max > current_max) {

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -376,7 +376,7 @@ string GetPartitionColumnName(ColumnRefExpression &colref) {
 }
 
 void DuckLakeTableEntry::ValidateSortExpressionColumns(DuckLakeTableEntry &table,
-                                                        const vector<reference<ParsedExpression>> &expressions) {
+                                                       const vector<reference<ParsedExpression>> &expressions) {
 	vector<string> missing_columns;
 	for (auto &expr : expressions) {
 		ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1194,7 +1194,9 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transact
 		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
 		    info.alter_table_type != AlterTableType::REMOVE_COLUMN &&
 		    info.alter_table_type != AlterTableType::RENAME_TABLE &&
-		    info.alter_table_type != AlterTableType::ALTER_COLUMN_TYPE) {
+		    info.alter_table_type != AlterTableType::ALTER_COLUMN_TYPE &&
+		    info.alter_table_type != AlterTableType::SET_NOT_NULL &&
+		    info.alter_table_type != AlterTableType::DROP_NOT_NULL) {
 			throw NotImplementedException("ALTER on a table with transaction-local inlined data is not supported %s",
 			                              EnumUtil::ToString(info.alter_table_type));
 		}

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1196,6 +1196,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transact
 		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
 		    info.alter_table_type != AlterTableType::REMOVE_COLUMN &&
 		    info.alter_table_type != AlterTableType::RENAME_TABLE &&
+		    info.alter_table_type != AlterTableType::RENAME_COLUMN &&
 		    info.alter_table_type != AlterTableType::ALTER_COLUMN_TYPE &&
 		    info.alter_table_type != AlterTableType::SET_NOT_NULL &&
 		    info.alter_table_type != AlterTableType::DROP_NOT_NULL) {

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -981,7 +981,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto new_field_ids = make_shared_ptr<DuckLakeFieldData>();
 	for (idx_t col_idx = 0; col_idx < current_field_ids.size(); col_idx++) {
 		auto &field_id = current_field_ids[col_idx];
-		if (child_field_id && field_id->Name() == info.column_path[0]) {
+		if (child_field_id && StringUtil::CIEquals(field_id->Name(), info.column_path[0])) {
 			auto new_field_id = field_id->AddField(info.column_path, std::move(child_field_id));
 			auto &col = table_info.columns.GetColumnMutable(PhysicalIndex(col_idx));
 			col.SetType(new_field_id->Type());
@@ -1033,7 +1033,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto new_field_ids = make_shared_ptr<DuckLakeFieldData>();
 	for (idx_t col_idx = 0; col_idx < current_field_ids.size(); col_idx++) {
 		auto &field_id = current_field_ids[col_idx];
-		if (field_id->Name() == info.column_path[0]) {
+		if (StringUtil::CIEquals(field_id->Name(), info.column_path[0])) {
 			auto new_field_id = field_id->RemoveField(info.column_path);
 			auto &col = table_info.columns.GetColumnMutable(PhysicalIndex(col_idx));
 			col.SetType(new_field_id->Type());
@@ -1089,7 +1089,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto new_field_ids = make_shared_ptr<DuckLakeFieldData>();
 	for (idx_t col_idx = 0; col_idx < current_field_ids.size(); col_idx++) {
 		auto &field_id = current_field_ids[col_idx];
-		if (field_id->Name() == info.column_path[0]) {
+		if (StringUtil::CIEquals(field_id->Name(), info.column_path[0])) {
 			auto new_field_id = field_id->RenameField(info.column_path, info.new_name);
 			auto &col = table_info.columns.GetColumnMutable(PhysicalIndex(col_idx));
 			col.SetType(new_field_id->Type());
@@ -1154,8 +1154,8 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transaction, AlterTableInfo &info) {
 	if (transaction.HasTransactionInlinedData(GetTableId())) {
-		// Only ADD_COLUMN is supported with transaction-local inlined data
-		if (info.alter_table_type != AlterTableType::ADD_COLUMN) {
+		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
+		    info.alter_table_type != AlterTableType::RENAME_TABLE) {
 			throw NotImplementedException("ALTER on a table with transaction-local inlined data is not supported %s",
 			                              EnumUtil::ToString(info.alter_table_type));
 		}

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -633,6 +633,10 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 			}
 		}
 	}
+	if (transaction.HasTransactionInlinedData(GetTableId())) {
+		transaction.RemoveColumnFromLocalInlinedData(GetTableId(), col.Logical(), field_id);
+	}
+
 	auto removed_index = col.Logical();
 	for (idx_t c_idx = 0; c_idx < table_info.constraints.size(); c_idx++) {
 		auto &constraint = table_info.constraints[c_idx];
@@ -1172,6 +1176,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transaction, AlterTableInfo &info) {
 	if (transaction.HasTransactionInlinedData(GetTableId())) {
 		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
+		    info.alter_table_type != AlterTableType::REMOVE_COLUMN &&
 		    info.alter_table_type != AlterTableType::RENAME_TABLE) {
 			throw NotImplementedException("ALTER on a table with transaction-local inlined data is not supported %s",
 			                              EnumUtil::ToString(info.alter_table_type));

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1193,7 +1193,8 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transact
 	if (transaction.HasTransactionInlinedData(GetTableId())) {
 		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
 		    info.alter_table_type != AlterTableType::REMOVE_COLUMN &&
-		    info.alter_table_type != AlterTableType::RENAME_TABLE) {
+		    info.alter_table_type != AlterTableType::RENAME_TABLE &&
+		    info.alter_table_type != AlterTableType::ALTER_COLUMN_TYPE) {
 			throw NotImplementedException("ALTER on a table with transaction-local inlined data is not supported %s",
 			                              EnumUtil::ToString(info.alter_table_type));
 		}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1392,9 +1392,10 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
-			// flushed files (with max_partial_file_snapshot) have embedded row_ids, we gotta use the original row_id_start
-			auto row_id_start = file.flush_row_id_start.IsValid() ? file.flush_row_id_start.GetIndex()
-			                                                      : new_stats.next_row_id;
+			// flushed files (with max_partial_file_snapshot) have embedded row_ids, we gotta use the original
+			// row_id_start
+			auto row_id_start =
+			    file.flush_row_id_start.IsValid() ? file.flush_row_id_start.GetIndex() : new_stats.next_row_id;
 			auto data_file = GetNewDataFile(file, commit_state.commit_snapshot, table_id, row_id_start);
 			for (auto &del_file : file.delete_files) {
 				// this transaction-local file already has deletes - write them out

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1041,6 +1041,7 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 			auto &latest_table = tables.front().get();
 			DuckLakeTableInfo inlined_entry;
 			inlined_entry.id = new_table_id;
+			inlined_entry.schema_id = latest_table.ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId();
 			inlined_entry.uuid = latest_table.GetTableUUID();
 			inlined_entry.columns = latest_table.GetTableColumns();
 			result.new_inlined_data_tables.push_back(std::move(inlined_entry));
@@ -1066,6 +1067,7 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 		if (!already_added) {
 			DuckLakeTableInfo table_entry;
 			table_entry.id = committed_id;
+			table_entry.schema_id = table.ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId();
 			table_entry.uuid = table.GetTableUUID();
 			table_entry.columns = table.GetTableColumns();
 			result.new_inlined_data_tables.push_back(std::move(table_entry));

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1823,10 +1823,9 @@ void DuckLakeTransaction::FlushChanges() {
 			}
 			can_retry = true;
 			DuckLakeCommitState commit_state(commit_snapshot);
-			string batch_queries = CommitChanges(commit_state, transaction_changes, stats);
-
 			// write the new snapshot
-			batch_queries += metadata_manager->InsertSnapshot();
+			string batch_queries = metadata_manager->InsertSnapshot();
+			batch_queries += CommitChanges(commit_state, transaction_changes, stats);
 
 			batch_queries += WriteSnapshotChanges(commit_state, transaction_changes);
 

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1392,7 +1392,10 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
-			auto data_file = GetNewDataFile(file, commit_state.commit_snapshot, table_id, new_stats.next_row_id);
+			// flushed files (with max_partial_file_snapshot) have embedded row_ids, we gotta use the original row_id_start
+			auto row_id_start = file.flush_row_id_start.IsValid() ? file.flush_row_id_start.GetIndex()
+			                                                      : new_stats.next_row_id;
+			auto data_file = GetNewDataFile(file, commit_state.commit_snapshot, table_id, row_id_start);
 			for (auto &del_file : file.delete_files) {
 				// this transaction-local file already has deletes - write them out
 				DuckLakeDeleteFile delete_file = del_file;

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -389,8 +389,7 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 				auto &child_expression = expressions[col_idx.GetIndex()]->Cast<BoundReferenceExpression>();
 				auto column_reference =
 				    make_uniq<BoundReferenceExpression>(child_expression.return_type, child_expression.index);
-				expressions.push_back(
-				    GetPartitionExpressionForUpdate(context, std::move(column_reference), field));
+				expressions.push_back(GetPartitionExpressionForUpdate(context, std::move(column_reference), field));
 			}
 		}
 	}

--- a/src/storage/statistics/ducklake_variant_stats.cpp
+++ b/src/storage/statistics/ducklake_variant_stats.cpp
@@ -248,10 +248,10 @@ struct NestedVariantStats {
 	}
 
 	void ConvertStats(const unordered_map<string, DuckLakeVariantStats> &field_stats, BaseStatistics &main_stats) {
-		auto &untyped_value_index_stats = StructStats::GetChildStats(main_stats, 0);
-		untyped_value_index_stats.SetHasNull();
+		auto &stats = StructStats::GetChildStats(main_stats, VariantStats::TYPED_VALUE_INDEX);
 
-		auto &stats = StructStats::GetChildStats(main_stats, 1);
+		auto &untyped_value_index_stats = StructStats::GetChildStats(main_stats, VariantStats::UNTYPED_VALUE_INDEX);
+		untyped_value_index_stats.SetHasNull();
 		if (!full_field_name.empty()) {
 			// field, find it in the stats
 			auto entry = field_stats.find(full_field_name);
@@ -377,7 +377,7 @@ unique_ptr<BaseStatistics> DuckLakeColumnVariantStats::ToStats() const {
 	// get the type
 	auto shredded_type = nested_stats.ToType(shredded_field_stats);
 	auto full_shredding_type = TypeVisitor::VisitReplace(shredded_type, [](const LogicalType &type) {
-		return LogicalType::STRUCT({{"untyped_value_index", LogicalType::UINTEGER}, {"typed_value", type}});
+		return LogicalType::STRUCT({{"typed_value", type}, {"untyped_value_index", LogicalType::UINTEGER}});
 	});
 	auto variant_stats = VariantStats::CreateShredded(full_shredding_type);
 

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -626,7 +626,7 @@
       "reason": "FIXME: Variant Bugs?",
       "paths": [
           "test/parquet/variant/variant_comparison.test",
-        " test/sql/storage/types/variant/variant_shredding_omit_untyped.test"
+        "test/sql/storage/types/variant/variant_shredding_omit_untyped.test"
       ]
     }
   ]

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -638,6 +638,17 @@
           "test/parquet/variant/variant_comparison.test",
         "test/sql/storage/types/variant/variant_shredding_omit_untyped.test"
       ]
+    },
+    {
+      "reason": "FIXME: inline of GEOMETRY not yet supported",
+      "paths": [
+        "test/geoparquet/no_spatial.test",
+        "test/geoparquet/mixed.test",
+        "test/sql/types/geo/geometry_shred_empty.test",
+        "test/sql/types/geo/geometry.test",
+        "test/sql/types/geo/geometry_wkb.test",
+        "test/sql/types/geo/geometry_shred_fetch.test"
+      ]
     }
   ]
 }

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -621,5 +621,13 @@
           "test/sql/storage/types/variant/variant_extract_stats.test"
       ]
     }
+    ,
+    {
+      "reason": "FIXME: Variant Bugs?",
+      "paths": [
+          "test/parquet/variant/variant_comparison.test",
+        " test/sql/storage/types/variant/variant_shredding_omit_untyped.test"
+      ]
+    }
   ]
 }

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -6,5 +6,35 @@
     "parquet",
     "ducklake",
     "icu"
+  ],   "skip_tests": [
+   {
+      "reason": "Snapshot ID differs due to flush",
+      "paths": [
+        "test/sql/table_changes/ducklake_table_insertions.test",
+        "test/sql/add_files/add_files.test",
+        "test/sql/add_files/add_files_compaction.test",
+        "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
+        "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",
+        "test/sql/rewrite_data_files/test_rewrite_db.test",
+        "test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test",
+        "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
+        "test/sql/functions/ducklake_snapshots.test",
+        "test/sql/alter/expire_snapshot_bug.test",
+        "test/sql/compaction/compaction_alter_table.test",
+        "test/sql/compaction/mix_large_small_insertions.test",
+        "test/sql/compaction/compaction_partitioned_non_adjacent.test",
+        "test/sql/compaction/merge_rewrite_partial_file_info.test",
+        "test/sql/compaction/small_insert_compaction.test",
+        "test/sql/compaction/compaction_partitioned_table.test",
+        "test/sql/compaction/merge_adjacent_max_files.test",
+        "test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test",
+        "test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test",
+        "test/sql/sorted_table/merge_adjacent_sorted_basic.test",
+        "test/sql/compaction/multi_compaction.test",
+        "test/sql/compaction/merge_adjacent_partial_max.test",
+        "test/sql/compaction/merge_adjacent_options.test",
+        "test/sql/delete/test_delete_partial_max_snapshot.test"
+      ]
+    }
   ]
 }

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -6,5 +6,13 @@
     "parquet",
     "ducklake",
     "icu"
+  ],
+  "skip_tests": [
+    {
+      "reason": "Parquet is statically loaded in this config, test requires missing parquet",
+      "paths": [
+        "test/sql/general/missing_parquet.test"
+      ]
+    }
   ]
 }

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -1,0 +1,10 @@
+{
+  "description": "Run DuckLake tests with data inlining disabled.",
+  "on_init": "SET ducklake_default_data_inlining_row_limit = 0;",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "parquet",
+    "ducklake",
+    "icu"
+  ]
+}

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -8,7 +8,7 @@
     "icu"
   ],   "skip_tests": [
    {
-      "reason": "Snapshot ID differs due to flush",
+      "reason": "Snapshot ID differs due to flush - time travel and snapshot-specific checks",
       "paths": [
         "test/sql/table_changes/ducklake_table_insertions.test",
         "test/sql/add_files/add_files.test",
@@ -21,18 +21,11 @@
         "test/sql/functions/ducklake_snapshots.test",
         "test/sql/alter/expire_snapshot_bug.test",
         "test/sql/compaction/compaction_alter_table.test",
-        "test/sql/compaction/mix_large_small_insertions.test",
         "test/sql/compaction/compaction_partitioned_non_adjacent.test",
-        "test/sql/compaction/merge_rewrite_partial_file_info.test",
         "test/sql/compaction/small_insert_compaction.test",
         "test/sql/compaction/compaction_partitioned_table.test",
-        "test/sql/compaction/merge_adjacent_max_files.test",
-        "test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test",
-        "test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test",
-        "test/sql/sorted_table/merge_adjacent_sorted_basic.test",
-        "test/sql/compaction/multi_compaction.test",
         "test/sql/compaction/merge_adjacent_partial_max.test",
-        "test/sql/compaction/merge_adjacent_options.test",
+        "test/sql/compaction/merge_rewrite_partial_file_info.test",
         "test/sql/delete/test_delete_partial_max_snapshot.test"
       ]
     }

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -6,28 +6,5 @@
     "parquet",
     "ducklake",
     "icu"
-  ],   "skip_tests": [
-   {
-      "reason": "Snapshot ID differs due to flush - time travel and snapshot-specific checks",
-      "paths": [
-        "test/sql/table_changes/ducklake_table_insertions.test",
-        "test/sql/add_files/add_files.test",
-        "test/sql/add_files/add_files_compaction.test",
-        "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
-        "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",
-        "test/sql/rewrite_data_files/test_rewrite_db.test",
-        "test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test",
-        "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
-        "test/sql/functions/ducklake_snapshots.test",
-        "test/sql/alter/expire_snapshot_bug.test",
-        "test/sql/compaction/compaction_alter_table.test",
-        "test/sql/compaction/compaction_partitioned_non_adjacent.test",
-        "test/sql/compaction/small_insert_compaction.test",
-        "test/sql/compaction/compaction_partitioned_table.test",
-        "test/sql/compaction/merge_adjacent_partial_max.test",
-        "test/sql/compaction/merge_rewrite_partial_file_info.test",
-        "test/sql/delete/test_delete_partial_max_snapshot.test"
-      ]
-    }
   ]
 }

--- a/test/sql/add_files/add_file_partitioned.test
+++ b/test/sql/add_files/add_file_partitioned.test
@@ -39,46 +39,40 @@ FROM read_parquet('${DATA_PATH}/add_file_partitioned/main/partitioned_t/partitio
 ----
 4	2
 
-query IIII
-FROM metadata.ducklake_file_partition_value;
-----
-2	1	0	1
-3	1	0	2
-4	1	0	3
-
 query III
-SELECT data_file_id, min_value, max_value FROM metadata.ducklake_file_column_stats where column_id = 2
+SELECT table_id, partition_key_index, partition_value FROM metadata.ducklake_file_partition_value;
 ----
-2	1	1
-3	2	2
-4	3	3
+1	0	1
+1	0	2
+1	0	3
+
+query I
+SELECT count(*) FROM metadata.ducklake_file_column_stats where column_id = 2
+----
+3
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'partitioned_t', '${DATA_PATH}/add_file_partitioned/main/partitioned_t/partition_column=2/file.parquet')
 
 # Added file has proper min/max
-query III
-SELECT data_file_id, min_value, max_value FROM metadata.ducklake_file_column_stats where column_id = 2
+query I
+SELECT count(*) FROM metadata.ducklake_file_column_stats where column_id = 2
 ----
-2	1	1
-3	2	2
-4	3	3
-6	2	2
+4
 
 # Added file has partition value
-query IIII
-FROM metadata.ducklake_file_partition_value;
-----
-2	1	0	1
-3	1	0	2
-4	1	0	3
-6	1	0	2
-
 query III
-FROM partitioned_t where partition_column = 2;
+SELECT table_id, partition_key_index, partition_value FROM metadata.ducklake_file_partition_value;
 ----
-5	2	1
-4	2	2
+1	0	1
+1	0	2
+1	0	3
+1	0	2
+
+query I
+SELECT COUNT(*) FROM partitioned_t where partition_column = 2;
+----
+2
 
 statement ok
 COPY (SELECT 4 AS id, 2 as partition_column, 2 as other_partition_column) TO '${DATA_PATH}/add_file_partitioned/main/partitioned_t/file.parquet' (FORMAT parquet);

--- a/test/sql/add_files/add_file_partitioned.test
+++ b/test/sql/add_files/add_file_partitioned.test
@@ -29,6 +29,9 @@ statement ok
 INSERT INTO partitioned_t VALUES (5,2,1), (6,3,3);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 COPY (SELECT 4 AS id, 2 as other_partition_column) TO '${DATA_PATH}/add_file_partitioned/main/partitioned_t/partition_column=2/file.parquet' (FORMAT parquet);
 
 query II
@@ -39,16 +42,16 @@ FROM read_parquet('${DATA_PATH}/add_file_partitioned/main/partitioned_t/partitio
 query IIII
 FROM metadata.ducklake_file_partition_value;
 ----
-0	1	0	1
-1	1	0	2
-2	1	0	3
+2	1	0	1
+3	1	0	2
+4	1	0	3
 
 query III
 SELECT data_file_id, min_value, max_value FROM metadata.ducklake_file_column_stats where column_id = 2
 ----
-0	1	1
-1	2	2
-2	3	3
+2	1	1
+3	2	2
+4	3	3
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'partitioned_t', '${DATA_PATH}/add_file_partitioned/main/partitioned_t/partition_column=2/file.parquet')
@@ -57,19 +60,19 @@ CALL ducklake_add_data_files('ducklake', 'partitioned_t', '${DATA_PATH}/add_file
 query III
 SELECT data_file_id, min_value, max_value FROM metadata.ducklake_file_column_stats where column_id = 2
 ----
-0	1	1
-1	2	2
-2	3	3
-4	2	2
+2	1	1
+3	2	2
+4	3	3
+6	2	2
 
 # Added file has partition value
 query IIII
 FROM metadata.ducklake_file_partition_value;
 ----
-0	1	0	1
-1	1	0	2
-2	1	0	3
-4	1	0	2
+2	1	0	1
+3	1	0	2
+4	1	0	3
+6	1	0	2
 
 query III
 FROM partitioned_t where partition_column = 2;
@@ -96,6 +99,9 @@ statement ok
 INSERT INTO other_partitioned_t VALUES (5,1,2), (6,1,2);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 COPY (SELECT 4 AS id, 2 as partition_column, 2 as other_partition_column) TO '${DATA_PATH}/add_file_partitioned/main/other_partitioned_t/other_partition_column=2/file.parquet' (FORMAT parquet);
 
 statement error
@@ -108,6 +114,9 @@ ALTER TABLE partitioned_t SET PARTITIONED BY (other_partition_column);
 
 statement ok
 INSERT INTO partitioned_t VALUES (5,1,2), (6,1,2);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement error
 CALL ducklake_add_data_files('ducklake', 'partitioned_t', '${DATA_PATH}/add_file_partitioned/main/partitioned_t/partition_column=2/file.parquet')
@@ -126,6 +135,9 @@ INSERT INTO multi_partition_t VALUES
     (1, 'a', '2024-01-15'),
     (2, 'b', '2024-02-10'),
     (3, 'c', '2024-04-20');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # 1. Create a file that matches the full partition (year, month, day)
 statement ok

--- a/test/sql/add_files/add_files.test
+++ b/test/sql/add_files/add_files.test
@@ -127,9 +127,14 @@ FROM ducklake.test
 300	NULL
 400	50
 
+# compute the version for the state after add_data_files my_file3
+# in inline mode there is an extra flush snapshot, so the version differs
+statement ok
+SET VARIABLE v_file3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%') WHERE rn = 4);
+
 # schema-level time travel works, also on files we added here
 query III
-FROM ducklake.test AT (VERSION => 7)
+FROM ducklake.test AT (VERSION => getvariable('v_file3'))
 ----
 100	hello	NULL
 200	world	NULL
@@ -173,7 +178,7 @@ SELECT col1, col2, col3 FROM ducklake.test
 
 # time travel still works
 query III
-FROM ducklake.test AT (VERSION => 7)
+FROM ducklake.test AT (VERSION => getvariable('v_file3'))
 ----
 100	hello	NULL
 200	world	NULL

--- a/test/sql/add_files/add_files.test
+++ b/test/sql/add_files/add_files.test
@@ -20,6 +20,9 @@ CREATE TABLE ducklake.test(col1 INTEGER, col2 VARCHAR);
 statement ok
 INSERT INTO ducklake.test VALUES (100, 'hello');
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # write a parquet file outside of DuckLake
 statement ok
 COPY (SELECT 200 col1, 'world' col2) TO '${DATA_PATH}/ducklake_add_files/main/test/my_file.parquet';
@@ -126,7 +129,7 @@ FROM ducklake.test
 
 # schema-level time travel works, also on files we added here
 query III
-FROM ducklake.test AT (VERSION => 6)
+FROM ducklake.test AT (VERSION => 7)
 ----
 100	hello	NULL
 200	world	NULL
@@ -170,7 +173,7 @@ SELECT col1, col2, col3 FROM ducklake.test
 
 # time travel still works
 query III
-FROM ducklake.test AT (VERSION => 6)
+FROM ducklake.test AT (VERSION => 7)
 ----
 100	hello	NULL
 200	world	NULL

--- a/test/sql/add_files/add_files_compaction.test
+++ b/test/sql/add_files/add_files_compaction.test
@@ -30,7 +30,11 @@ INSERT INTO ducklake.test VALUES (1);
 statement ok
 INSERT INTO ducklake.test2 VALUES (42);
 
-# snapshot 5..8
+# snapshot 5: flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 6..9
 loop i 2 6
 
 statement ok
@@ -50,10 +54,10 @@ query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
 3	0	1
-5	1	2
-6	2	3
-7	3	4
-8	4	5
+6	1	2
+7	2	3
+8	3	4
+9	4	5
 
 statement ok
 CALL ducklake.merge_adjacent_files();
@@ -104,7 +108,7 @@ SELECT * FROM ducklake.test AT (VERSION => 4)
 
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
+SELECT * FROM ducklake.test AT (VERSION => 6) ORDER BY ALL
 ----
 1
 2
@@ -114,10 +118,10 @@ query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
 3	0	1
-5	1	2
-6	2	3
-7	3	4
-8	4	5
+6	1	2
+7	2	3
+8	3	4
+9	4	5
 
 # table insertions function
 query II
@@ -131,14 +135,14 @@ SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4)
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 7) ORDER BY ALL
 ----
 0	1
 1	2
 2	3
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 9) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 10) ORDER BY ALL
 ----
 0	1
 1	2

--- a/test/sql/add_files/add_files_compaction.test
+++ b/test/sql/add_files/add_files_compaction.test
@@ -50,14 +50,14 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_add_files_compaction/**/*')
 ----
 6
 
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	0	1
-6	1	2
-7	2	3
-8	3	4
-9	4	5
+0	1
+1	2
+2	3
+3	4
+4	5
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake.merge_adjacent_files()
@@ -97,55 +97,76 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_add_files_compaction/**/*')
 ----
 2
 
+# compute dynamic snapshot IDs for time travel and table insertions
+# s1: first insert into test (table_id=1)
+statement ok
+SET VARIABLE s1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 1);
+
+# s_test2: first insert into test2 (table_id=2)
+statement ok
+SET VARIABLE s_test2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[2]%') WHERE rn = 1);
+
+# s2: second insert into test (first add_data_files)
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
+# s3: third insert into test
+statement ok
+SET VARIABLE s3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 3);
+
+# s_last: last snapshot
+statement ok
+SET VARIABLE s_last = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
 # verify correct behavior when operating on the compacted file
 # time travel
 query I
-SELECT * FROM ducklake.test AT (VERSION => 3)
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s1'))
 ----
 1
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 4)
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s_test2'))
 ----
 1
 
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 6) ORDER BY ALL
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s2')) ORDER BY ALL
 ----
 1
 2
 
-# reading snapshot id and row id
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+# reading row id
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	0	1
-6	1	2
-7	2	3
-8	3	4
-9	4	5
+0	1
+1	2
+2	3
+3	4
+4	5
 
 # table insertions function
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 3) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s1')) ORDER BY ALL
 ----
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s_test2')) ORDER BY ALL
 ----
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 7) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s3')) ORDER BY ALL
 ----
 0	1
 1	2
 2	3
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 10) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s_last')) ORDER BY ALL
 ----
 0	1
 1	2

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive/', METADATA_CATALOG 'metadata');
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive/', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
 
 statement ok
 CREATE TABLE partitioned_tbl(part_key INT, part_key2 INT, val VARCHAR);
@@ -46,7 +46,7 @@ SELECT part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE part_key=1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-2].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # rename the hive partition
 statement ok
@@ -79,7 +79,7 @@ SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE new_part_key=1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
 
 # type promotion
 statement ok

--- a/test/sql/add_files/add_files_hive.test
+++ b/test/sql/add_files/add_files_hive.test
@@ -46,7 +46,7 @@ SELECT part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE part_key=1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-2].*
 
 # rename the hive partition
 statement ok
@@ -79,7 +79,7 @@ SELECT new_part_key, part_key2, val FROM ducklake.test ORDER BY ALL
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.test WHERE new_part_key=1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
 
 # type promotion
 statement ok

--- a/test/sql/add_files/add_removed_files.test
+++ b/test/sql/add_files/add_removed_files.test
@@ -21,6 +21,9 @@ statement ok
 INSERT INTO ducklake.test VALUES (100, 'hello');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 SET VARIABLE parquet_files = (SELECT LIST(data_file) FROM ducklake_list_files('ducklake', 'test'))
 
 statement ok
@@ -30,8 +33,9 @@ DROP TABLE ducklake.test
 statement ok
 CREATE TABLE ducklake.test(col1 INTEGER, col2 VARCHAR);
 
+# The flushed file contains _ducklake_internal_row_id column, so we need to ignore extra columns
 statement ok
-CALL ducklake_add_data_files('ducklake', 'test', getvariable('parquet_files')[1])
+CALL ducklake_add_data_files('ducklake', 'test', getvariable('parquet_files')[1], ignore_extra_columns => true)
 
 query II
 FROM ducklake.test

--- a/test/sql/alter/expire_snapshot_bug.test
+++ b/test/sql/alter/expire_snapshot_bug.test
@@ -34,29 +34,33 @@ insert into b values(1);
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query II
-SELECT snapshot_id, changes FROM snapshots();
-----
-0	{schemas_created=[main]}
-1	{tables_created=[main.a]}
-2	{inlined_insert=[1]}
-3	{flushed_inlined=[1]}
-4	{tables_created=[main.b]}
-5	{inlined_insert=[1]}
-6	{flushed_inlined=[1]}
+# Compute key snapshot IDs dynamically so the test works with or without data inlining.
+# With inlining: INSERT creates inlined_insert + FLUSH creates flushed_inlined (2 snapshots each).
+# Without inlining: INSERT creates tables_inserted_into (1 snapshot), FLUSH is a no-op.
+
+# s_rename_b: the snapshot where table a was renamed to b (shows as tables_created=[main.b])
+statement ok
+SET VARIABLE s_rename_b = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%tables_created%main.b%');
+
+# Expire all snapshots before the rename to b (schema creation, table a creation, insert into a, flush of a)
+statement ok
+SET VARIABLE v_before_rename_b = (SELECT list(snapshot_id ORDER BY snapshot_id)::BIGINT[] FROM ducklake_snapshots('ducklake') WHERE snapshot_id < getvariable('s_rename_b'));
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [0,1,2,3])
+CALL ducklake_expire_snapshots('ducklake', versions => getvariable('v_before_rename_b'));
 
+# Data should still be accessible after expiring old snapshots
 query I
 FROM b;
 ----
 0
 1
 
+# Expire the rename-to-b snapshot itself
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [4])
+CALL ducklake_expire_snapshots('ducklake', versions => [getvariable('s_rename_b')]);
 
+# Data should still be accessible
 query I
 FROM b;
 ----
@@ -66,12 +70,9 @@ FROM b;
 statement ok
 alter table b rename to c;
 
-query II
-SELECT snapshot_id, changes FROM snapshots();
-----
-5	{inlined_insert=[1]}
-6	{flushed_inlined=[1]}
-7	{tables_created=[main.c]}
+# s_rename_c: the snapshot where table b was renamed to c (shows as tables_created=[main.c])
+statement ok
+SET VARIABLE s_rename_c = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%tables_created%main.c%');
 
 query I
 FROM c;
@@ -79,9 +80,14 @@ FROM c;
 0
 1
 
+# Expire all snapshots before the rename to c (insert into b, flush of b)
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [5,6])
+SET VARIABLE v_before_rename_c = (SELECT list(snapshot_id ORDER BY snapshot_id)::BIGINT[] FROM ducklake_snapshots('ducklake') WHERE snapshot_id < getvariable('s_rename_c'));
 
+statement ok
+CALL ducklake_expire_snapshots('ducklake', versions => getvariable('v_before_rename_c'));
+
+# Data should still be accessible
 query I
 FROM c;
 ----
@@ -91,8 +97,9 @@ FROM c;
 statement ok
 DROP TABLE c;
 
+# Expire the rename-to-c snapshot (the DROP created the latest snapshot which cannot be expired)
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [7])
+CALL ducklake_expire_snapshots('ducklake', versions => [getvariable('s_rename_c')]);
 
 # all traces of the table are gone
 foreach tbl ducklake_table ducklake_column ducklake_table_stats ducklake_table_column_stats ducklake_data_file ducklake_delete_file

--- a/test/sql/alter/expire_snapshot_bug.test
+++ b/test/sql/alter/expire_snapshot_bug.test
@@ -23,23 +23,30 @@ statement ok
 insert into a values(0);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 alter table a rename to b;
 
 statement ok
 insert into b values(1);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query II
 SELECT snapshot_id, changes FROM snapshots();
 ----
 0	{schemas_created=[main]}
 1	{tables_created=[main.a]}
-2	{tables_inserted_into=[1]}
-3	{tables_created=[main.b]}
-4	{tables_inserted_into=[1]}
+2	{inlined_insert=[1]}
+3	{flushed_inlined=[1]}
+4	{tables_created=[main.b]}
+5	{inlined_insert=[1]}
+6	{flushed_inlined=[1]}
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [0,1,2])
+CALL ducklake_expire_snapshots('ducklake', versions => [0,1,2,3])
 
 query I
 FROM b;
@@ -48,7 +55,7 @@ FROM b;
 1
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [3])
+CALL ducklake_expire_snapshots('ducklake', versions => [4])
 
 query I
 FROM b;
@@ -62,8 +69,9 @@ alter table b rename to c;
 query II
 SELECT snapshot_id, changes FROM snapshots();
 ----
-4	{tables_inserted_into=[1]}
-5	{tables_created=[main.c]}
+5	{inlined_insert=[1]}
+6	{flushed_inlined=[1]}
+7	{tables_created=[main.c]}
 
 query I
 FROM c;
@@ -72,7 +80,7 @@ FROM c;
 1
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [4,5])
+CALL ducklake_expire_snapshots('ducklake', versions => [5,6])
 
 query I
 FROM c;
@@ -84,7 +92,7 @@ statement ok
 DROP TABLE c;
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [5])
+CALL ducklake_expire_snapshots('ducklake', versions => [7])
 
 # all traces of the table are gone
 foreach tbl ducklake_table ducklake_column ducklake_table_stats ducklake_table_column_stats ducklake_data_file ducklake_delete_file

--- a/test/sql/attach/different_paths.test
+++ b/test/sql/attach/different_paths.test
@@ -16,6 +16,9 @@ statement ok
 CREATE TABLE t AS SELECT range a FROM range(10);
 
 statement ok
+CALL ducklake_flush_inlined_data('a_ducklake')
+
+statement ok
 USE memory;
 
 statement ok

--- a/test/sql/cleanup/cleanup_old_files.test
+++ b/test/sql/cleanup/cleanup_old_files.test
@@ -23,13 +23,25 @@ statement ok
 INSERT INTO t VALUES (1), (2), (3);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO t VALUES (4), (5);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 DELETE FROM t WHERE x <= 2;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO t VALUES (6), (7);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 't');

--- a/test/sql/cleanup/create_drop_cleanup.test
+++ b/test/sql/cleanup/create_drop_cleanup.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 BEGIN
@@ -21,7 +21,7 @@ statement ok
 CREATE TABLE ducklake.tbl(i INT);
 
 statement ok
-INSERT INTO ducklake.tbl SELECT * FROM range(20);
+INSERT INTO ducklake.tbl VALUES (42);
 
 query I
 SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_createq_drop_cleanup/main/tbl/*.parquet')

--- a/test/sql/cleanup/create_drop_cleanup.test
+++ b/test/sql/cleanup/create_drop_cleanup.test
@@ -11,8 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# Disable inlining - this test needs physical files to verify cleanup behavior
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 BEGIN

--- a/test/sql/cleanup/create_drop_cleanup.test
+++ b/test/sql/cleanup/create_drop_cleanup.test
@@ -11,7 +11,6 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test needs physical files to verify cleanup behavior
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup')
 
@@ -23,9 +22,6 @@ CREATE TABLE ducklake.tbl(i INT);
 
 statement ok
 INSERT INTO ducklake.tbl SELECT * FROM range(20);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_createq_drop_cleanup/main/tbl/*.parquet')

--- a/test/sql/cleanup/create_drop_cleanup.test
+++ b/test/sql/cleanup/create_drop_cleanup.test
@@ -22,7 +22,10 @@ statement ok
 CREATE TABLE ducklake.tbl(i INT);
 
 statement ok
-INSERT INTO ducklake.tbl VALUES (42);
+INSERT INTO ducklake.tbl SELECT * FROM range(20);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_createq_drop_cleanup/main/tbl/*.parquet')

--- a/test/sql/cleanup/create_drop_cleanup.test
+++ b/test/sql/cleanup/create_drop_cleanup.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # Disable inlining - this test needs physical files to verify cleanup behavior
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_createq_drop_cleanup')
 
 statement ok
 BEGIN

--- a/test/sql/comments/comment_on_column.test
+++ b/test/sql/comments/comment_on_column.test
@@ -17,9 +17,12 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/du
 statement ok
 CREATE TABLE ducklake.test_table as SELECT 1 as test_table_column
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 ### Comment on column from table
 query I
-select comment from duckdb_columns() where column_name='test_table_column';
+select comment from duckdb_columns() where column_name='test_table_column' and database_name='ducklake';
 ----
 NULL
 
@@ -27,7 +30,7 @@ statement ok
 COMMENT ON COLUMN ducklake.test_table.test_table_column IS 'very gezellige column'
 
 query I
-select comment from duckdb_columns() where column_name='test_table_column';
+select comment from duckdb_columns() where column_name='test_table_column' and database_name='ducklake';
 ----
 very gezellige column
 
@@ -38,7 +41,7 @@ statement ok
 COMMENT ON COLUMN ducklake.test_table.test_table_column IS 'toch niet zo gezellig'
 
 query I
-select comment from duckdb_columns() where column_name='test_table_column';
+select comment from duckdb_columns() where column_name='test_table_column' and database_name='ducklake';
 ----
 toch niet zo gezellig
 
@@ -47,6 +50,6 @@ statement ok
 ROLLBACK
 
 query I
-select comment from duckdb_columns() where column_name='test_table_column';
+select comment from duckdb_columns() where column_name='test_table_column' and database_name='ducklake';
 ----
 very gezellige column

--- a/test/sql/compaction/compaction_alter_table.test
+++ b/test/sql/compaction/compaction_alter_table.test
@@ -141,8 +141,8 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_alter_files/**/*')
 query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
 ----
-2	1	1	10
-4	2	2	20
+2	0	1	10
+4	1	2	20
 
 # VERSION => 10 has snapshots 1-10
 # Schema after alter(6) is (id, i, j)
@@ -150,10 +150,10 @@ SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
 query IIIII
 SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 10) ORDER BY ALL
 ----
-2	1	1	10	NULL
-4	2	2	20	NULL
-7	3	3	30	300
-9	4	4	40	400
+2	0	1	10	NULL
+4	1	2	20	NULL
+7	2	3	30	300
+9	3	4	40	400
 
 # VERSION => 15 has snapshots 1-15
 # Schema after alter(11) is (id, j) - i column dropped
@@ -161,22 +161,22 @@ SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 10) ORDER BY ALL
 query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 15) ORDER BY ALL
 ----
-2	1	1	NULL
-4	2	2	NULL
-7	3	3	300
-9	4	4	400
-12	5	5	500
-14	6	6	600
+2	0	1	NULL
+4	1	2	NULL
+7	2	3	300
+9	3	4	400
+12	4	5	500
+14	5	6	600
 
-# Current state (rowids are now 1-based after compaction)
+# Current state (rowids are now 0-based after compaction)
 query IIIII
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	1	1	NULL	NULL
-4	2	2	NULL	NULL
-7	3	3	300	NULL
-9	4	4	400	NULL
-12	5	5	500	NULL
-14	6	6	600	NULL
-17	7	7	700	hello
-19	8	8	800	world
+2	0	1	NULL	NULL
+4	1	2	NULL	NULL
+7	2	3	300	NULL
+9	3	4	400	NULL
+12	4	5	500	NULL
+14	5	6	600	NULL
+17	6	7	700	hello
+19	7	8	800	world

--- a/test/sql/compaction/compaction_alter_table.test
+++ b/test/sql/compaction/compaction_alter_table.test
@@ -14,65 +14,97 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_alter_files')
 
-# snapshot 1
+# snapshot 1 (create)
 statement ok
 CREATE TABLE ducklake.test(id INTEGER, i INTEGER);
 
-# snapshot 2
+# snapshot 2 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (1, 10);
 
-# snapshot 3
+# snapshot 3 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 4 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (2, 20);
 
-# snapshot 4
+# snapshot 5 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 6 (alter)
 statement ok
 ALTER TABLE ducklake.test ADD COLUMN j INTEGER
 
-# snapshot 5
+# snapshot 7 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (3, 30, 300);
 
-# snapshot 6
+# snapshot 8 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 9 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (4, 40, 400);
 
-# snapshot 7
+# snapshot 10 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 11 (alter)
 statement ok
 ALTER TABLE ducklake.test DROP COLUMN i
 
-# snapshot 8
+# snapshot 12 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (5, 500);
 
-# snapshot 9
+# snapshot 13 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 14 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (6, 600);
 
-# snapshot 10
+# snapshot 15 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 16 (alter)
 statement ok
 ALTER TABLE ducklake.test ADD COLUMN i VARCHAR
 
-# snapshot 11
+# snapshot 17 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (7, 700, 'hello');
 
-# snapshot 12
+# snapshot 18 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 19 (inlined_insert)
 statement ok
 INSERT INTO ducklake.test VALUES (8, 800, 'world');
+
+# snapshot 20 (flushed_inlined)
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query IIIII
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
 2	0	1	NULL	NULL
-3	1	2	NULL	NULL
-5	2	3	300	NULL
-6	3	4	400	NULL
-8	4	5	500	NULL
-9	5	6	600	NULL
-11	6	7	700	hello
-12	7	8	800	world
+4	1	2	NULL	NULL
+7	2	3	300	NULL
+9	3	4	400	NULL
+12	4	5	500	NULL
+14	5	6	600	NULL
+17	6	7	700	hello
+19	7	8	800	world
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_alter_files/**/*')
@@ -99,38 +131,47 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_alter_files/**/*')
 
 # verify correct behavior when operating on the compacted file
 # time travel
+# VERSION => 5 has snapshots 1-5: create(1), insert(2), flush(3), insert(4), flush(5)
+# Schema is (id, i) - no j column yet
 query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 3) ORDER BY ALL
+SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
 ----
-2	0	1	10
-3	1	2	20
+2	1	1	10
+4	2	2	20
 
+# VERSION => 10 has snapshots 1-10
+# Schema after alter(6) is (id, i, j)
+# Rows: insert(2), insert(4), insert(7), insert(9)
 query IIIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 6) ORDER BY ALL
+SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 10) ORDER BY ALL
 ----
-2	0	1	10	NULL
-3	1	2	20	NULL
-5	2	3	30	300
-6	3	4	40	400
+2	1	1	10	NULL
+4	2	2	20	NULL
+7	3	3	30	300
+9	4	4	40	400
 
+# VERSION => 15 has snapshots 1-15
+# Schema after alter(11) is (id, j) - i column dropped
+# Rows: insert(2), insert(4), insert(7), insert(9), insert(12), insert(14)
 query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 9) ORDER BY ALL
+SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 15) ORDER BY ALL
 ----
-2	0	1	NULL
-3	1	2	NULL
-5	2	3	300
-6	3	4	400
-8	4	5	500
-9	5	6	600
+2	1	1	NULL
+4	2	2	NULL
+7	3	3	300
+9	4	4	400
+12	5	5	500
+14	6	6	600
 
+# Current state (rowids are now 1-based after compaction)
 query IIIII
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1	NULL	NULL
-3	1	2	NULL	NULL
-5	2	3	300	NULL
-6	3	4	400	NULL
-8	4	5	500	NULL
-9	5	6	600	NULL
-11	6	7	700	hello
-12	7	8	800	world
+2	1	1	NULL	NULL
+4	2	2	NULL	NULL
+7	3	3	300	NULL
+9	4	4	400	NULL
+12	5	5	500	NULL
+14	6	6	600	NULL
+17	7	7	700	hello
+19	8	8	800	world

--- a/test/sql/compaction/compaction_alter_table.test
+++ b/test/sql/compaction/compaction_alter_table.test
@@ -94,22 +94,35 @@ INSERT INTO ducklake.test VALUES (8, 800, 'world');
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query IIIII
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query IIII
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1	NULL	NULL
-4	1	2	NULL	NULL
-7	2	3	300	NULL
-9	3	4	400	NULL
-12	4	5	500	NULL
-14	5	6	600	NULL
-17	6	7	700	hello
-19	7	8	800	world
+0	1	NULL	NULL
+1	2	NULL	NULL
+2	3	300	NULL
+3	4	400	NULL
+4	5	500	NULL
+5	6	600	NULL
+6	7	700	hello
+7	8	800	world
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_alter_files/**/*')
 ----
 8
+
+# compute dynamic snapshot IDs for time travel queries
+# the 2nd insert snapshot (after 2nd insert, before any alter) - schema is (id, i)
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
+# the 4th insert snapshot (after 4th insert, after ALTER ADD j) - schema is (id, i, j)
+statement ok
+SET VARIABLE s4 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 4);
+
+# the 6th insert snapshot (after 6th insert, after ALTER DROP i) - schema is (id, j)
+statement ok
+SET VARIABLE s6 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 6);
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
@@ -136,47 +149,42 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_alter_files/**/*')
 
 # verify correct behavior when operating on the compacted file
 # time travel
-# VERSION => 5 has snapshots 1-5: create(1), insert(2), flush(3), insert(4), flush(5)
-# Schema is (id, i) - no j column yet
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
+# s2 = 2nd insert snapshot: schema is (id, i) - no j column yet
+query III
+SELECT rowid, * FROM ducklake.test AT (VERSION => getvariable('s2')) ORDER BY ALL
 ----
-2	0	1	10
-4	1	2	20
+0	1	10
+1	2	20
 
-# VERSION => 10 has snapshots 1-10
-# Schema after alter(6) is (id, i, j)
-# Rows: insert(2), insert(4), insert(7), insert(9)
-query IIIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 10) ORDER BY ALL
-----
-2	0	1	10	NULL
-4	1	2	20	NULL
-7	2	3	30	300
-9	3	4	40	400
-
-# VERSION => 15 has snapshots 1-15
-# Schema after alter(11) is (id, j) - i column dropped
-# Rows: insert(2), insert(4), insert(7), insert(9), insert(12), insert(14)
+# s4 = 4th insert snapshot: schema after ALTER ADD j is (id, i, j)
 query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.test AT (VERSION => 15) ORDER BY ALL
+SELECT rowid, * FROM ducklake.test AT (VERSION => getvariable('s4')) ORDER BY ALL
 ----
-2	0	1	NULL
-4	1	2	NULL
-7	2	3	300
-9	3	4	400
-12	4	5	500
-14	5	6	600
+0	1	10	NULL
+1	2	20	NULL
+2	3	30	300
+3	4	40	400
+
+# s6 = 6th insert snapshot: schema after ALTER DROP i is (id, j)
+query III
+SELECT rowid, * FROM ducklake.test AT (VERSION => getvariable('s6')) ORDER BY ALL
+----
+0	1	NULL
+1	2	NULL
+2	3	300
+3	4	400
+4	5	500
+5	6	600
 
 # Current state (rowids are now 0-based after compaction)
-query IIIII
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query IIII
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1	NULL	NULL
-4	1	2	NULL	NULL
-7	2	3	300	NULL
-9	3	4	400	NULL
-12	4	5	500	NULL
-14	5	6	600	NULL
-17	6	7	700	hello
-19	7	8	800	world
+0	1	NULL	NULL
+1	2	NULL	NULL
+2	3	300	NULL
+3	4	400	NULL
+4	5	500	NULL
+5	6	600	NULL
+6	7	700	hello
+7	8	800	world

--- a/test/sql/compaction/compaction_cleanup_global.test
+++ b/test/sql/compaction/compaction_cleanup_global.test
@@ -22,13 +22,16 @@ statement ok
 INSERT INTO ducklake.test FROM range(10)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 DELETE FROM ducklake.test
 
 statement ok
 DROP TABLE ducklake.test
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', dry_run => false, versions => [2])
+CALL ducklake_expire_snapshots('ducklake', dry_run => false, versions => [2,3,4])
 
 statement ok
 CALL ducklake.set_option('delete_older_than', '1 week')

--- a/test/sql/compaction/compaction_delete_conflict.test
+++ b/test/sql/compaction/compaction_delete_conflict.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflicts_compaction_files')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflicts_compaction_files', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SET immediate_transaction_mode=true
@@ -21,15 +21,11 @@ SET immediate_transaction_mode=true
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
-# Insert more than 10 rows per insert so flush creates files
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(1, 12);
+INSERT INTO ducklake.test VALUES (1);
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(12, 23);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
+INSERT INTO ducklake.test VALUES (2);
 
 # try to commit a delete after a compaction: conflict
 statement ok con1
@@ -55,13 +51,10 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(23, 34);
+INSERT INTO ducklake.test VALUES (3);
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(34, 45);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
+INSERT INTO ducklake.test VALUES (4);
 
 # try to commit a compaction after a deletion: conflict
 statement ok con1
@@ -87,13 +80,10 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(45, 56);
+INSERT INTO ducklake.test VALUES (5);
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(56, 67);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
+INSERT INTO ducklake.test VALUES (6);
 
 # two transactions both try to compact: conflict
 statement ok con1
@@ -121,13 +111,10 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(67, 78);
+INSERT INTO ducklake.test VALUES (7);
 
 statement ok
-INSERT INTO ducklake.test SELECT * FROM range(78, 89);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
+INSERT INTO ducklake.test VALUES (8);
 
 # compaction and insert: no conflict
 statement ok con1
@@ -142,7 +129,7 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 test	3	1
 
 statement ok con2
-INSERT INTO ducklake.test SELECT * FROM range(89, 100);
+INSERT INTO ducklake.test VALUES (9);
 
 statement ok con1
 COMMIT
@@ -153,58 +140,8 @@ COMMIT
 query I
 SELECT * FROM ducklake.test ORDER BY ALL
 ----
-45
-46
-47
-48
-49
-50
-51
-52
-53
-54
-55
-56
-57
-58
-59
-60
-61
-62
-63
-64
-65
-66
-67
-68
-69
-70
-71
-72
-73
-74
-75
-76
-77
-78
-79
-80
-81
-82
-83
-84
-85
-86
-87
-88
-89
-90
-91
-92
-93
-94
-95
-96
-97
-98
-99
+5
+6
+7
+8
+9

--- a/test/sql/compaction/compaction_delete_conflict.test
+++ b/test/sql/compaction/compaction_delete_conflict.test
@@ -21,11 +21,15 @@ SET immediate_transaction_mode=true
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
+# Insert more than 10 rows per insert so flush creates files
 statement ok
-INSERT INTO ducklake.test VALUES (1);
+INSERT INTO ducklake.test SELECT * FROM range(1, 12);
 
 statement ok
-INSERT INTO ducklake.test VALUES (2);
+INSERT INTO ducklake.test SELECT * FROM range(12, 23);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # try to commit a delete after a compaction: conflict
 statement ok con1
@@ -49,10 +53,13 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test VALUES (3);
+INSERT INTO ducklake.test SELECT * FROM range(23, 34);
 
 statement ok
-INSERT INTO ducklake.test VALUES (4);
+INSERT INTO ducklake.test SELECT * FROM range(34, 45);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # try to commit a compaction after a deletion: conflict
 statement ok con1
@@ -76,10 +83,13 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test VALUES (5);
+INSERT INTO ducklake.test SELECT * FROM range(45, 56);
 
 statement ok
-INSERT INTO ducklake.test VALUES (6);
+INSERT INTO ducklake.test SELECT * FROM range(56, 67);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # two transactions both try to compact: conflict
 statement ok con1
@@ -103,10 +113,13 @@ COMMIT
 
 
 statement ok
-INSERT INTO ducklake.test VALUES (7);
+INSERT INTO ducklake.test SELECT * FROM range(67, 78);
 
 statement ok
-INSERT INTO ducklake.test VALUES (8);
+INSERT INTO ducklake.test SELECT * FROM range(78, 89);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # compaction and insert: no conflict
 statement ok con1
@@ -119,7 +132,7 @@ statement ok con1
 CALL ducklake_merge_adjacent_files('ducklake');
 
 statement ok con2
-INSERT INTO ducklake.test VALUES (9);
+INSERT INTO ducklake.test SELECT * FROM range(89, 100);
 
 statement ok con1
 COMMIT
@@ -130,8 +143,58 @@ COMMIT
 query I
 SELECT * FROM ducklake.test ORDER BY ALL
 ----
-5
-6
-7
-8
-9
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85
+86
+87
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97
+98
+99

--- a/test/sql/compaction/compaction_encrypted.test
+++ b/test/sql/compaction/compaction_encrypted.test
@@ -64,9 +64,9 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 ----
 1
 
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	1	1
-4	2	2
-6	3	3
+1	1
+2	2
+3	3

--- a/test/sql/compaction/compaction_encrypted.test
+++ b/test/sql/compaction/compaction_encrypted.test
@@ -29,6 +29,9 @@ statement ok
 INSERT INTO ducklake.test VALUES (3);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
 
 # delete the old files

--- a/test/sql/compaction/compaction_encrypted.test
+++ b/test/sql/compaction/compaction_encrypted.test
@@ -67,6 +67,6 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1
-3	1	2
-4	2	3
+2	1	1
+4	2	2
+6	3	3

--- a/test/sql/compaction/compaction_encrypted.test
+++ b/test/sql/compaction/compaction_encrypted.test
@@ -67,6 +67,6 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 query II
 SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-1	1
-2	2
-3	3
+0	1
+1	2
+2	3

--- a/test/sql/compaction/compaction_hive_structure.test
+++ b/test/sql/compaction/compaction_hive_structure.test
@@ -11,9 +11,8 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# This test has table renames - insert >10 rows to bypass inlining (known bug with rename + inlined data)
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_hive')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_hive', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 use ducklake
@@ -48,9 +47,6 @@ INSERT INTO sales
       (6, 'Product B', 150.0, '2023-07-02');
 
 statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
-statement ok
 CALL merge_adjacent_files();
 
 statement ok
@@ -71,7 +67,6 @@ FROM sales
 5	Product C	300.0	2023-07-02
 6	Product B	150.0	2023-07-02
 
-# Insert >10 rows to bypass inlining (workaround for known bug with rename + inlined data)
 statement ok
 CREATE TABLE test_table AS SELECT 1 as partition_col, random() as value LIMIT 0;
 
@@ -79,10 +74,10 @@ statement ok
 ALTER TABLE test_table SET PARTITIONED BY (partition_col);
 
 statement ok
-INSERT INTO test_table SELECT 1 as partition_col, random() as value FROM range(15);
+INSERT INTO test_table SELECT 1 as partition_col, random() as value;
 
 statement ok
-INSERT INTO test_table SELECT 2 as partition_col, random() as value FROM range(15);
+INSERT INTO test_table SELECT 2 as partition_col, random() as value;
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'test_table') where data_file like '%partition_col%'
@@ -93,7 +88,7 @@ statement ok
 ALTER TABLE test_table RENAME TO test_table_renamed;
 
 statement ok
-INSERT INTO test_table_renamed SELECT 2 as partition_col, random() as value FROM range(15);
+INSERT INTO test_table_renamed SELECT 2 as partition_col, random() as value;
 
 query I
 SELECT count(*)  FROM ducklake_list_files('ducklake', 'test_table_renamed') where data_file like '%partition_col%';

--- a/test/sql/compaction/compaction_hive_structure.test
+++ b/test/sql/compaction/compaction_hive_structure.test
@@ -11,7 +11,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test has table renames which have bugs with inlined data
+# This test has table renames - insert >10 rows to bypass inlining (known bug with rename + inlined data)
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_hive')
 
@@ -48,6 +48,9 @@ INSERT INTO sales
       (6, 'Product B', 150.0, '2023-07-02');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 CALL merge_adjacent_files();
 
 statement ok
@@ -68,6 +71,7 @@ FROM sales
 5	Product C	300.0	2023-07-02
 6	Product B	150.0	2023-07-02
 
+# Insert >10 rows to bypass inlining (workaround for known bug with rename + inlined data)
 statement ok
 CREATE TABLE test_table AS SELECT 1 as partition_col, random() as value LIMIT 0;
 
@@ -75,10 +79,10 @@ statement ok
 ALTER TABLE test_table SET PARTITIONED BY (partition_col);
 
 statement ok
-INSERT INTO test_table SELECT 1 as partition_col, random() as value;
+INSERT INTO test_table SELECT 1 as partition_col, random() as value FROM range(15);
 
 statement ok
-INSERT INTO test_table SELECT 2 as partition_col, random() as value;
+INSERT INTO test_table SELECT 2 as partition_col, random() as value FROM range(15);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'test_table') where data_file like '%partition_col%'
@@ -89,7 +93,7 @@ statement ok
 ALTER TABLE test_table RENAME TO test_table_renamed;
 
 statement ok
-INSERT INTO test_table_renamed SELECT 2 as partition_col, random() as value;
+INSERT INTO test_table_renamed SELECT 2 as partition_col, random() as value FROM range(15);
 
 query I
 SELECT count(*)  FROM ducklake_list_files('ducklake', 'test_table_renamed') where data_file like '%partition_col%';

--- a/test/sql/compaction/compaction_hive_structure.test
+++ b/test/sql/compaction/compaction_hive_structure.test
@@ -11,6 +11,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# Disable inlining - this test has table renames which have bugs with inlined data
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_hive')
 

--- a/test/sql/compaction/compaction_multiple_rename_column.test
+++ b/test/sql/compaction/compaction_multiple_rename_column.test
@@ -20,7 +20,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/compaction_multiple_rename_column.db
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/compaction_multiple_rename_column')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/compaction_multiple_rename_column', DATA_INLINING_ROW_LIMIT 0)
 
 # Create table with user_id column (schema version 1)
 statement ok
@@ -37,12 +37,12 @@ ALTER TABLE ducklake.test RENAME COLUMN user_id TO temp;
 statement ok
 ALTER TABLE ducklake.test RENAME COLUMN temp TO user_id;
 
-# INSERT DATA AT SCHEMA VERSION 3 - with enough rows to create files directly
+# INSERT DATA AT SCHEMA VERSION 3 - files are created at this schema version
 statement ok
-INSERT INTO ducklake.test SELECT i, i*100 FROM range(15) t(i);
+INSERT INTO ducklake.test VALUES (1, 100);
 
 statement ok
-INSERT INTO ducklake.test SELECT i+15, i*100+15 FROM range(15) t(i);
+INSERT INTO ducklake.test VALUES (2, 200);
 
 # Rename user_id -> distinct_id (schema version 4)
 # With the bug, WriteDroppedColumns sets end_snapshot on ALL entries with this column_id
@@ -57,7 +57,7 @@ statement ok
 DETACH ducklake;
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/compaction_multiple_rename_column')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/compaction_multiple_rename_column', DATA_INLINING_ROW_LIMIT 0)
 
 # Compact the files created at schema version 3
 # This loads the corrupted schema where both 'user_id' entries are visible
@@ -69,10 +69,7 @@ test	2	1
 
 # Verify current data is correct
 query II
-SELECT id, distinct_id FROM ducklake.test ORDER BY id LIMIT 5;
+SELECT id, distinct_id FROM ducklake.test ORDER BY id;
 ----
-0	0
 1	100
 2	200
-3	300
-4	400

--- a/test/sql/compaction/compaction_multiple_rename_column.test
+++ b/test/sql/compaction/compaction_multiple_rename_column.test
@@ -37,12 +37,12 @@ ALTER TABLE ducklake.test RENAME COLUMN user_id TO temp;
 statement ok
 ALTER TABLE ducklake.test RENAME COLUMN temp TO user_id;
 
-# INSERT DATA AT SCHEMA VERSION 3 - files are created at this schema version
+# INSERT DATA AT SCHEMA VERSION 3 - with enough rows to create files directly
 statement ok
-INSERT INTO ducklake.test VALUES (1, 100);
+INSERT INTO ducklake.test SELECT i, i*100 FROM range(15) t(i);
 
 statement ok
-INSERT INTO ducklake.test VALUES (2, 200);
+INSERT INTO ducklake.test SELECT i+15, i*100+15 FROM range(15) t(i);
 
 # Rename user_id -> distinct_id (schema version 4)
 # With the bug, WriteDroppedColumns sets end_snapshot on ALL entries with this column_id
@@ -67,7 +67,10 @@ CALL ducklake_merge_adjacent_files('ducklake', 'test');
 
 # Verify current data is correct
 query II
-SELECT id, distinct_id FROM ducklake.test ORDER BY id;
+SELECT id, distinct_id FROM ducklake.test ORDER BY id LIMIT 5;
 ----
+0	0
 1	100
 2	200
+3	300
+4	400

--- a/test/sql/compaction/compaction_partitioned_non_adjacent.test
+++ b/test/sql/compaction/compaction_partitioned_non_adjacent.test
@@ -49,13 +49,13 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_partitioned_compact_non_adjacen
 ----
 4
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	2	100
-7	2	1	20
-9	3	2	200
+0	1	10
+1	2	100
+2	1	20
+3	2	200
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
@@ -89,24 +89,30 @@ ORDER BY ALL
 2	1
 2	2
 
+statement ok
+SET VARIABLE s1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 1);
+
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
 query II
-SELECT * FROM ducklake.partitioned AT (VERSION => 3)
+SELECT * FROM ducklake.partitioned AT (VERSION => getvariable('s1'))
 ----
 1	10
 
 query II rowsort
-SELECT * FROM ducklake.partitioned AT (VERSION => 5)
+SELECT * FROM ducklake.partitioned AT (VERSION => getvariable('s2'))
 ----
 1	10
 2	100
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	2	100
-7	2	1	20
-9	3	2	200
+0	1	10
+1	2	100
+2	1	20
+3	2	200
 
 # insert and compact again
 statement ok
@@ -133,17 +139,17 @@ INSERT INTO ducklake.partitioned VALUES (2, 400);
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	2	100
-7	2	1	20
-9	3	2	200
-12	4	1	30
-14	5	2	300
-16	6	1	40
-18	7	2	400
+0	1	10
+1	2	100
+2	1	20
+3	2	200
+4	1	30
+5	2	300
+6	1	40
+7	2	400
 
 # we're back up to 6 files
 query I
@@ -168,14 +174,14 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_partitioned_compact_non_adjacen
 ----
 2
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	2	100
-7	2	1	20
-9	3	2	200
-12	4	1	30
-14	5	2	300
-16	6	1	40
-18	7	2	400
+0	1	10
+1	2	100
+2	1	20
+3	2	200
+4	1	30
+5	2	300
+6	1	40
+7	2	400

--- a/test/sql/compaction/compaction_partitioned_non_adjacent.test
+++ b/test/sql/compaction/compaction_partitioned_non_adjacent.test
@@ -24,13 +24,25 @@ statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 10);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 100);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 20);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 200);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_partitioned_compact_non_adjacent_files/**/*.parquet')
@@ -41,9 +53,9 @@ query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
 3	0	1	10
-4	1	2	100
-5	2	1	20
-6	3	2	200
+5	1	2	100
+7	2	1	20
+9	3	2	200
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
@@ -80,7 +92,7 @@ SELECT * FROM ducklake.partitioned AT (VERSION => 3)
 1	10
 
 query II rowsort
-SELECT * FROM ducklake.partitioned AT (VERSION => 4)
+SELECT * FROM ducklake.partitioned AT (VERSION => 5)
 ----
 1	10
 2	100
@@ -89,34 +101,46 @@ query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
 3	0	1	10
-4	1	2	100
-5	2	1	20
-6	3	2	200
+5	1	2	100
+7	2	1	20
+9	3	2	200
 
 # insert and compact again
 statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 30);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 300);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 40);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 400);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
 3	0	1	10
-4	1	2	100
-5	2	1	20
-6	3	2	200
-8	4	1	30
-9	5	2	300
-10	6	1	40
-11	7	2	400
+5	1	2	100
+7	2	1	20
+9	3	2	200
+12	4	1	30
+14	5	2	300
+16	6	1	40
+18	7	2	400
 
 # we're back up to 6 files
 query I
@@ -142,10 +166,10 @@ query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
 3	0	1	10
-4	1	2	100
-5	2	1	20
-6	3	2	200
-8	4	1	30
-9	5	2	300
-10	6	1	40
-11	7	2	400
+5	1	2	100
+7	2	1	20
+9	3	2	200
+12	4	1	30
+14	5	2	300
+16	6	1	40
+18	7	2	400

--- a/test/sql/compaction/compaction_partitioned_table.test
+++ b/test/sql/compaction/compaction_partitioned_table.test
@@ -49,13 +49,13 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_partitioned_compact_files/**/*.
 ----
 4
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	1	20
-7	2	2	100
-9	3	2	200
+0	1	10
+1	1	20
+2	2	100
+3	2	200
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
@@ -89,21 +89,28 @@ ORDER BY ALL
 2	1
 2	2
 
+# compute snapshot IDs dynamically (inline mode creates 2 snapshots per INSERT, no-inline creates 1)
+statement ok
+SET VARIABLE s1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 1);
+
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
 query II
-SELECT * FROM ducklake.partitioned AT (VERSION => 3)
+SELECT * FROM ducklake.partitioned AT (VERSION => getvariable('s1'))
 ----
 1	10
 
 query II
-SELECT * FROM ducklake.partitioned AT (VERSION => 5)
+SELECT * FROM ducklake.partitioned AT (VERSION => getvariable('s2'))
 ----
 1	10
 1	20
 
-query IIII
-SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
+query III
+SELECT rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-5	1	1	20
-7	2	2	100
-9	3	2	200
+0	1	10
+1	1	20
+2	2	100
+3	2	200

--- a/test/sql/compaction/compaction_partitioned_table.test
+++ b/test/sql/compaction/compaction_partitioned_table.test
@@ -24,13 +24,25 @@ statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 10);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (1, 20);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 100);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.partitioned VALUES (2, 200);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_partitioned_compact_files/**/*.parquet')
@@ -41,9 +53,9 @@ query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
 3	0	1	10
-4	1	1	20
-5	2	2	100
-6	3	2	200
+5	1	1	20
+7	2	2	100
+9	3	2	200
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
@@ -80,7 +92,7 @@ SELECT * FROM ducklake.partitioned AT (VERSION => 3)
 1	10
 
 query II
-SELECT * FROM ducklake.partitioned AT (VERSION => 4)
+SELECT * FROM ducklake.partitioned AT (VERSION => 5)
 ----
 1	10
 1	20
@@ -88,7 +100,7 @@ SELECT * FROM ducklake.partitioned AT (VERSION => 4)
 query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	0	1	10
-4	1	1	20
-5	2	2	100
-6	3	2	200
+3	1	1	10
+5	2	1	20
+7	3	2	100
+9	4	2	200

--- a/test/sql/compaction/compaction_partitioned_table.test
+++ b/test/sql/compaction/compaction_partitioned_table.test
@@ -103,7 +103,7 @@ SELECT * FROM ducklake.partitioned AT (VERSION => 5)
 query IIII
 SELECT snapshot_id, rowid, * FROM ducklake.partitioned ORDER BY ALL
 ----
-3	1	1	10
-5	2	1	20
-7	3	2	100
-9	4	2	200
+3	0	1	10
+5	1	1	20
+7	2	2	100
+9	3	2	200

--- a/test/sql/compaction/compaction_schema_version_per_table.test
+++ b/test/sql/compaction/compaction_schema_version_per_table.test
@@ -51,7 +51,7 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'table_to_compact')
 query III
 FROM __ducklake_metadata_ducklake.ducklake_schema_versions
 ----
-1	2	1
+1	1	1
 
 
 statement ok
@@ -92,12 +92,12 @@ CALL ducklake_flush_inlined_data('ducklake')
 
 # table_to_compact (id 1)  only has one schema still
 # another_table (id 3)  has two schemas
-query III
-FROM __ducklake_metadata_ducklake.ducklake_schema_versions
+query II
+SELECT schema_version, table_id FROM __ducklake_metadata_ducklake.ducklake_schema_versions
 ----
-1	2	1
-7	4	3
-14	5	3
+1	1
+3	3
+4	3
 
 statement ok
 INSERT INTO ducklake.table_to_compact VALUES (9), (10);

--- a/test/sql/compaction/compaction_schema_version_per_table.test
+++ b/test/sql/compaction/compaction_schema_version_per_table.test
@@ -20,10 +20,16 @@ statement ok
 CREATE TABLE table_to_compact AS SELECT range a FROM range(5);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 CREATE VIEW view_bumps_schema_version AS SELECT 42;
 
 statement ok
 INSERT INTO table_to_compact VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # compaction should work because the table's schema didn't change (only a view was created)
 statement ok
@@ -43,7 +49,7 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'table_to_compact')
 query III
 FROM __ducklake_metadata_ducklake.ducklake_schema_versions
 ----
-1	1	1
+1	2	1
 
 
 statement ok
@@ -53,11 +59,19 @@ statement ok
 INSERT INTO ducklake.another_table VALUES (100), (200);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.another_table VALUES (300), (400);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 INSERT INTO ducklake.table_to_compact VALUES (7), (8);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 ALTER TABLE ducklake.another_table ADD COLUMN y VARCHAR;
@@ -66,19 +80,28 @@ statement ok
 INSERT INTO ducklake.another_table VALUES (300, 1), (400,2);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.another_table VALUES (500, 1), (600,2);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # table_to_compact (id 1)  only has one schema still
 # another_table (id 3)  has two schemas
 query III
 FROM __ducklake_metadata_ducklake.ducklake_schema_versions
 ----
-1	1	1
-5	3	3
-9	4	3
+1	2	1
+7	4	3
+14	5	3
 
 statement ok
 INSERT INTO ducklake.table_to_compact VALUES (9), (10);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # we should have 3 data files for table_to_compact (1 merged + 2 new inserts)
 query I

--- a/test/sql/compaction/merge_adjacent_file_size_filter.test
+++ b/test/sql/compaction/merge_adjacent_file_size_filter.test
@@ -11,7 +11,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_file_size_filter/')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_file_size_filter/', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake;
@@ -23,12 +23,12 @@ statement ok
 CREATE TABLE example (key integer, data varchar);
 
 # Create files of varying sizes
-# Small files (~400 bytes each) - insert 11 rows to bypass inlining
+# Small files (~400 bytes each)
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
 
 # Medium files (~1800 bytes each due to more data)
 statement ok
@@ -72,11 +72,11 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_s
 ----
 2
 
-# Verify data is still correct (22 + 200 = 222)
+# Verify data is still correct
 query I
 SELECT count(*) FROM example
 ----
-222
+220
 
 # Reset: drop and recreate table
 statement ok
@@ -88,12 +88,12 @@ CALL ducklake_expire_snapshots('ducklake', older_than => now());
 statement ok
 CREATE TABLE example (key integer, data varchar);
 
-# Create files again - insert 11 rows to bypass inlining
+# Create files again
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
 
 statement ok
 INSERT INTO example SELECT i + 100, repeat('medium', 100) FROM range(100) t(i);
@@ -119,11 +119,11 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_s
 ----
 2
 
-# Verify data is still correct (22 + 200 = 222)
+# Verify data is still correct
 query I
 SELECT count(*) FROM example
 ----
-222
+220
 
 # Reset again
 statement ok
@@ -135,12 +135,12 @@ CALL ducklake_expire_snapshots('ducklake', older_than => now());
 statement ok
 CREATE TABLE example (key integer, data varchar);
 
-# Create 4 files again - insert 11 rows to bypass inlining
+# Create 4 files again
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
+INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
 
 statement ok
 INSERT INTO example SELECT i + 100, repeat('medium', 100) FROM range(100) t(i);
@@ -173,8 +173,8 @@ CALL ducklake_merge_adjacent_files('ducklake', 'example', max_file_size=>0);
 ----
 max_file_size option must be greater than zero
 
-# Verify data is still correct after all operations (22 + 200 = 222)
+# Verify data is still correct after all operations
 query I
 SELECT count(*) FROM example
 ----
-222
+220

--- a/test/sql/compaction/merge_adjacent_file_size_filter.test
+++ b/test/sql/compaction/merge_adjacent_file_size_filter.test
@@ -23,12 +23,12 @@ statement ok
 CREATE TABLE example (key integer, data varchar);
 
 # Create files of varying sizes
-# Small files (~400 bytes each)
+# Small files (~400 bytes each) - insert 11 rows to bypass inlining
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
 
 # Medium files (~1800 bytes each due to more data)
 statement ok
@@ -70,11 +70,11 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_s
 ----
 2
 
-# Verify data is still correct
+# Verify data is still correct (22 + 200 = 222)
 query I
 SELECT count(*) FROM example
 ----
-220
+222
 
 # Reset: drop and recreate table
 statement ok
@@ -86,12 +86,12 @@ CALL ducklake_expire_snapshots('ducklake', older_than => now());
 statement ok
 CREATE TABLE example (key integer, data varchar);
 
-# Create files again
+# Create files again - insert 11 rows to bypass inlining
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
 
 statement ok
 INSERT INTO example SELECT i + 100, repeat('medium', 100) FROM range(100) t(i);
@@ -115,11 +115,11 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_s
 ----
 2
 
-# Verify data is still correct
+# Verify data is still correct (22 + 200 = 222)
 query I
 SELECT count(*) FROM example
 ----
-220
+222
 
 # Reset again
 statement ok
@@ -131,12 +131,12 @@ CALL ducklake_expire_snapshots('ducklake', older_than => now());
 statement ok
 CREATE TABLE example (key integer, data varchar);
 
-# Create 4 files again
+# Create 4 files again - insert 11 rows to bypass inlining
 statement ok
-INSERT INTO example SELECT i, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i, 'small' FROM range(11) t(i);
 
 statement ok
-INSERT INTO example SELECT i + 10, 'small' FROM range(10) t(i);
+INSERT INTO example SELECT i + 11, 'small' FROM range(11) t(i);
 
 statement ok
 INSERT INTO example SELECT i + 100, repeat('medium', 100) FROM range(100) t(i);
@@ -168,8 +168,8 @@ CALL ducklake_merge_adjacent_files('ducklake', 'example', max_file_size=>0);
 ----
 max_file_size option must be greater than zero
 
-# Verify data is still correct after all operations
+# Verify data is still correct after all operations (22 + 200 = 222)
 query I
 SELECT count(*) FROM example
 ----
-220
+222

--- a/test/sql/compaction/merge_adjacent_global_option.test
+++ b/test/sql/compaction/merge_adjacent_global_option.test
@@ -11,30 +11,30 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_global_option')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_global_option', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 use ducklake
 
-# Create one Table with two files - insert 11 rows to bypass inlining
+# Create one Table with two files
 statement ok
 CREATE TABLE example (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO example SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO example (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO example SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO example (key, value) VALUES ('baz', 'qux');
 
 # Create another Table with two files
 statement ok
 CREATE TABLE example_2 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO example_2 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO example_2 (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO example_2 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO example_2 (key, value) VALUES ('baz', 'qux');
 
 # Different schema with another table with two files
 statement ok
@@ -44,28 +44,28 @@ statement ok
 CREATE TABLE s1.example (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO s1.example SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example (key, value) VALUES ('baz', 'qux');
 
 statement ok
 CREATE TABLE s1.example_2 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example_2 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example_2 (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO s1.example_2 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example_2 (key, value) VALUES ('baz', 'qux');
 
 statement ok
 CREATE TABLE s1.example_3 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example_3 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example_3 (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO s1.example_3 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
+INSERT INTO s1.example_3 (key, value) VALUES ('baz', 'qux');
 
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
@@ -103,7 +103,7 @@ s1	example_2	2	1
 
 # We can set specific tables to be merged
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file ORDER BY data_file_id
+SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 0	1
 1	1
@@ -127,7 +127,7 @@ s1	example	2	1
 s1	example_3	2	1
 
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file ORDER BY data_file_id
+SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 0	1
 1	1

--- a/test/sql/compaction/merge_adjacent_global_option.test
+++ b/test/sql/compaction/merge_adjacent_global_option.test
@@ -16,25 +16,25 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/me
 statement ok
 use ducklake
 
-# Create one Table with two files
+# Create one Table with two files - insert 11 rows to bypass inlining
 statement ok
 CREATE TABLE example (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO example (key, value) VALUES ('foo', 'bar');
+INSERT INTO example SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
-INSERT INTO example (key, value) VALUES ('baz', 'qux');
+INSERT INTO example SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
 
 # Create another Table with two files
 statement ok
 CREATE TABLE example_2 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO example_2 (key, value) VALUES ('foo', 'bar');
+INSERT INTO example_2 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
-INSERT INTO example_2 (key, value) VALUES ('baz', 'qux');
+INSERT INTO example_2 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
 
 # Different schema with another table with two files
 statement ok
@@ -44,28 +44,28 @@ statement ok
 CREATE TABLE s1.example (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example (key, value) VALUES ('foo', 'bar');
+INSERT INTO s1.example SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
-INSERT INTO s1.example (key, value) VALUES ('baz', 'qux');
+INSERT INTO s1.example SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
 CREATE TABLE s1.example_2 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example_2 (key, value) VALUES ('foo', 'bar');
+INSERT INTO s1.example_2 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
-INSERT INTO s1.example_2 (key, value) VALUES ('baz', 'qux');
+INSERT INTO s1.example_2 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
 CREATE TABLE s1.example_3 (key VARCHAR, value VARCHAR);
 
 statement ok
-INSERT INTO s1.example_3 (key, value) VALUES ('foo', 'bar');
+INSERT INTO s1.example_3 SELECT 'foo' || i::VARCHAR, 'bar' || i::VARCHAR FROM range(11) t(i);
 
 statement ok
-INSERT INTO s1.example_3 (key, value) VALUES ('baz', 'qux');
+INSERT INTO s1.example_3 SELECT 'baz' || i::VARCHAR, 'qux' || i::VARCHAR FROM range(11) t(i);
 
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
@@ -99,7 +99,7 @@ CALL ducklake_merge_adjacent_files('ducklake');
 
 # We can set specific tables to be merged
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file ORDER BY data_file_id
 ----
 0	1
 1	1
@@ -118,7 +118,7 @@ statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
 
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file ORDER BY data_file_id
 ----
 0	1
 1	1

--- a/test/sql/compaction/merge_adjacent_max_files.test
+++ b/test/sql/compaction/merge_adjacent_max_files.test
@@ -11,7 +11,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_max_files/')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/merge_adjacent_max_files/', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake;
@@ -25,9 +25,6 @@ loop i 0 20
 statement ok
 INSERT INTO example VALUES (${i});
 
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
 endloop
 
 query III
@@ -36,10 +33,10 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 example	20	1
 
 # We create max one file, since we use the default size limits, one file should fit all
-query I
-SELECT max(data_file_id) = min(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+query II
+SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-true
+20	20
 
 statement ok
 DROP TABLE example;
@@ -58,9 +55,6 @@ loop i 0 20
 
 statement ok
 INSERT INTO example VALUES (${i});
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 endloop
 
@@ -89,45 +83,66 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 20
 
-query I
-SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-20
-
 query II
-SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
+SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-example	1
-example	1
+40	21
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
+----
+example	5	1
+example	5	1
 
 # We create two new files, and remove as many as necessary to create them
-query I
-SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-true
-
 query II
-SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
+SELECT max(data_file_id), min (data_file_id) > 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-example	1
+42	True
 
-# We create max one file - active file count decreased
-query I
-SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
 ----
-true
+example	3	1
 
-statement ok
+# We create max one file
+query II
+SELECT max(data_file_id), min (data_file_id) > 31 FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+43	True
+
+query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000) ORDER BY ALL
+----
+example	4	1
+example	5	1
 
 # We basically do max compaction, limiting the size set
+query II
+SELECT max(data_file_id) > 43, min (data_file_id) > 32 FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+True	True
 
-# Keep merging until fully compacted
-statement ok
+query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
+----
+example	3	1
 
-statement ok
+# Calling it again, merges one more time both snapshots as they are under the size limit
+query I
+SELECT max(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+46
+
+query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
+----
+
+# Calling it again, produces no changes
+query I
+SELECT max(data_file_id) BETWEEN 46 AND 48 FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+True
 
 # Check data is still correct
 query I
@@ -160,9 +175,6 @@ INSERT INTO table1 VALUES (${i});
 statement ok
 INSERT INTO table2 VALUES (${i});
 
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
 endloop
 
 query I
@@ -172,17 +184,17 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 
 # Compact entire database with max_compacted_files=1 per table
 # Each table should get at most 1 compaction operation
-query II
-SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
 ----
-table1	1
-table2	1
+table1	5	1
+table2	5	1
 
 # Both tables got compacted (1 operation each)
 query I
-SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-true
+12
 
 # Check data is still correct
 query I

--- a/test/sql/compaction/merge_adjacent_max_files.test
+++ b/test/sql/compaction/merge_adjacent_max_files.test
@@ -25,6 +25,9 @@ loop i 0 20
 statement ok
 INSERT INTO example VALUES (${i});
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 endloop
 
 query III
@@ -36,7 +39,7 @@ example	20	1
 query II
 SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-20	20
+40	40
 
 statement ok
 DROP TABLE example;
@@ -50,11 +53,14 @@ CALL ducklake.set_option('target_file_size', '1KB');
 statement ok
 CREATE TABLE example (key integer);
 
-# Generate 100 files
+# Generate 20 files
 loop i 0 20
 
 statement ok
 INSERT INTO example VALUES (${i});
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 endloop
 
@@ -86,63 +92,42 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 query II
 SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-40	21
+80	42
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
 ----
-example	5	1
-example	5	1
+example	<REGEX>:\d+	1
+example	<REGEX>:\d+	1
 
 # We create two new files, and remove as many as necessary to create them
 query II
-SELECT max(data_file_id), min (data_file_id) > 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-42	True
-
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
-----
-example	3	1
-
-# We create max one file
-query II
-SELECT max(data_file_id), min (data_file_id) > 31 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-43	True
-
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000) ORDER BY ALL
-----
-example	4	1
-example	5	1
-
-# We basically do max compaction, limiting the size set
-query II
-SELECT max(data_file_id) > 43, min (data_file_id) > 32 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id) > 80, min (data_file_id) > 42 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 True	True
 
 query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
+----
+example	<REGEX>:\d+	1
+
+# We create max one file
+query II
+SELECT max(data_file_id) > 80, min (data_file_id) > 42 FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+True	True
+
+statement ok
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000) ORDER BY ALL
+
+# We basically do max compaction, limiting the size set
+
+# Keep merging until fully compacted
+statement ok
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
-----
-example	3	1
 
-# Calling it again, merges one more time both snapshots as they are under the size limit
-query I
-SELECT max(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-46
-
-query III
+statement ok
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
-----
-
-# Calling it again, produces no changes
-query I
-SELECT max(data_file_id) BETWEEN 46 AND 48 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-True
 
 # Check data is still correct
 query I
@@ -175,6 +160,9 @@ INSERT INTO table1 VALUES (${i});
 statement ok
 INSERT INTO table2 VALUES (${i});
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 endloop
 
 query I
@@ -187,14 +175,14 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
 ----
-table1	5	1
-table2	5	1
+table1	<REGEX>:\d+	1
+table2	<REGEX>:\d+	1
 
 # Both tables got compacted (1 operation each)
 query I
-SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-12
+true
 
 # Check data is still correct
 query I

--- a/test/sql/compaction/merge_adjacent_max_files.test
+++ b/test/sql/compaction/merge_adjacent_max_files.test
@@ -36,10 +36,10 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 example	20	1
 
 # We create max one file, since we use the default size limits, one file should fit all
-query II
-SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+query I
+SELECT max(data_file_id) = min(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-40	40
+true
 
 statement ok
 DROP TABLE example;
@@ -89,33 +89,33 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 20
 
-query II
-SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-80	42
+20
 
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
+query II
+SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
 ----
-example	<REGEX>:\d+	1
-example	<REGEX>:\d+	1
+example	1
+example	1
 
 # We create two new files, and remove as many as necessary to create them
-query II
-SELECT max(data_file_id) > 80, min (data_file_id) > 42 FROM __ducklake_metadata_ducklake.ducklake_data_file
+query I
+SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-True	True
+true
 
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
-----
-example	<REGEX>:\d+	1
-
-# We create max one file
 query II
-SELECT max(data_file_id) > 80, min (data_file_id) > 42 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
 ----
-True	True
+example	1
+
+# We create max one file - active file count decreased
+query I
+SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+----
+true
 
 statement ok
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000) ORDER BY ALL
@@ -172,11 +172,11 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 
 # Compact entire database with max_compacted_files=1 per table
 # Each table should get at most 1 compaction operation
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
+query II
+SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
 ----
-table1	<REGEX>:\d+	1
-table2	<REGEX>:\d+	1
+table1	1
+table2	1
 
 # Both tables got compacted (1 operation each)
 query I

--- a/test/sql/compaction/merge_adjacent_max_files.test
+++ b/test/sql/compaction/merge_adjacent_max_files.test
@@ -19,20 +19,25 @@ USE ducklake;
 statement ok
 CREATE TABLE example (key integer);
 
-# Generate 100 files
+# Generate 20 files by inserting 11 rows each to bypass inlining
 loop i 0 20
 
 statement ok
-INSERT INTO example VALUES (${i});
+INSERT INTO example SELECT ${i} * 11 + j FROM range(11) t(j);
 
 endloop
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
+----
+20
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1);
 
 # We create max one file, since we use the default size limits, one file should fit all
 query II
-SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id), min(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 20	20
 
@@ -48,11 +53,11 @@ CALL ducklake.set_option('target_file_size', '1KB');
 statement ok
 CREATE TABLE example (key integer);
 
-# Generate 100 files
+# Generate 20 files by inserting 11 rows each to bypass inlining
 loop i 0 20
 
 statement ok
-INSERT INTO example VALUES (${i});
+INSERT INTO example SELECT ${i} * 11 + j FROM range(11) t(j);
 
 endloop
 
@@ -82,7 +87,7 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 20
 
 query II
-SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id), min(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 40	21
 
@@ -91,48 +96,48 @@ CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2
 
 # We create two new files, and remove as many as necessary to create them
 query II
-SELECT max(data_file_id), min (data_file_id) > 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id), min(data_file_id) >= 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-42	True
+42	true
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1);
 
 # We create max one file
 query II
-SELECT max(data_file_id), min (data_file_id) > 31 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id), min(data_file_id) >= 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-43	True
+43	true
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000);
 
 # We basically do max compaction, limiting the size set
 query II
-SELECT max(data_file_id) > 43, min (data_file_id) > 32 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id) > 43, min(data_file_id) >= 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-True	True
+true	true
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000);
 
 # Calling it again, merges one more time both snapshots as they are under the size limit
 query I
-SELECT max(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id) BETWEEN 48 AND 52 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-46
+true
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000);
 
-# Calling it again, produces no changes
+# Calling it again, produces no changes or small increment
 query I
-SELECT max(data_file_id) BETWEEN 46 AND 48 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT max(data_file_id) BETWEEN 48 AND 55 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-True
+true
 
-# Check data is still correct
+# Check data is still correct (20 inserts * 11 rows = 220 rows)
 query I
 select count(*) FROM example;
 ----
-20
+220

--- a/test/sql/compaction/merge_adjacent_options.test
+++ b/test/sql/compaction/merge_adjacent_options.test
@@ -83,16 +83,12 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT table_id, count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file GROUP BY table_id ORDER BY ALL
 ----
-1	1
-3	1
+1	2
+2	2
+4	2
 5	2
-7	2
-9	4
-11	4
-13	5
-15	5
 
 # We define a table_name but not a schema name so we should be able to merge from example_2
 query III
@@ -102,15 +98,12 @@ example_2	2	1
 
 # We write a new file for table id 2
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT table_id, count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file GROUP BY table_id ORDER BY ALL
 ----
-1	1
-3	1
-9	4
-11	4
-13	5
-15	5
-16	2
+1	2
+2	1
+4	2
+5	2
 
 
 # If we define the schema we do table id 5
@@ -120,14 +113,12 @@ SELECT schema_name, table_name, files_processed, files_created FROM ducklake_mer
 s1	example_2	2	1
 
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT table_id, count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file GROUP BY table_id ORDER BY ALL
 ----
-1	1
-3	1
-9	4
-11	4
-16	2
-17	5
+1	2
+2	1
+4	2
+5	1
 
 # If we call with nothing, all tables, schemas go in, so we compress both remaining tables
 query IIII
@@ -137,12 +128,12 @@ main	example	2	1
 s1	example	2	1
 
 query II
-SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT table_id, count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file GROUP BY table_id ORDER BY ALL
 ----
-16	2
-17	5
-18	1
-19	4
+1	1
+2	1
+4	1
+5	1
 
 statement error
 CALL ducklake_merge_adjacent_files('ducklake', 'example_2', schema=>'bogus');

--- a/test/sql/compaction/merge_adjacent_options.test
+++ b/test/sql/compaction/merge_adjacent_options.test
@@ -24,7 +24,13 @@ statement ok
 INSERT INTO example (key, value) VALUES ('foo', 'bar');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO example (key, value) VALUES ('baz', 'qux');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Create another Table with two files
 statement ok
@@ -34,7 +40,13 @@ statement ok
 INSERT INTO example_2 (key, value) VALUES ('foo', 'bar');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO example_2 (key, value) VALUES ('baz', 'qux');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Different schema with another table with two files
 statement ok
@@ -47,7 +59,13 @@ statement ok
 INSERT INTO s1.example (key, value) VALUES ('foo', 'bar');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO s1.example (key, value) VALUES ('baz', 'qux');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 CREATE TABLE s1.example_2 (key VARCHAR, value VARCHAR);
@@ -56,19 +74,25 @@ statement ok
 INSERT INTO s1.example_2 (key, value) VALUES ('foo', 'bar');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO s1.example_2 (key, value) VALUES ('baz', 'qux');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-0	1
 1	1
-2	2
-3	2
-4	4
-5	4
-6	5
-7	5
+3	1
+5	2
+7	2
+9	4
+11	4
+13	5
+15	5
 
 # We define a table_name but not a schema name so we should be able to merge from example_2
 statement ok
@@ -78,13 +102,13 @@ CALL ducklake_merge_adjacent_files('ducklake', 'example_2');
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-0	1
 1	1
-4	4
-5	4
-6	5
-7	5
-8	2
+3	1
+9	4
+11	4
+13	5
+15	5
+16	2
 
 
 # If we define the schema we do table id 5
@@ -94,12 +118,12 @@ CALL ducklake_merge_adjacent_files('ducklake', 'example_2', schema=>'s1');
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-0	1
 1	1
-4	4
-5	4
-8	2
-9	5
+3	1
+9	4
+11	4
+16	2
+17	5
 
 # If we call with nothing, all tables, schemas go in, so we compress both remaining tables
 statement ok
@@ -108,10 +132,10 @@ CALL ducklake_merge_adjacent_files('ducklake');
 query II
 SELECT data_file_id, table_id FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-8	2
-9	5
-10	1
-11	4
+16	2
+17	5
+18	1
+19	4
 
 statement error
 CALL ducklake_merge_adjacent_files('ducklake', 'example_2', schema=>'bogus');

--- a/test/sql/compaction/merge_adjacent_partial_max.test
+++ b/test/sql/compaction/merge_adjacent_partial_max.test
@@ -24,19 +24,37 @@ statement ok
 insert into t values (0);
 
 statement ok
-insert into t values (0);
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 insert into t values (0);
 
 statement ok
-insert into t values (0);
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 insert into t values (0);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 insert into t values (0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+insert into t values (0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+insert into t values (0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
@@ -46,4 +64,4 @@ t	6	1
 query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-7
+12

--- a/test/sql/compaction/merge_adjacent_partial_max.test
+++ b/test/sql/compaction/merge_adjacent_partial_max.test
@@ -56,12 +56,16 @@ insert into t values (0);
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
+# Capture expected partial_max before merge: max begin_snapshot of active files
+statement ok
+SET VARIABLE expected_pm = (SELECT max(begin_snapshot) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL);
+
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
 ----
 t	6	1
 
 query I
-SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT partial_max = getvariable('expected_pm') FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
 ----
-12
+true

--- a/test/sql/compaction/merge_adjacent_partial_max.test
+++ b/test/sql/compaction/merge_adjacent_partial_max.test
@@ -38,6 +38,10 @@ insert into t values (0);
 statement ok
 insert into t values (0);
 
+# flush inlined data to create parquet files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 't');
 

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_merge_expire_snapshots_schema')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_merge_expire_snapshots_schema', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake;
@@ -20,12 +20,11 @@ USE ducklake;
 statement ok
 CREATE TABLE example (key VARCHAR, value VARCHAR);
 
-# With 15 rows, files are created directly
 statement ok
-INSERT INTO example SELECT 'foo' || i, 'bar' || i FROM range(15) t(i);
+INSERT INTO example (key, value) VALUES ('foo', 'bar');
 
 statement ok
-INSERT INTO example SELECT 'baz' || i, 'qux' || i FROM range(15) t(i);
+INSERT INTO example (key, value) VALUES ('baz', 'qux');
 
 query II
 SELECT snapshot_id, changes FROM snapshots();
@@ -57,34 +56,32 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 1
 
 query II
-FROM example ORDER BY key LIMIT 4
+FROM example
 ----
-baz0	qux0
-baz1	qux1
-baz10	qux10
-baz11	qux11
+foo	bar
+baz	qux
 
 # Add a few schema changes
 statement ok
-INSERT INTO example SELECT 'a' || i, 'b' || i FROM range(15) t(i);
+INSERT INTO example (key, value) VALUES ('a', 'b');
 
 statement ok
 ALTER TABLE example ADD COLUMN j INTEGER
 
 statement ok
-INSERT INTO example SELECT 'c' || i, 'd' || i, i FROM range(15) t(i);
+INSERT INTO example VALUES ('c', 'd', 1);
 
 statement ok
-INSERT INTO example SELECT 'e' || i, 'f' || i, i+15 FROM range(15) t(i);
+INSERT INTO example VALUES ('e', 'f', 2);
 
 statement ok
 ALTER TABLE example DROP COLUMN key
 
 statement ok
-INSERT INTO example SELECT 'k' || i, i+30 FROM range(15) t(i);
+INSERT INTO example VALUES ('k', 3);
 
 statement ok
-INSERT INTO example SELECT 'ff' || i, i+45 FROM range(15) t(i);
+INSERT INTO example VALUES ('f', 9);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
@@ -107,7 +104,7 @@ SELECT snapshot_id, changes FROM snapshots();
 
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [5,6,7,8,9,10]);
+CALL ducklake_expire_snapshots('ducklake', versions => [5,6,7,8]);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
@@ -124,15 +121,12 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 3
 
 query II
-FROM example ORDER BY ALL LIMIT 10
+FROM example ORDER BY ALL
 ----
-b0	NULL
-b1	NULL
-b10	NULL
-b11	NULL
-b12	NULL
-b13	NULL
-b14	NULL
-b2	NULL
-b3	NULL
-b4	NULL
+b	NULL
+bar	NULL
+d	1
+f	2
+f	9
+k	3
+qux	NULL

--- a/test/sql/compaction/merge_files_expired_snapshots.test
+++ b/test/sql/compaction/merge_files_expired_snapshots.test
@@ -20,11 +20,12 @@ USE ducklake;
 statement ok
 CREATE TABLE example (key VARCHAR, value VARCHAR);
 
+# With 15 rows, files are created directly
 statement ok
-INSERT INTO example (key, value) VALUES ('foo', 'bar');
+INSERT INTO example SELECT 'foo' || i, 'bar' || i FROM range(15) t(i);
 
 statement ok
-INSERT INTO example (key, value) VALUES ('baz', 'qux');
+INSERT INTO example SELECT 'baz' || i, 'qux' || i FROM range(15) t(i);
 
 query II
 SELECT snapshot_id, changes FROM snapshots();
@@ -56,32 +57,34 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 1
 
 query II
-FROM example
+FROM example ORDER BY key LIMIT 4
 ----
-foo	bar
-baz	qux
+baz0	qux0
+baz1	qux1
+baz10	qux10
+baz11	qux11
 
 # Add a few schema changes
 statement ok
-INSERT INTO example (key, value) VALUES ('a', 'b');
+INSERT INTO example SELECT 'a' || i, 'b' || i FROM range(15) t(i);
 
 statement ok
 ALTER TABLE example ADD COLUMN j INTEGER
 
 statement ok
-INSERT INTO example VALUES ('c', 'd', 1);
+INSERT INTO example SELECT 'c' || i, 'd' || i, i FROM range(15) t(i);
 
 statement ok
-INSERT INTO example VALUES ('e', 'f', 2);
+INSERT INTO example SELECT 'e' || i, 'f' || i, i+15 FROM range(15) t(i);
 
 statement ok
 ALTER TABLE example DROP COLUMN key
 
 statement ok
-INSERT INTO example VALUES ('k', 3);
+INSERT INTO example SELECT 'k' || i, i+30 FROM range(15) t(i);
 
 statement ok
-INSERT INTO example VALUES ('f', 9);
+INSERT INTO example SELECT 'ff' || i, i+45 FROM range(15) t(i);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
@@ -104,7 +107,7 @@ SELECT snapshot_id, changes FROM snapshots();
 
 
 statement ok
-CALL ducklake_expire_snapshots('ducklake', versions => [5,6,7,8]);
+CALL ducklake_expire_snapshots('ducklake', versions => [5,6,7,8,9,10]);
 
 query I
 SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
@@ -121,12 +124,15 @@ SELECT count(*) FROM ducklake_list_files('ducklake', 'example');
 3
 
 query II
-FROM example ORDER BY ALL
+FROM example ORDER BY ALL LIMIT 10
 ----
-b	NULL
-bar	NULL
-d	1
-f	2
-f	9
-k	3
-qux	NULL
+b0	NULL
+b1	NULL
+b10	NULL
+b11	NULL
+b12	NULL
+b13	NULL
+b14	NULL
+b2	NULL
+b3	NULL
+b4	NULL

--- a/test/sql/compaction/merge_rewrite_partial_file_info.test
+++ b/test/sql/compaction/merge_rewrite_partial_file_info.test
@@ -24,12 +24,18 @@ CALL ducklake_set_option('ducklake', 'target_file_size', '10KB');
 statement ok
 CREATE TABLE t (id INTEGER, data VARCHAR);
 
+statement ok
+SET VARIABLE snap_create = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
 # Create a LARGE file A that won't be merged (exceeds target_file_size)
 statement ok
 INSERT INTO t SELECT i, repeat('x', 100) FROM range(5000) t(i);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE snap_A = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # Create small files B and C that WILL be merged
 statement ok
@@ -39,10 +45,16 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
+SET VARIABLE snap_B = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
+statement ok
 INSERT INTO t SELECT i + 5100, 'small2' FROM range(100) t(i);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE snap_C = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # At this point we have 3 files
 query I
@@ -60,6 +72,9 @@ query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
 ----
 t	2	1
+
+statement ok
+SET VARIABLE snap_merge_BC = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # State now:
 # - File A (ids 0-4999): NO partial_max
@@ -84,10 +99,16 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
+SET VARIABLE snap_D = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
+statement ok
 INSERT INTO t SELECT i + 5210, 'small4' FROM range(10) t(i);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE snap_E = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # Set small target file size so only D & E get merged
 statement ok
@@ -105,6 +126,9 @@ query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
 ----
 t	2	1
+
+statement ok
+SET VARIABLE snap_merge_DE = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # State now:
 # - File A: NO partial_max
@@ -134,12 +158,18 @@ DELETE FROM t WHERE id < 4900;
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
+statement ok
+SET VARIABLE snap_del_A = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
 # Delete from merged file BC (has partial_max)
 statement ok
 DELETE FROM t WHERE id >= 5000 AND id < 5150;
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE snap_del_BC = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # Set large target to merge all files
 statement ok
@@ -150,6 +180,9 @@ query III
 SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0)
 ----
 t	2	1
+
+statement ok
+SET VARIABLE snap_rewrite = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # Merge all of them into a single file
 query III
@@ -166,5 +199,61 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't');
 # Ensure the final count is correct after all operations
 query I
 SELECT COUNT(*) FROM t;
+----
+170
+
+# Ensure time-travel works across all snapshots
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_create'))
+----
+0
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_A'))
+----
+5000
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_B'))
+----
+5100
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_C'))
+----
+5200
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_merge_BC'))
+----
+5200
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_D'))
+----
+5210
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_E'))
+----
+5220
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_merge_DE'))
+----
+5220
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_del_A'))
+----
+320
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_del_BC'))
+----
+170
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('snap_rewrite'))
 ----
 170

--- a/test/sql/compaction/merge_rewrite_partial_file_info.test
+++ b/test/sql/compaction/merge_rewrite_partial_file_info.test
@@ -50,6 +50,11 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't');
 ----
 3
 
+# Capture expected partial_max before merge: max begin_snapshot of the small files (B and C)
+# (exclude file A which has the smallest begin_snapshot and won't be merged)
+statement ok
+SET VARIABLE expected_pm_1 = (SELECT max(begin_snapshot) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL AND begin_snapshot != (SELECT min(begin_snapshot) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL));
+
 # Merge B+C into a single file (A is too big to merge)
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
@@ -57,19 +62,20 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 t	2	1
 
 # State now:
-# - File A (ids 0-4999): NO partial_max, begin_snapshot=2
-# - Merged BC (ids 5000-5199): HAS partial_max=4, begin_snapshot=3
+# - File A (ids 0-4999): NO partial_max
+# - Merged BC (ids 5000-5199): HAS partial_max
 query I
 SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't') WHERE delete_file IS NULL;
 ----
 2
 
-# Only merged BC has partial_max
+# Only merged BC has partial_max - verify it equals expected value
 query I
-SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
+SELECT CASE WHEN partial_max IS NULL THEN NULL ELSE partial_max = getvariable('expected_pm_1') END
+FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL ORDER BY data_file_id;
 ----
 NULL
-4
+true
 
 statement ok
 INSERT INTO t SELECT i + 5200, 'small3' FROM range(10) t(i);
@@ -87,6 +93,13 @@ CALL ducklake_flush_inlined_data('ducklake')
 statement ok
 CALL ducklake_set_option('ducklake', 'target_file_size', '1KB');
 
+# Capture expected partial_max for D+E merge: max begin_snapshot of files created after the first merge
+statement ok
+SET VARIABLE merge1_snap = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%merge%');
+
+statement ok
+SET VARIABLE expected_pm_2 = (SELECT max(begin_snapshot) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL AND begin_snapshot > getvariable('merge1_snap'));
+
 # Merge D+E into a single file (A is too big to merge)
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
@@ -94,20 +107,25 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 t	2	1
 
 # State now:
-# - File A (ids 0-4999): NO partial_max, begin_snapshot=2
-# - Merged BC (ids 5000-5199): HAS partial_max=4, begin_snapshot=3
-# - Merged DE (ids 5200-5219): HAS partial_max=7, begin_snapshot=6
+# - File A: NO partial_max
+# - Merged BC: HAS partial_max = expected_pm_1
+# - Merged DE: HAS partial_max = expected_pm_2
 query I
 SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't') WHERE delete_file IS NULL;
 ----
 3
 
 query I
-SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
+SELECT CASE WHEN partial_max IS NULL THEN NULL
+  WHEN partial_max = getvariable('expected_pm_1') THEN true
+  WHEN partial_max = getvariable('expected_pm_2') THEN true
+  ELSE false
+END
+FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL ORDER BY data_file_id;
 ----
 NULL
-4
-8
+true
+true
 
 # Delete from file A (no partial_max)
 statement ok

--- a/test/sql/compaction/merge_rewrite_partial_file_info.test
+++ b/test/sql/compaction/merge_rewrite_partial_file_info.test
@@ -28,12 +28,21 @@ CREATE TABLE t (id INTEGER, data VARCHAR);
 statement ok
 INSERT INTO t SELECT i, repeat('x', 100) FROM range(5000) t(i);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Create small files B and C that WILL be merged
 statement ok
 INSERT INTO t SELECT i + 5000, 'small1' FROM range(100) t(i);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO t SELECT i + 5100, 'small2' FROM range(100) t(i);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # At this point we have 3 files
 query I
@@ -58,13 +67,19 @@ query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
 ----
 NULL
-4
+5
 
 statement ok
 INSERT INTO t SELECT i + 5200, 'small3' FROM range(10) t(i);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO t SELECT i + 5210, 'small4' FROM range(10) t(i);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Set small target file size so only D & E get merged
 statement ok
@@ -87,16 +102,22 @@ query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
 ----
 NULL
-4
-7
+5
+10
 
 # Delete from file A (no partial_max)
 statement ok
 DELETE FROM t WHERE id < 4900;
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Delete from merged file BC (has partial_max)
 statement ok
 DELETE FROM t WHERE id >= 5000 AND id < 5150;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Set large target to merge all files
 statement ok
@@ -116,32 +137,8 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't');
 ----
 1
 
-# Ensure the time-travel works
-query II
-SELECT * FROM (
-  SELECT '01_count_after_init' as version, COUNT(*) FROM t AT (VERSION => 1)
-  UNION SELECT '02_count_after_A' as version, COUNT(*) FROM t AT (VERSION => 2)
-  UNION SELECT '03_count_after_B' as version, COUNT(*) FROM t AT (VERSION => 3)
-  UNION SELECT '04_count_after_C' as version, COUNT(*) FROM t AT (VERSION => 4)
-  UNION SELECT '05_count_after_BC' as version, COUNT(*) FROM t AT (VERSION => 5)
-  UNION SELECT '06_count_after_D' as version, COUNT(*) FROM t AT (VERSION => 6)
-  UNION SELECT '07_count_after_E' as version, COUNT(*) FROM t AT (VERSION => 7)
-  UNION SELECT '08_count_after_DE' as version, COUNT(*) FROM t AT (VERSION => 8)
-  UNION SELECT '09_count_after_delete_from_A' as version, COUNT(*) FROM t AT (VERSION => 9)
-  UNION SELECT '10_count_after_delete_from_BC' as version, COUNT(*) FROM t AT (VERSION => 10)
-  UNION SELECT '11_count_after_rewrite' as version, COUNT(*) FROM t AT (VERSION => 11)
-  UNION SELECT '12_final' as version, COUNT(*) FROM t
-) ORDER BY version ASC;
+# Ensure the final count is correct after all operations
+query I
+SELECT COUNT(*) FROM t;
 ----
-01_count_after_init	0
-02_count_after_A	5000
-03_count_after_B	5100
-04_count_after_C	5200
-05_count_after_BC	5200
-06_count_after_D	5210
-07_count_after_E	5220
-08_count_after_DE	5220
-09_count_after_delete_from_A	320
-10_count_after_delete_from_BC	170
-11_count_after_rewrite	170
-12_final	170
+170

--- a/test/sql/compaction/merge_rewrite_partial_file_info.test
+++ b/test/sql/compaction/merge_rewrite_partial_file_info.test
@@ -67,7 +67,7 @@ query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
 ----
 NULL
-5
+4
 
 statement ok
 INSERT INTO t SELECT i + 5200, 'small3' FROM range(10) t(i);
@@ -102,8 +102,8 @@ query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL;
 ----
 NULL
-5
-10
+4
+8
 
 # Delete from file A (no partial_max)
 statement ok

--- a/test/sql/compaction/mix_large_small_insertions.test
+++ b/test/sql/compaction/mix_large_small_insertions.test
@@ -67,16 +67,15 @@ INSERT INTO ducklake.tbl VALUES (3, 'friends');
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# Row snapshot_id corresponds to inlined_insert (odd numbers: 2, 5, 7, 10, 12)
-# Large inserts are at 4 and 9 (tables_inserted_into)
-query IIII
-SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (4, 9) ORDER BY ALL
+# Only show small insert rows (exclude large inserts with id >= 100000)
+query III
+SELECT rowid, * FROM ducklake.tbl WHERE id < 10 ORDER BY ALL
 ----
-0	2	1	hello
-10001	5	2	world
-10002	7	3	and
-20003	10	3	my
-20004	12	3	friends
+0	1	hello
+10001	2	world
+10002	3	and
+20003	3	my
+20004	3	friends
 
 # we should have 7 files now
 query I
@@ -85,26 +84,26 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_mix_files/**/*.parqu
 7
 
 # now compact and cleanup
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
+query II
+SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake')
 ----
-tbl	4	1
+tbl	1
 
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
 
-# now we should have 4 files
+# we should have fewer files now (2 large files + 1 merged small file)
 query I
-SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_mix_files/**/*.parquet')
+SELECT COUNT(*) < 7 FROM GLOB('${DATA_PATH}/ducklake_compaction_mix_files/**/*.parquet')
 ----
-4
+true
 
-# all row-ids and snapshots are still intact
-query IIII
-SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (4, 9) ORDER BY ALL
+# all row-ids are still intact
+query III
+SELECT rowid, * FROM ducklake.tbl WHERE id < 10 ORDER BY ALL
 ----
-0	2	1	hello
-10001	5	2	world
-10002	7	3	and
-20003	10	3	my
-20004	12	3	friends
+0	1	hello
+10001	2	world
+10002	3	and
+20003	3	my
+20004	3	friends

--- a/test/sql/compaction/mix_large_small_insertions.test
+++ b/test/sql/compaction/mix_large_small_insertions.test
@@ -24,42 +24,59 @@ CREATE TABLE ducklake.tbl(id INTEGER, str VARCHAR);
 
 # perform a mix of large and small insertions
 
-# snapshot 2
+# snapshot 2 (inlined_insert), flush snapshot 3 (flushed_inlined)
 statement ok
 INSERT INTO ducklake.tbl VALUES (1, 'hello');
 
-# snapshot 3
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 4 (large insert creates files directly - tables_inserted_into)
 statement ok
 INSERT INTO ducklake.tbl SELECT 100000 + i, concat('thisisastring', i) FROM range(10000) t(i)
 
-# snapshot 4
+# snapshot 5 (inlined_insert), flush snapshot 6 (flushed_inlined)
 statement ok
 INSERT INTO ducklake.tbl VALUES (2, 'world');
 
-# snapshot 5
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 7 (inlined_insert), flush snapshot 8 (flushed_inlined)
 statement ok
 INSERT INTO ducklake.tbl VALUES (3, 'and');
 
-# snapshot 6
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 9 (large insert creates files directly - tables_inserted_into)
 statement ok
 INSERT INTO ducklake.tbl SELECT 200000 + i, concat('thisisalsoastring', i) FROM range(10000) t(i)
 
-# snapshot 7
+# snapshot 10 (inlined_insert), flush snapshot 11 (flushed_inlined)
 statement ok
 INSERT INTO ducklake.tbl VALUES (3, 'my');
 
-# snapshot 8
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 12 (inlined_insert), flush snapshot 13 (flushed_inlined)
 statement ok
 INSERT INTO ducklake.tbl VALUES (3, 'friends');
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Row snapshot_id corresponds to inlined_insert (odd numbers: 2, 5, 7, 10, 12)
+# Large inserts are at 4 and 9 (tables_inserted_into)
 query IIII
-SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (3, 6) ORDER BY ALL
+SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (4, 9) ORDER BY ALL
 ----
 0	2	1	hello
-10001	4	2	world
-10002	5	3	and
-20003	7	3	my
-20004	8	3	friends
+10001	5	2	world
+10002	7	3	and
+20003	10	3	my
+20004	12	3	friends
 
 # we should have 7 files now
 query I
@@ -74,18 +91,18 @@ CALL ducklake_merge_adjacent_files('ducklake');
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
 
-# now we should have 3 files
+# now we should have 4 files
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_mix_files/**/*.parquet')
 ----
-3
+4
 
 # all row-ids and snapshots are still intact
 query IIII
-SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (3, 6) ORDER BY ALL
+SELECT rowid, snapshot_id, * FROM ducklake.tbl WHERE snapshot_id NOT IN (4, 9) ORDER BY ALL
 ----
 0	2	1	hello
-10001	4	2	world
-10002	5	3	and
-20003	7	3	my
-20004	8	3	friends
+10001	5	2	world
+10002	7	3	and
+20003	10	3	my
+20004	12	3	friends

--- a/test/sql/compaction/mix_large_small_insertions.test
+++ b/test/sql/compaction/mix_large_small_insertions.test
@@ -88,7 +88,7 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_mix_files/**/*.parqu
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
 ----
-tbl	5	1
+tbl	4	1
 
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);

--- a/test/sql/compaction/multi_compaction.test
+++ b/test/sql/compaction/multi_compaction.test
@@ -23,10 +23,19 @@ statement ok
 INSERT INTO ducklake.test VALUES (${BASE} + 1);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.test VALUES (${BASE} + 2);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO ducklake.test VALUES (${BASE} + 3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
@@ -55,9 +64,9 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1
-3	1	2
-4	2	3
-6	3	4
-7	4	5
-8	5	6
+2	1	1
+4	2	2
+6	3	3
+9	4	4
+11	5	5
+13	6	6

--- a/test/sql/compaction/multi_compaction.test
+++ b/test/sql/compaction/multi_compaction.test
@@ -37,10 +37,10 @@ INSERT INTO ducklake.test VALUES (${BASE} + 3);
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
+query II
+SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake')
 ----
-test	<REGEX>:\d+	1
+test	1
 
 endloop
 
@@ -60,13 +60,13 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 ----
 1
 
-# row-ids/snapshot-ids are kept also across multiple compaction runs
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+# row-ids are kept also across multiple compaction runs
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1
-4	1	2
-6	2	3
-9	3	4
-11	4	5
-13	5	6
+0	1
+1	2
+2	3
+3	4
+4	5
+5	6

--- a/test/sql/compaction/multi_compaction.test
+++ b/test/sql/compaction/multi_compaction.test
@@ -64,9 +64,9 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	1	1
-4	2	2
-6	3	3
-9	4	4
-11	5	5
-13	6	6
+2	0	1
+4	1	2
+6	2	3
+9	3	4
+11	4	5
+13	5	6

--- a/test/sql/compaction/multi_compaction.test
+++ b/test/sql/compaction/multi_compaction.test
@@ -28,6 +28,10 @@ INSERT INTO ducklake.test VALUES (${BASE} + 2);
 statement ok
 INSERT INTO ducklake.test VALUES (${BASE} + 3);
 
+# flush inlined data to create parquet files before merge
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
 
@@ -53,9 +57,9 @@ SELECT * FROM ducklake.test AT (VERSION => 2)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-2	0	1
-3	1	2
-4	2	3
-6	3	4
-7	4	5
-8	5	6
+2	3	1
+3	4	2
+4	5	3
+6	6	4
+7	7	5
+8	8	6

--- a/test/sql/compaction/small_insert_compaction.test
+++ b/test/sql/compaction/small_insert_compaction.test
@@ -17,50 +17,48 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_files', METADATA_CATALOG 'xx')
 
-# snapshot 1
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
-# snapshot 2
 statement ok
 CREATE TABLE ducklake.test2(i INTEGER);
 
-# snapshot 3, flush 4
+# insert 1 into test
 statement ok
 INSERT INTO ducklake.test VALUES (1);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 5, flush 6: random change that does not modify the "test" table
+# insert into test2: random change that does not modify the "test" table
 statement ok
 INSERT INTO ducklake.test2 VALUES (42);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 7, flush 8
+# insert 2 into test
 statement ok
 INSERT INTO ducklake.test VALUES (2);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 9, flush 10
+# insert 3 into test
 statement ok
 INSERT INTO ducklake.test VALUES (3);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 11, flush 12
+# insert 4 into test
 statement ok
 INSERT INTO ducklake.test VALUES (4);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 13, flush 14
+# insert 5 into test
 statement ok
 INSERT INTO ducklake.test VALUES (5);
 
@@ -72,16 +70,14 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_files/**/*')
 ----
 6
 
-# Row snapshot_ids correspond to inlined_insert (odd: 3, 7, 9, 11, 13)
-# not flushed_inlined (even: 4, 8, 10, 12, 14)
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	0	1
-7	1	2
-9	2	3
-11	3	4
-13	4	5
+0	1
+1	2
+2	3
+3	4
+4	5
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake.merge_adjacent_files() ORDER BY ALL
@@ -121,56 +117,77 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_files/**/*')
 ----
 2
 
+# compute snapshot IDs dynamically so the test works in both inline and no-inline modes
+# s1 = 1st insert into test (table_id=1)
+statement ok
+SET VARIABLE s1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 1);
+
+# s_test2 = insert into test2 (table_id=2) - used to verify unrelated inserts don't affect test
+statement ok
+SET VARIABLE s_test2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[2]%') WHERE rn = 1);
+
+# s2 = 2nd insert into test (table_id=1)
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
+# s3 = 3rd insert into test (table_id=1)
+statement ok
+SET VARIABLE s3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 3);
+
+# s_last = last snapshot (after compaction)
+statement ok
+SET VARIABLE s_last = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
 # verify correct behavior when operating on the compacted file
 # time travel
 query I
-SELECT * FROM ducklake.test AT (VERSION => 4)
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s1'))
 ----
 1
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 6)
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s_test2'))
 ----
 1
 
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 8) ORDER BY ALL
+SELECT * FROM ducklake.test AT (VERSION => getvariable('s2')) ORDER BY ALL
 ----
 1
 2
 
-# reading snapshot id and row id
+# reading row id
 # After compaction, rowids start at 0 (they get compacted)
-query III
-SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
+query II
+SELECT rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	0	1
-7	1	2
-9	2	3
-11	3	4
-13	4	5
+0	1
+1	2
+2	3
+3	4
+4	5
 
 # table insertions function
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s1')) ORDER BY ALL
 ----
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s_test2')) ORDER BY ALL
 ----
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 10) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s3')) ORDER BY ALL
 ----
 0	1
 1	2
 2	3
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 15) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, getvariable('s_last')) ORDER BY ALL
 ----
 0	1
 1	2

--- a/test/sql/compaction/small_insert_compaction.test
+++ b/test/sql/compaction/small_insert_compaction.test
@@ -25,43 +25,63 @@ CREATE TABLE ducklake.test(i INTEGER);
 statement ok
 CREATE TABLE ducklake.test2(i INTEGER);
 
-# snapshot 3
+# snapshot 3, flush 4
 statement ok
 INSERT INTO ducklake.test VALUES (1);
 
-# snapshot 4: random change that does not modify the "test" table
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 5, flush 6: random change that does not modify the "test" table
 statement ok
 INSERT INTO ducklake.test2 VALUES (42);
 
-# snapshot 5
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 7, flush 8
 statement ok
 INSERT INTO ducklake.test VALUES (2);
 
-# snapshot 6
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 9, flush 10
 statement ok
 INSERT INTO ducklake.test VALUES (3);
 
-# snapshot 7
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 11, flush 12
 statement ok
 INSERT INTO ducklake.test VALUES (4);
 
-# snapshot 8
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# snapshot 13, flush 14
 statement ok
 INSERT INTO ducklake.test VALUES (5);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_files/**/*')
 ----
 6
 
+# Row snapshot_ids correspond to inlined_insert (odd: 3, 7, 9, 11, 13)
+# not flushed_inlined (even: 4, 8, 10, 12, 14)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
 3	0	1
-5	1	2
-6	2	3
-7	3	4
-8	4	5
+7	1	2
+9	2	3
+11	3	4
+13	4	5
 
 statement ok
 CALL ducklake.merge_adjacent_files();
@@ -101,55 +121,56 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_compaction_files/**/*')
 # verify correct behavior when operating on the compacted file
 # time travel
 query I
-SELECT * FROM ducklake.test AT (VERSION => 3)
-----
-1
-
-query I
 SELECT * FROM ducklake.test AT (VERSION => 4)
 ----
 1
 
+query I
+SELECT * FROM ducklake.test AT (VERSION => 6)
+----
+1
+
 
 query I
-SELECT * FROM ducklake.test AT (VERSION => 5) ORDER BY ALL
+SELECT * FROM ducklake.test AT (VERSION => 8) ORDER BY ALL
 ----
 1
 2
 
 # reading snapshot id and row id
+# After compaction, rowids start at 1 (they get compacted)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	0	1
-5	1	2
-6	2	3
-7	3	4
-8	4	5
+3	1	1
+7	2	2
+9	3	3
+11	4	4
+13	5	5
 
 # table insertions function
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 3) ORDER BY ALL
-----
-0	1
-
-query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4) ORDER BY ALL
 ----
-0	1
+1	1
 
 query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6) ORDER BY ALL
 ----
-0	1
-1	2
-2	3
+1	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 9) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 10) ORDER BY ALL
 ----
-0	1
-1	2
-2	3
-3	4
-4	5
+1	1
+2	2
+3	3
+
+query II
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 15) ORDER BY ALL
+----
+1	1
+2	2
+3	3
+4	4
+5	5

--- a/test/sql/compaction/small_insert_compaction.test
+++ b/test/sql/compaction/small_insert_compaction.test
@@ -141,39 +141,39 @@ SELECT * FROM ducklake.test AT (VERSION => 8) ORDER BY ALL
 2
 
 # reading snapshot id and row id
-# After compaction, rowids start at 1 (they get compacted)
+# After compaction, rowids start at 0 (they get compacted)
 query III
 SELECT snapshot_id, rowid, * FROM ducklake.test ORDER BY ALL
 ----
-3	1	1
-7	2	2
-9	3	3
-11	4	4
-13	5	5
+3	0	1
+7	1	2
+9	2	3
+11	3	4
+13	4	5
 
 # table insertions function
 query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4) ORDER BY ALL
 ----
-1	1
+0	1
 
 query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6) ORDER BY ALL
 ----
-1	1
+0	1
 
 query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 10) ORDER BY ALL
 ----
-1	1
-2	2
-3	3
+0	1
+1	2
+2	3
 
 query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 15) ORDER BY ALL
 ----
-1	1
-2	2
-3	3
-4	4
-5	5
+0	1
+1	2
+2	3
+3	4
+4	5

--- a/test/sql/data_inlining/data_inlining_per_schema_alter.test
+++ b/test/sql/data_inlining/data_inlining_per_schema_alter.test
@@ -1,0 +1,48 @@
+# name: test/sql/data_inlining/data_inlining_per_schema_alter.test
+# description: test that per-schema inlining settings are respected after ALTER TABLE
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_per_schema_alter', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+# create a schema and disable inlining for it
+statement ok
+CREATE SCHEMA ducklake.s1
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0, schema=> 's1')
+
+# create a table in the schema with inlining disabled
+statement ok
+CREATE TABLE ducklake.s1.t1(i INTEGER, j VARCHAR)
+
+statement ok
+INSERT INTO ducklake.s1.t1 VALUES (1, 'hello'), (2, 'world')
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+0
+
+# ALTER TABLE ADD COLUMN triggers the column_schema_change path
+statement ok
+ALTER TABLE ducklake.s1.t1 ADD COLUMN k INTEGER DEFAULT 42
+
+query III
+SELECT * FROM ducklake.s1.t1 ORDER BY i
+----
+1	hello	42
+2	world	42
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+0

--- a/test/sql/data_inlining/data_inlining_transaction_local_alter.test
+++ b/test/sql/data_inlining/data_inlining_transaction_local_alter.test
@@ -17,40 +17,80 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/du
 statement ok
 CREATE TABLE ducklake.test(i INTEGER, j INTEGER)
 
-# insert -> alter is not supported
+# insert -> alter IS now supported for ADD COLUMN
 statement ok
 BEGIN
 
 statement ok
 INSERT INTO ducklake.test VALUES (42, 84);
 
-statement error
-ALTER TABLE ducklake.test ADD COLUMN k INTEGER
-----
-ALTER on a table with transaction-local inlined data is not supported
-
-statement ok
-ROLLBACK
-
-# alter -> insert works
-statement ok
-BEGIN
-
 statement ok
 ALTER TABLE ducklake.test ADD COLUMN k INTEGER
-
-statement ok
-INSERT INTO ducklake.test VALUES (42, 84, 100);
 
 query III
 FROM ducklake.test
 ----
-42	84	100
+42	84	NULL
 
 statement ok
 COMMIT
 
+# verify data persists after commit
 query III
 FROM ducklake.test
 ----
-42	84	100
+42	84	NULL
+
+# test ADD COLUMN with DEFAULT value
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.test VALUES (100, 200, 300);
+
+statement ok
+ALTER TABLE ducklake.test ADD COLUMN l INTEGER DEFAULT 42
+
+# existing rows should have the default value 42
+query IIII
+FROM ducklake.test
+----
+42	84	NULL	42
+100	200	300	42
+
+statement ok
+COMMIT
+
+# verify data persists after commit
+query IIII
+FROM ducklake.test
+----
+42	84	NULL	42
+100	200	300	42
+
+# alter -> insert works (add another column without default)
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test ADD COLUMN m VARCHAR
+
+statement ok
+INSERT INTO ducklake.test VALUES (500, 600, 700, 800, 'hello');
+
+query IIIII
+FROM ducklake.test
+----
+42	84	NULL	42	NULL
+100	200	300	42	NULL
+500	600	700	800	hello
+
+statement ok
+COMMIT
+
+query IIIII
+FROM ducklake.test
+----
+42	84	NULL	42	NULL
+100	200	300	42	NULL
+500	600	700	800	hello

--- a/test/sql/data_inlining/data_inlining_transaction_local_alter_type_rename.test
+++ b/test/sql/data_inlining/data_inlining_transaction_local_alter_type_rename.test
@@ -1,0 +1,108 @@
+# name: test/sql/data_inlining/data_inlining_transaction_local_alter_type_rename.test
+# description: test ALTER COLUMN TYPE and RENAME COLUMN on transaction-local inlined data
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_inlining_alter_type_rename', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.rename_test(i INTEGER, j VARCHAR)
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.rename_test VALUES (1, 'hello'), (2, 'world')
+
+statement ok
+ALTER TABLE ducklake.rename_test RENAME COLUMN j TO name
+
+query IT
+SELECT i, name FROM ducklake.rename_test ORDER BY i
+----
+1	hello
+2	world
+
+statement ok
+COMMIT
+
+query IT
+SELECT i, name FROM ducklake.rename_test ORDER BY i
+----
+1	hello
+2	world
+
+statement ok
+CREATE TABLE ducklake.type_test(i INTEGER, v INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.type_test VALUES (1, 100), (2, 200)
+
+statement ok
+ALTER TABLE ducklake.type_test ALTER v TYPE BIGINT
+
+query II
+SELECT i, v FROM ducklake.type_test ORDER BY i
+----
+1	100
+2	200
+
+statement ok
+COMMIT
+
+query II
+SELECT i, v FROM ducklake.type_test ORDER BY i
+----
+1	100
+2	200
+
+query I
+SELECT typeof(v) FROM ducklake.type_test LIMIT 1
+----
+BIGINT
+
+statement ok
+CREATE TABLE ducklake.type_test2(i INTEGER, v FLOAT)
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.type_test2 VALUES (1, 1.5)
+
+statement ok
+ALTER TABLE ducklake.type_test2 ALTER v TYPE DOUBLE
+
+query IR
+SELECT i, v FROM ducklake.type_test2 ORDER BY i
+----
+1	1.5
+
+statement ok
+INSERT INTO ducklake.type_test2 VALUES (2, 2.5)
+
+query IR
+SELECT i, v FROM ducklake.type_test2 ORDER BY i
+----
+1	1.5
+2	2.5
+
+statement ok
+COMMIT
+
+query IR
+SELECT i, v FROM ducklake.type_test2 ORDER BY i
+----
+1	1.5
+2	2.5

--- a/test/sql/default/add_column_with_default.test
+++ b/test/sql/default/add_column_with_default.test
@@ -24,6 +24,9 @@ statement ok
 INSERT INTO ducklake.test VALUES (2);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 BEGIN
 
 statement ok
@@ -50,13 +53,17 @@ FROM ducklake.test ORDER BY ALL
 100	100
 
 # alter the default
+# First insert with old defaults (outside transaction to avoid inlining conflict with ALTER)
+statement ok
+INSERT INTO ducklake.test DEFAULT VALUES
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 foreach finaltransaction ROLLBACK COMMIT
 
 statement ok
 BEGIN
-
-statement ok
-INSERT INTO ducklake.test DEFAULT VALUES
 
 statement ok
 ALTER TABLE ducklake.test ALTER i SET DEFAULT 1000
@@ -91,6 +98,9 @@ SELECT table_id, column_id, initial_default, default_value, default_value_type, 
 
 statement ok
 INSERT INTO ducklake.test DEFAULT VALUES
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query II
 FROM ducklake.test ORDER BY ALL

--- a/test/sql/delete/delete_metadata.test
+++ b/test/sql/delete/delete_metadata.test
@@ -25,6 +25,9 @@ CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
 statement ok
 DELETE FROM ducklake.test WHERE id IN (100, 200, 300);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Verify there is 1 delete file
 query I
 SELECT sum(delete_file_count) FROM ducklake_table_info('ducklake') WHERE table_name = 'test';

--- a/test/sql/delete/delete_same_transaction.test
+++ b/test/sql/delete/delete_same_transaction.test
@@ -11,7 +11,6 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test needs physical files to verify delete file cleanup
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_delete_same_transaction_files')
 

--- a/test/sql/delete/delete_same_transaction.test
+++ b/test/sql/delete/delete_same_transaction.test
@@ -11,8 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# Disable inlining - this test needs physical files to verify delete file cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_delete_same_transaction_files')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_delete_same_transaction_files', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 BEGIN

--- a/test/sql/delete/delete_same_transaction.test
+++ b/test/sql/delete/delete_same_transaction.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # Disable inlining - this test needs physical files to verify delete file cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_delete_same_transaction_files', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_delete_same_transaction_files')
 
 statement ok
 BEGIN

--- a/test/sql/delete/test_delete_partial_max_snapshot.test
+++ b/test/sql/delete/test_delete_partial_max_snapshot.test
@@ -24,6 +24,9 @@ statement ok
 insert into test values (11),(12),(13);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 delete from test where id = 1
 
 statement ok
@@ -32,8 +35,10 @@ delete from test where id = 5
 statement ok
 delete from test where id = 12
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_delete_file
 ----
-4
-NULL
+6

--- a/test/sql/delete/test_delete_partial_max_snapshot.test
+++ b/test/sql/delete/test_delete_partial_max_snapshot.test
@@ -38,7 +38,14 @@ delete from test where id = 12
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
+# partial_max of the consolidated delete file should equal the Nth delete snapshot (N = delete_count)
+statement ok
+SET VARIABLE n = (SELECT delete_count FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE delete_count > 1);
+
+statement ok
+SET VARIABLE expected_pm = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%') WHERE rn = getvariable('n'));
+
 query I
-SELECT partial_max FROM __ducklake_metadata_ducklake.ducklake_delete_file
+SELECT partial_max = getvariable('expected_pm') FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE delete_count > 1
 ----
-6
+true

--- a/test/sql/functions/ducklake_snapshots.test
+++ b/test/sql/functions/ducklake_snapshots.test
@@ -99,7 +99,7 @@ COMMIT
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
 ----
-7	6	{schemas_created=[s1], tables_created=[s1.tbl], inlined_insert=[4]}
+7	5	{schemas_created=[s1], tables_created=[s1.tbl], inlined_insert=[4]}
 
 # alter table
 statement ok
@@ -108,7 +108,7 @@ ALTER TABLE ducklake.s1.tbl SET PARTITIONED BY (i)
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=8
 ----
-8	7	{tables_altered=[4]}
+8	6	{tables_altered=[4]}
 
 # create a table and alter it
 statement ok
@@ -126,7 +126,7 @@ COMMIT
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=9
 ----
-9	8	{tables_created=[s1.tbl2], tables_altered=[6]}
+9	7	{tables_created=[s1.tbl2], tables_altered=[6]}
 
 # create a view
 statement ok
@@ -135,7 +135,7 @@ CREATE VIEW ducklake.v1 AS SELECT 42
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=10
 ----
-10	9	{views_created=[main.v1]}
+10	8	{views_created=[main.v1]}
 
 statement ok
 DROP VIEW ducklake.v1
@@ -143,7 +143,7 @@ DROP VIEW ducklake.v1
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=11
 ----
-11	10	{views_dropped=[8]}
+11	9	{views_dropped=[8]}
 
 # comments
 statement ok
@@ -155,7 +155,7 @@ COMMENT ON VIEW ducklake.comment_view IS 'con1'
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=13
 ----
-13	12	{views_altered=[9]}
+13	11	{views_altered=[9]}
 
 # deletes
 statement ok
@@ -164,4 +164,4 @@ DELETE FROM ducklake.s1.tbl
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake') WHERE snapshot_id=14
 ----
-14	12	{inlined_delete=[4]}
+14	11	{inlined_delete=[4]}

--- a/test/sql/functions/ducklake_snapshots.test
+++ b/test/sql/functions/ducklake_snapshots.test
@@ -39,16 +39,40 @@ DROP TABLE ducklake.s1.tbl
 statement ok
 DROP SCHEMA ducklake.s1
 
+# check the DDL snapshots that are the same in both modes
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots()
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id <= 2
 ----
 0	0	{schemas_created=[main]}
 1	1	{schemas_created=[s1]}
 2	2	{tables_created=[s1.tbl]}
-3	2	{inlined_insert=[2]}
-4	2	{flushed_inlined=[2]}
-5	3	{tables_dropped=[2]}
-6	4	{schemas_dropped=[1]}
+
+# verify insert-related snapshot(s) exist - inlined_insert or tables_inserted_into
+query I
+SELECT count(*) FROM ducklake.snapshots() WHERE changes::VARCHAR LIKE '%insert%=[2]%'
+----
+1
+
+# in inline mode there is also a flushed_inlined snapshot; verify the count of insert+flush snapshots
+query I
+SELECT count(*) FROM ducklake.snapshots() WHERE changes::VARCHAR LIKE '%insert%=[2]%' OR changes::VARCHAR LIKE '%flushed_inlined=[2]%'
+----
+<REGEX>:1|2
+
+# verify the drop table and drop schema snapshots exist with correct schema_versions
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE changes::VARCHAR LIKE '%tables_dropped=%'
+----
+3
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE changes::VARCHAR LIKE '%schemas_dropped=%'
+----
+4
+
+# capture the last snapshot_id after the initial sequence (schemas_dropped snapshot)
+statement ok
+SET VARIABLE base_snap = (SELECT max(snapshot_id) FROM ducklake.snapshots())
 
 # this transaction does nothing in a round-about way
 # no snapshot is created here
@@ -73,9 +97,11 @@ DROP SCHEMA ducklake.s1
 statement ok
 COMMIT
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
+# verify that no new snapshot was created by the no-op transaction
+query I
+SELECT count(*) FROM ducklake.snapshots() WHERE snapshot_id > getvariable('base_snap')
 ----
+0
 
 # this transaction actually makes some changes
 statement ok
@@ -96,19 +122,54 @@ CALL ducklake_flush_inlined_data('ducklake')
 statement ok
 COMMIT
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
+# verify the real transaction snapshot - it should be right after base_snap
+# schema_version should be 5 (base was 4, DDL in this transaction bumps it)
+# capture the table_id from the insert change for later checks
+statement ok
+SET VARIABLE real_txn_snap = getvariable('base_snap') + 1
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE snapshot_id = getvariable('real_txn_snap')
 ----
-7	5	{schemas_created=[s1], tables_created=[s1.tbl], inlined_insert=[4]}
+5
+
+# the changes should include schemas_created, tables_created, and some insert reference
+query I
+SELECT changes::VARCHAR LIKE '%schemas_created=[s1]%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('real_txn_snap')
+----
+true
+
+query I
+SELECT changes::VARCHAR LIKE '%tables_created=[s1.tbl]%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('real_txn_snap')
+----
+true
+
+query I
+SELECT changes::VARCHAR LIKE '%insert%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('real_txn_snap')
+----
+true
+
+# capture the table_id used for the recreated tbl
+statement ok
+SET VARIABLE tbl_id = (SELECT regexp_extract(changes::VARCHAR, 'insert.*=\[(\d+)\]', 1)::INT FROM ducklake.snapshots() WHERE snapshot_id = getvariable('real_txn_snap'))
 
 # alter table
 statement ok
 ALTER TABLE ducklake.s1.tbl SET PARTITIONED BY (i)
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=8
+statement ok
+SET VARIABLE alter_snap = getvariable('real_txn_snap') + 1
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE snapshot_id = getvariable('alter_snap')
 ----
-8	6	{tables_altered=[4]}
+6
+
+# verify the altered table_id matches the one from the real transaction
+query I
+SELECT changes::VARCHAR LIKE '%tables_altered=[' || getvariable('tbl_id') || ']%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('alter_snap')
+----
+true
 
 # create a table and alter it
 statement ok
@@ -123,27 +184,51 @@ ALTER TABLE ducklake.s1.tbl2 SET PARTITIONED BY (i)
 statement ok
 COMMIT
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=9
+statement ok
+SET VARIABLE create_alter_snap = getvariable('alter_snap') + 1
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE snapshot_id = getvariable('create_alter_snap')
 ----
-9	7	{tables_created=[s1.tbl2], tables_altered=[6]}
+7
+
+query I
+SELECT changes::VARCHAR LIKE '%tables_created=[s1.tbl2]%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('create_alter_snap')
+----
+true
+
+query I
+SELECT changes::VARCHAR LIKE '%tables_altered=%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('create_alter_snap')
+----
+true
 
 # create a view
 statement ok
 CREATE VIEW ducklake.v1 AS SELECT 42
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=10
+statement ok
+SET VARIABLE view_snap = getvariable('create_alter_snap') + 1
+
+query II
+SELECT schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id = getvariable('view_snap')
 ----
-10	8	{views_created=[main.v1]}
+8	{views_created=[main.v1]}
 
 statement ok
 DROP VIEW ducklake.v1
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=11
+statement ok
+SET VARIABLE drop_view_snap = getvariable('view_snap') + 1
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE snapshot_id = getvariable('drop_view_snap')
 ----
-11	9	{views_dropped=[8]}
+9
+
+query I
+SELECT changes::VARCHAR LIKE '%views_dropped=%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('drop_view_snap')
+----
+true
 
 # comments
 statement ok
@@ -152,16 +237,34 @@ CREATE VIEW ducklake.comment_view AS SELECT 42;
 statement ok con1
 COMMENT ON VIEW ducklake.comment_view IS 'con1'
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=13
+# the comment creates 2 snapshots: one for the view creation, one for the comment
+statement ok
+SET VARIABLE comment_snap = getvariable('drop_view_snap') + 2
+
+query I
+SELECT schema_version FROM ducklake.snapshots() WHERE snapshot_id = getvariable('comment_snap')
 ----
-13	11	{views_altered=[9]}
+11
+
+query I
+SELECT changes::VARCHAR LIKE '%views_altered=%' FROM ducklake.snapshots() WHERE snapshot_id = getvariable('comment_snap')
+----
+true
 
 # deletes
 statement ok
 DELETE FROM ducklake.s1.tbl
 
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake') WHERE snapshot_id=14
+statement ok
+SET VARIABLE delete_snap = getvariable('comment_snap') + 1
+
+query I
+SELECT schema_version FROM ducklake_snapshots('ducklake') WHERE snapshot_id = getvariable('delete_snap')
 ----
-14	11	{inlined_delete=[4]}
+11
+
+# verify delete snapshot contains either inlined_delete or tables_deleted_from
+query I
+SELECT changes::VARCHAR LIKE '%delete%=[' || getvariable('tbl_id') || ']%' FROM ducklake_snapshots('ducklake') WHERE snapshot_id = getvariable('delete_snap')
+----
+true

--- a/test/sql/functions/ducklake_snapshots.test
+++ b/test/sql/functions/ducklake_snapshots.test
@@ -31,6 +31,9 @@ statement ok
 INSERT INTO ducklake.s1.tbl VALUES (42);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 DROP TABLE ducklake.s1.tbl
 
 statement ok
@@ -42,9 +45,10 @@ SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots()
 0	0	{schemas_created=[main]}
 1	1	{schemas_created=[s1]}
 2	2	{tables_created=[s1.tbl]}
-3	2	{tables_inserted_into=[2]}
-4	3	{tables_dropped=[2]}
-5	4	{schemas_dropped=[1]}
+3	2	{inlined_insert=[2]}
+4	2	{flushed_inlined=[2]}
+5	3	{tables_dropped=[2]}
+6	4	{schemas_dropped=[1]}
 
 # this transaction does nothing in a round-about way
 # no snapshot is created here
@@ -70,7 +74,7 @@ statement ok
 COMMIT
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=6
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
 ----
 
 # this transaction actually makes some changes
@@ -87,21 +91,24 @@ statement ok
 INSERT INTO ducklake.s1.tbl VALUES (42);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 COMMIT
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=6
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
 ----
-6	5	{schemas_created=[s1], tables_created=[s1.tbl], tables_inserted_into=[4]}
+7	6	{schemas_created=[s1], tables_created=[s1.tbl], inlined_insert=[4]}
 
 # alter table
 statement ok
 ALTER TABLE ducklake.s1.tbl SET PARTITIONED BY (i)
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=7
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=8
 ----
-7	6	{tables_altered=[4]}
+8	7	{tables_altered=[4]}
 
 # create a table and alter it
 statement ok
@@ -117,26 +124,26 @@ statement ok
 COMMIT
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=8
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=9
 ----
-8	7	{tables_created=[s1.tbl2], tables_altered=[6]}
+9	8	{tables_created=[s1.tbl2], tables_altered=[6]}
 
 # create a view
 statement ok
 CREATE VIEW ducklake.v1 AS SELECT 42
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=9
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=10
 ----
-9	8	{views_created=[main.v1]}
+10	9	{views_created=[main.v1]}
 
 statement ok
 DROP VIEW ducklake.v1
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=10
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=11
 ----
-10	9	{views_dropped=[8]}
+11	10	{views_dropped=[8]}
 
 # comments
 statement ok
@@ -146,15 +153,15 @@ statement ok con1
 COMMENT ON VIEW ducklake.comment_view IS 'con1'
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=12
+SELECT snapshot_id, schema_version, changes FROM ducklake.snapshots() WHERE snapshot_id=13
 ----
-12	11	{views_altered=[9]}
+13	12	{views_altered=[9]}
 
 # deletes
 statement ok
 DELETE FROM ducklake.s1.tbl
 
 query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake') WHERE snapshot_id=13
+SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake') WHERE snapshot_id=14
 ----
-13	11	{tables_deleted_from=[4]}
+14	12	{inlined_delete=[4]}

--- a/test/sql/general/default_path.test
+++ b/test/sql/general/default_path.test
@@ -18,6 +18,10 @@ CREATE TABLE ducklake.test(i INTEGER, j INTEGER);
 statement ok
 INSERT INTO ducklake.test VALUES (1, 2), (NULL, 3);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT COUNT(*) FROM glob('__TEST_DIR__/ducklake_default_paths.db.files/**') WHERE 'main/test/' IN file.replace('\', '/')
 ----
@@ -32,6 +36,10 @@ CREATE TABLE ducklake.s1.test(i INTEGER);
 
 statement ok
 INSERT INTO ducklake.s1.test VALUES (42);
+
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM glob('__TEST_DIR__/ducklake_default_paths.db.files/**') WHERE 's1/test/' IN file.replace('\', '/')

--- a/test/sql/general/missing_parquet.test
+++ b/test/sql/general/missing_parquet.test
@@ -2,6 +2,8 @@
 # description: Test with missing parquet extension
 # group: [general]
 
+mode skip
+
 require ducklake
 
 require no_extension_autoloading "EXPECTED This is meant to test missing parquet extension"

--- a/test/sql/general/missing_parquet.test
+++ b/test/sql/general/missing_parquet.test
@@ -2,8 +2,6 @@
 # description: Test with missing parquet extension
 # group: [general]
 
-mode skip
-
 require ducklake
 
 require no_extension_autoloading "EXPECTED This is meant to test missing parquet extension"
@@ -11,7 +9,7 @@ require no_extension_autoloading "EXPECTED This is meant to test missing parquet
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_missing_parquet')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_missing_parquet', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')

--- a/test/sql/general/paths.test
+++ b/test/sql/general/paths.test
@@ -21,6 +21,10 @@ CREATE TABLE ducklake.test(i INTEGER, j INTEGER);
 statement ok
 INSERT INTO ducklake.test VALUES (1, 2), (NULL, 3);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_paths_files/**') WHERE 'test' IN file
 ----
@@ -56,6 +60,10 @@ CREATE TABLE ducklake.s1.test(i INTEGER);
 
 statement ok
 INSERT INTO ducklake.s1.test VALUES (42);
+
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_paths_files/**') WHERE 's1' IN file

--- a/test/sql/list_files/ducklake_list_files.test
+++ b/test/sql/list_files/ducklake_list_files.test
@@ -14,34 +14,40 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_list_files');
 
-# snapshot 1
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
-# snapshot 2
 statement ok
 INSERT INTO ducklake.test FROM range(100);
 
-# snapshot 3
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO ducklake.test FROM range(100, 200);
 
-# snapshot 4
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO ducklake.test FROM range(200, 300);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # partitions
-# snapshot 5
 statement ok
 CREATE TABLE ducklake.partitioned_tbl(part_key INT, value INT);
 
-# snapshot 6
 statement ok
 ALTER TABLE ducklake.partitioned_tbl SET PARTITIONED BY (part_key);
 
-# snapshot 7
 statement ok
 INSERT INTO ducklake.partitioned_tbl VALUES (1, 50), (2, 100);
+
+# flush to create partitioned files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
@@ -94,6 +100,10 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test') WHERE delete_file I
 # now delete
 statement ok
 DELETE FROM ducklake.test WHERE i%2=0 AND i < 150
+
+# flush to create delete files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # we have two delete files now (we did not delete from the last file)
 query I

--- a/test/sql/merge/merge_multi_partition_timestamp.test
+++ b/test/sql/merge/merge_multi_partition_timestamp.test
@@ -25,6 +25,9 @@ ALTER TABLE t SET PARTITIONED BY (year(ts), month(ts));
 statement ok
 INSERT INTO t VALUES (1, '2025-01-15');
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # MERGE a new row with ts='2025-03-20' (year=2025, month=3)
 statement ok
 MERGE INTO t USING (SELECT 2 as id, '2025-03-20'::TIMESTAMP as ts) AS src ON t.id = src.id

--- a/test/sql/merge/merge_partition.test
+++ b/test/sql/merge/merge_partition.test
@@ -24,6 +24,9 @@ statement ok
 insert into my_timeseries VALUES ('2025-09-15',42)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 MERGE INTO my_timeseries
     USING (
         SELECT
@@ -65,10 +68,16 @@ statement ok
 insert into my_timeseries VALUES ('2025-09-15', 43, 39)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 CREATE TABLE my_timeseries_new (ts TIMESTAMP, x DOUBLE PRECISION, y DOUBLE PRECISION);
 
 statement ok
 insert into my_timeseries_new VALUES ('2025-09-15', 43, 33)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 MERGE INTO my_timeseries old

--- a/test/sql/merge/merge_partition_update.test
+++ b/test/sql/merge/merge_partition_update.test
@@ -25,6 +25,9 @@ ALTER TABLE my_timeseries SET PARTITIONED BY (year(ts));
 statement ok
 INSERT INTO my_timeseries VALUES ('2025-09-17'::TIMESTAMP, 42::DOUBLE PRECISION);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 MERGE INTO my_timeseries

--- a/test/sql/migration/migration.test
+++ b/test/sql/migration/migration.test
@@ -30,6 +30,10 @@ ATTACH 'ducklake:__TEST_DIR__/${version}.db' AS ducklake (DATA_PATH '__TEST_DIR_
 statement ok
 INSERT INTO ducklake.test VALUES (42);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 FROM ducklake.test
 ----

--- a/test/sql/partitioning/basic_partitioning.test
+++ b/test/sql/partitioning/basic_partitioning.test
@@ -29,7 +29,13 @@ statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(10000) t(i)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 ALTER TABLE partitioned_tbl RENAME TO partitioned_tbl_renamed
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # check if rename causes partition info to get dropped
 query I
@@ -39,6 +45,9 @@ SELECT COUNT(*) FROM ducklake_metadata.ducklake_partition_info WHERE end_snapsho
 
 statement ok
 ALTER TABLE partitioned_tbl_renamed RENAME TO partitioned_tbl
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=0
@@ -69,6 +78,9 @@ SELECT * FROM ducklake_metadata.ducklake_file_partition_value
 # append to partition
 statement ok
 INSERT INTO partitioned_tbl SELECT (i%2) + 1, concat('thisisanotherstring_', i) FROM range(10000) t(i)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=2
@@ -105,6 +117,9 @@ SELECT COUNT(*) FROM partition_tbl2 WHERE part_key=0
 statement ok
 COMMIT
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query III
 SELECT data_file_id, partition_id, regexp_extract(path, '.*(part_key=[0-9])[/\\].*', 1)
 FROM ducklake_metadata.ducklake_data_file
@@ -139,6 +154,9 @@ SELECT COUNT(*) FROM partition_tbl3 WHERE part_key=0
 
 statement ok
 COMMIT
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM partition_tbl3 WHERE part_key=0

--- a/test/sql/partitioning/disable_hive_partitioning.test
+++ b/test/sql/partitioning/disable_hive_partitioning.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partition_use_hive', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partition_use_hive', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -33,21 +33,19 @@ ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
 statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
 
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
 # This is partitioned
-query I
-SELECT COUNT (*) FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
+query II
+FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-3
+0	thisisastring_0
+0	thisisastring_2
+0	thisisastring_4
 
 statement ok
 ALTER TABLE hiveless_partitioned_tbl SET PARTITIONED BY (part_key);
 
-# Insert more than 10 rows to bypass inlining (direct file write respects hive_file_pattern=False)
 statement ok
-INSERT INTO hiveless_partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(20) t(i)
+INSERT INTO hiveless_partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
 
 statement error
 FROM '${DATA_PATH}/ducklake_partition_use_hive/main/hiveless_partitioned_tbl/part_key=0/*.parquet'
@@ -59,17 +57,18 @@ CALL ducklake.set_option('hive_file_pattern', False, table_name => 'partitioned_
 
 
 # What if we now insert more data into our partitioned table
-# Insert more than 10 rows to bypass inlining (direct file write respects hive_file_pattern=False)
 statement ok
-INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(20) t(i)
+INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
 
-# Data remains the same (only original 5 rows in hive-style files, with internal columns from flush)
-query I
-SELECT COUNT(*) FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
+# Data remains the same
+query II
+FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-3
+0	thisisastring_0
+0	thisisastring_2
+0	thisisastring_4
 
-# But we can query all data normally (original 5 + new 20 = 25 rows, 13 with part_key=0)
+# But we can query it in its totality normally
 query II
 FROM partitioned_tbl where part_key = 0
 ----
@@ -79,10 +78,3 @@ FROM partitioned_tbl where part_key = 0
 0	thisisastring_0
 0	thisisastring_2
 0	thisisastring_4
-0	thisisastring_6
-0	thisisastring_8
-0	thisisastring_10
-0	thisisastring_12
-0	thisisastring_14
-0	thisisastring_16
-0	thisisastring_18

--- a/test/sql/partitioning/disable_hive_partitioning.test
+++ b/test/sql/partitioning/disable_hive_partitioning.test
@@ -37,12 +37,10 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # This is partitioned
-query IIII
-FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
+query I
+SELECT COUNT (*) FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-0	thisisastring_0	0	4
-0	thisisastring_2	2	4
-0	thisisastring_4	4	4
+3
 
 statement ok
 ALTER TABLE hiveless_partitioned_tbl SET PARTITIONED BY (part_key);
@@ -66,12 +64,10 @@ statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(20) t(i)
 
 # Data remains the same (only original 5 rows in hive-style files, with internal columns from flush)
-query IIII
-FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
+query I
+SELECT COUNT(*) FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-0	thisisastring_0	0	4
-0	thisisastring_2	2	4
-0	thisisastring_4	4	4
+3
 
 # But we can query all data normally (original 5 + new 20 = 25 rows, 13 with part_key=0)
 query II

--- a/test/sql/partitioning/disable_hive_partitioning.test
+++ b/test/sql/partitioning/disable_hive_partitioning.test
@@ -33,19 +33,23 @@ ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
 statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # This is partitioned
-query II
+query IIII
 FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-0	thisisastring_0
-0	thisisastring_2
-0	thisisastring_4
+0	thisisastring_0	0	4
+0	thisisastring_2	2	4
+0	thisisastring_4	4	4
 
 statement ok
 ALTER TABLE hiveless_partitioned_tbl SET PARTITIONED BY (part_key);
 
+# Insert more than 10 rows to bypass inlining (direct file write respects hive_file_pattern=False)
 statement ok
-INSERT INTO hiveless_partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
+INSERT INTO hiveless_partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(20) t(i)
 
 statement error
 FROM '${DATA_PATH}/ducklake_partition_use_hive/main/hiveless_partitioned_tbl/part_key=0/*.parquet'
@@ -57,18 +61,19 @@ CALL ducklake.set_option('hive_file_pattern', False, table_name => 'partitioned_
 
 
 # What if we now insert more data into our partitioned table
+# Insert more than 10 rows to bypass inlining (direct file write respects hive_file_pattern=False)
 statement ok
-INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(5) t(i)
+INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(20) t(i)
 
-# Data remains the same
-query II
+# Data remains the same (only original 5 rows in hive-style files, with internal columns from flush)
+query IIII
 FROM '${DATA_PATH}/ducklake_partition_use_hive/main/partitioned_tbl/part_key=0/*.parquet'
 ----
-0	thisisastring_0
-0	thisisastring_2
-0	thisisastring_4
+0	thisisastring_0	0	4
+0	thisisastring_2	2	4
+0	thisisastring_4	4	4
 
-# But we can query it in its totality normally
+# But we can query all data normally (original 5 + new 20 = 25 rows, 13 with part_key=0)
 query II
 FROM partitioned_tbl where part_key = 0
 ----
@@ -78,3 +83,10 @@ FROM partitioned_tbl where part_key = 0
 0	thisisastring_0
 0	thisisastring_2
 0	thisisastring_4
+0	thisisastring_6
+0	thisisastring_8
+0	thisisastring_10
+0	thisisastring_12
+0	thisisastring_14
+0	thisisastring_16
+0	thisisastring_18

--- a/test/sql/partitioning/multi_key_partition.test
+++ b/test/sql/partitioning/multi_key_partition.test
@@ -30,12 +30,12 @@ INSERT INTO partitioned_tbl VALUES (10, 100, 1000, 'data 1'), (20,200,2000, 'dat
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-query IIIII
-SELECT data_file_id, partition_id, regexp_extract(path, '.*(a=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(b=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(c=[0-9]+)[/\\].*', 1) FROM ducklake_metadata.ducklake_data_file
+query IIII
+SELECT partition_id, regexp_extract(path, '.*(a=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(b=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(c=[0-9]+)[/\\].*', 1) FROM ducklake_metadata.ducklake_data_file
 ORDER BY ALL
 ----
-1	2	a=10	b=100	c=1000
-2	2	a=20	b=200	c=2000
+2	a=10	b=100	c=1000
+2	a=20	b=200	c=2000
 
 # verify files are pruned when querying the partitions
 # Note: with inlining, Total Files Read may include inlined data sources (up to 3)
@@ -54,12 +54,12 @@ EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE c=1000
 ----
 analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
-query IIII
-SELECT * FROM ducklake_metadata.ducklake_file_partition_value ORDER BY ALL
+query III
+SELECT table_id,partition_key_index, partition_value FROM ducklake_metadata.ducklake_file_partition_value ORDER BY ALL
 ----
-1	1	0	10
-1	1	1	100
-1	1	2	1000
-2	1	0	20
-2	1	1	200
-2	1	2	2000
+1	0	10
+1	0	20
+1	1	100
+1	1	200
+1	2	1000
+1	2	2000

--- a/test/sql/partitioning/multi_key_partition.test
+++ b/test/sql/partitioning/multi_key_partition.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_mk_partitioning', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_mk_partitioning', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -27,39 +27,35 @@ ALTER TABLE partitioned_tbl SET PARTITIONED BY (a,b,c);
 statement ok
 INSERT INTO partitioned_tbl VALUES (10, 100, 1000, 'data 1'), (20,200,2000, 'data 2')
 
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
-query IIII
-SELECT partition_id, regexp_extract(path, '.*(a=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(b=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(c=[0-9]+)[/\\].*', 1) FROM ducklake_metadata.ducklake_data_file
+query IIIII
+SELECT data_file_id, partition_id, regexp_extract(path, '.*(a=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(b=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(c=[0-9]+)[/\\].*', 1) FROM ducklake_metadata.ducklake_data_file
 ORDER BY ALL
 ----
-2	a=10	b=100	c=1000
-2	a=20	b=200	c=2000
+0	2	a=10	b=100	c=1000
+1	2	a=20	b=200	c=2000
 
 # verify files are pruned when querying the partitions
-# Note: with inlining, Total Files Read may include inlined data sources (up to 3)
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE a=10
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE b=100
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE c=1000
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
-query III
-SELECT table_id,partition_key_index, partition_value FROM ducklake_metadata.ducklake_file_partition_value ORDER BY ALL
+query IIII
+SELECT * FROM ducklake_metadata.ducklake_file_partition_value ORDER BY ALL
 ----
-1	0	10
-1	0	20
-1	1	100
-1	1	200
-1	2	1000
-1	2	2000
+0	1	0	10
+0	1	1	100
+0	1	2	1000
+1	1	0	20
+1	1	1	200
+1	1	2	2000

--- a/test/sql/partitioning/multi_key_partition.test
+++ b/test/sql/partitioning/multi_key_partition.test
@@ -27,35 +27,39 @@ ALTER TABLE partitioned_tbl SET PARTITIONED BY (a,b,c);
 statement ok
 INSERT INTO partitioned_tbl VALUES (10, 100, 1000, 'data 1'), (20,200,2000, 'data 2')
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query IIIII
 SELECT data_file_id, partition_id, regexp_extract(path, '.*(a=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(b=[0-9]+)[/\\].*', 1), regexp_extract(path, '.*(c=[0-9]+)[/\\].*', 1) FROM ducklake_metadata.ducklake_data_file
 ORDER BY ALL
 ----
-0	2	a=10	b=100	c=1000
-1	2	a=20	b=200	c=2000
+1	2	a=10	b=100	c=1000
+2	2	a=20	b=200	c=2000
 
 # verify files are pruned when querying the partitions
+# Note: with inlining, Total Files Read may include inlined data sources (up to 3)
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE a=10
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE b=100
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE c=1000
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 query IIII
 SELECT * FROM ducklake_metadata.ducklake_file_partition_value ORDER BY ALL
 ----
-0	1	0	10
-0	1	1	100
-0	1	2	1000
-1	1	0	20
-1	1	1	200
-1	1	2	2000
+1	1	0	10
+1	1	1	100
+1	1	2	1000
+2	1	0	20
+2	1	1	200
+2	1	2	2000

--- a/test/sql/remove_orphans/remove_orphaned_files.test
+++ b/test/sql/remove_orphans/remove_orphaned_files.test
@@ -26,7 +26,13 @@ statement ok
 insert into test values (1);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 insert into test values (2);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')

--- a/test/sql/remove_orphans/remove_orphaned_files.test
+++ b/test/sql/remove_orphans/remove_orphaned_files.test
@@ -25,8 +25,16 @@ CREATE TABLE test (a integer)
 statement ok
 insert into test values (1);
 
+# flush to create file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 insert into test values (2);
+
+# flush to create file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake');

--- a/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
+++ b/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
@@ -20,38 +20,52 @@ USE ducklake
 statement ok
 CREATE TABLE test(key INTEGER, values VARCHAR);
 
-# 2	{tables_inserted_into=[1]}
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(100) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Let's do a few insertions interleaved with deletions
-# 3	{tables_deleted_from=[1]}
 statement ok
 DELETE FROM test
 WHERE key < 50;
 
-# 4	{tables_inserted_into=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(100,200) t(i)
 
-# 5	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key < 80;
 
-# 6	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key  = 120;
 
-# 7	{tables_inserted_into=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(200,300) t(i)
 
-# 8	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key  > 200 and key < 250;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_multiple_inserts/**/*')
@@ -81,44 +95,51 @@ SELECT snapshot_id, changes FROM snapshots();
 ----
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
-2	{tables_inserted_into=[1]}
-3	{tables_deleted_from=[1]}
-4	{tables_inserted_into=[1]}
+2	{inlined_insert=[1]}
+3	{flushed_inlined=[1]}
+4	{inlined_delete=[1]}
 5	{tables_deleted_from=[1]}
-6	{tables_deleted_from=[1]}
-7	{tables_inserted_into=[1]}
-8	{tables_deleted_from=[1]}
-9	{rewrite_delete=[1]}
+6	{inlined_insert=[1]}
+7	{flushed_inlined=[1]}
+8	{inlined_delete=[1]}
+9	{tables_deleted_from=[1]}
+10	{inlined_delete=[1]}
+11	{tables_deleted_from=[1]}
+12	{inlined_insert=[1]}
+13	{flushed_inlined=[1]}
+14	{inlined_delete=[1]}
+15	{tables_deleted_from=[1]}
+16	{rewrite_delete=[1]}
 
 loop i 0 2
 
 query I
-select count(*) from test AT (VERSION => 3);
+select count(*) from test AT (VERSION => 5);
 ----
 50
 
 query I
-select count(*) from test AT (VERSION => 4);
+select count(*) from test AT (VERSION => 7);
 ----
 150
 
 query I
-select count(*) from test AT (VERSION => 5);
+select count(*) from test AT (VERSION => 9);
 ----
 120
 
 query I
-select count(*) from test AT (VERSION => 6);
+select count(*) from test AT (VERSION => 11);
 ----
 119
 
 query I
-select count(*) from test AT (VERSION => 7);
+select count(*) from test AT (VERSION => 13);
 ----
 219
 
 query I
-select count(*) from test AT (VERSION => 8);
+select count(*) from test AT (VERSION => 15);
 ----
 170
 

--- a/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
+++ b/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
@@ -92,55 +92,80 @@ select count(*) from test;
 170
 
 # Test previous snapshots are all-right
-query II
-SELECT snapshot_id, changes FROM snapshots();
+# In inline mode, DELETE of 1 row creates an inlined_delete + flushed tables_deleted_from (11 snapshots)
+# In no-inline mode, it goes directly to tables_deleted_from (10 snapshots)
+
+# Verify key snapshot type counts (same in both inline and no-inline mode)
+query I
+SELECT count(*) FROM snapshots() WHERE changes::VARCHAR LIKE '%tables_inserted_into%=[1]%'
 ----
-0	{schemas_created=[main]}
-1	{tables_created=[main.test]}
-2	{tables_inserted_into=[1]}
-3	{tables_deleted_from=[1]}
-4	{tables_inserted_into=[1]}
-5	{tables_deleted_from=[1]}
-6	{inlined_delete=[1]}
-7	{tables_deleted_from=[1]}
-8	{tables_inserted_into=[1]}
-9	{tables_deleted_from=[1]}
-10	{rewrite_delete=[1]}
+3
+
+query I
+SELECT count(*) FROM snapshots() WHERE changes::VARCHAR LIKE '%rewrite_delete%=[1]%'
+----
+1
+
+# Compute dynamic snapshot IDs for versions that differ between inline/no-inline mode
+# In inline mode: DELETE of 1 row creates inlined_delete + flushed tables_deleted_from (extra snapshot)
+# In no-inline mode: DELETE of 1 row goes directly to tables_deleted_from (no extra snapshot)
+
+# s_del3 = 3rd non-rewrite delete (DELETE WHERE key = 120)
+# inline: snapshot 6 (inlined_delete), no-inline: snapshot 6 (tables_deleted_from)
+statement ok
+SET VARIABLE s_del3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%') WHERE rn = 3);
+
+# s_ins3 = 3rd insert (INSERT range(200,300))
+# inline: snapshot 8, no-inline: snapshot 7
+statement ok
+SET VARIABLE s_ins3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 3);
+
+# s_del_last = last non-rewrite delete (DELETE WHERE key > 200 AND key < 250)
+# inline: snapshot 9, no-inline: snapshot 8
+statement ok
+SET VARIABLE s_del_last = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%');
 
 loop i 0 2
 
+# VERSION 2: after first INSERT (100 rows)
 query I
 select count(*) from test AT (VERSION => 2);
 ----
 100
 
+# VERSION 3: after DELETE key < 50 (50 rows remain)
 query I
 select count(*) from test AT (VERSION => 3);
 ----
 50
 
+# VERSION 4: after second INSERT (150 rows)
 query I
 select count(*) from test AT (VERSION => 4);
 ----
 150
 
+# VERSION 5: after DELETE key < 80 (120 rows remain)
 query I
 select count(*) from test AT (VERSION => 5);
 ----
 120
 
+# After DELETE key = 120 (119 rows remain) - snapshot ID varies by mode
 query I
-select count(*) from test AT (VERSION => 6);
+select count(*) from test AT (VERSION => getvariable('s_del3'));
 ----
 119
 
+# After third INSERT range(200,300) (219 rows) - snapshot ID varies by mode
 query I
-select count(*) from test AT (VERSION => 8);
+select count(*) from test AT (VERSION => getvariable('s_ins3'));
 ----
 219
 
+# After DELETE key > 200 AND key < 250 (170 rows remain) - snapshot ID varies by mode
 query I
-select count(*) from test AT (VERSION => 9);
+select count(*) from test AT (VERSION => getvariable('s_del_last'));
 ----
 170
 

--- a/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
+++ b/test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test
@@ -95,51 +95,50 @@ SELECT snapshot_id, changes FROM snapshots();
 ----
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
-2	{inlined_insert=[1]}
-3	{flushed_inlined=[1]}
-4	{inlined_delete=[1]}
+2	{tables_inserted_into=[1]}
+3	{tables_deleted_from=[1]}
+4	{tables_inserted_into=[1]}
 5	{tables_deleted_from=[1]}
-6	{inlined_insert=[1]}
-7	{flushed_inlined=[1]}
-8	{inlined_delete=[1]}
+6	{inlined_delete=[1]}
+7	{tables_deleted_from=[1]}
+8	{tables_inserted_into=[1]}
 9	{tables_deleted_from=[1]}
-10	{inlined_delete=[1]}
-11	{tables_deleted_from=[1]}
-12	{inlined_insert=[1]}
-13	{flushed_inlined=[1]}
-14	{inlined_delete=[1]}
-15	{tables_deleted_from=[1]}
-16	{rewrite_delete=[1]}
+10	{rewrite_delete=[1]}
 
 loop i 0 2
 
 query I
-select count(*) from test AT (VERSION => 5);
+select count(*) from test AT (VERSION => 2);
+----
+100
+
+query I
+select count(*) from test AT (VERSION => 3);
 ----
 50
 
 query I
-select count(*) from test AT (VERSION => 7);
+select count(*) from test AT (VERSION => 4);
 ----
 150
 
 query I
-select count(*) from test AT (VERSION => 9);
+select count(*) from test AT (VERSION => 5);
 ----
 120
 
 query I
-select count(*) from test AT (VERSION => 11);
+select count(*) from test AT (VERSION => 6);
 ----
 119
 
 query I
-select count(*) from test AT (VERSION => 13);
+select count(*) from test AT (VERSION => 8);
 ----
 219
 
 query I
-select count(*) from test AT (VERSION => 15);
+select count(*) from test AT (VERSION => 9);
 ----
 170
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
@@ -22,38 +22,52 @@ loop i 0 2
 statement ok
 CREATE TABLE test(key INTEGER, values VARCHAR);
 
-# 2	{tables_inserted_into=[1]}
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(100) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Let's do a few insertions interleaved with deletions
-# 3	{tables_deleted_from=[1]}
 statement ok
 DELETE FROM test
 WHERE key < 50;
 
-# 4	{tables_inserted_into=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(100,200) t(i)
 
-# 5	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key < 80;
 
-# 6	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key  = 120;
 
-# 7	{tables_inserted_into=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(200,300) t(i)
 
-# 8	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test
 WHERE key  > 200 and key < 250;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 skipif i=1
 query I
@@ -132,32 +146,32 @@ select count(*) from test;
 170
 
 query I
-select count(*) from test AT (VERSION => 3);
+select count(*) from test AT (VERSION => 5);
 ----
 50
 
 query I
-select count(*) from test AT (VERSION => 4);
+select count(*) from test AT (VERSION => 7);
 ----
 150
 
 query I
-select count(*) from test AT (VERSION => 5);
+select count(*) from test AT (VERSION => 9);
 ----
 120
 
 query I
-select count(*) from test AT (VERSION => 6);
+select count(*) from test AT (VERSION => 11);
 ----
 119
 
 query I
-select count(*) from test AT (VERSION => 7);
+select count(*) from test AT (VERSION => 13);
 ----
 219
 
 query I
-select count(*) from test AT (VERSION => 8);
+select count(*) from test AT (VERSION => 15);
 ----
 170
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
@@ -176,13 +176,22 @@ select count(*) from test AT (VERSION => 6);
 ----
 119
 
+# compute snapshot IDs dynamically so the test works in both inline and no-inline modes
+# s_ins3 = the 3rd INSERT snapshot (INSERT 200-299, count=219)
+statement ok
+SET VARIABLE s_ins3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 3);
+
+# s_del_last = the first DELETE snapshot after s_ins3 that is not a rewrite (DELETE >200 AND <250, count=170)
+statement ok
+SET VARIABLE s_del_last = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%' AND snapshot_id > getvariable('s_ins3'));
+
 query I
-select count(*) from test AT (VERSION => 8);
+select count(*) from test AT (VERSION => getvariable('s_ins3'));
 ----
 219
 
 query I
-select count(*) from test AT (VERSION => 9);
+select count(*) from test AT (VERSION => getvariable('s_del_last'));
 ----
 170
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test
@@ -146,32 +146,37 @@ select count(*) from test;
 170
 
 query I
-select count(*) from test AT (VERSION => 5);
+select count(*) from test AT (VERSION => 2);
+----
+100
+
+query I
+select count(*) from test AT (VERSION => 3);
 ----
 50
 
 query I
-select count(*) from test AT (VERSION => 7);
+select count(*) from test AT (VERSION => 4);
 ----
 150
 
 query I
-select count(*) from test AT (VERSION => 9);
+select count(*) from test AT (VERSION => 5);
 ----
 120
 
 query I
-select count(*) from test AT (VERSION => 11);
+select count(*) from test AT (VERSION => 6);
 ----
 119
 
 query I
-select count(*) from test AT (VERSION => 13);
+select count(*) from test AT (VERSION => 8);
 ----
 219
 
 query I
-select count(*) from test AT (VERSION => 15);
+select count(*) from test AT (VERSION => 9);
 ----
 170
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
@@ -37,15 +37,20 @@ statement ok
 DELETE FROM test
 WHERE key > 5000;
 
+# flush to create one combined delete file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query II
 SELECT snapshot_id, changes FROM snapshots();
 ----
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
 2	{tables_inserted_into=[1]}
-3	{tables_deleted_from=[1]}
-4	{tables_deleted_from=[1]}
+3	{inlined_delete=[1]}
+4	{inlined_delete=[1]}
 5	{tables_deleted_from=[1]}
+6	{tables_deleted_from=[1]}
 
 query I
 SELECT delete_file is not null FROM ducklake_list_files('ducklake', 'test')
@@ -55,7 +60,7 @@ True
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
+2
 
 # This won't do much, since our default threshold is too high
 statement ok
@@ -64,7 +69,7 @@ CALL ducklake_rewrite_data_files('ducklake', 'test');
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
+2
 
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 'test', delete_threshold => 0.5);
@@ -73,7 +78,7 @@ CALL ducklake_rewrite_data_files('ducklake', 'test', delete_threshold => 0.5);
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
+2
 
 query I
 SELECT COUNT(*) from test
@@ -88,11 +93,15 @@ statement ok
 DELETE FROM test
 WHERE key > 4000;
 
+# flush to create delete file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
-5
+2
+4
 
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 'test');
@@ -100,8 +109,8 @@ CALL ducklake_rewrite_data_files('ducklake', 'test');
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
-5
+2
+4
 
 query I
 SELECT COUNT(*) from test
@@ -112,15 +121,19 @@ statement ok
 DELETE FROM test
 WHERE key = 3000;
 
+# flush to create delete file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 'test');
 
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-3
-5
-7
+2
+4
+6
 
 # Test that a manual delete_threshold option has priority over the global value.
 statement ok
@@ -142,7 +155,7 @@ The rewrite_delete_threshold must be between 0 and 1
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_rewrite_data/**/*')
 ----
-9
+8
 
 # delete the old files
 statement ok
@@ -161,14 +174,17 @@ SELECT snapshot_id, changes FROM snapshots();
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
 2	{tables_inserted_into=[1]}
-3	{tables_deleted_from=[1]}
-4	{tables_deleted_from=[1]}
+3	{inlined_delete=[1]}
+4	{inlined_delete=[1]}
 5	{tables_deleted_from=[1]}
-6	{rewrite_delete=[1]}
-7	{tables_deleted_from=[1]}
-8	{rewrite_delete=[1]}
+6	{tables_deleted_from=[1]}
+7	{rewrite_delete=[1]}
+8	{inlined_delete=[1]}
 9	{tables_deleted_from=[1]}
 10	{rewrite_delete=[1]}
+11	{inlined_delete=[1]}
+12	{tables_deleted_from=[1]}
+13	{rewrite_delete=[1]}
 
 query I
 select count(*) from test AT (VERSION => 3);
@@ -193,7 +209,7 @@ select count(*) from test AT (VERSION => 6);
 query I
 select count(*) from test AT (VERSION => 7);
 ----
-3001
+4001
 
 query I
 select count(*) from test AT (VERSION => 8);
@@ -203,10 +219,25 @@ select count(*) from test AT (VERSION => 8);
 query I
 select count(*) from test AT (VERSION => 9);
 ----
-3000
+3001
 
 query I
 select count(*) from test AT (VERSION => 10);
+----
+3001
+
+query I
+select count(*) from test AT (VERSION => 11);
+----
+3000
+
+query I
+select count(*) from test AT (VERSION => 12);
+----
+3000
+
+query I
+select count(*) from test AT (VERSION => 13);
 ----
 3000
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
@@ -166,22 +166,29 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_rewrite_data/**/*')
 7
 
 # Let's check every snapshot has the right answer
-query II
-SELECT snapshot_id, changes FROM snapshots();
-----
-0	{schemas_created=[main]}
-1	{tables_created=[main.test]}
-2	{tables_inserted_into=[1]}
-3	{tables_deleted_from=[1]}
-4	{tables_deleted_from=[1]}
-5	{tables_deleted_from=[1]}
-6	{rewrite_delete=[1]}
-7	{tables_deleted_from=[1]}
-8	{rewrite_delete=[1]}
-9	{inlined_delete=[1]}
-10	{tables_deleted_from=[1]}
-11	{rewrite_delete=[1]}
+# Snapshots 0-8 are identical in both inline and non-inline modes.
+# In inline mode there is an extra inlined_delete snapshot (9) and flush snapshot (10) before the final rewrite (11).
+# In non-inline mode the delete goes directly to tables_deleted_from (9) and then the final rewrite (10).
+# Use dynamic checks to handle both modes.
 
+# Verify the common snapshots (0-8) are always present
+query I
+SELECT count(*) FROM snapshots() WHERE snapshot_id <= 8
+----
+9
+
+# Verify overall snapshot structure
+query I
+SELECT count(*) FROM snapshots() WHERE changes::VARCHAR LIKE '%rewrite_delete%=[1]%'
+----
+3
+
+query I
+SELECT count(*) FROM snapshots() WHERE changes::VARCHAR LIKE '%tables_inserted_into%=[1]%'
+----
+1
+
+# Time travel: versions 3-8 are the same in both modes
 query I
 select count(*) from test AT (VERSION => 3);
 ----
@@ -212,18 +219,19 @@ select count(*) from test AT (VERSION => 8);
 ----
 3001
 
+# Versions 9+ differ between inline and non-inline modes.
+# In both modes, after version 8 the remaining snapshots all have count=3000.
+# Use dynamic snapshot IDs for the remaining versions.
+statement ok
+SET VARIABLE s_last = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'))
+
 query I
 select count(*) from test AT (VERSION => 9);
 ----
 3000
 
 query I
-select count(*) from test AT (VERSION => 10);
-----
-3000
-
-query I
-select count(*) from test AT (VERSION => 11);
+select count(*) from test AT (VERSION => getvariable('s_last'));
 ----
 3000
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
@@ -117,6 +117,9 @@ statement ok
 DELETE FROM test
 WHERE key = 3000;
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', 'test')
 ----
@@ -175,8 +178,9 @@ SELECT snapshot_id, changes FROM snapshots();
 6	{rewrite_delete=[1]}
 7	{tables_deleted_from=[1]}
 8	{rewrite_delete=[1]}
-9	{tables_deleted_from=[1]}
-10	{rewrite_delete=[1]}
+9	{inlined_delete=[1]}
+10	{tables_deleted_from=[1]}
+11	{rewrite_delete=[1]}
 
 query I
 select count(*) from test AT (VERSION => 3);
@@ -215,6 +219,11 @@ select count(*) from test AT (VERSION => 9);
 
 query I
 select count(*) from test AT (VERSION => 10);
+----
+3000
+
+query I
+select count(*) from test AT (VERSION => 11);
 ----
 3000
 

--- a/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
+++ b/test/sql/rewrite_data_files/test_last_snapshot_rewrite.test
@@ -24,6 +24,9 @@ CREATE TABLE test(key INTEGER, values VARCHAR);
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(10000) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Let's do three rounds of deletions
 statement ok
 DELETE FROM test
@@ -47,10 +50,9 @@ SELECT snapshot_id, changes FROM snapshots();
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
 2	{tables_inserted_into=[1]}
-3	{inlined_delete=[1]}
-4	{inlined_delete=[1]}
+3	{tables_deleted_from=[1]}
+4	{tables_deleted_from=[1]}
 5	{tables_deleted_from=[1]}
-6	{tables_deleted_from=[1]}
 
 query I
 SELECT delete_file is not null FROM ducklake_list_files('ducklake', 'test')
@@ -60,7 +62,7 @@ True
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
+3
 
 # This won't do much, since our default threshold is too high
 statement ok
@@ -69,7 +71,7 @@ CALL ducklake_rewrite_data_files('ducklake', 'test');
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
+3
 
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 'test', delete_threshold => 0.5);
@@ -78,7 +80,7 @@ CALL ducklake_rewrite_data_files('ducklake', 'test', delete_threshold => 0.5);
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
+3
 
 query I
 SELECT COUNT(*) from test
@@ -100,8 +102,8 @@ CALL ducklake_flush_inlined_data('ducklake')
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
-4
+3
+5
 
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', 'test');
@@ -109,8 +111,8 @@ CALL ducklake_rewrite_data_files('ducklake', 'test');
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
-4
+3
+5
 
 query I
 SELECT COUNT(*) from test
@@ -131,9 +133,9 @@ CALL ducklake_rewrite_data_files('ducklake', 'test');
 query I
 SELECT delete_file_id FROM ducklake_metadata.ducklake_delete_file
 ----
-2
-4
-6
+3
+5
+7
 
 # Test that a manual delete_threshold option has priority over the global value.
 statement ok
@@ -155,7 +157,7 @@ The rewrite_delete_threshold must be between 0 and 1
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/ducklake_rewrite_data/**/*')
 ----
-8
+9
 
 # delete the old files
 statement ok
@@ -174,17 +176,20 @@ SELECT snapshot_id, changes FROM snapshots();
 0	{schemas_created=[main]}
 1	{tables_created=[main.test]}
 2	{tables_inserted_into=[1]}
-3	{inlined_delete=[1]}
-4	{inlined_delete=[1]}
+3	{tables_deleted_from=[1]}
+4	{tables_deleted_from=[1]}
 5	{tables_deleted_from=[1]}
-6	{tables_deleted_from=[1]}
-7	{rewrite_delete=[1]}
-8	{inlined_delete=[1]}
-9	{tables_deleted_from=[1]}
-10	{rewrite_delete=[1]}
-11	{inlined_delete=[1]}
-12	{tables_deleted_from=[1]}
-13	{rewrite_delete=[1]}
+6	{rewrite_delete=[1]}
+7	{tables_deleted_from=[1]}
+8	{rewrite_delete=[1]}
+9	{inlined_delete=[1]}
+10	{tables_deleted_from=[1]}
+11	{rewrite_delete=[1]}
+
+query I
+select count(*) from test AT (VERSION => 2);
+----
+10000
 
 query I
 select count(*) from test AT (VERSION => 3);
@@ -209,7 +214,7 @@ select count(*) from test AT (VERSION => 6);
 query I
 select count(*) from test AT (VERSION => 7);
 ----
-4001
+3001
 
 query I
 select count(*) from test AT (VERSION => 8);
@@ -219,25 +224,15 @@ select count(*) from test AT (VERSION => 8);
 query I
 select count(*) from test AT (VERSION => 9);
 ----
-3001
+3000
 
 query I
 select count(*) from test AT (VERSION => 10);
 ----
-3001
+3000
 
 query I
 select count(*) from test AT (VERSION => 11);
-----
-3000
-
-query I
-select count(*) from test AT (VERSION => 12);
-----
-3000
-
-query I
-select count(*) from test AT (VERSION => 13);
 ----
 3000
 

--- a/test/sql/rewrite_data_files/test_rewrite_concurrency.test
+++ b/test/sql/rewrite_data_files/test_rewrite_concurrency.test
@@ -32,6 +32,9 @@ CREATE TABLE test(key INTEGER, values VARCHAR);
 statement ok
 INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(100) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Let's do three rounds of deletions
 statement ok
 DELETE FROM test
@@ -44,6 +47,9 @@ WHERE key > 90;
 statement ok
 DELETE FROM test
 WHERE key > 41;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 concurrentloop i 0 2
 
@@ -64,43 +70,48 @@ FROM test
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
 ----
-0	2	6
-4	6	NULL
+1	2	8
+3	8	NULL
 
 # Lets time travel
 query I
-SELECT count(*) FROM test AT (VERSION => 2)
+SELECT count(*) FROM test AT (VERSION => 3)
 ----
 100
 
 query I
-SELECT count(*) FROM test AT (VERSION => 3)
+SELECT count(*) FROM test AT (VERSION => 4)
 ----
 61
 
 query I
-SELECT count(*) FROM test AT (VERSION => 4)
-----
-52
-
-query I
 SELECT count(*) FROM test AT (VERSION => 5)
 ----
-3
+52
 
 query I
 SELECT count(*) FROM test AT (VERSION => 6)
 ----
 3
 
-# We have 2 deletion files to delete due to the merging of deletion files
+query I
+SELECT count(*) FROM test AT (VERSION => 7)
+----
+3
+
+query I
+SELECT count(*) FROM test AT (VERSION => 8)
+----
+3
+
+# With inlining, deletion files are handled differently
 query I
 SELECT COUNT(*) FROM ducklake_metadata.ducklake_files_scheduled_for_deletion
 ----
-2
+0
 
-# We have one file from snapshots 3 - 6, as we written a new data file in 6
+# We have one file from snapshots 4 - 8, as we written a new data file in 8
 query II
 SELECT begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
 ----
-3	6
+4	8

--- a/test/sql/rewrite_data_files/test_rewrite_concurrency.test
+++ b/test/sql/rewrite_data_files/test_rewrite_concurrency.test
@@ -67,51 +67,79 @@ FROM test
 40	thisisastring_40
 41	thisisastring_41
 
-query III
-SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
+# verify we have exactly 2 data files: one old (ended) and one new (active)
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NOT NULL
 ----
-0	2	7
-4	7	NULL
+1
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+# compute snapshot IDs dynamically so the test works in both inline and no-inline modes
+# s_insert = the INSERT snapshot
+statement ok
+SET VARIABLE s_insert = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%');
+
+# s_del1, s_del2, s_del3 = the three DELETE snapshots (either tables_deleted_from or inlined_delete, but not rewrite_delete)
+statement ok
+SET VARIABLE s_del1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%') WHERE rn = 1);
+
+statement ok
+SET VARIABLE s_del2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%') WHERE rn = 2);
+
+statement ok
+SET VARIABLE s_del3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND changes::VARCHAR NOT LIKE '%rewrite%') WHERE rn = 3);
+
+# s_rewrite = the rewrite snapshot
+statement ok
+SET VARIABLE s_rewrite = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%rewrite_delete%=[1]%');
+
+# s_last = last snapshot
+statement ok
+SET VARIABLE s_last = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 # Lets time travel
 query I
-SELECT count(*) FROM test AT (VERSION => 2)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_insert'))
 ----
 100
 
 query I
-SELECT count(*) FROM test AT (VERSION => 3)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_del1'))
 ----
 61
 
 query I
-SELECT count(*) FROM test AT (VERSION => 4)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_del2'))
 ----
 52
 
 query I
-SELECT count(*) FROM test AT (VERSION => 5)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_del3'))
 ----
 3
 
 query I
-SELECT count(*) FROM test AT (VERSION => 6)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_rewrite'))
 ----
 3
 
 query I
-SELECT count(*) FROM test AT (VERSION => 7)
+SELECT count(*) FROM test AT (VERSION => getvariable('s_last'))
 ----
 3
 
-# With inlining, deletion files are handled differently
+# verify files are scheduled for deletion after rewrite
 query I
-SELECT COUNT(*) FROM ducklake_metadata.ducklake_files_scheduled_for_deletion
+SELECT COUNT(*) >= 1 FROM ducklake_metadata.ducklake_files_scheduled_for_deletion
 ----
-2
+true
 
-# We have one file from snapshots 3 - 7, as we written a new data file in 7
-query II
-SELECT begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
+# verify delete files have been ended (end_snapshot IS NOT NULL) after rewrite
+query I
+SELECT COUNT(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NOT NULL
 ----
-3	7
+1

--- a/test/sql/rewrite_data_files/test_rewrite_concurrency.test
+++ b/test/sql/rewrite_data_files/test_rewrite_concurrency.test
@@ -70,24 +70,29 @@ FROM test
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
 ----
-1	2	8
-3	8	NULL
+0	2	7
+4	7	NULL
 
 # Lets time travel
 query I
-SELECT count(*) FROM test AT (VERSION => 3)
+SELECT count(*) FROM test AT (VERSION => 2)
 ----
 100
 
 query I
-SELECT count(*) FROM test AT (VERSION => 4)
+SELECT count(*) FROM test AT (VERSION => 3)
 ----
 61
 
 query I
-SELECT count(*) FROM test AT (VERSION => 5)
+SELECT count(*) FROM test AT (VERSION => 4)
 ----
 52
+
+query I
+SELECT count(*) FROM test AT (VERSION => 5)
+----
+3
 
 query I
 SELECT count(*) FROM test AT (VERSION => 6)
@@ -99,19 +104,14 @@ SELECT count(*) FROM test AT (VERSION => 7)
 ----
 3
 
-query I
-SELECT count(*) FROM test AT (VERSION => 8)
-----
-3
-
 # With inlining, deletion files are handled differently
 query I
 SELECT COUNT(*) FROM ducklake_metadata.ducklake_files_scheduled_for_deletion
 ----
-0
+2
 
-# We have one file from snapshots 4 - 8, as we written a new data file in 8
+# We have one file from snapshots 3 - 7, as we written a new data file in 7
 query II
 SELECT begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
 ----
-4	8
+3	7

--- a/test/sql/rewrite_data_files/test_rewrite_db.test
+++ b/test/sql/rewrite_data_files/test_rewrite_db.test
@@ -23,29 +23,39 @@ loop i 0 2
 statement ok
 CREATE TABLE test_${i} (key INTEGER, values VARCHAR);
 
-# 2	{tables_inserted_into=[1]}
 statement ok
 INSERT INTO test_${i}  SELECT i, concat('thisisastring_', i) FROM range(100) t(i)
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Let's do a few insertions interleaved with deletions
-# 3	{tables_deleted_from=[1]}
 statement ok
 DELETE FROM test_${i}
 WHERE key < 50;
 
-# 4	{tables_inserted_into=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO test_${i}  SELECT i, concat('thisisastring_', i) FROM range(100,200) t(i)
 
-# 5	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test_${i}
 WHERE key < 80;
 
-# 6	{tables_deleted_from=[1]}
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 DELETE FROM test_${i}
 WHERE key  = 120;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 endloop
 
@@ -53,86 +63,86 @@ endloop
 query IIII
 SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file
 ----
-0	3	3	NULL
-2	4	6	NULL
-5	8	9	NULL
-7	9	12	NULL
+1	5	4	NULL
+4	6	10	NULL
+8	12	15	NULL
+11	13	21	NULL
 
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
 ----
-0	2	NULL
-2	4	NULL
-5	8	NULL
-7	10	NULL
+1	2	NULL
+4	6	NULL
+8	13	NULL
+11	17	NULL
 
 # Now lets call the rewrite function in the whole DB
 statement ok
 CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
 
-# Check ze files after rewrite, we should have removed the last file of each table (i.e., id 4 and 9)
+# Check ze files after rewrite, we should have removed the last file of each table
 query IIII
 SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
 ----
-0	3	3	13
-2	4	6	13
-5	8	9	13
-7	9	12	13
+1	5	4	23
+4	6	10	23
+8	12	15	23
+11	13	21	23
 
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file  ORDER BY ALL
 ----
-0	2	13
-2	4	13
-5	8	13
-7	10	13
-10	13	NULL
-11	13	NULL
+1	2	23
+4	6	23
+8	13	23
+11	17	23
+14	23	NULL
+15	23	NULL
 
 # Validate some results
 query I
-select count(*) from test_0 AT (VERSION => 3);
+select count(*) from test_0 AT (VERSION => 4);
 ----
 50
 
 query I
-select count(*) from test_0 AT (VERSION => 4);
+select count(*) from test_0 AT (VERSION => 6);
 ----
 150
 
 query I
-select count(*) from test_0 AT (VERSION => 5);
+select count(*) from test_0 AT (VERSION => 10);
 ----
-120
+119
 
 query I
-select count(*) from test_0 AT (VERSION => 6);
+select count(*) from test_0 AT (VERSION => 12);
 ----
 119
 
 # Check other table
 query I
-select count(*) from test_1 AT (VERSION => 8);
+select count(*) from test_1 AT (VERSION => 13);
 ----
 100
 
 query I
-select count(*) from test_1 AT (VERSION => 9);
+select count(*) from test_1 AT (VERSION => 15);
 ----
 50
 
 query I
-select count(*) from test_1 AT (VERSION => 10);
+select count(*) from test_1 AT (VERSION => 17);
 ----
 150
 
 query I
-select count(*) from test_1 AT (VERSION => 11);
+select count(*) from test_1 AT (VERSION => 21);
 ----
-120
+119
 
 query I
-select count(*) from test_1 AT (VERSION => 12);
+select count(*) from test_1 AT (VERSION => 22);
 ----
 119
 

--- a/test/sql/rewrite_data_files/test_rewrite_db.test
+++ b/test/sql/rewrite_data_files/test_rewrite_db.test
@@ -63,18 +63,18 @@ endloop
 query IIII
 SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file
 ----
-1	5	4	NULL
-4	6	10	NULL
-8	12	15	NULL
-11	13	21	NULL
+0	3	3	NULL
+2	4	6	NULL
+5	8	10	NULL
+7	9	13	NULL
 
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
 ----
-1	2	NULL
-4	6	NULL
-8	13	NULL
-11	17	NULL
+0	2	NULL
+2	4	NULL
+5	9	NULL
+7	11	NULL
 
 # Now lets call the rewrite function in the whole DB
 statement ok
@@ -84,65 +84,80 @@ CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
 query IIII
 SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
 ----
-1	5	4	23
-4	6	10	23
-8	12	15	23
-11	13	21	23
+0	3	3	15
+2	4	6	15
+5	8	10	15
+7	9	13	15
 
 query III
 SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file  ORDER BY ALL
 ----
-1	2	23
-4	6	23
-8	13	23
-11	17	23
-14	23	NULL
-15	23	NULL
+0	2	15
+2	4	15
+5	9	15
+7	11	15
+10	15	NULL
+11	15	NULL
 
 # Validate some results
 query I
-select count(*) from test_0 AT (VERSION => 4);
+select count(*) from test_0 AT (VERSION => 2);
+----
+100
+
+query I
+select count(*) from test_0 AT (VERSION => 3);
 ----
 50
 
 query I
-select count(*) from test_0 AT (VERSION => 6);
+select count(*) from test_0 AT (VERSION => 4);
 ----
 150
 
 query I
-select count(*) from test_0 AT (VERSION => 10);
+select count(*) from test_0 AT (VERSION => 5);
+----
+120
+
+query I
+select count(*) from test_0 AT (VERSION => 6);
 ----
 119
 
 query I
-select count(*) from test_0 AT (VERSION => 12);
+select count(*) from test_0 AT (VERSION => 7);
 ----
 119
 
 # Check other table
 query I
-select count(*) from test_1 AT (VERSION => 13);
+select count(*) from test_1 AT (VERSION => 9);
 ----
 100
 
 query I
-select count(*) from test_1 AT (VERSION => 15);
+select count(*) from test_1 AT (VERSION => 10);
 ----
 50
 
 query I
-select count(*) from test_1 AT (VERSION => 17);
+select count(*) from test_1 AT (VERSION => 11);
 ----
 150
 
 query I
-select count(*) from test_1 AT (VERSION => 21);
+select count(*) from test_1 AT (VERSION => 12);
+----
+120
+
+query I
+select count(*) from test_1 AT (VERSION => 13);
 ----
 119
 
 query I
-select count(*) from test_1 AT (VERSION => 22);
+select count(*) from test_1 AT (VERSION => 14);
 ----
 119
 

--- a/test/sql/rewrite_data_files/test_rewrite_db.test
+++ b/test/sql/rewrite_data_files/test_rewrite_db.test
@@ -59,22 +59,21 @@ CALL ducklake_flush_inlined_data('ducklake')
 
 endloop
 
-# Check ze files before rewrite
-query IIII
-SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file
-----
-0	3	3	NULL
-2	4	6	NULL
-5	8	10	NULL
-7	9	13	NULL
+# Capture the snapshot before rewrite (last snapshot_id)
+statement ok
+SET VARIABLE pre_rewrite_snap = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'))
 
-query III
-SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file
+# Check ze files before rewrite - verify counts and structural properties
+# The exact begin_snapshot values differ between inline and no-inline modes
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
 ----
-0	2	NULL
-2	4	NULL
-5	9	NULL
-7	11	NULL
+4
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+4
 
 # Now lets call the rewrite function in the whole DB
 query III
@@ -83,87 +82,144 @@ SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_fil
 test_0	2	1
 test_1	2	1
 
+# Capture the rewrite snapshot id
+statement ok
+SET VARIABLE rewrite_snap = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'))
+
 # Check ze files after rewrite, we should have removed the last file of each table
-query IIII
-SELECT data_file_id, delete_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_delete_file ORDER BY ALL
-----
-0	3	3	15
-2	4	6	15
-5	8	10	15
-7	9	13	15
-
-query III
-SELECT data_file_id, begin_snapshot, end_snapshot FROM ducklake_metadata.ducklake_data_file  ORDER BY ALL
-----
-0	2	15
-2	4	15
-5	9	15
-7	11	15
-10	15	NULL
-11	15	NULL
-
-# Validate some results
+# All old delete files should now have end_snapshot = rewrite_snap
 query I
-select count(*) from test_0 AT (VERSION => 2);
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot = getvariable('rewrite_snap')
+----
+4
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+# All old data files should have end_snapshot = rewrite_snap, plus 2 new ones with end_snapshot IS NULL
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot = getvariable('rewrite_snap')
+----
+4
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+2
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE begin_snapshot = getvariable('rewrite_snap') AND end_snapshot IS NULL
+----
+2
+
+# Validate time travel results for test_0
+# Capture snapshot IDs for test_0 operations (table_id=1)
+# test_0 insert 1
+statement ok
+SET VARIABLE t0_insert1 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%')
+
+# test_0 delete 1 (first delete snapshot for table 1)
+statement ok
+SET VARIABLE t0_del1 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%')
+
+# test_0 insert 2 (second insert for table 1)
+statement ok
+SET VARIABLE t0_insert2 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%' AND snapshot_id > getvariable('t0_del1'))
+
+# test_0 delete 2 (second delete for table 1, after second insert)
+statement ok
+SET VARIABLE t0_del2 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' AND snapshot_id > getvariable('t0_insert2'))
+
+# test_0 last delete snapshot (last delete-related snapshot for table 1)
+statement ok
+SET VARIABLE t0_del3 = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[1]%' OR changes::VARCHAR LIKE '%inlined_delete=[1]%')
+
+# After first insert: 100 rows
+query I
+select count(*) from test_0 AT (VERSION => getvariable('t0_insert1'));
 ----
 100
 
+# After first delete (key < 50): 50 rows
 query I
-select count(*) from test_0 AT (VERSION => 3);
+select count(*) from test_0 AT (VERSION => getvariable('t0_del1'));
 ----
 50
 
+# After second insert: 150 rows
 query I
-select count(*) from test_0 AT (VERSION => 4);
+select count(*) from test_0 AT (VERSION => getvariable('t0_insert2'));
 ----
 150
 
+# After second delete (key < 80): 120 rows
 query I
-select count(*) from test_0 AT (VERSION => 5);
+select count(*) from test_0 AT (VERSION => getvariable('t0_del2'));
 ----
 120
 
+# After last delete (key = 120): 119 rows
+# In inline mode this is a flushed_inlined snapshot; in no-inline it's a tables_deleted_from
 query I
-select count(*) from test_0 AT (VERSION => 6);
+select count(*) from test_0 AT (VERSION => getvariable('t0_del3'));
 ----
 119
 
-query I
-select count(*) from test_0 AT (VERSION => 7);
-----
-119
+# Validate time travel results for test_1
+# Capture snapshot IDs for test_1 operations (table_id=2)
+# test_1 insert 1
+statement ok
+SET VARIABLE t1_insert1 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[2]%')
 
-# Check other table
+# test_1 delete 1
+statement ok
+SET VARIABLE t1_del1 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[2]%')
+
+# test_1 insert 2
+statement ok
+SET VARIABLE t1_insert2 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[2]%' AND snapshot_id > getvariable('t1_del1'))
+
+# test_1 delete 2
+statement ok
+SET VARIABLE t1_del2 = (SELECT min(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[2]%' AND snapshot_id > getvariable('t1_insert2'))
+
+# test_1 last delete snapshot
+statement ok
+SET VARIABLE t1_del3 = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%delete%=[2]%' OR changes::VARCHAR LIKE '%inlined_delete=[2]%')
+
+# After first insert: 100 rows
 query I
-select count(*) from test_1 AT (VERSION => 9);
+select count(*) from test_1 AT (VERSION => getvariable('t1_insert1'));
 ----
 100
 
+# After first delete (key < 50): 50 rows
 query I
-select count(*) from test_1 AT (VERSION => 10);
+select count(*) from test_1 AT (VERSION => getvariable('t1_del1'));
 ----
 50
 
+# After second insert: 150 rows
 query I
-select count(*) from test_1 AT (VERSION => 11);
+select count(*) from test_1 AT (VERSION => getvariable('t1_insert2'));
 ----
 150
 
+# After second delete (key < 80): 120 rows
 query I
-select count(*) from test_1 AT (VERSION => 12);
+select count(*) from test_1 AT (VERSION => getvariable('t1_del2'));
 ----
 120
 
+# After last delete (key = 120): 119 rows
 query I
-select count(*) from test_1 AT (VERSION => 13);
+select count(*) from test_1 AT (VERSION => getvariable('t1_del3'));
 ----
 119
 
-query I
-select count(*) from test_1 AT (VERSION => 14);
-----
-119
-
+# Check current state
 query I
 select count(*) from test_0;
 ----

--- a/test/sql/rewrite_data_files/test_rewrite_merge_adjacent.test
+++ b/test/sql/rewrite_data_files/test_rewrite_merge_adjacent.test
@@ -23,9 +23,15 @@ CREATE TABLE t (a VARCHAR, b INT);
 statement ok
 INSERT INTO t VALUES ('text', 1);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Generates the 2nd file
 statement ok
 INSERT INTO t VALUES ('text2', 2);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Generates the 3rd file
 statement ok

--- a/test/sql/rewrite_data_files/test_rewrite_partitioning.test
+++ b/test/sql/rewrite_data_files/test_rewrite_partitioning.test
@@ -28,8 +28,16 @@ ALTER TABLE partitioned SET PARTITIONED BY (part_key);
 statement ok
 INSERT INTO partitioned VALUES (1, 1, 10), (1, 2, 20);
 
+# flush to create file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 INSERT INTO partitioned VALUES (2, 1, 100), (2, 2, 200);
+
+# flush to create file
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # We should have 2 data files (one per insert, but inserts had multiple rows)
 query I
@@ -49,6 +57,10 @@ USING _merge_source AS source
 ON (target.part_key = source.part_key AND target.id = source.id)
 WHEN MATCHED THEN UPDATE SET value = source.value
 WHEN NOT MATCHED THEN INSERT *;
+
+# flush to create delete files from inlined deletions
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify delete files were created by MERGE
 query I

--- a/test/sql/rewrite_data_files/test_rewrite_preserves_row_id.test
+++ b/test/sql/rewrite_data_files/test_rewrite_preserves_row_id.test
@@ -23,6 +23,9 @@ CREATE TABLE test(a INTEGER, b INTEGER);
 statement ok
 INSERT INTO test SELECT i, i * 10 FROM range(1, 11) t(i);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # Verify initial row IDs (0-9)
 query III
 SELECT rowid, a, b FROM test ORDER BY a
@@ -41,6 +44,9 @@ SELECT rowid, a, b FROM test ORDER BY a
 # Delete even rows (a = 2, 4, 6, 8, 10)
 statement ok
 DELETE FROM test WHERE a % 2 = 0;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify row IDs after delete - should have gaps (0, 2, 4, 6, 8)
 query III
@@ -203,6 +209,9 @@ SELECT COUNT(*) FROM test_large
 statement ok
 INSERT INTO test VALUES (11, 110), (12, 120);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # New rows should get row IDs starting after the max existing row ID (which was 9)
 query III
 SELECT rowid, a, b FROM test WHERE a > 10 ORDER BY a
@@ -213,6 +222,9 @@ SELECT rowid, a, b FROM test WHERE a > 10 ORDER BY a
 # Test deleting and rewriting again preserves row IDs
 statement ok
 DELETE FROM test WHERE a = 3;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 SELECT rowid, a, b FROM test ORDER BY a

--- a/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
+++ b/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
@@ -11,7 +11,6 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# disable inlining for this test - conflict detection requires file-based operations
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflict_rewrite', METADATA_CATALOG 'ducklake_metadata')
 
@@ -60,7 +59,6 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # try to commit a compaction after a deletion: conflict
-# Need more than 10 rows to trigger file-based delete (not inlined)
 statement ok con1
 BEGIN
 

--- a/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
+++ b/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
@@ -11,8 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# disable inlining for this test - conflict detection requires file-based operations
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflict_rewrite', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflict_rewrite', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
+++ b/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # disable inlining for this test - conflict detection requires file-based operations
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflict_rewrite', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_conflict_rewrite', METADATA_CATALOG 'ducklake_metadata')
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
+++ b/test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test
@@ -25,7 +25,13 @@ statement ok
 INSERT INTO ducklake.test  FROM range(100) t(i)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 DELETE FROM ducklake.TEST WHERE i <10
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # try to commit a delete after a compaction: conflict
 statement ok con1
@@ -50,7 +56,11 @@ COMMIT
 statement ok
 DELETE FROM ducklake.TEST WHERE i <20
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # try to commit a compaction after a deletion: conflict
+# Need more than 10 rows to trigger file-based delete (not inlined)
 statement ok con1
 BEGIN
 
@@ -58,7 +68,7 @@ statement ok con2
 BEGIN
 
 statement ok con1
-DELETE FROM ducklake.TEST WHERE i <30
+DELETE FROM ducklake.TEST WHERE i >=30 AND i < 50
 
 statement ok con2
 CALL ducklake_rewrite_data_files('ducklake', 'test', delete_threshold => 0);
@@ -71,7 +81,10 @@ COMMIT
 ----
 
 statement ok
-DELETE FROM ducklake.TEST WHERE i <40
+DELETE FROM ducklake.TEST WHERE i >=50 AND i < 70
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # two transactions both try to compact: conflict
 statement ok con1
@@ -99,6 +112,9 @@ INSERT INTO ducklake.test VALUES (7);
 statement ok
 INSERT INTO ducklake.test VALUES (8);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # compaction and insert: no conflict
 statement ok con1
 BEGIN
@@ -121,4 +137,4 @@ COMMIT
 query I
 SELECT count(*) FROM ducklake.test ORDER BY ALL
 ----
-63
+43

--- a/test/sql/schema_evolution/field_ids.test
+++ b/test/sql/schema_evolution/field_ids.test
@@ -21,13 +21,19 @@ CREATE TABLE ducklake.t1(t1_c1 INT, t1_c2 VARCHAR, t1_c3 TIMESTAMP);
 statement ok
 INSERT INTO ducklake.t1 VALUES (42, 'hello', TIMESTAMP '1992-01-01');
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # CTAS
 statement ok
 CREATE TABLE ducklake.t2 AS SELECT 84 t2_c1, 'world' t2_c2
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query III
 SELECT name, type, field_id FROM parquet_schema('${DATA_PATH}/ducklake_field_ids_files/main/t1/*.parquet')
-WHERE name <> 'duckdb_schema'
+WHERE name NOT IN ('duckdb_schema', '_ducklake_internal_row_id', '_ducklake_internal_snapshot_id')
 ORDER BY name
 ----
 t1_c1	INT32	1
@@ -37,7 +43,7 @@ t1_c3	INT64	3
 
 query III
 SELECT name, type, field_id FROM parquet_schema('${DATA_PATH}/ducklake_field_ids_files/main/t2/*.parquet')
-WHERE name <> 'duckdb_schema'
+WHERE name NOT IN ('duckdb_schema', '_ducklake_internal_row_id', '_ducklake_internal_snapshot_id')
 ORDER BY name
 ----
 t2_c1	INT32	1
@@ -51,9 +57,12 @@ SELECT {'c1': 42, 'c2': {'n1': 84, 'n2': 32}} struct_col,
        [{'x': 42, 'y': 84}] as list_of_structs,
        {'l': [1,2,3], 'l2': 42, 'l3': {'x': 42, 'y': 84}} as struct_of_lists
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query II
 SELECT name, field_id FROM parquet_schema('${DATA_PATH}/ducklake_field_ids_files/main/t3/*.parquet')
-WHERE name <> 'duckdb_schema'
+WHERE name NOT IN ('duckdb_schema', '_ducklake_internal_row_id', '_ducklake_internal_snapshot_id')
 ORDER BY name
 ----
 c1	2

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -29,6 +29,10 @@ CREATE TABLE ducklake.test(i INTEGER);
 statement ok
 INSERT INTO ducklake.test VALUES (1), (2), (3);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # verify we are using the correct path
 query I
 SELECT COUNT(*) FROM glob('__TEST_DIR__/my_data_path/**/*.parquet')
@@ -67,6 +71,10 @@ CREATE TABLE ducklake.test(i INTEGER);
 
 statement ok
 INSERT INTO ducklake.test VALUES (1), (2), (3);
+
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # verify we are using the correct path
 query I

--- a/test/sql/sorted_table/merge_adjacent_sorted_basic.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_basic.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -60,17 +58,15 @@ FROM sort_on_compaction
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
-ORDER BY ALL
 ----
-1	1
-3	1
+2
 
 statement ok
 ALTER TABLE ducklake.sort_on_compaction SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -81,17 +77,11 @@ SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_ver
 ----
 1
 
-# Ensure that the snapshot changes match expectations
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
+# Ensure that the latest snapshot change is the ALTER
+query I
+SELECT changes::VARCHAR LIKE '%tables_altered%' FROM ducklake_snapshots('ducklake') ORDER BY snapshot_id DESC LIMIT 1
 ----
-0	0	{schemas_created=[main]}
-1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{inlined_insert=[1]}
-3	1	{flushed_inlined=[1]}
-4	1	{inlined_insert=[1]}
-5	1	{flushed_inlined=[1]}
-6	2	{tables_altered=[1]}
+true
 
 # Even multiple changes back to back should not change the schema_version
 statement ok
@@ -106,19 +96,11 @@ SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_ver
 ----
 1
 
-# Ensure that the snapshot changes match expectations
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
+# Ensure the last two snapshots are also alters
+query I
+SELECT count(*) FROM (SELECT changes FROM ducklake_snapshots('ducklake') ORDER BY snapshot_id DESC LIMIT 3) WHERE changes::VARCHAR LIKE '%tables_altered%'
 ----
-0	0	{schemas_created=[main]}
-1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{inlined_insert=[1]}
-3	1	{flushed_inlined=[1]}
-4	1	{inlined_insert=[1]}
-5	1	{flushed_inlined=[1]}
-6	2	{tables_altered=[1]}
-7	3	{tables_altered=[1]}
-8	4	{tables_altered=[1]}
+3
 
 # Do some other kind of alter table on that table to make sure that it does not interfere
 statement ok
@@ -141,16 +123,17 @@ FROM sort_on_compaction
 5	1	woot5	NULL
 7	1	woot7	NULL
 
-# We write a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+# We write a new file for the table (should be exactly 1 after merge)
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
+AND df.end_snapshot IS NULL
 ----
-4	1
+1
 
 
 # Column does not exist in the table
@@ -169,53 +152,53 @@ ALTER TABLE sort_on_compaction SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_ke
 
 # Drop the table, then expire the snapshots, then validate that the catalog data has been removed
 
-# Pre-expiration catalog status:
-query IIIIIII
+# Pre-expiration catalog status - verify sort expressions and directions exist
+query IIII
 SELECT
-si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index, se.expression, se.sort_direction, se.null_order
+se.sort_key_index, se.expression, se.sort_direction, se.null_order
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON si.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
-ORDER BY ALL
+ORDER BY si.begin_snapshot, se.sort_key_index
 ----
-1	6	7	0	sort_key_1	ASC	NULLS_LAST
-1	6	7	1	sort_key_2	ASC	NULLS_LAST
-1	7	8	0	sort_key_1	DESC	NULLS_LAST
-1	7	8	1	sort_key_2	DESC	NULLS_LAST
-1	8	11	0	sort_key_1	ASC	NULLS_LAST
-1	8	11	1	sort_key_2	ASC	NULLS_LAST
-1	11	12	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
-1	12	NULL	0	sort_key_1	ASC	NULLS_LAST
-1	12	NULL	1	sort_key_2	ASC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
+0	sort_key_1	DESC	NULLS_LAST
+1	sort_key_2	DESC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
+0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
 
 
 statement ok
 drop table sort_on_compaction;
 
 # History should be present as long as the snapshots are not yet expired
-query IIIIIII
+query IIII
 SELECT
-si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index, se.expression, se.sort_direction, se.null_order
+se.sort_key_index, se.expression, se.sort_direction, se.null_order
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON si.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
-ORDER BY ALL
+ORDER BY si.begin_snapshot, se.sort_key_index
 ----
-1	6	7	0	sort_key_1	ASC	NULLS_LAST
-1	6	7	1	sort_key_2	ASC	NULLS_LAST
-1	7	8	0	sort_key_1	DESC	NULLS_LAST
-1	7	8	1	sort_key_2	DESC	NULLS_LAST
-1	8	11	0	sort_key_1	ASC	NULLS_LAST
-1	8	11	1	sort_key_2	ASC	NULLS_LAST
-1	11	12	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
-1	12	13	0	sort_key_1	ASC	NULLS_LAST
-1	12	13	1	sort_key_2	ASC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
+0	sort_key_1	DESC	NULLS_LAST
+1	sort_key_2	DESC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
+0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
+0	sort_key_1	ASC	NULLS_LAST
+1	sort_key_2	ASC	NULLS_LAST
 
 statement ok
 CALL ducklake_expire_snapshots('ducklake', older_than => now());

--- a/test/sql/sorted_table/merge_adjacent_sorted_basic.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_basic.test
@@ -23,24 +23,30 @@ CREATE TABLE sort_on_compaction (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2
 statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM sort_on_compaction
@@ -55,16 +61,16 @@ FROM sort_on_compaction
 4	0	woot4
 
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-0	1
 1	1
+3	1
 
 statement ok
 ALTER TABLE ducklake.sort_on_compaction SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -81,9 +87,11 @@ SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
 ----
 0	0	{schemas_created=[main]}
 1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{tables_inserted_into=[1]}
-3	1	{tables_inserted_into=[1]}
-4	2	{tables_altered=[1]}
+2	1	{inlined_insert=[1]}
+3	1	{flushed_inlined=[1]}
+4	1	{inlined_insert=[1]}
+5	1	{flushed_inlined=[1]}
+6	2	{tables_altered=[1]}
 
 # Even multiple changes back to back should not change the schema_version
 statement ok
@@ -104,11 +112,13 @@ SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
 ----
 0	0	{schemas_created=[main]}
 1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{tables_inserted_into=[1]}
-3	1	{tables_inserted_into=[1]}
-4	2	{tables_altered=[1]}
-5	3	{tables_altered=[1]}
-6	4	{tables_altered=[1]}
+2	1	{inlined_insert=[1]}
+3	1	{flushed_inlined=[1]}
+4	1	{inlined_insert=[1]}
+5	1	{flushed_inlined=[1]}
+6	2	{tables_altered=[1]}
+7	3	{tables_altered=[1]}
+8	4	{tables_altered=[1]}
 
 # Do some other kind of alter table on that table to make sure that it does not interfere
 statement ok
@@ -131,14 +141,14 @@ FROM sort_on_compaction
 
 # We write a new file for the table
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ----
-2	1
+4	1
 
 
 # Column does not exist in the table
@@ -161,18 +171,18 @@ SELECT
 si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index, se.expression, se.sort_direction, se.null_order
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON si.table_id = t.table_id 
-WHERE 
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON si.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-1	4	5	0	sort_key_1	ASC	NULLS_LAST
-1	4	5	1	sort_key_2	ASC	NULLS_LAST
-1	5	6	0	sort_key_1	DESC	NULLS_LAST
-1	5	6	1	sort_key_2	DESC	NULLS_LAST
-1	6	NULL	0	sort_key_1	ASC	NULLS_LAST
-1	6	NULL	1	sort_key_2	ASC	NULLS_LAST
+1	6	7	0	sort_key_1	ASC	NULLS_LAST
+1	6	7	1	sort_key_2	ASC	NULLS_LAST
+1	7	8	0	sort_key_1	DESC	NULLS_LAST
+1	7	8	1	sort_key_2	DESC	NULLS_LAST
+1	8	NULL	0	sort_key_1	ASC	NULLS_LAST
+1	8	NULL	1	sort_key_2	ASC	NULLS_LAST
 
 
 statement ok
@@ -184,18 +194,18 @@ SELECT
 si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index, se.expression, se.sort_direction, se.null_order
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON si.table_id = t.table_id 
-WHERE 
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON si.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-1	4	5	0	sort_key_1	ASC	NULLS_LAST
-1	4	5	1	sort_key_2	ASC	NULLS_LAST
-1	5	6	0	sort_key_1	DESC	NULLS_LAST
-1	5	6	1	sort_key_2	DESC	NULLS_LAST
-1	6	9	0	sort_key_1	ASC	NULLS_LAST
-1	6	9	1	sort_key_2	ASC	NULLS_LAST
+1	6	7	0	sort_key_1	ASC	NULLS_LAST
+1	6	7	1	sort_key_2	ASC	NULLS_LAST
+1	7	8	0	sort_key_1	DESC	NULLS_LAST
+1	7	8	1	sort_key_2	DESC	NULLS_LAST
+1	8	11	0	sort_key_1	ASC	NULLS_LAST
+1	8	11	1	sort_key_2	ASC	NULLS_LAST
 
 statement ok
 CALL ducklake_expire_snapshots('ducklake', older_than => now());

--- a/test/sql/sorted_table/merge_adjacent_sorted_basic.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_basic.test
@@ -181,15 +181,15 @@ WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-1	4	5	0	sort_key_1	ASC	NULLS_LAST
-1	4	5	1	sort_key_2	ASC	NULLS_LAST
-1	5	6	0	sort_key_1	DESC	NULLS_LAST
-1	5	6	1	sort_key_2	DESC	NULLS_LAST
-1	6	9	0	sort_key_1	ASC	NULLS_LAST
-1	6	9	1	sort_key_2	ASC	NULLS_LAST
-1	9	10	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
-1	10	NULL	0	sort_key_1	ASC	NULLS_LAST
-1	10	NULL	1	sort_key_2	ASC	NULLS_LAST
+1	6	7	0	sort_key_1	ASC	NULLS_LAST
+1	6	7	1	sort_key_2	ASC	NULLS_LAST
+1	7	8	0	sort_key_1	DESC	NULLS_LAST
+1	7	8	1	sort_key_2	DESC	NULLS_LAST
+1	8	11	0	sort_key_1	ASC	NULLS_LAST
+1	8	11	1	sort_key_2	ASC	NULLS_LAST
+1	11	12	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
+1	12	NULL	0	sort_key_1	ASC	NULLS_LAST
+1	12	NULL	1	sort_key_2	ASC	NULLS_LAST
 
 
 statement ok
@@ -207,15 +207,15 @@ WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-1	4	5	0	sort_key_1	ASC	NULLS_LAST
-1	4	5	1	sort_key_2	ASC	NULLS_LAST
-1	5	6	0	sort_key_1	DESC	NULLS_LAST
-1	5	6	1	sort_key_2	DESC	NULLS_LAST
-1	6	9	0	sort_key_1	ASC	NULLS_LAST
-1	6	9	1	sort_key_2	ASC	NULLS_LAST
-1	9	10	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
-1	10	11	0	sort_key_1	ASC	NULLS_LAST
-1	10	11	1	sort_key_2	ASC	NULLS_LAST
+1	6	7	0	sort_key_1	ASC	NULLS_LAST
+1	6	7	1	sort_key_2	ASC	NULLS_LAST
+1	7	8	0	sort_key_1	DESC	NULLS_LAST
+1	7	8	1	sort_key_2	DESC	NULLS_LAST
+1	8	11	0	sort_key_1	ASC	NULLS_LAST
+1	8	11	1	sort_key_2	ASC	NULLS_LAST
+1	11	12	0	concat(sort_key_1, '_', sort_key_2)	ASC	NULLS_LAST
+1	12	13	0	sort_key_1	ASC	NULLS_LAST
+1	12	13	1	sort_key_2	ASC	NULLS_LAST
 
 statement ok
 CALL ducklake_expire_snapshots('ducklake', older_than => now());

--- a/test/sql/sorted_table/merge_adjacent_sorted_case_insensitivity.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_case_insensitivity.test
@@ -22,24 +22,30 @@ CREATE TABLE sort_on_compaction (unique_id BIGINT, Sort_Key_1 BIGINT, Sort_Key_2
 statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM sort_on_compaction
@@ -80,24 +86,30 @@ CREATE TABLE sort_on_compaction_2 (unique_id BIGINT, sort_key_1 BIGINT, sort_key
 statement ok
 INSERT INTO sort_on_compaction_2 (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_on_compaction_2 (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM sort_on_compaction_2

--- a/test/sql/sorted_table/merge_adjacent_sorted_drop_recreate.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_drop_recreate.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -70,8 +68,8 @@ FROM table_to_recreate
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
@@ -79,8 +77,8 @@ WHERE
 t.table_name = 'table_to_recreate'
 ORDER BY ALL
 ----
-1	3
-3	3
+3
+3
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'table_to_recreate')
@@ -102,13 +100,13 @@ FROM table_to_recreate
 4	0	woot4
 
 # We write a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'table_to_recreate'
 ----
-4	3
+3
 

--- a/test/sql/sorted_table/merge_adjacent_sorted_drop_recreate.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_drop_recreate.test
@@ -33,24 +33,30 @@ CREATE TABLE table_to_recreate (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2 
 statement ok
 INSERT INTO table_to_recreate (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO table_to_recreate (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM table_to_recreate
@@ -65,16 +71,16 @@ FROM table_to_recreate
 4	0	woot4
 
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'table_to_recreate'
 ORDER BY ALL
 ----
-0	3
 1	3
+3	3
 
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'table_to_recreate');
@@ -95,12 +101,12 @@ FROM table_to_recreate
 
 # We write a new file for the table
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'table_to_recreate'
 ----
-2	3
+4	3
 

--- a/test/sql/sorted_table/merge_adjacent_sorted_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_expression.test
@@ -41,16 +41,16 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT  df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_expression_test'
 ----
-1	1
-3	1
+1
+1
 
 # Set sorted by an expression (concatenation of two columns)
 statement ok
@@ -74,15 +74,15 @@ statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'sort_expression_test');
 
 # Verify we have 1 data file after compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT  df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_expression_test'
 ----
-4	1
+1
 
 # Verify data is now sorted by the concatenation of sort_key_1 and sort_key_2
 # Expected order by sort_key_1 || sort_key_2:

--- a/test/sql/sorted_table/merge_adjacent_sorted_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_expression.test
@@ -27,12 +27,18 @@ VALUES
     (4, 'a', 'z');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_expression_test (unique_id, sort_key_1, sort_key_2)
 VALUES
     (5, 'b', 'x'),
     (6, 'c', 'z'),
     (7, 'a', 'x'),
     (8, 'b', 'y');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
 query II
@@ -43,8 +49,8 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_expression_test'
 ----
-0	1
 1	1
+3	1
 
 # Set sorted by an expression (concatenation of two columns)
 statement ok
@@ -76,7 +82,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_expression_test'
 ----
-2	1
+4	1
 
 # Verify data is now sorted by the concatenation of sort_key_1 and sort_key_2
 # Expected order by sort_key_1 || sort_key_2:
@@ -124,7 +130,13 @@ statement ok
 INSERT INTO rename_expr_test VALUES (1, 'x', 'y'), (2, 'a', 'b');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO rename_expr_test VALUES (3, 'p', 'q'), (4, 'm', 'n');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Set sorted by an expression using both columns
 statement ok
@@ -168,7 +180,13 @@ statement ok
 INSERT INTO multi_rename_test VALUES (1, 'John', 'Doe'), (2, 'Alice', 'Smith');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO multi_rename_test VALUES (3, 'Bob', 'Jones'), (4, 'Carol', 'Brown');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Set sorted by concatenation of both name columns
 statement ok

--- a/test/sql/sorted_table/merge_adjacent_sorted_macro_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_macro_expression.test
@@ -39,16 +39,15 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-1	1
-3	1
+2
 
 statement ok
 CREATE MACRO zip_varchar(i, j, num_chars := 6) AS (
@@ -66,10 +65,10 @@ CREATE MACRO zip_varchar(i, j, num_chars := 6) AS (
 );
 
 # Check Macro Tables
-query IIIII
-FROM __ducklake_metadata_ducklake.ducklake_macro;
+query I
+SELECT macro_name FROM __ducklake_metadata_ducklake.ducklake_macro;
 ----
-0	2	zip_varchar	6	NULL
+zip_varchar
 
 # Test that the macro is working as intended independently of sorting
 query III
@@ -99,15 +98,15 @@ statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'macro_sort_test');
 
 # Verify we have 1 data file after compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-4	1
+1
 
 # Verify data is now sorted by the macro
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_macro_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_macro_expression.test
@@ -21,17 +21,22 @@ statement ok
 CREATE TABLE macro_sort_test (i VARCHAR, j VARCHAR);
 
 statement ok
-INSERT INTO macro_sort_test 
-SELECT 'ZYX' AS i, 'CBA' AS j 
-UNION ALL 
-SELECT 'ABC' AS i, 'XYZ' AS j 
-
+INSERT INTO macro_sort_test
+SELECT 'ZYX' AS i, 'CBA' AS j
+UNION ALL
+SELECT 'ABC' AS i, 'XYZ' AS j
 
 statement ok
-INSERT INTO macro_sort_test 
-SELECT '321' AS i, '000' AS j 
-UNION ALL 
-SELECT '123' AS i, '000' AS j 
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO macro_sort_test
+SELECT '321' AS i, '000' AS j
+UNION ALL
+SELECT '123' AS i, '000' AS j
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
 query II
@@ -42,8 +47,8 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-0	1
 1	1
+3	1
 
 statement ok
 CREATE MACRO zip_varchar(i, j, num_chars := 6) AS (
@@ -64,7 +69,7 @@ CREATE MACRO zip_varchar(i, j, num_chars := 6) AS (
 query IIIII
 FROM __ducklake_metadata_ducklake.ducklake_macro;
 ----
-0	2	zip_varchar	4	NULL
+0	2	zip_varchar	6	NULL
 
 # Test that the macro is working as intended independently of sorting
 query III
@@ -102,7 +107,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-2	1
+4	1
 
 # Verify data is now sorted by the macro
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_macro_expression_transaction.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_macro_expression_transaction.test
@@ -39,16 +39,16 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-1	1
-3	1
+1
+1
 
 statement ok
 BEGIN
@@ -99,15 +99,15 @@ statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'macro_sort_test');
 
 # Verify we have 1 data file after compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-4	1
+1
 
 # Verify data is now sorted by the macro
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_macro_expression_transaction.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_macro_expression_transaction.test
@@ -21,17 +21,22 @@ statement ok
 CREATE TABLE macro_sort_test (i VARCHAR, j VARCHAR);
 
 statement ok
-INSERT INTO macro_sort_test 
-SELECT 'ZYX' AS i, 'CBA' AS j 
-UNION ALL 
-SELECT 'ABC' AS i, 'XYZ' AS j 
-
+INSERT INTO macro_sort_test
+SELECT 'ZYX' AS i, 'CBA' AS j
+UNION ALL
+SELECT 'ABC' AS i, 'XYZ' AS j
 
 statement ok
-INSERT INTO macro_sort_test 
-SELECT '321' AS i, '000' AS j 
-UNION ALL 
-SELECT '123' AS i, '000' AS j 
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO macro_sort_test
+SELECT '321' AS i, '000' AS j
+UNION ALL
+SELECT '123' AS i, '000' AS j
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
 query II
@@ -42,8 +47,8 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-0	1
 1	1
+3	1
 
 statement ok
 BEGIN
@@ -102,7 +107,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'macro_sort_test'
 ----
-2	1
+4	1
 
 # Verify data is now sorted by the macro
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_nested_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_nested_expression.test
@@ -41,16 +41,16 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_nested_expr_test'
 ----
-1	1
-3	1
+1
+1
 
 # Set sorted by a nested expression: concat(substr(power(unique_id, unique_id)::varchar, 1, 1), name)
 statement ok
@@ -75,15 +75,15 @@ statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'sort_nested_expr_test');
 
 # Verify we have 1 data file after compaction
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT df.table_id
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_nested_expr_test'
 ----
-4	1
+1
 
 # Verify data is now sorted by the nested expression
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_nested_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_nested_expression.test
@@ -27,12 +27,18 @@ VALUES
     (4, 'four');
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_nested_expr_test (unique_id, name)
 VALUES
     (5, 'five'),
     (6, 'six'),
     (7, 'seven'),
     (8, 'eight');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify we have 2 data files before compaction
 query II
@@ -43,8 +49,8 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_nested_expr_test'
 ----
-0	1
 1	1
+3	1
 
 # Set sorted by a nested expression: concat(substr(power(unique_id, unique_id)::varchar, 1, 1), name)
 statement ok
@@ -77,7 +83,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_nested_expr_test'
 ----
-2	1
+4	1
 
 # Verify data is now sorted by the nested expression
 query III

--- a/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
@@ -11,7 +11,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake;
@@ -30,10 +30,10 @@ ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_changed;
 statement ok
 ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert data twice to create two files (>10 rows each to bypass inlining)
+# Insert data twice to create two files
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(11) t(i)
+FROM range(4) t(i)
 SELECT
     i AS unique_id,
     i % 2 AS sort_key_1_changed,
@@ -44,11 +44,11 @@ ORDER BY
 
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(11) t(i)
+FROM range(4) t(i)
 SELECT
-    i + 11 AS unique_id,
-    (i + 11) % 2 AS sort_key_1_changed,
-    'woot' || (i + 11) AS sort_key_2_changed
+    i + 4 AS unique_id,
+    (i + 4) % 2 AS sort_key_1_changed,
+    'woot' || (i + 4) AS sort_key_2_changed
 ORDER BY
     i DESC
 ;

--- a/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
@@ -53,14 +53,21 @@ ORDER BY
     i DESC
 ;
 
-# Compaction should fail because the sort columns no longer exist
+# Flush fails because of the renamed columns - SORTED BY references old column names
+# (With inlining, the error now happens at flush time instead of at merge_adjacent_files time)
 statement error
-CALL ducklake_merge_adjacent_files('ducklake', 'renamed_columns_test');
+CALL ducklake_flush_inlined_data('ducklake')
 ----
 Binder Error: Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
 
+# Fix the SORTED BY settings to use new column names
 statement ok
 ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
 
+# Now flush should work
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Compaction should also work now
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'renamed_columns_test');

--- a/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
@@ -30,10 +30,10 @@ ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_changed;
 statement ok
 ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert data twice to create two files
+# Insert data twice to create two files (>10 rows each to bypass inlining)
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(4) t(i)
+FROM range(11) t(i)
 SELECT
     i AS unique_id,
     i % 2 AS sort_key_1_changed,
@@ -44,11 +44,11 @@ ORDER BY
 
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(4) t(i)
+FROM range(11) t(i)
 SELECT
-    i + 4 AS unique_id,
-    (i + 4) % 2 AS sort_key_1_changed,
-    'woot' || (i + 4) AS sort_key_2_changed
+    i + 11 AS unique_id,
+    (i + 11) % 2 AS sort_key_1_changed,
+    'woot' || (i + 11) AS sort_key_2_changed
 ORDER BY
     i DESC
 ;

--- a/test/sql/sorted_table/merge_adjacent_sorted_repeated.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_repeated.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -60,8 +58,8 @@ FROM prevent_duplicates
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
@@ -69,8 +67,7 @@ WHERE
 t.table_name = 'prevent_duplicates'
 ORDER BY ALL
 ----
-1	1
-3	1
+2
 
 statement ok
 ALTER TABLE ducklake.prevent_duplicates SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -96,28 +93,26 @@ FROM prevent_duplicates
 7	1	woot7
 
 # We write a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'prevent_duplicates'
 ----
-4	1
+1
 
 # We should only have 2 rows in the metadata table for this DuckLake table
-query IIII
-SELECT
-si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
 WHERE
 si.table_id = 1
 ORDER BY ALL
 ----
-1	6	NULL	0
-1	6	NULL	1
+2
 
 
 # Multiple SET SORTED BY calls with different sort orders should have separate catalog entries
@@ -164,8 +159,8 @@ FROM multiple_set_sorted
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
@@ -173,8 +168,7 @@ WHERE
 t.table_name = 'multiple_set_sorted'
 ORDER BY ALL
 ----
-6	4
-8	4
+2
 
 statement ok
 ALTER TABLE ducklake.multiple_set_sorted SET SORTED BY (sort_key_1 DESC NULLS FIRST, sort_key_2 DESC NULLS FIRST);
@@ -200,28 +194,22 @@ FROM multiple_set_sorted
 7	1	woot7
 
 # We write a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'multiple_set_sorted'
 ----
-9	4
+1
 
 # We should have 4 rows in the metadata table for this DuckLake table
-query IIIIIIII
-SELECT
-si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index,
-se.expression, se.dialect, se.sort_direction, se.null_order
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_sort_info si
 JOIN __ducklake_metadata_ducklake.ducklake_sort_expression se USING (sort_id)
 WHERE
 si.table_id = 4
-ORDER BY si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index
 ----
-4	14	15	0	sort_key_1	duckdb	DESC	NULLS_FIRST
-4	14	15	1	sort_key_2	duckdb	DESC	NULLS_FIRST
-4	15	NULL	0	sort_key_1	duckdb	ASC	NULLS_LAST
-4	15	NULL	1	sort_key_2	duckdb	ASC	NULLS_LAST
+4

--- a/test/sql/sorted_table/merge_adjacent_sorted_repeated.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_repeated.test
@@ -23,24 +23,30 @@ CREATE TABLE prevent_duplicates (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2
 statement ok
 INSERT INTO prevent_duplicates (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO prevent_duplicates (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM prevent_duplicates
@@ -63,8 +69,8 @@ WHERE
 t.table_name = 'prevent_duplicates'
 ORDER BY ALL
 ----
-0	1
 1	1
+3	1
 
 statement ok
 ALTER TABLE ducklake.prevent_duplicates SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -96,7 +102,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'prevent_duplicates'
 ----
-2	1
+4	1
 
 # We should only have 2 rows in the metadata table for this DuckLake table
 query IIII
@@ -108,8 +114,8 @@ WHERE
 si.table_id = 1
 ORDER BY ALL
 ----
-1	4	NULL	0
-1	4	NULL	1
+1	6	NULL	0
+1	6	NULL	1
 
 
 # Multiple SET SORTED BY calls with different sort orders should have separate catalog entries
@@ -119,24 +125,30 @@ CREATE TABLE multiple_set_sorted (unique_id BIGINT, sort_key_1 BIGINT, sort_key_
 statement ok
 INSERT INTO multiple_set_sorted (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO multiple_set_sorted (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM multiple_set_sorted
@@ -159,8 +171,8 @@ WHERE
 t.table_name = 'multiple_set_sorted'
 ORDER BY ALL
 ----
-3	4
-4	4
+6	4
+8	4
 
 statement ok
 ALTER TABLE ducklake.multiple_set_sorted SET SORTED BY (sort_key_1 DESC NULLS FIRST, sort_key_2 DESC NULLS FIRST);
@@ -192,7 +204,7 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'multiple_set_sorted'
 ----
-5	4
+9	4
 
 # We should have 4 rows in the metadata table for this DuckLake table
 query IIIIIIII
@@ -205,7 +217,7 @@ WHERE
 si.table_id = 4
 ORDER BY si.table_id, si.begin_snapshot, si.end_snapshot, se.sort_key_index
 ----
-4	10	11	0	sort_key_1	duckdb	DESC	NULLS_FIRST
-4	10	11	1	sort_key_2	duckdb	DESC	NULLS_FIRST
-4	11	NULL	0	sort_key_1	duckdb	ASC	NULLS_LAST
-4	11	NULL	1	sort_key_2	duckdb	ASC	NULLS_LAST
+4	14	15	0	sort_key_1	duckdb	DESC	NULLS_FIRST
+4	14	15	1	sort_key_2	duckdb	DESC	NULLS_FIRST
+4	15	NULL	0	sort_key_1	duckdb	ASC	NULLS_LAST
+4	15	NULL	1	sort_key_2	duckdb	ASC	NULLS_LAST

--- a/test/sql/sorted_table/merge_adjacent_sorted_reset.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_reset.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -60,8 +58,8 @@ FROM reset_sorted_test
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
@@ -69,8 +67,7 @@ WHERE
 t.table_name = 'reset_sorted_test'
 ORDER BY ALL
 ----
-1	1
-3	1
+2
 
 statement ok
 ALTER TABLE ducklake.reset_sorted_test SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -97,12 +94,12 @@ FROM reset_sorted_test
 4	0	woot4
 
 # We write a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT COUNT(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'reset_sorted_test'
 ----
-4	1
+1

--- a/test/sql/sorted_table/merge_adjacent_sorted_reset.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_reset.test
@@ -23,24 +23,30 @@ CREATE TABLE reset_sorted_test (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2 
 statement ok
 INSERT INTO reset_sorted_test (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO reset_sorted_test (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM reset_sorted_test
@@ -63,8 +69,8 @@ WHERE
 t.table_name = 'reset_sorted_test'
 ORDER BY ALL
 ----
-0	1
 1	1
+3	1
 
 statement ok
 ALTER TABLE ducklake.reset_sorted_test SET SORTED BY (sort_key_1 ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
@@ -97,4 +103,4 @@ ON df.table_id = t.table_id
 WHERE
 t.table_name = 'reset_sorted_test'
 ----
-2	1
+4	1

--- a/test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -60,17 +58,15 @@ FROM sort_on_compaction
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
-ORDER BY ALL
 ----
-1	1
-3	1
+2
 
 statement ok
 BEGIN
@@ -105,27 +101,21 @@ FROM sort_on_compaction
 7	1	woot7	NULL
 
 
-# Ensure that the snapshot changes match expectations
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
+# Ensure that the snapshot changes include the merge
+query I
+SELECT changes::VARCHAR LIKE '%merge_adjacent%' FROM ducklake_snapshots('ducklake') ORDER BY snapshot_id DESC LIMIT 1
 ----
-0	0	{schemas_created=[main]}
-1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{inlined_insert=[1]}
-3	1	{flushed_inlined=[1]}
-4	1	{inlined_insert=[1]}
-5	1	{flushed_inlined=[1]}
-6	2	{tables_altered=[1]}
-7	2	{merge_adjacent=[1]}
+true
 
 
-# We wrote a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+# We wrote a new file for the table (exactly 1 active after merge)
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
+AND df.end_snapshot IS NULL
 ----
-4	1
+1

--- a/test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_transaction_alter_table_unrelated.test
@@ -23,24 +23,30 @@ CREATE TABLE sort_on_compaction (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2
 statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM sort_on_compaction
@@ -55,16 +61,16 @@ FROM sort_on_compaction
 4	0	woot4
 
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-0	1
 1	1
+3	1
 
 statement ok
 BEGIN
@@ -103,19 +109,21 @@ SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
 ----
 0	0	{schemas_created=[main]}
 1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{tables_inserted_into=[1]}
-3	1	{tables_inserted_into=[1]}
-4	2	{tables_altered=[1]}
-5	2	{merge_adjacent=[1]}
+2	1	{inlined_insert=[1]}
+3	1	{flushed_inlined=[1]}
+4	1	{inlined_insert=[1]}
+5	1	{flushed_inlined=[1]}
+6	2	{tables_altered=[1]}
+7	2	{merge_adjacent=[1]}
 
 
 # We wrote a new file for the table
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ----
-2	1
+4	1

--- a/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
@@ -8,8 +8,6 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-
-
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_options_sorted/')
 
@@ -60,17 +58,15 @@ FROM sort_on_compaction
 5	1	woot5
 4	0	woot4
 
-query II
-SELECT df.data_file_id, df.table_id
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
-ORDER BY ALL
 ----
-1	1
-3	1
+2
 
 statement ok
 BEGIN
@@ -123,28 +119,21 @@ FROM sort_on_compaction
 7	1	woot7
 
 
-# Ensure that the snapshot changes match expectations
-query III
-SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
+# Ensure that the snapshot changes include the merge
+query I
+SELECT changes::VARCHAR LIKE '%merge_adjacent%' FROM ducklake_snapshots('ducklake') ORDER BY snapshot_id DESC LIMIT 1
 ----
-0	0	{schemas_created=[main]}
-1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{inlined_insert=[1]}
-3	1	{flushed_inlined=[1]}
-4	1	{inlined_insert=[1]}
-5	1	{flushed_inlined=[1]}
-6	2	{tables_altered=[1]}
-7	3	{tables_altered=[1]}
-8	3	{merge_adjacent=[1]}
+true
 
 
-# We wrote a new file for the table
-query II
-SELECT df.data_file_id, df.table_id
+# We wrote a new file for the table (exactly 1 active after merge)
+query I
+SELECT count(*)
 FROM __ducklake_metadata_ducklake.ducklake_data_file df
 JOIN __ducklake_metadata_ducklake.ducklake_table t
 ON df.table_id = t.table_id
 WHERE
 t.table_name = 'sort_on_compaction'
+AND df.end_snapshot IS NULL
 ----
-4	1
+1

--- a/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
@@ -23,24 +23,30 @@ CREATE TABLE sort_on_compaction (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2
 statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i AS unique_id,
     i % 2 AS sort_key_1,
     'woot' || i AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 INSERT INTO sort_on_compaction (unique_id, sort_key_1, sort_key_2)
 FROM range(4) t(i)
-SELECT 
+SELECT
     i + 4 AS unique_id,
     (i + 4) % 2 AS sort_key_1,
     'woot' || (i + 4) AS sort_key_2
-ORDER BY 
+ORDER BY
     i DESC
 ;
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 FROM sort_on_compaction
@@ -55,16 +61,16 @@ FROM sort_on_compaction
 4	0	woot4
 
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ORDER BY ALL
 ----
-0	1
 1	1
+3	1
 
 statement ok
 BEGIN
@@ -115,26 +121,28 @@ FROM sort_on_compaction
 7	1	woot7
 
 
-# Ensure that the snapshot changeßs match expectations
+# Ensure that the snapshot changes match expectations
 query III
 SELECT snapshot_id, schema_version, changes FROM ducklake_snapshots('ducklake')
 ----
 0	0	{schemas_created=[main]}
 1	1	{tables_created=[main.sort_on_compaction]}
-2	1	{tables_inserted_into=[1]}
-3	1	{tables_inserted_into=[1]}
-4	2	{tables_altered=[1]}
-5	3	{tables_altered=[1]}
-6	3	{merge_adjacent=[1]}
+2	1	{inlined_insert=[1]}
+3	1	{flushed_inlined=[1]}
+4	1	{inlined_insert=[1]}
+5	1	{flushed_inlined=[1]}
+6	2	{tables_altered=[1]}
+7	3	{tables_altered=[1]}
+8	3	{merge_adjacent=[1]}
 
 
 # We wrote a new file for the table
 query II
-SELECT df.data_file_id, df.table_id 
-FROM __ducklake_metadata_ducklake.ducklake_data_file df 
-JOIN __ducklake_metadata_ducklake.ducklake_table t 
-ON df.table_id = t.table_id 
-WHERE 
+SELECT df.data_file_id, df.table_id
+FROM __ducklake_metadata_ducklake.ducklake_data_file df
+JOIN __ducklake_metadata_ducklake.ducklake_table t
+ON df.table_id = t.table_id
+WHERE
 t.table_name = 'sort_on_compaction'
 ----
-2	1
+4	1

--- a/test/sql/stats/filter_pushdown.test
+++ b/test/sql/stats/filter_pushdown.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_filter_pushdown_files')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_filter_pushdown_files', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 CREATE TABLE ducklake.filter_pushdown(v INTEGER, i INTEGER, d DATE, k DECIMAL(9, 3), s VARCHAR);
@@ -47,9 +47,6 @@ INSERT INTO ducklake.filter_pushdown
 SELECT i % 1000 v, i, (TIMESTAMP '1970-01-01' + interval (i) hour)::DATE, i / 10, printf('%06d', i)
 FROM range(500000,501000) t(i);
 
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
 # integer filters
 query IIIII
 SELECT * FROM ducklake.filter_pushdown WHERE i=527
@@ -64,7 +61,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>100998
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>100998
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
@@ -74,7 +71,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i<100001
@@ -95,7 +92,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d=DATE '2000-01-23';
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d=DATE '2000-01-23';
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # decimal filter
 query IIIII
@@ -106,7 +103,7 @@ SELECT * FROM ducklake.filter_pushdown WHERE k=25.3;
 query II
 EXPLAIN ANALYZE SELECT * FROM ducklake.filter_pushdown WHERE k=25.3;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # varchar filter
 query I
@@ -117,7 +114,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE s>= '500023';
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE s>= '500023';
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # multiple filters
 query I
@@ -128,7 +125,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d >= DATE '2011-05-29' AND k
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d >= DATE '2011-05-29' AND k < 50000;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # OR filters
 query I
@@ -139,7 +136,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i in (500, 600, 700);
@@ -149,7 +146,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i in (500, 600, 700);
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i IN (500, 600, 700);
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # file 4 -
 # Single row so it should be able to be pruned with != filter
@@ -157,9 +154,6 @@ statement ok
 INSERT INTO ducklake.filter_pushdown
 SELECT i % 1000 v, i, (TIMESTAMP '1970-01-01' + interval (i) hour)::DATE, i / 10, printf('%06d', i)
 FROM range(501000, 501001) t(i);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 # != (not equal) pushdown - should prune file with constant value
 query I
@@ -170,4 +164,4 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i != 501000;
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i != 501000;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [3-5].*
+analyzed_plan	<REGEX>:.*Total Files Read: 3.*

--- a/test/sql/stats/filter_pushdown.test
+++ b/test/sql/stats/filter_pushdown.test
@@ -47,6 +47,9 @@ INSERT INTO ducklake.filter_pushdown
 SELECT i % 1000 v, i, (TIMESTAMP '1970-01-01' + interval (i) hour)::DATE, i / 10, printf('%06d', i)
 FROM range(500000,501000) t(i);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # integer filters
 query IIIII
 SELECT * FROM ducklake.filter_pushdown WHERE i=527
@@ -61,7 +64,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>100998
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>100998
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
@@ -71,7 +74,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i>=100999
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i<100001
@@ -92,7 +95,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d=DATE '2000-01-23';
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d=DATE '2000-01-23';
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # decimal filter
 query IIIII
@@ -103,7 +106,7 @@ SELECT * FROM ducklake.filter_pushdown WHERE k=25.3;
 query II
 EXPLAIN ANALYZE SELECT * FROM ducklake.filter_pushdown WHERE k=25.3;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # varchar filter
 query I
@@ -114,7 +117,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE s>= '500023';
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE s>= '500023';
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # multiple filters
 query I
@@ -125,7 +128,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d >= DATE '2011-05-29' AND k
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE d >= DATE '2011-05-29' AND k < 50000;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # OR filters
 query I
@@ -136,7 +139,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i=527 OR i=100527;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+analyzed_plan	<REGEX>:.*Total Files Read: [2-4].*
 
 query I
 SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i in (500, 600, 700);
@@ -146,7 +149,7 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i in (500, 600, 700);
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i IN (500, 600, 700);
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # file 4 -
 # Single row so it should be able to be pruned with != filter
@@ -154,6 +157,9 @@ statement ok
 INSERT INTO ducklake.filter_pushdown
 SELECT i % 1000 v, i, (TIMESTAMP '1970-01-01' + interval (i) hour)::DATE, i / 10, printf('%06d', i)
 FROM range(501000, 501001) t(i);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # != (not equal) pushdown - should prune file with constant value
 query I
@@ -164,4 +170,4 @@ SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i != 501000;
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.filter_pushdown WHERE i != 501000;
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 3.*
+analyzed_plan	<REGEX>:.*Total Files Read: [3-5].*

--- a/test/sql/stats/variant_shredded_stats.test
+++ b/test/sql/stats/variant_shredded_stats.test
@@ -10,7 +10,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS db2 (DATA_PATH '${DATA_PATH}/ducklake_variant_stats', METADATA_CATALOG 'dl')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS db2 (DATA_PATH '${DATA_PATH}/ducklake_variant_stats', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 use db2;

--- a/test/sql/table_changes/ducklake_table_deletions_compacted.test
+++ b/test/sql/table_changes/ducklake_table_deletions_compacted.test
@@ -50,6 +50,10 @@ INSERT INTO test SELECT i + 8000 FROM range(1000) t(i)
 statement ok
 INSERT INTO test SELECT i + 9000 FROM range(1000) t(i)
 
+# flush inlined data to create files for compaction
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 # compact all files into one
 statement ok
 CALL merge_adjacent_files()

--- a/test/sql/table_changes/ducklake_table_insertions.test
+++ b/test/sql/table_changes/ducklake_table_insertions.test
@@ -25,30 +25,33 @@ INSERT INTO ducklake.test VALUES (1);
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 3
+# snapshot 4
 statement ok
 INSERT INTO ducklake.test VALUES (2);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 4
+# snapshot 6
 statement ok
 INSERT INTO ducklake.test VALUES (3);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 5
+# snapshot 8
 statement ok
 INSERT INTO ducklake.test VALUES (NULL);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 6
+# snapshot 10
 statement ok
 INSERT INTO ducklake.test FROM range(10, 12);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
@@ -61,36 +64,36 @@ SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 2)
 0	1
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 3);
-----
-0	1
-1	2
-
-query II
 SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4);
 ----
 0	1
 1	2
+
+query II
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6);
+----
+0	1
+1	2
 2	3
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 4, 5);
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 6, 8);
 ----
 2	3
 3	NULL
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 5, 5);
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 8, 8);
 ----
 3	NULL
 
-# snapshot 7: merge (no data changes, just reorganization)
-# snapshot 8: update a subset of the rows
+# snapshot 12: merge (no data changes, just reorganization)
+# snapshot 13: update a subset of the rows
 statement ok
 UPDATE ducklake.test SET i=i+100 WHERE i < 11;
 
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 8, 8) ORDER BY rowid
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 13, 13) ORDER BY rowid
 ----
 0	101
 1	102
@@ -99,7 +102,7 @@ SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 8, 8)
 
 # the change feed has both the original rows and the updated rows
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 8) ORDER BY ALL
+SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 13) ORDER BY ALL
 ----
 0	1
 0	101

--- a/test/sql/table_changes/ducklake_table_insertions.test
+++ b/test/sql/table_changes/ducklake_table_insertions.test
@@ -39,6 +39,9 @@ statement ok
 INSERT INTO ducklake.test FROM range(10, 12);
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 CALL ducklake_merge_adjacent_files('ducklake');
 
 query II

--- a/test/sql/table_changes/ducklake_table_insertions.test
+++ b/test/sql/table_changes/ducklake_table_insertions.test
@@ -14,39 +14,34 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_table_insertions_files');
 
-# snapshot 1
 statement ok
 CREATE TABLE ducklake.test(i INTEGER);
 
-# snapshot 2
+# 5 inserts, each followed by flush
 statement ok
 INSERT INTO ducklake.test VALUES (1);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 4
 statement ok
 INSERT INTO ducklake.test VALUES (2);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 6
 statement ok
 INSERT INTO ducklake.test VALUES (3);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 8
 statement ok
 INSERT INTO ducklake.test VALUES (NULL);
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# snapshot 10
 statement ok
 INSERT INTO ducklake.test FROM range(10, 12);
 
@@ -58,42 +53,68 @@ SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_f
 ----
 test	5	1
 
+# Compute insert snapshot IDs dynamically (differs between inline and non-inline modes)
+statement ok
+PREPARE ti AS SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', $1, $2) ORDER BY ALL;
+
+# s1..s5 = snapshot IDs for the 1st through 5th inserts into table 1
+statement ok
+SET VARIABLE s1 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 1);
+
+statement ok
+SET VARIABLE s2 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 2);
+
+statement ok
+SET VARIABLE s3 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 3);
+
+statement ok
+SET VARIABLE s4 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 4);
+
+# Insertions from start through 1st insert
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 2);
+EXECUTE ti(0, getvariable('s1'));
 ----
 0	1
 
+# Insertions from start through 2nd insert
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 4);
+EXECUTE ti(0, getvariable('s2'));
 ----
 0	1
 1	2
 
+# Insertions from start through 3rd insert
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 6);
+EXECUTE ti(0, getvariable('s3'));
 ----
 0	1
 1	2
 2	3
 
+# Insertions from 3rd through 4th insert
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 6, 8);
+EXECUTE ti(getvariable('s3'), getvariable('s4'));
 ----
 2	3
 3	NULL
 
+# Insertions at 4th insert only
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 8, 8);
+EXECUTE ti(getvariable('s4'), getvariable('s4'));
 ----
 3	NULL
 
-# snapshot 12: merge (no data changes, just reorganization)
-# snapshot 13: update a subset of the rows
+# merge (no data changes, just reorganization)
+# then update a subset of the rows
 statement ok
 UPDATE ducklake.test SET i=i+100 WHERE i < 11;
 
+# s_update = snapshot ID of the UPDATE (the next insert-related snapshot after the 5th)
+statement ok
+SET VARIABLE s_update = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) as rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 6);
+
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 13, 13) ORDER BY rowid
+EXECUTE ti(getvariable('s_update'), getvariable('s_update'));
 ----
 0	101
 1	102
@@ -102,7 +123,7 @@ SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 13, 1
 
 # the change feed has both the original rows and the updated rows
 query II
-SELECT rowid, * FROM ducklake_table_insertions('ducklake', 'main', 'test', 0, 13) ORDER BY ALL
+EXECUTE ti(0, getvariable('s_update'));
 ----
 0	1
 0	101

--- a/test/sql/transaction/basic_transaction.test
+++ b/test/sql/transaction/basic_transaction.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -57,17 +57,12 @@ statement ok
 BEGIN
 
 statement ok
-INSERT INTO test SELECT i, i*2 FROM range(20) t(i)
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
+INSERT INTO test VALUES (42, 84)
 
 query II
-SELECT * FROM test LIMIT 3
+SELECT * FROM test
 ----
-0	0
-1	2
-2	4
+42	84
 
 # the data exists as files in the data directory
 query I
@@ -79,10 +74,9 @@ statement ok
 ROLLBACK
 
 # rolling back deletes the rows from the table
-query I
-SELECT COUNT(*) FROM test
+query II
+SELECT * FROM test
 ----
-0
 
 # it also deletes the written files from the data directory
 query I

--- a/test/sql/transaction/basic_transaction.test
+++ b/test/sql/transaction/basic_transaction.test
@@ -11,7 +11,6 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test needs physical files to verify transaction rollback cleanup
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta')
 
@@ -57,7 +56,6 @@ CREATE TABLE test(i INTEGER, j INTEGER);
 statement ok
 BEGIN
 
-# Insert more than DATA_INLINING_ROW_LIMIT (10) rows so flush creates a parquet file
 statement ok
 INSERT INTO test SELECT i, i*2 FROM range(20) t(i)
 

--- a/test/sql/transaction/basic_transaction.test
+++ b/test/sql/transaction/basic_transaction.test
@@ -11,8 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# Disable inlining - this test needs physical files to verify transaction rollback cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake

--- a/test/sql/transaction/basic_transaction.test
+++ b/test/sql/transaction/basic_transaction.test
@@ -57,13 +57,19 @@ CREATE TABLE test(i INTEGER, j INTEGER);
 statement ok
 BEGIN
 
+# Insert more than DATA_INLINING_ROW_LIMIT (10) rows so flush creates a parquet file
 statement ok
-INSERT INTO test VALUES (42, 84)
+INSERT INTO test SELECT i, i*2 FROM range(20) t(i)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query II
-SELECT * FROM test
+SELECT * FROM test LIMIT 3
 ----
-42	84
+0	0
+1	2
+2	4
 
 # the data exists as files in the data directory
 query I
@@ -75,9 +81,10 @@ statement ok
 ROLLBACK
 
 # rolling back deletes the rows from the table
-query II
-SELECT * FROM test
+query I
+SELECT COUNT(*) FROM test
 ----
+0
 
 # it also deletes the written files from the data directory
 query I

--- a/test/sql/transaction/basic_transaction.test
+++ b/test/sql/transaction/basic_transaction.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # Disable inlining - this test needs physical files to verify transaction rollback cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_tl_files', METADATA_CATALOG 'ducklake_meta')
 
 statement ok
 USE ducklake

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -11,8 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
+# Disable inlining - this test needs physical files to verify transaction conflict cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -11,9 +11,9 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test needs physical files to verify transaction conflict cleanup
+# Disable inlining, this test needs physical files to verify transaction conflict cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -11,7 +11,6 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining, this test needs physical files to verify transaction conflict cleanup
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
@@ -33,9 +32,6 @@ CREATE TABLE ducklake.test(s VARCHAR);
 
 statement ok con2
 INSERT INTO ducklake.test VALUES ('hello'), ('world');
-
-statement ok con2
-CALL ducklake_flush_inlined_data('ducklake')
 
 statement ok con1
 COMMIT

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -11,9 +11,10 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 test-env DATA_PATH __TEST_DIR__
 
 
-# Disable inlining - this test needs physical files to verify transaction conflict cleanup
+# Disable inlining - this test requires inlining to be set to 0, since we don't flush lines not commited
+# from inlined tables
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -34,6 +34,9 @@ CREATE TABLE ducklake.test(s VARCHAR);
 statement ok con2
 INSERT INTO ducklake.test VALUES ('hello'), ('world');
 
+statement ok con2
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok con1
 COMMIT
 

--- a/test/sql/transaction/transaction_conflict_cleanup.test
+++ b/test/sql/transaction/transaction_conflict_cleanup.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # Disable inlining - this test needs physical files to verify transaction conflict cleanup
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_files_conflict_cleanup')
 
 statement ok
 SET immediate_transaction_mode=true

--- a/test/sql/types/map.test
+++ b/test/sql/types/map.test
@@ -24,6 +24,9 @@ SELECT * FROM ducklake.test
 statement ok
 INSERT INTO ducklake.test VALUES (MAP {'i': 1, 'j': 2}), (MAP {'j': 3}), (NULL);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT * FROM ducklake.test
 ----
@@ -42,6 +45,9 @@ SELECT * FROM ducklake.test WHERE s.i=100
 
 statement ok
 INSERT INTO ducklake.test VALUES (MAP {'i': 4, 'j': 5}), (MAP {'i': 6});
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT * FROM ducklake.test

--- a/test/sql/update/update_partitioning.test
+++ b/test/sql/update/update_partitioning.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_update_partitioning', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_update_partitioning', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -28,13 +28,7 @@ statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(10000) t(i)
 
 statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
-statement ok
 UPDATE partitioned_tbl SET part_key=2 WHERE part_key=0
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 # verify files are partitioned
 query III
@@ -59,7 +53,7 @@ SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=2
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=2
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
 
 # query the old partition with time travel
 query I
@@ -70,4 +64,4 @@ SELECT COUNT(*) FROM partitioned_tbl AT (VERSION => 3) WHERE part_key=0
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl AT (VERSION => 3) WHERE part_key=0
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*

--- a/test/sql/update/update_partitioning.test
+++ b/test/sql/update/update_partitioning.test
@@ -28,7 +28,13 @@ statement ok
 INSERT INTO partitioned_tbl SELECT i%2, concat('thisisastring_', i) FROM range(10000) t(i)
 
 statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
 UPDATE partitioned_tbl SET part_key=2 WHERE part_key=0
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 # verify files are partitioned
 query III
@@ -53,7 +59,7 @@ SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=2
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=2
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*
 
 # query the old partition with time travel
 query I
@@ -64,4 +70,4 @@ SELECT COUNT(*) FROM partitioned_tbl AT (VERSION => 3) WHERE part_key=0
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl AT (VERSION => 3) WHERE part_key=0
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+analyzed_plan	<REGEX>:.*Total Files Read: [1-3].*

--- a/test/sql/update/update_rollback.test
+++ b/test/sql/update/update_rollback.test
@@ -17,6 +17,10 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/du
 statement ok
 CREATE TABLE ducklake.test AS SELECT 1000 + i id, i % 10 as val FROM range(1000) t(i);
 
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 statement ok
 BEGIN
 

--- a/test/sql/virtualcolumns/ducklake_virtual_columns.test
+++ b/test/sql/virtualcolumns/ducklake_virtual_columns.test
@@ -20,6 +20,9 @@ CREATE TABLE ducklake.test(i INTEGER);
 statement ok
 INSERT INTO ducklake.test VALUES (1), (2), (3);
 
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT file_row_number FROM ducklake.test
 ----


### PR DESCRIPTION
This PR makes data inlining the default behavior in DuckLake. Small inserts/deletes (up to 10 rows) are now stored directly in the catalog rather than creating separate Parquet files.

Due to this change, all tests are now also executed with inlining by default, so this PR implements many features and fixes related to inlining.

1.  ALTER TABLE Support with Inlined Data. We now support `ADD COLUMN`,`DROP COLUMN`, `RENAME TABLE`, `ALTER COLUMN TYPE`,`SET/DROP NOT NULL`.
2.  Expression Map Support in Inlined Data Reader.
3.  SQLite and Postgres now also support more data types and edge cases. In Postgres, varchars are now stored as `BYTEA` so we can support null bytes in them.

For testing, we adjusted tests whenever possible to make sure they can work with both inlining and not inlining, as in producing files in the correct numbers, in the same place, checking snapshots, and time-traveling. Due to the change in default behavior, a new CI was also added to ensure all tests are executed without using inlining.
