### PR TITLE
Respect `SET SORTED BY` for inserts

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -34,10 +34,10 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 //! Binds ORDER BY expressions directly using ExpressionBinder.
-static vector<BoundOrderByNode> BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
-                                               const vector<string> &column_names,
-                                               const vector<LogicalType> &column_types,
-                                               vector<OrderByNode> &pre_bound_orders) {
+vector<BoundOrderByNode> DuckLakeCompactor::BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
+                                                           const vector<string> &column_names,
+                                                           const vector<LogicalType> &column_types,
+                                                           vector<OrderByNode> &pre_bound_orders) {
 	// Create a child binder with the table columns in scope
 	auto child_binder = Binder::CreateBinder(binder.context, &binder);
 	child_binder->bind_context.AddGenericBinding(table_index, table_name, column_names, column_types);
@@ -362,7 +362,8 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 	auto table_index = bindings[0].table_index;
 
 	// Bind the ORDER BY expressions
-	auto orders = BindSortOrders(binder, table.name, table_index, current_columns, column_types, pre_bound_orders);
+	auto orders = DuckLakeCompactor::BindSortOrders(binder, table.name, table_index, current_columns, column_types,
+	                                                pre_bound_orders);
 
 	// Create the LogicalOrder operator
 	auto order = make_uniq<LogicalOrder>(std::move(orders));

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -47,13 +47,16 @@ vector<OrderByNode> DuckLakeCompactor::ParseSortOrders(const DuckLakeSort &sort_
 }
 
 //! Binds ORDER BY expressions directly using ExpressionBinder.
-vector<BoundOrderByNode> DuckLakeCompactor::BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
-                                                           const vector<string> &column_names,
-                                                           const vector<LogicalType> &column_types,
+vector<BoundOrderByNode> DuckLakeCompactor::BindSortOrders(Binder &binder, DuckLakeTableEntry &table,
+                                                           idx_t table_index,
                                                            vector<OrderByNode> &pre_bound_orders) {
+	auto &columns = table.GetColumns();
+	auto column_names = columns.GetColumnNames();
+	auto column_types = columns.GetColumnTypes();
+
 	// Create a child binder with the table columns in scope
 	auto child_binder = Binder::CreateBinder(binder.context, &binder);
-	child_binder->bind_context.AddGenericBinding(table_index, table_name, column_names, column_types);
+	child_binder->bind_context.AddGenericBinding(table_index, table.name, column_names, column_types);
 
 	// Bind each ORDER BY expression directly
 	vector<BoundOrderByNode> orders;
@@ -353,16 +356,11 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 	// Resolve types for the input plan (could be LogicalGet or LogicalProjection)
 	plan->ResolveOperatorTypes();
 
-	auto &columns = table.GetColumns();
-	auto current_columns = columns.GetColumnNames();
-	auto column_types = columns.GetColumnTypes();
-
 	D_ASSERT(!bindings.empty());
 	auto table_index = bindings[0].table_index;
 
 	// Bind the ORDER BY expressions
-	auto orders = DuckLakeCompactor::BindSortOrders(binder, table.name, table_index, current_columns, column_types,
-	                                                pre_bound_orders);
+	auto orders = DuckLakeCompactor::BindSortOrders(binder, table, table_index, pre_bound_orders);
 
 	// Create the LogicalOrder operator
 	auto order = make_uniq<LogicalOrder>(std::move(orders));

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -345,11 +345,7 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 	}
 
 	// Validate all column references in sort expressions exist in the table
-	vector<reference<ParsedExpression>> sort_expressions;
-	for (auto &pre_bound_order : pre_bound_orders) {
-		sort_expressions.push_back(*pre_bound_order.expression);
-	}
-	DuckLakeTableEntry::ValidateSortExpressionColumns(table, sort_expressions);
+	DuckLakeTableEntry::ValidateSortExpressionColumns(table, pre_bound_orders);
 
 	// Resolve types for the input plan (could be LogicalGet or LogicalProjection)
 	plan->ResolveOperatorTypes();

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -33,6 +33,19 @@ namespace duckdb {
 // Sort Binding Helpers
 //===--------------------------------------------------------------------===//
 
+//! Parses sort expressions from DuckLakeSort into OrderByNode vectors (DuckDB dialect only).
+vector<OrderByNode> DuckLakeCompactor::ParseSortOrders(const DuckLakeSort &sort_data) {
+	vector<OrderByNode> pre_bound_orders;
+	for (auto &field : sort_data.fields) {
+		if (field.dialect != "duckdb") {
+			continue;
+		}
+		auto parsed_expression = Parser::ParseExpressionList(field.expression);
+		pre_bound_orders.emplace_back(field.sort_direction, field.null_order, std::move(parsed_expression[0]));
+	}
+	return pre_bound_orders;
+}
+
 //! Binds ORDER BY expressions directly using ExpressionBinder.
 vector<BoundOrderByNode> DuckLakeCompactor::BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
                                                            const vector<string> &column_names,
@@ -328,17 +341,7 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 	auto bindings = plan->GetColumnBindings();
 
 	// Parse the sort expressions from the sort_data
-	vector<OrderByNode> pre_bound_orders;
-	for (auto &pre_bound_order : sort_data->fields) {
-		if (pre_bound_order.dialect != "duckdb") {
-			continue;
-		}
-		auto parsed_expression = Parser::ParseExpressionList(pre_bound_order.expression);
-		OrderByNode order_node(pre_bound_order.sort_direction, pre_bound_order.null_order,
-		                       std::move(parsed_expression[0]));
-		pre_bound_orders.emplace_back(std::move(order_node));
-	}
-
+	auto pre_bound_orders = DuckLakeCompactor::ParseSortOrders(*sort_data);
 	if (pre_bound_orders.empty()) {
 		// Then the sorts were not in the DuckDB dialect and we return the original plan
 		return std::move(plan);

--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -12,7 +12,7 @@ struct DuckLakeOptionMetadata {
 	const char *description;
 };
 
-using ducklake_option_array = std::array<DuckLakeOptionMetadata, 20>;
+using ducklake_option_array = std::array<DuckLakeOptionMetadata, 21>;
 
 static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
     {{"data_inlining_row_limit", "Maximum amount of rows to inline in a single insert"},
@@ -39,7 +39,8 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
      {"encrypted", "Whether or not to encrypt Parquet files written to the data path"},
      {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"},
      {"write_deletion_vectors", "[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion "
-                                "vectors (puffin) instead of positional delete files (parquet)"}}};
+                                "vectors (puffin) instead of positional delete files (parquet)"},
+     {"sort_on_insert", "Whether to sort data on INSERT according to SET SORTED BY (default: true)"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -98,6 +98,8 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else if (option == "write_deletion_vectors") {
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
+	} else if (option == "sort_on_insert") {
+		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -90,6 +90,7 @@ public:
 	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files);
 	static unique_ptr<LogicalOperator> InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
 	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data);
+	static vector<OrderByNode> ParseSortOrders(const DuckLakeSort &sort_data);
 	static vector<BoundOrderByNode> BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
 	                                               const vector<string> &column_names,
 	                                               const vector<LogicalType> &column_types,

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -90,6 +90,10 @@ public:
 	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files);
 	static unique_ptr<LogicalOperator> InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
 	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data);
+	static vector<BoundOrderByNode> BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
+	                                               const vector<string> &column_names,
+	                                               const vector<LogicalType> &column_types,
+	                                               vector<OrderByNode> &pre_bound_orders);
 
 private:
 	ClientContext &context;

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -91,9 +91,7 @@ public:
 	static unique_ptr<LogicalOperator> InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
 	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data);
 	static vector<OrderByNode> ParseSortOrders(const DuckLakeSort &sort_data);
-	static vector<BoundOrderByNode> BindSortOrders(Binder &binder, const string &table_name, idx_t table_index,
-	                                               const vector<string> &column_names,
-	                                               const vector<LogicalType> &column_types,
+	static vector<BoundOrderByNode> BindSortOrders(Binder &binder, DuckLakeTableEntry &table, idx_t table_index,
 	                                               vector<OrderByNode> &pre_bound_orders);
 
 private:

--- a/src/include/storage/ducklake_table_entry.hpp
+++ b/src/include/storage/ducklake_table_entry.hpp
@@ -123,8 +123,7 @@ public:
 	vector<column_t> GetRowIdColumns() const override;
 
 	//! Validates that all column references in sort expressions exist in the table
-	static void ValidateSortExpressionColumns(DuckLakeTableEntry &table,
-	                                          const vector<reference<ParsedExpression>> &expressions);
+	static void ValidateSortExpressionColumns(DuckLakeTableEntry &table, const vector<OrderByNode> &orders);
 
 private:
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, RenameTableInfo &info);

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -770,14 +770,7 @@ static optional_ptr<PhysicalOperator> PlanInsertSort(ClientContext &context, Phy
                                                      PhysicalOperator &plan, DuckLakeTableEntry &table,
                                                      optional_ptr<DuckLakeSort> sort_data) {
 	// Parse the sort expressions from the sort_data
-	vector<OrderByNode> pre_bound_orders;
-	for (auto &field : sort_data->fields) {
-		if (field.dialect != "duckdb") {
-			continue;
-		}
-		auto parsed_expression = Parser::ParseExpressionList(field.expression);
-		pre_bound_orders.emplace_back(field.sort_direction, field.null_order, std::move(parsed_expression[0]));
-	}
+	auto pre_bound_orders = DuckLakeCompactor::ParseSortOrders(*sort_data);
 	if (pre_bound_orders.empty()) {
 		return nullptr;
 	}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -815,15 +815,13 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 
 	// Sort data according to the table's SET SORTED BY configuration
 	auto sort_data = ducklake_table.GetSortData();
-	if (sort_data) {
-		auto &ducklake_schema_for_sort = ducklake_table.ParentSchema().Cast<DuckLakeSchemaEntry>();
-		bool sort_on_insert = GetConfigOption<string>("sort_on_insert", ducklake_schema_for_sort.GetSchemaId(),
-		                                              ducklake_table.GetTableId(), "true") == "true";
-		if (sort_on_insert) {
-			auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
-			if (sorted_plan) {
-				plan = sorted_plan;
-			}
+	auto &ducklake_schema_for_sort = ducklake_table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	bool sort_on_insert = GetConfigOption<string>("sort_on_insert", ducklake_schema_for_sort.GetSchemaId(),
+		                                         ducklake_table.GetTableId(), "true") == "true";
+	if (sort_data && sort_on_insert) {
+		auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
+		if (sorted_plan) {
+			plan = sorted_plan;
 		}
 	}
 
@@ -833,6 +831,17 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 	if (data_inlining_row_limit > 0) {
 		plan = planner.Make<DuckLakeInlineData>(*plan, data_inlining_row_limit);
 		inline_data = plan->Cast<DuckLakeInlineData>();
+
+		// When sort_on_insert=false but inlining is enabled, add sorting AFTER
+		// the inline data operator. Data that exceeds the inlining limit passes
+		// through to parquet files and must be sorted. Data that is inlined
+		// (absorbed by DuckLakeInlineData) never reaches this sort operator.
+		if (sort_data && !sort_on_insert) {
+			auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
+			if (sorted_plan) {
+				plan = sorted_plan;
+			}
+		}
 	}
 	DuckLakeCopyInput copy_input(context, ducklake_table);
 	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -783,13 +783,11 @@ static optional_ptr<PhysicalOperator> PlanInsertSort(ClientContext &context, Phy
 	}
 
 	// Validate all column references in sort expressions exist in the table
-	// If columns have been renamed and the sort expressions are stale, gracefully skip sorting
 	vector<reference<ParsedExpression>> sort_expressions;
 	for (auto &order : pre_bound_orders) {
 		sort_expressions.push_back(*order.expression);
 	}
 	DuckLakeTableEntry::ValidateSortExpressionColumns(table, sort_expressions);
-
 
 	// Bind the ORDER BY expressions
 	auto &columns = table.GetColumns();
@@ -834,9 +832,14 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 	// Sort data according to the table's SET SORTED BY configuration
 	auto sort_data = ducklake_table.GetSortData();
 	if (sort_data) {
-		auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
-		if (sorted_plan) {
-			plan = sorted_plan;
+		auto &ducklake_schema_for_sort = ducklake_table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+		bool sort_on_insert = GetConfigOption<string>("sort_on_insert", ducklake_schema_for_sort.GetSchemaId(),
+		                                              ducklake_table.GetTableId(), "true") == "true";
+		if (sort_on_insert) {
+			auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
+			if (sorted_plan) {
+				plan = sorted_plan;
+			}
 		}
 	}
 

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -779,14 +779,9 @@ static optional_ptr<PhysicalOperator> PlanInsertSort(ClientContext &context, Phy
 	DuckLakeTableEntry::ValidateSortExpressionColumns(table, pre_bound_orders);
 
 	// Bind the ORDER BY expressions
-	auto &columns = table.GetColumns();
-	auto column_names = columns.GetColumnNames();
-	auto column_types = columns.GetColumnTypes();
-
 	auto binder = Binder::CreateBinder(context);
 	idx_t table_index = 0;
-	auto orders = DuckLakeCompactor::BindSortOrders(*binder, table.name, table_index, column_names, column_types,
-	                                                pre_bound_orders);
+	auto orders = DuckLakeCompactor::BindSortOrders(*binder, table, table_index, pre_bound_orders);
 
 	// Convert BoundColumnRefExpression to BoundReferenceExpression for physical plan
 	for (auto &order : orders) {

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -9,14 +9,21 @@
 #include "storage/ducklake_inline_data.hpp"
 #include "storage/ducklake_geo_stats.hpp"
 #include "common/ducklake_types.hpp"
+#include "functions/ducklake_compaction_functions.hpp"
 
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
+#include "duckdb/execution/operator/order/physical_order.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/expression_binder.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/main/extension_helper.hpp"
@@ -749,6 +756,68 @@ string DuckLakeCatalog::GenerateEncryptionKey(ClientContext &context) const {
 	return string(char_ptr_cast(bytes), ENCRYPTION_KEY_SIZE);
 }
 
+static void ResolveColumnRefs(unique_ptr<Expression> &expr) {
+	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
+		auto &col_ref = expr->Cast<BoundColumnRefExpression>();
+		expr = make_uniq<BoundReferenceExpression>(col_ref.return_type,
+		                                           NumericCast<storage_t>(col_ref.binding.column_index));
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(*expr, [](unique_ptr<Expression> &child) { ResolveColumnRefs(child); });
+}
+
+static optional_ptr<PhysicalOperator> PlanInsertSort(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                     PhysicalOperator &plan, DuckLakeTableEntry &table,
+                                                     optional_ptr<DuckLakeSort> sort_data) {
+	// Parse the sort expressions from the sort_data
+	vector<OrderByNode> pre_bound_orders;
+	for (auto &field : sort_data->fields) {
+		if (field.dialect != "duckdb") {
+			continue;
+		}
+		auto parsed_expression = Parser::ParseExpressionList(field.expression);
+		pre_bound_orders.emplace_back(field.sort_direction, field.null_order, std::move(parsed_expression[0]));
+	}
+	if (pre_bound_orders.empty()) {
+		return nullptr;
+	}
+
+	// Validate all column references in sort expressions exist in the table
+	// If columns have been renamed and the sort expressions are stale, gracefully skip sorting
+	vector<reference<ParsedExpression>> sort_expressions;
+	for (auto &order : pre_bound_orders) {
+		sort_expressions.push_back(*order.expression);
+	}
+	DuckLakeTableEntry::ValidateSortExpressionColumns(table, sort_expressions);
+
+
+	// Bind the ORDER BY expressions
+	auto &columns = table.GetColumns();
+	auto column_names = columns.GetColumnNames();
+	auto column_types = columns.GetColumnTypes();
+
+	auto binder = Binder::CreateBinder(context);
+	idx_t table_index = 0;
+	auto orders = DuckLakeCompactor::BindSortOrders(*binder, table.name, table_index, column_names, column_types,
+	                                                pre_bound_orders);
+
+	// Convert BoundColumnRefExpression to BoundReferenceExpression for physical plan
+	for (auto &order : orders) {
+		ResolveColumnRefs(order.expression);
+	}
+
+	// Create identity projection map
+	vector<idx_t> projection_map;
+	for (idx_t i = 0; i < plan.types.size(); i++) {
+		projection_map.push_back(i);
+	}
+
+	auto &order_op = planner.Make<PhysicalOrder>(plan.types, std::move(orders), std::move(projection_map),
+	                                             plan.estimated_cardinality);
+	order_op.children.push_back(plan);
+	return &order_op;
+}
+
 PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
                                               optional_ptr<PhysicalOperator> plan) {
 	if (op.return_chunk) {
@@ -761,6 +830,16 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 	auto &ducklake_table = op.table.Cast<DuckLakeTableEntry>();
+
+	// Sort data according to the table's SET SORTED BY configuration
+	auto sort_data = ducklake_table.GetSortData();
+	if (sort_data) {
+		auto sorted_plan = PlanInsertSort(context, planner, *plan, ducklake_table, sort_data);
+		if (sorted_plan) {
+			plan = sorted_plan;
+		}
+	}
+
 	optional_ptr<DuckLakeInlineData> inline_data;
 
 	idx_t data_inlining_row_limit = GetInliningLimit(context, ducklake_table, plan->types);

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -783,11 +783,7 @@ static optional_ptr<PhysicalOperator> PlanInsertSort(ClientContext &context, Phy
 	}
 
 	// Validate all column references in sort expressions exist in the table
-	vector<reference<ParsedExpression>> sort_expressions;
-	for (auto &order : pre_bound_orders) {
-		sort_expressions.push_back(*order.expression);
-	}
-	DuckLakeTableEntry::ValidateSortExpressionColumns(table, sort_expressions);
+	DuckLakeTableEntry::ValidateSortExpressionColumns(table, pre_bound_orders);
 
 	// Bind the ORDER BY expressions
 	auto &columns = table.GetColumns();

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
@@ -102,12 +103,37 @@ DuckLakeTableEntry::DuckLakeTableEntry(DuckLakeTableEntry &parent, CreateTableIn
 	                                           local_change.is_column_new);
 }
 
+static void ReplaceColumnRefName(ParsedExpression &expr, const string &old_name, const string &new_name) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = expr.Cast<ColumnRefExpression>();
+		if (!colref.IsQualified() && StringUtil::CIEquals(colref.GetColumnName(), old_name)) {
+			colref.column_names.back() = new_name;
+		}
+		return;
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    expr, [&](ParsedExpression &child) { ReplaceColumnRefName(child, old_name, new_name); });
+}
+
 // ALTER TABLE RENAME COLUMN
 DuckLakeTableEntry::DuckLakeTableEntry(DuckLakeTableEntry &parent, CreateTableInfo &info, LocalChange local_change,
                                        const string &new_name)
     : DuckLakeTableEntry(parent, info, local_change) {
 	D_ASSERT(local_change.type == LocalChangeType::RENAME_COLUMN);
 	field_data = DuckLakeFieldData::RenameColumn(*field_data, local_change.field_index, new_name);
+	// Update sort expressions to reference the new column name
+	if (sort_data) {
+		auto old_field = parent.GetFieldData().GetByFieldIndex(local_change.field_index);
+		D_ASSERT(old_field);
+		auto &old_col_name = old_field->Name();
+		for (auto &sort_field : sort_data->fields) {
+			auto parsed = Parser::ParseExpressionList(sort_field.expression);
+			if (!parsed.empty()) {
+				ReplaceColumnRefName(*parsed[0], old_col_name, new_name);
+				sort_field.expression = parsed[0]->ToString();
+			}
+		}
+	}
 }
 
 // ALTER TABLE DROP COLUMN

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -394,11 +394,11 @@ string GetPartitionColumnName(ColumnRefExpression &colref) {
 }
 
 void DuckLakeTableEntry::ValidateSortExpressionColumns(DuckLakeTableEntry &table,
-                                                       const vector<reference<ParsedExpression>> &expressions) {
+                                                       const vector<OrderByNode> &orders) {
 	vector<string> missing_columns;
-	for (auto &expr : expressions) {
+	for (auto &order : orders) {
 		ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
-		    expr.get(), [&](const ColumnRefExpression &colref) {
+		    *order.expression, [&](const ColumnRefExpression &colref) {
 			    if (colref.IsQualified()) {
 				    throw InvalidInputException(
 				        "Unexpected qualified column reference - only unqualified columns are supported");
@@ -1193,11 +1193,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	}
 
 	// Validate all column references in all sort expressions
-	vector<reference<ParsedExpression>> sort_expressions;
-	for (auto &order_node : info.orders) {
-		sort_expressions.push_back(*order_node.expression);
-	}
-	ValidateSortExpressionColumns(*this, sort_expressions);
+	ValidateSortExpressionColumns(*this, info.orders);
 
 	auto sort_data = make_uniq<DuckLakeSort>();
 	sort_data->sort_id = transaction.GetLocalCatalogId();

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1624,6 +1624,11 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 			transaction_changes.altered_tables_with_schema_version_changes.insert(table_id);
 			if (local_change.type == LocalChangeType::RENAME_COLUMN) {
 				column_schema_change = true;
+				// persist updated sort expressions (column name was updated in the table entry)
+				if (table.GetSortData()) {
+					auto sort_key = GetNewSortKey(commit_state, table);
+					result.new_sort_keys.push_back(std::move(sort_key));
+				}
 			}
 			break;
 		}

--- a/test/sql/sorted_table/data_inlining_flush_sorted_renamed.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_renamed.test
@@ -1,5 +1,5 @@
 # name: test/sql/sorted_table/data_inlining_flush_sorted_renamed.test
-# description: if column names have changed, inlining flush should fail until sorted by valid column names
+# description: if column names have changed, insert and flush should fail until sorted by valid column names
 # group: [sorted_table]
 
 require ducklake
@@ -14,7 +14,7 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_inlining_flush_data_renamed', DATA_INLINING_ROW_LIMIT 10)
 
-# SET SORTED BY then rename columns - flush should error on missing columns
+# SET SORTED BY then rename columns - insert should error on missing columns
 statement ok
 CREATE TABLE ducklake.renamed_columns_test (unique_id INTEGER, sort_key_1 INTEGER, sort_key_2 VARCHAR);
 
@@ -28,7 +28,23 @@ ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1
 statement ok
 ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert data (will be inlined initially)
+# Insert should fail because the sort expressions reference old column names
+statement error
+INSERT INTO ducklake.renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
+FROM range(5) t(i)
+SELECT
+    i AS unique_id,
+    i % 2 AS sort_key_1_changed,
+    'woot' || i AS sort_key_2_changed
+;
+----
+Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
+
+# Fix the sort expression to use the new column names
+statement ok
+ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
+
+# Now insert succeeds and data is sorted
 statement ok
 INSERT INTO ducklake.renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
 FROM range(5) t(i)
@@ -38,15 +54,6 @@ SELECT
     'woot' || i AS sort_key_2_changed
 ;
 
-# Flush should fail because the sort columns no longer exist
-statement error
-CALL ducklake_flush_inlined_data('ducklake', table_name => 'renamed_columns_test');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
-
-statement ok
-ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
-
-# Once sorting the new column names, we succeed
+# Flush also succeeds
 statement ok
 CALL ducklake_flush_inlined_data('ducklake', table_name => 'renamed_columns_test');

--- a/test/sql/sorted_table/data_inlining_flush_sorted_renamed.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_renamed.test
@@ -28,23 +28,7 @@ ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1
 statement ok
 ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert should fail because the sort expressions reference old column names
-statement error
-INSERT INTO ducklake.renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(5) t(i)
-SELECT
-    i AS unique_id,
-    i % 2 AS sort_key_1_changed,
-    'woot' || i AS sort_key_2_changed
-;
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
-
-# Fix the sort expression to use the new column names
-statement ok
-ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
-
-# Now insert succeeds and data is sorted
+# Insert succeeds because sort expressions are updated during rename
 statement ok
 INSERT INTO ducklake.renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
 FROM range(5) t(i)

--- a/test/sql/sorted_table/data_inlining_flush_sorted_transaction_renamed.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_transaction_renamed.test
@@ -69,7 +69,7 @@ ORDER BY
 	 i DESC
 ;
 
-# First 5 rows should reflect the sort order, second 5 rows should reflect insertion order
+# Both batches should reflect the sort order (sort_key_1 ASC, sort_key_2 ASC)
 query IIII
 FROM ducklake.renamed_columns_test
 ----
@@ -78,11 +78,11 @@ FROM ducklake.renamed_columns_test
 4	0	woot4	NULL
 1	1	woot1	NULL
 3	1	woot3	NULL
-9	1	woot9	NULL
-8	0	woot8	NULL
-7	1	woot7	NULL
 6	0	woot6	NULL
+8	0	woot8	NULL
 5	1	woot5	NULL
+7	1	woot7	NULL
+9	1	woot9	NULL
 
 
 statement ok

--- a/test/sql/sorted_table/data_inlining_flush_sorted_transaction_renamed.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_transaction_renamed.test
@@ -1,5 +1,5 @@
 # name: test/sql/sorted_table/data_inlining_flush_sorted_transaction_renamed.test
-# description: if column names have changed, inlining flush should fail until sorted by valid column names
+# description: sort expressions should be updated when columns are renamed
 # group: [sorted_table]
 
 # Irrelevant alter table
@@ -98,46 +98,12 @@ ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1 ASC NULLS LA
 statement ok
 ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_renamed;
 
-statement error
-CALL ducklake_flush_inlined_data('ducklake', table_name => 'renamed_columns_test');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1
-
-statement ok
-ROLLBACK 
-
-# Now it should all succeed!
-statement ok
-BEGIN
-
-# Alter a column in the table to reflect 
-statement ok
-ALTER TABLE ducklake.renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_renamed;
-
-statement ok
-ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_renamed ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
-
+# Flush succeeds because sort expressions are updated during rename
 statement ok
 CALL ducklake_flush_inlined_data('ducklake', table_name => 'renamed_columns_test');
 
-# The order is already reflected within the commit
-query IIII
-FROM ducklake.renamed_columns_test
-----
-0	0	woot0	NULL
-2	0	woot2	NULL
-4	0	woot4	NULL
-1	1	woot1	NULL
-3	1	woot3	NULL
-6	0	woot6	NULL
-8	0	woot8	NULL
-5	1	woot5	NULL
-7	1	woot7	NULL
-9	1	woot9	NULL
-
-
 statement ok
-COMMIT 
+COMMIT
 
 query IIII
 FROM ducklake.renamed_columns_test

--- a/test/sql/sorted_table/insert_sorted_basic.test
+++ b/test/sql/sorted_table/insert_sorted_basic.test
@@ -107,25 +107,6 @@ SELECT * FROM ducklake.test_insert_select
 4
 5
 
-# NULL values with NULLS LAST (default for ASC)
-statement ok
-CREATE TABLE ducklake.test_nulls(i INTEGER)
-
-statement ok
-ALTER TABLE ducklake.test_nulls SET SORTED BY (i ASC NULLS LAST)
-
-statement ok
-INSERT INTO ducklake.test_nulls VALUES (3), (NULL), (1), (NULL), (2)
-
-query I
-SELECT * FROM ducklake.test_nulls
-----
-1
-2
-3
-NULL
-NULL
-
 # NULL values with NULLS FIRST
 statement ok
 CREATE TABLE ducklake.test_nulls_first(i INTEGER)
@@ -144,22 +125,6 @@ NULL
 1
 2
 3
-
-# no sort data - insertion order preserved
-statement ok
-CREATE TABLE ducklake.test_nosort(i INTEGER)
-
-statement ok
-INSERT INTO ducklake.test_nosort VALUES (3), (1), (5), (2), (4)
-
-query I
-SELECT * FROM ducklake.test_nosort
-----
-3
-1
-5
-2
-4
 
 # RESET SORTED BY then INSERT - should not sort
 statement ok
@@ -183,12 +148,12 @@ SELECT * FROM ducklake.test_reset
 2
 4
 
-# list type column with sort on a different column
+# list type column 
 statement ok
 CREATE TABLE ducklake.test_complex(i INTEGER, l INTEGER[])
 
 statement ok
-ALTER TABLE ducklake.test_complex SET SORTED BY (i DESC)
+ALTER TABLE ducklake.test_complex SET SORTED BY (l DESC)
 
 statement ok
 INSERT INTO ducklake.test_complex VALUES (1, [10, 20]), (3, [30]), (2, [40, 50, 60])
@@ -196,6 +161,6 @@ INSERT INTO ducklake.test_complex VALUES (1, [10, 20]), (3, [30]), (2, [40, 50, 
 query II
 SELECT * FROM ducklake.test_complex
 ----
-3	[30]
 2	[40, 50, 60]
+3	[30]
 1	[10, 20]

--- a/test/sql/sorted_table/insert_sorted_basic.test
+++ b/test/sql/sorted_table/insert_sorted_basic.test
@@ -1,0 +1,201 @@
+# name: test/sql/sorted_table/insert_sorted_basic.test
+# description: test that INSERT operations automatically sort data according to SET SORTED BY
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/insert_sorted_basic')
+
+# basic integer sort DESC
+statement ok
+CREATE TABLE ducklake.test_int(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_int SET SORTED BY (i DESC)
+
+statement ok
+INSERT INTO ducklake.test_int VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_int
+----
+5
+4
+3
+2
+1
+
+# basic integer sort ASC
+statement ok
+CREATE TABLE ducklake.test_asc(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_asc SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_asc VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_asc
+----
+1
+2
+3
+4
+5
+
+# multiple sort columns
+statement ok
+CREATE TABLE ducklake.test_multi(a INTEGER, b VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.test_multi SET SORTED BY (a ASC, b DESC)
+
+statement ok
+INSERT INTO ducklake.test_multi VALUES (2, 'x'), (1, 'b'), (1, 'a'), (2, 'z'), (1, 'c')
+
+query II
+SELECT * FROM ducklake.test_multi
+----
+1	c
+1	b
+1	a
+2	z
+2	x
+
+# string sort
+statement ok
+CREATE TABLE ducklake.test_str(s VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.test_str SET SORTED BY (s ASC)
+
+statement ok
+INSERT INTO ducklake.test_str VALUES ('banana'), ('apple'), ('cherry'), ('date')
+
+query I
+SELECT * FROM ducklake.test_str
+----
+apple
+banana
+cherry
+date
+
+# INSERT ... SELECT
+statement ok
+CREATE TABLE ducklake.test_insert_select(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_insert_select SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_insert_select SELECT * FROM (VALUES (5), (3), (1), (4), (2)) t(i)
+
+query I
+SELECT * FROM ducklake.test_insert_select
+----
+1
+2
+3
+4
+5
+
+# NULL values with NULLS LAST (default for ASC)
+statement ok
+CREATE TABLE ducklake.test_nulls(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_nulls SET SORTED BY (i ASC NULLS LAST)
+
+statement ok
+INSERT INTO ducklake.test_nulls VALUES (3), (NULL), (1), (NULL), (2)
+
+query I
+SELECT * FROM ducklake.test_nulls
+----
+1
+2
+3
+NULL
+NULL
+
+# NULL values with NULLS FIRST
+statement ok
+CREATE TABLE ducklake.test_nulls_first(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_nulls_first SET SORTED BY (i ASC NULLS FIRST)
+
+statement ok
+INSERT INTO ducklake.test_nulls_first VALUES (3), (NULL), (1), (NULL), (2)
+
+query I
+SELECT * FROM ducklake.test_nulls_first
+----
+NULL
+NULL
+1
+2
+3
+
+# no sort data - insertion order preserved
+statement ok
+CREATE TABLE ducklake.test_nosort(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.test_nosort VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_nosort
+----
+3
+1
+5
+2
+4
+
+# RESET SORTED BY then INSERT - should not sort
+statement ok
+CREATE TABLE ducklake.test_reset(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_reset SET SORTED BY (i ASC)
+
+statement ok
+ALTER TABLE ducklake.test_reset RESET SORTED BY
+
+statement ok
+INSERT INTO ducklake.test_reset VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_reset
+----
+3
+1
+5
+2
+4
+
+# list type column with sort on a different column
+statement ok
+CREATE TABLE ducklake.test_complex(i INTEGER, l INTEGER[])
+
+statement ok
+ALTER TABLE ducklake.test_complex SET SORTED BY (i DESC)
+
+statement ok
+INSERT INTO ducklake.test_complex VALUES (1, [10, 20]), (3, [30]), (2, [40, 50, 60])
+
+query II
+SELECT * FROM ducklake.test_complex
+----
+3	[30]
+2	[40, 50, 60]
+1	[10, 20]

--- a/test/sql/sorted_table/insert_sorted_expression.test
+++ b/test/sql/sorted_table/insert_sorted_expression.test
@@ -48,21 +48,48 @@ SELECT * FROM ducklake.test_arith
 2	2
 1	2
 
-# sort by expression: negative / unary
+# sort by multiple expressions: primary sort on length(name), secondary on (a * b) DESC
 statement ok
-CREATE TABLE ducklake.test_neg(i INTEGER)
+CREATE TABLE ducklake.test_multi_expr(a INTEGER, b INTEGER, name VARCHAR)
 
 statement ok
-ALTER TABLE ducklake.test_neg SET SORTED BY ((-i) ASC)
+ALTER TABLE ducklake.test_multi_expr SET SORTED BY (length(name) ASC, (a * b) DESC)
 
 statement ok
-INSERT INTO ducklake.test_neg VALUES (3), (1), (5), (2), (4)
+INSERT INTO ducklake.test_multi_expr VALUES (3, 4, 'ab'), (2, 5, 'abc'), (1, 1, 'ab'), (5, 2, 'abc'), (7, 1, 'a')
 
-query I
-SELECT * FROM ducklake.test_neg
+# length('a')=1, length('ab')=2, length('abc')=3
+# within length=2: (3*4)=12 > (1*1)=1
+# within length=3: (2*5)=10 = (5*2)=10 (stable order)
+query III
+SELECT * FROM ducklake.test_multi_expr
 ----
-5
-4
-3
-2
-1
+7	1	a
+3	4	ab
+1	1	ab
+2	5	abc
+5	2	abc
+
+# sort by complex nested expression: concat(substr(power(unique_id, unique_id)::varchar, 1, 1), name)
+statement ok
+CREATE TABLE ducklake.test_nested_expr(unique_id BIGINT, name VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.test_nested_expr SET SORTED BY (concat(substr(power(unique_id, unique_id)::varchar, 1, 1), name) ASC NULLS LAST)
+
+statement ok
+INSERT INTO ducklake.test_nested_expr VALUES (1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, 'five'), (6, 'six'), (7, 'seven'), (8, 'eight')
+
+query III
+SELECT *, concat(substr(power(unique_id, unique_id)::varchar, 1, 1), name) as sort_col 
+FROM ducklake.test_nested_expr
+----
+8	eight	1eight
+1	one	1one
+4	four	2four
+3	three	2three
+5	five	3five
+6	six	4six
+2	two	4two
+7	seven	8seven
+

--- a/test/sql/sorted_table/insert_sorted_expression.test
+++ b/test/sql/sorted_table/insert_sorted_expression.test
@@ -1,0 +1,68 @@
+# name: test/sql/sorted_table/insert_sorted_expression.test
+# description: test that INSERT operations sort data using expression-based sort keys
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/insert_sorted_expr')
+
+# sort by expression: concat
+statement ok
+CREATE TABLE ducklake.test_concat(first_name VARCHAR, last_name VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.test_concat SET SORTED BY (concat(last_name, ', ', first_name) ASC)
+
+statement ok
+INSERT INTO ducklake.test_concat VALUES ('John', 'Smith'), ('Alice', 'Brown'), ('Bob', 'Johnson')
+
+query II
+SELECT * FROM ducklake.test_concat
+----
+Alice	Brown
+Bob	Johnson
+John	Smith
+
+# sort by expression: arithmetic
+statement ok
+CREATE TABLE ducklake.test_arith(a INTEGER, b INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_arith SET SORTED BY ((a + b) DESC)
+
+statement ok
+INSERT INTO ducklake.test_arith VALUES (1, 2), (5, 1), (2, 2), (3, 5)
+
+query II
+SELECT * FROM ducklake.test_arith
+----
+3	5
+5	1
+2	2
+1	2
+
+# sort by expression: negative / unary
+statement ok
+CREATE TABLE ducklake.test_neg(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_neg SET SORTED BY ((-i) ASC)
+
+statement ok
+INSERT INTO ducklake.test_neg VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_neg
+----
+5
+4
+3
+2
+1

--- a/test/sql/sorted_table/insert_sorted_macro_expression.test
+++ b/test/sql/sorted_table/insert_sorted_macro_expression.test
@@ -1,0 +1,90 @@
+# name: test/sql/sorted_table/insert_sorted_macro_expression.test
+# description: test that INSERT operations sort data using a DuckLake macro in SET SORTED BY
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/insert_sorted_macro_expr')
+
+statement ok
+USE ducklake;
+
+# create the zip_varchar macro
+statement ok
+CREATE MACRO zip_varchar(i, j, num_chars := 6) AS (
+    [
+       list_value(z[1], z[2])
+       FOR z
+       IN list_zip(
+          substr(i, 1, num_chars).rpad(num_chars, ' ').string_split(''),
+          substr(j, 1, num_chars).rpad(num_chars, ' ').string_split('')
+       )
+    ].flatten().array_to_string('')
+);
+
+# verify the macro works independently
+query I
+SELECT zip_varchar('ABC', 'XYZ', num_chars := 3)
+----
+AXBYCZ
+
+# create table and set sorted by the macro expression
+statement ok
+CREATE TABLE macro_sort_insert(i VARCHAR, j VARCHAR)
+
+statement ok
+ALTER TABLE macro_sort_insert SET SORTED BY (zip_varchar(i, j, num_chars := 3) ASC NULLS LAST)
+
+statement ok
+INSERT INTO macro_sort_insert VALUES ('ZYX', 'CBA'), ('ABC', 'XYZ'), ('321', '000'), ('123', '000')
+
+query III
+SELECT i, j, zip_varchar(i, j, num_chars := 3) FROM macro_sort_insert
+----
+123	000	102030
+321	000	302010
+ABC	XYZ	AXBYCZ
+ZYX	CBA	ZCYBXA
+
+# second insert also gets sorted
+statement ok
+INSERT INTO macro_sort_insert VALUES ('MMM', 'NNN'), ('AAA', 'AAA'), ('ZZZ', 'ZZZ')
+
+query III
+SELECT i, j, zip_varchar(i, j, num_chars := 3) FROM macro_sort_insert
+----
+123	000	102030
+321	000	302010
+ABC	XYZ	AXBYCZ
+ZYX	CBA	ZCYBXA
+AAA	AAA	AAAAAA
+MMM	NNN	MNMNMN
+ZZZ	ZZZ	ZZZZZZ
+
+# RESET SORTED BY - subsequent insert should not sort
+statement ok
+ALTER TABLE macro_sort_insert RESET SORTED BY
+
+statement ok
+INSERT INTO macro_sort_insert VALUES ('PPP', 'QQQ'), ('BBB', 'CCC')
+
+# new rows should be in insertion order
+query III
+SELECT i, j, zip_varchar(i, j, num_chars := 3) FROM macro_sort_insert
+----
+123	000	102030
+321	000	302010
+ABC	XYZ	AXBYCZ
+ZYX	CBA	ZCYBXA
+AAA	AAA	AAAAAA
+MMM	NNN	MNMNMN
+ZZZ	ZZZ	ZZZZZZ
+PPP	QQQ	PQPQPQ
+BBB	CCC	BCBCBC

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -144,6 +144,10 @@ CREATE TABLE ducklake.test_compaction(i INTEGER)
 statement ok
 ALTER TABLE ducklake.test_compaction SET SORTED BY (i ASC)
 
+# Disable inlining to test compaction behavior
+statement ok 
+CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 'test_compaction')
+
 statement ok
 INSERT INTO ducklake.test_compaction VALUES (5), (3), (1)
 

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -8,6 +8,8 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
+test-env DUCKLAKE_CONNECTION_2 __TEST_DIR__/{UUID}_2.db
+
 test-env DATA_PATH __TEST_DIR__
 
 statement ok
@@ -189,7 +191,7 @@ statement ok
 DETACH ducklake
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake2 (DATA_PATH '${DATA_PATH}/sort_on_insert_flush', DATA_INLINING_ROW_LIMIT 10)
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION_2}' AS ducklake2 (DATA_PATH '${DATA_PATH}/sort_on_insert_flush', DATA_INLINING_ROW_LIMIT 10)
 
 statement ok
 CALL ducklake_set_option('ducklake2', 'sort_on_insert', 'false')

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -199,7 +199,7 @@ ALTER TABLE ducklake2.test_flush SET SORTED BY (i DESC)
 statement ok
 INSERT INTO ducklake2.test_flush  VALUES (1), (0), (3), (2), (4)
 
-# data is inlined, not sorted on insert
+# sort_on_insert is disabled
 query I
 SELECT * FROM ducklake2.test_flush
 ----
@@ -230,6 +230,88 @@ SELECT * FROM ducklake2.test_flush
 2
 1
 0
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/sort_on_insert_flush/**')
+----
+1
+
+statement ok
+CALL ducklake_set_option('ducklake2', 'sort_on_insert', 'true')
+
+# Insert more than the inlining limit. This should be sorted on insert (now that sort_on_insert is re-enabled).
+statement ok
+INSERT INTO ducklake2.test_flush 
+VALUES (15), (16), (17), (18), (19), (14), (13), (12), (11), (10), (20)
+
+query I
+SELECT * FROM ducklake2.test_flush
+----
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+20
+19
+18
+17
+16
+15
+14
+13
+12
+11
+10
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/sort_on_insert_flush/**')
+----
+2
+
+# Insert less than the inlining limit. This will be sorted on insert also
+statement ok
+INSERT INTO ducklake2.test_flush 
+VALUES (22), (21), (23)
+
+query I
+SELECT * FROM ducklake2.test_flush
+----
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+20
+19
+18
+17
+16
+15
+14
+13
+12
+11
+10
+23
+22
+21
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/sort_on_insert_flush/**')
+----
+2
+
 
 # -----------------------------------------------
 # Test 7: Invalid input - non-boolean value throws error

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -1,0 +1,244 @@
+# name: test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+# description: test the sort_on_insert option to control whether INSERT sorts data
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/sort_on_insert_option')
+
+# -----------------------------------------------
+# Test 1: Default behavior - INSERT sorts (sort_on_insert not set, defaults to true)
+# -----------------------------------------------
+statement ok
+CREATE TABLE ducklake.test_default(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_default SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_default VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_default
+----
+1
+2
+3
+4
+5
+
+# -----------------------------------------------
+# Test 2: sort_on_insert=false globally - INSERT does NOT sort
+# -----------------------------------------------
+statement ok
+CALL ducklake_set_option('ducklake', 'sort_on_insert', 'false')
+
+statement ok
+CREATE TABLE ducklake.test_global_false(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_global_false SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_global_false VALUES (3), (1), (5), (2), (4)
+
+# data should NOT be sorted - insertion order preserved
+query I
+SELECT * FROM ducklake.test_global_false
+----
+3
+1
+5
+2
+4
+
+# -----------------------------------------------
+# Test 3: sort_on_insert=true explicitly - INSERT sorts
+# -----------------------------------------------
+statement ok
+CALL ducklake_set_option('ducklake', 'sort_on_insert', 'true')
+
+statement ok
+CREATE TABLE ducklake.test_explicit_true(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_explicit_true SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_explicit_true VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_explicit_true
+----
+1
+2
+3
+4
+5
+
+# -----------------------------------------------
+# Test 4: Table-scoped sort_on_insert=false - only that table skips sorting
+# -----------------------------------------------
+
+# reset global to default (true)
+statement ok
+CALL ducklake_set_option('ducklake', 'sort_on_insert', 'true')
+
+statement ok
+CREATE TABLE ducklake.test_table_scoped(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_table_scoped SET SORTED BY (i ASC)
+
+statement ok
+CALL ducklake.set_option('sort_on_insert', 'false', table_name => 'test_table_scoped')
+
+statement ok
+INSERT INTO ducklake.test_table_scoped VALUES (3), (1), (5), (2), (4)
+
+# this table should NOT be sorted
+query I
+SELECT * FROM ducklake.test_table_scoped
+----
+3
+1
+5
+2
+4
+
+# another table should still sort
+statement ok
+CREATE TABLE ducklake.test_other_table(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_other_table SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_other_table VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_other_table
+----
+1
+2
+3
+4
+5
+
+# -----------------------------------------------
+# Test 5: Compaction still sorts when sort_on_insert=false
+# -----------------------------------------------
+statement ok
+CALL ducklake_set_option('ducklake', 'sort_on_insert', 'false')
+
+statement ok
+CREATE TABLE ducklake.test_compaction(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_compaction SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_compaction VALUES (5), (3), (1)
+
+statement ok
+INSERT INTO ducklake.test_compaction VALUES (4), (2), (6)
+
+# data is NOT sorted on insert
+query I
+SELECT * FROM ducklake.test_compaction
+----
+5
+3
+1
+4
+2
+6
+
+# compaction should still sort
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'test_compaction')
+----
+test_compaction	2	1
+
+# after compaction, data should be sorted
+query I
+SELECT * FROM ducklake.test_compaction
+----
+1
+2
+3
+4
+5
+6
+
+# -----------------------------------------------
+# Test 6: Flush still sorts when sort_on_insert=false
+# -----------------------------------------------
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake2 (DATA_PATH '${DATA_PATH}/sort_on_insert_flush', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CALL ducklake_set_option('ducklake2', 'sort_on_insert', 'false')
+
+statement ok
+CREATE TABLE ducklake2.test_flush(i INTEGER)
+
+statement ok
+ALTER TABLE ducklake2.test_flush SET SORTED BY (i DESC)
+
+loop i 0 5
+
+statement ok
+INSERT INTO ducklake2.test_flush VALUES (${i})
+
+endloop
+
+# data is inlined, not sorted on insert
+query I
+SELECT * FROM ducklake2.test_flush
+----
+0
+1
+2
+3
+4
+
+# now insert some more unsorted values
+statement ok
+INSERT INTO ducklake2.test_flush VALUES (9), (7), (6), (8), (5)
+
+# flush should sort the data
+statement ok
+CALL ducklake_flush_inlined_data('ducklake2', table_name => 'test_flush')
+
+query I
+SELECT * FROM ducklake2.test_flush
+----
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+
+# -----------------------------------------------
+# Test 7: Invalid input - non-boolean value throws error
+# -----------------------------------------------
+statement error
+CALL ducklake_set_option('ducklake2', 'sort_on_insert', 'not_a_bool')
+----
+Could not convert string

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -196,21 +196,17 @@ CREATE TABLE ducklake2.test_flush(i INTEGER)
 statement ok
 ALTER TABLE ducklake2.test_flush SET SORTED BY (i DESC)
 
-loop i 0 5
-
 statement ok
-INSERT INTO ducklake2.test_flush VALUES (${i})
-
-endloop
+INSERT INTO ducklake2.test_flush  VALUES (1), (0), (3), (2), (4)
 
 # data is inlined, not sorted on insert
 query I
 SELECT * FROM ducklake2.test_flush
 ----
-0
 1
-2
+0
 3
+2
 4
 
 # now insert some more unsorted values

--- a/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
+++ b/test/sql/sorted_table/insert_sorted_sort_on_insert_option.test
@@ -312,6 +312,59 @@ SELECT COUNT(*) FROM GLOB('${DATA_PATH}/sort_on_insert_flush/**')
 ----
 2
 
+statement ok
+CALL ducklake_set_option('ducklake2', 'sort_on_insert', 'false')
+
+# Insert more than the inlining limit. This should be sorted on insert (since it should flush to parquet).
+statement ok
+INSERT INTO ducklake2.test_flush 
+VALUES (24), (25), (26), (27), (28), (29), (30), (31), (32), (33), (34)
+
+query I
+SELECT * FROM ducklake2.test_flush
+----
+9
+8
+7
+6
+5
+4
+3
+2
+1
+0
+20
+19
+18
+17
+16
+15
+14
+13
+12
+11
+10
+34
+33
+32
+31
+30
+29
+28
+27
+26
+25
+24
+23
+22
+21
+
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/sort_on_insert_flush/**')
+----
+3
+
 
 # -----------------------------------------------
 # Test 7: Invalid input - non-boolean value throws error

--- a/test/sql/sorted_table/insert_sorted_transaction.test
+++ b/test/sql/sorted_table/insert_sorted_transaction.test
@@ -1,0 +1,134 @@
+# name: test/sql/sorted_table/insert_sorted_transaction.test
+# description: test INSERT sorting behavior with transactions (ALTER TABLE, SET SORTED BY)
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/insert_sorted_txn')
+
+# test: BEGIN -> SET SORTED BY -> INSERT -> verify sorted -> COMMIT -> re-verify
+statement ok
+CREATE TABLE ducklake.test_txn_sort(i INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test_txn_sort SET SORTED BY (i DESC)
+
+statement ok
+INSERT INTO ducklake.test_txn_sort VALUES (3), (1), (5), (2), (4)
+
+# within transaction, data should be sorted
+query I
+SELECT * FROM ducklake.test_txn_sort
+----
+5
+4
+3
+2
+1
+
+statement ok
+COMMIT
+
+# after commit, sort order should persist
+query I
+SELECT * FROM ducklake.test_txn_sort
+----
+5
+4
+3
+2
+1
+
+# test: BEGIN -> SET SORTED BY -> INSERT -> ROLLBACK -> INSERT -> verify NOT sorted
+statement ok
+CREATE TABLE ducklake.test_txn_rollback(i INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test_txn_rollback SET SORTED BY (i ASC)
+
+statement ok
+INSERT INTO ducklake.test_txn_rollback VALUES (3), (1), (5), (2), (4)
+
+# within transaction, data should be sorted
+query I
+SELECT * FROM ducklake.test_txn_rollback
+----
+1
+2
+3
+4
+5
+
+statement ok
+ROLLBACK
+
+# after rollback the sort and data are gone
+query I
+SELECT COUNT(*) FROM ducklake.test_txn_rollback
+----
+0
+
+# insert without sort (sort was rolled back)
+statement ok
+INSERT INTO ducklake.test_txn_rollback VALUES (3), (1), (5), (2), (4)
+
+query I
+SELECT * FROM ducklake.test_txn_rollback
+----
+3
+1
+5
+2
+4
+
+# test: BEGIN -> ALTER TABLE ADD COLUMN -> INSERT with sort -> COMMIT -> re-verify
+statement ok
+CREATE TABLE ducklake.test_txn_alter(a INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_txn_alter SET SORTED BY (a DESC)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test_txn_alter ADD COLUMN b VARCHAR
+
+statement ok
+INSERT INTO ducklake.test_txn_alter VALUES (3, 'c'), (1, 'a'), (5, 'e'), (2, 'b'), (4, 'd')
+
+# within transaction, data should be sorted by a DESC
+query II
+SELECT * FROM ducklake.test_txn_alter
+----
+5	e
+4	d
+3	c
+2	b
+1	a
+
+statement ok
+COMMIT
+
+# after commit, sort order should persist with the new column
+query II
+SELECT * FROM ducklake.test_txn_alter
+----
+5	e
+4	d
+3	c
+2	b
+1	a

--- a/test/sql/sorted_table/insert_sorted_transaction.test
+++ b/test/sql/sorted_table/insert_sorted_transaction.test
@@ -132,3 +132,97 @@ SELECT * FROM ducklake.test_txn_alter
 3	c
 2	b
 1	a
+
+# test: BEGIN -> ADD COLUMN -> SET SORTED BY new column -> INSERT -> COMMIT
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.test_add_sort_insert(a INTEGER)
+
+statement ok
+ALTER TABLE ducklake.test_add_sort_insert ADD COLUMN b INTEGER
+
+statement ok
+ALTER TABLE ducklake.test_add_sort_insert SET SORTED BY (b ASC)
+
+statement ok
+INSERT INTO ducklake.test_add_sort_insert VALUES (10, 3), (20, 1), (30, 2)
+
+# within transaction, data should be sorted by the newly added column b
+query II
+SELECT * FROM ducklake.test_add_sort_insert
+----
+20	1
+30	2
+10	3
+
+statement ok
+COMMIT
+
+# after commit, sort order persists
+query II
+SELECT * FROM ducklake.test_add_sort_insert
+----
+20	1
+30	2
+10	3
+
+# test: BEGIN -> SET SORTED BY -> DROP that column -> INSERT should error -> ROLLBACK
+statement ok
+CREATE TABLE ducklake.test_sort_drop_insert(a INTEGER, b INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_insert SET SORTED BY (b ASC)
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_insert DROP COLUMN b
+
+statement error
+INSERT INTO ducklake.test_sort_drop_insert VALUES (1)
+----
+Columns in the SET SORTED BY statement were not found
+
+statement ok
+ROLLBACK
+
+# test: BEGIN -> SET SORTED BY -> DROP column -> ADD column back -> INSERT -> COMMIT
+statement ok
+CREATE TABLE ducklake.test_sort_drop_readd(a INTEGER, b INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_readd SET SORTED BY (b DESC)
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_readd DROP COLUMN b
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_readd ADD COLUMN b INTEGER
+
+statement ok
+INSERT INTO ducklake.test_sort_drop_readd VALUES (10, 3), (20, 1), (30, 2)
+
+# data should be sorted by the re-added column b DESC
+query II
+SELECT * FROM ducklake.test_sort_drop_readd
+----
+10	3
+30	2
+20	1
+
+statement ok
+COMMIT
+
+# after commit, sort order persists
+query II
+SELECT * FROM ducklake.test_sort_drop_readd
+----
+10	3
+30	2
+20	1

--- a/test/sql/sorted_table/merge_adjacent_sorted_expression.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_expression.test
@@ -146,17 +146,7 @@ ALTER TABLE rename_expr_test SET SORTED BY (col_a || col_b ASC);
 statement ok
 ALTER TABLE rename_expr_test RENAME COLUMN col_a TO col_a_renamed;
 
-# Compaction should fail with a descriptive error about the missing column
-statement error
-CALL ducklake_merge_adjacent_files('ducklake', 'rename_expr_test');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: col_a
-
-# Fix the sort expression to use the new column name
-statement ok
-ALTER TABLE rename_expr_test SET SORTED BY (col_a_renamed || col_b ASC);
-
-# Now compaction should succeed
+# Compaction succeeds because sort expressions are updated during rename
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'rename_expr_test');
 
@@ -199,8 +189,6 @@ ALTER TABLE multi_rename_test RENAME COLUMN first_name TO given_name;
 statement ok
 ALTER TABLE multi_rename_test RENAME COLUMN last_name TO family_name;
 
-# Compaction should fail listing both missing columns
-statement error
+# Compaction succeeds because sort expressions are updated during rename
+statement ok
 CALL ducklake_merge_adjacent_files('ducklake', 'multi_rename_test');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: first_name, last_name

--- a/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
@@ -16,7 +16,7 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/me
 statement ok
 USE ducklake;
 
-# SET SORTED BY then rename columns - compaction should error on missing columns
+# SET SORTED BY then rename columns - insert should error on missing columns
 statement ok
 CREATE TABLE renamed_columns_test (unique_id BIGINT, sort_key_1 BIGINT, sort_key_2 VARCHAR);
 
@@ -30,7 +30,25 @@ ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_changed;
 statement ok
 ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert data twice to create two files
+# Insert should fail because the sort expressions reference old column names
+statement error
+INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
+FROM range(4) t(i)
+SELECT
+    i AS unique_id,
+    i % 2 AS sort_key_1_changed,
+    'woot' || i AS sort_key_2_changed
+ORDER BY
+    i DESC
+;
+----
+Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
+
+# Fix the sort expression to use the new column names
+statement ok
+ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
+
+# Now inserts succeed and data is sorted
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
 FROM range(4) t(i)
@@ -53,15 +71,7 @@ ORDER BY
     i DESC
 ;
 
-# Compaction should fail because the sort columns no longer exist
-statement error
-CALL ducklake_merge_adjacent_files('ducklake', 'renamed_columns_test');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
-
-statement ok
-ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
-
+# Compaction should succeed now
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'renamed_columns_test')
 ----

--- a/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_renamed.test
@@ -30,25 +30,7 @@ ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_1 TO sort_key_1_changed;
 statement ok
 ALTER TABLE renamed_columns_test RENAME COLUMN sort_key_2 TO sort_key_2_changed;
 
-# Insert should fail because the sort expressions reference old column names
-statement error
-INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
-FROM range(4) t(i)
-SELECT
-    i AS unique_id,
-    i % 2 AS sort_key_1_changed,
-    'woot' || i AS sort_key_2_changed
-ORDER BY
-    i DESC
-;
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1, sort_key_2
-
-# Fix the sort expression to use the new column names
-statement ok
-ALTER TABLE ducklake.renamed_columns_test SET SORTED BY (sort_key_1_changed ASC NULLS LAST, sort_key_2_changed ASC NULLS LAST);
-
-# Now inserts succeed and data is sorted
+# Insert succeeds because sort expressions are updated during rename
 statement ok
 INSERT INTO renamed_columns_test (unique_id, sort_key_1_changed, sort_key_2_changed)
 FROM range(4) t(i)

--- a/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_transaction_renamed.test
@@ -81,31 +81,13 @@ ALTER TABLE sort_on_compaction RENAME COLUMN sort_key_1 TO sort_key_1_renamed;
 statement ok
 COMMIT
 
-# The compaction should fail due to the stale sort order
-statement error
-CALL ducklake_merge_adjacent_files('ducklake', 'sort_on_compaction');
-----
-Columns in the SET SORTED BY statement were not found in the DuckLake table. Unmatched columns were: sort_key_1
-
-statement ok
-BEGIN
-
-# Do some other kind of alter table on that table to make sure that it does not interfere
-statement ok
-ALTER TABLE sort_on_compaction RENAME COLUMN sort_key_1_renamed TO sort_key_1_renamed_again;
-
-statement ok
-ALTER TABLE ducklake.sort_on_compaction SET SORTED BY (sort_key_1_renamed_again ASC NULLS LAST, sort_key_2 ASC NULLS LAST);
-
-statement ok
-COMMIT
-
+# Compaction succeeds because sort expressions are updated during rename
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'sort_on_compaction')
 ----
 sort_on_compaction	2	1
 
-# Now we have the new sort order and the new column
+# Now we have the new sort order and the renamed column
 query III
 FROM sort_on_compaction
 ----


### PR DESCRIPTION
This removes another restriction from #642 - sorting can be configured to occur during inserts. There is an option to enable/disable this behavior (`sort_on_insert`), defaulting to `true` / enabled. It may be worth disabling sort on insert if insertion speed is the primary concern (since inline flush and compaction operations could still trigger sorting, but possibly in the background or at a more convenient time). 

The code couldn't be perfectly reused, since inserts operate on a physical plan rather than a logical plan like compaction and inline flush. However, I was able to reuse most of the logic thanks to splitting things out into helper functions.

There is also some slightly complex behavior when inlining. Data that is inserted inline will obey the `sort_on_insert` flag, except in the case that data that is inserted is larger than the inlining limit, in which case it will sort on insert anyway (to mirror the behavior of inline flush always sorting on insert). Let me know if this is not what we want and I can remove this piece and we can insert without sorting in that case instead.

I also don't do any deduplication of orderings in the plan, so if someone adds their own `ORDER BY` on their `INSERT` statement and also uses `SET SORTED BY`, I am guessing that the sort will happen twice. If that is an issue, let me know and I can see if I can learn how to handle that situation!

I did use Claude while building this, but I have reviewed the code and forced some refactoring when I didn't like Claude's approach and manually added more tests. Super open to feedback!