### PR TITLE
default catalog_type to duckdb

### DIFF
--- a/src/functions/ducklake_settings.cpp
+++ b/src/functions/ducklake_settings.cpp
@@ -21,14 +21,15 @@ static unique_ptr<FunctionData> DuckLakeSettingsBind(ClientContext &context, Tab
 	auto result = make_uniq<MetadataBindData>();
 	vector<Value> row_values;
 
-	// catalog_type: default to "duckdb" if not explicitly set (DuckDB is the default metadata storage)
+	// catalog_type: normalize the metadata type to a user-friendly name
+	// unknown types (including empty) default to "duckdb" since DuckDB is the default metadata storage
 	auto catalog_type = ducklake_catalog.MetadataType();
-	if (catalog_type.empty()) {
-		catalog_type = "duckdb";
-	} else if (catalog_type == "postgres_scanner") {
+	if (catalog_type == "postgres_scanner") {
 		catalog_type = "postgres";
 	} else if (catalog_type == "sqlite_scanner") {
 		catalog_type = "sqlite";
+	} else {
+		catalog_type = "duckdb";
 	}
 	row_values.push_back(Value(catalog_type));
 

--- a/src/functions/ducklake_settings.cpp
+++ b/src/functions/ducklake_settings.cpp
@@ -22,13 +22,13 @@ static unique_ptr<FunctionData> DuckLakeSettingsBind(ClientContext &context, Tab
 	vector<Value> row_values;
 
 	// catalog_type: normalize the metadata type to a user-friendly name
-	// unknown types (including empty) default to "duckdb" since DuckDB is the default metadata storage
 	auto catalog_type = ducklake_catalog.MetadataType();
 	if (catalog_type == "postgres_scanner") {
 		catalog_type = "postgres";
 	} else if (catalog_type == "sqlite_scanner") {
 		catalog_type = "sqlite";
-	} else {
+	} else if (catalog_type.empty() || catalog_type == "motherduck" || catalog_type == "md_server") {
+		// default to "duckdb" since DuckDB is the default metadata storage
 		catalog_type = "duckdb";
 	}
 	row_values.push_back(Value(catalog_type));


### PR DESCRIPTION
Small change to ducklake_settings function to default to "duckdb" catalog type if catalog is not one of the known alternatives (postgres, sqllite)