### PR TITLE
Skip hive partitioned columns from parquet files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1081,6 +1081,12 @@ DuckLakeFileProcessor::MapColumns(ParquetFileMetadata &file_metadata,
 			                            prefix.empty() ? prefix : prefix + ".", col->name, file_metadata.filename,
 			                            table.name);
 		}
+		auto hive_entry = hive_partitions.find(col->name);
+		if (hive_entry != hive_partitions.end()) {
+			column_maps.push_back(MapHiveColumn(file_metadata, entry->second.get(), Value(hive_entry->second)));
+			field_id_map.erase(entry);
+			continue;
+		}
 		column_maps.push_back(MapColumn(file_metadata, *col, entry->second.get(), prefix));
 		field_id_map.erase(entry);
 	}

--- a/test/sql/partitioning/partition_insert_bug.test
+++ b/test/sql/partitioning/partition_insert_bug.test
@@ -1,0 +1,46 @@
+# name: test/sql/partitioning/partition_insert_bug.test
+# description: Test an issue with mapping if hive-partition column exists in the parquet file
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_file_partition', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake
+
+statement ok
+COPY (SELECT 1 AS value, 'value' AS partition_key) TO '__TEST_DIR__/external_data/' (FORMAT PARQUET, PARTITION_BY (partition_key));
+
+statement ok
+CREATE TABLE test AS FROM '__TEST_DIR__/external_data/partition_key=value/data_0.parquet' WITH NO DATA;
+
+statement ok
+ALTER TABLE test SET PARTITIONED BY (partition_key);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/external_data/partition_key=value/data_0.parquet');
+
+query II
+FROM test;
+----
+1	value
+
+statement ok
+COPY (SELECT 1 AS value, 'value' AS partition_key) TO '__TEST_DIR__/external_data/partition_key=value/with_column.parquet';
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', '__TEST_DIR__/external_data/partition_key=value/with_column.parquet');
+
+query II
+FROM test;
+----
+1	value
+1	value


### PR DESCRIPTION
If we add a parquet file to a hive partition scheme, where this file has the partition column in the file, we skip it during mapping.

Fix: https://github.com/duckdb/ducklake/issues/791