### PR TITLE
Duckdb 1.5 test fixes

### DIFF
--- a/test/sql/compaction/merge_adjacent_max_files.test
+++ b/test/sql/compaction/merge_adjacent_max_files.test
@@ -83,66 +83,45 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
 20
 
-query II
-SELECT max(data_file_id), min (data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-40	21
-
+# max_compacted_files=2 should produce exactly 2 compaction operations
+# The exact files_processed per operation depends on parquet file sizes (platform-dependent)
 query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2) ORDER BY ALL
+SELECT count(*), bool_and(files_processed >= 2), bool_and(files_created = 1)
+FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>2)
 ----
-example	5	1
-example	5	1
+2	true	true
 
-# We create two new files, and remove as many as necessary to create them
-query II
-SELECT max(data_file_id), min (data_file_id) > 30 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-42	True
-
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
-----
-example	3	1
-
-# We create max one file
-query II
-SELECT max(data_file_id), min (data_file_id) > 31 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-43	True
-
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000) ORDER BY ALL
-----
-example	4	1
-example	5	1
-
-# We basically do max compaction, limiting the size set
-query II
-SELECT max(data_file_id) > 43, min (data_file_id) > 32 FROM __ducklake_metadata_ducklake.ducklake_data_file
-----
-True	True
-
-query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
-----
-example	3	1
-
-# Calling it again, merges one more time both snapshots as they are under the size limit
+# File count should have decreased
 query I
-SELECT max(data_file_id) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-46
+true
 
+# max_compacted_files=1 should produce exactly 1 compaction operation
 query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
+SELECT count(*), bool_and(files_processed >= 2), bool_and(files_created = 1)
+FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1)
 ----
+1	true	true
 
-# Calling it again, produces no changes
+# Compact all remaining files with a high limit - should produce at least 1 operation
 query I
-SELECT max(data_file_id) BETWEEN 46 AND 48 FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT count(*) >= 1 FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
 ----
-True
+true
+
+# Run compaction a few more times to merge files across size groups until fully compacted
+statement ok
+SELECT * FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000);
+
+statement ok
+SELECT * FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000);
+
+# Eventually no more compaction should be needed
+query I
+SELECT count(*) FROM ducklake_merge_adjacent_files('ducklake', 'example', max_compacted_files=>1000)
+----
+0
 
 # Check data is still correct
 query I
@@ -185,16 +164,16 @@ SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
 # Compact entire database with max_compacted_files=1 per table
 # Each table should get at most 1 compaction operation
 query III
-SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1) ORDER BY table_name
+SELECT count(*), bool_and(files_processed >= 2), bool_and(files_created = 1)
+FROM ducklake_merge_adjacent_files('ducklake', max_compacted_files=>1)
 ----
-table1	5	1
-table2	5	1
+2	true	true
 
-# Both tables got compacted (1 operation each)
+# Both tables got compacted (1 operation each), file count decreased
 query I
-SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file
+SELECT count(*) < 20 FROM __ducklake_metadata_ducklake.ducklake_data_file
 ----
-12
+true
 
 # Check data is still correct
 query I

--- a/test/sql/sorted_table/merge_adjacent_sorted_spatial_hilbert.test
+++ b/test/sql/sorted_table/merge_adjacent_sorted_spatial_hilbert.test
@@ -12,7 +12,7 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_sorted_nested_expression/')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/merge_adjacent_sorted_nested_expression/', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake;

--- a/test/sql/stats/filter_stress.test
+++ b/test/sql/stats/filter_stress.test
@@ -37,17 +37,17 @@ CREATE TABLE ducklake.events(i INTEGER, g INTEGER, maybe_null INTEGER, d DATE, s
 statement ok
 CALL ducklake_add_data_files('ducklake', 'events', '${DATA_PATH}/filter_stress_parquet/*.parquet');
 
-# Verify we produced lots of files
+# Verify we produced multiple files (exact count depends on thread count during COPY)
 query I
-SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'events')
+SELECT COUNT(*) > 1 FROM ducklake_list_files('ducklake', 'events')
 ----
-54
+true
 
 # Basic pruning sanity: constant filter should read all files
 query II
 EXPLAIN ANALYZE SELECT * FROM ducklake.events WHERE 1 = 1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 54 .*
+analyzed_plan	<REGEX>:.*Total Files Read: \d+ .*
 
 # Basic pruning sanity: equality should not read all files
 query II


### PR DESCRIPTION
Test fixes
- merge_adjacent_sorted_spatial_hilbert.test‎: This test was missed when data inlining was made the default. The test needs to disable inling, because it looks for some data files explicitly
- merge_adjacent_max_files.test‎: Replace exact file_processed counts with invariant checks. The exact parquet file size of the small parquet files the test generates is platform dependent. How many files fill up the the 1KB limit is then also platform dependent (we've seen 5 locally and 6 in CI).
- filter_stress.test‎: The test generates parquet files using the COPY command and then has assertions on the number of files produced. The number of files depend on how many threads are running the copy. If just 1 thread then it's 54 files, but with more threads it can be less files (we've seen 13 in CI). Changing the test to be more flexible
