### PR TITLE
Use Appender API for DuckDB metadata manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ testext
 test/python/__pycache__/
 .Rhistory
 scripts/data/
+duckdb_benchmark_data/

--- a/benchmark/ingest/add_files_small_files.benchmark
+++ b/benchmark/ingest/add_files_small_files.benchmark
@@ -1,0 +1,5 @@
+# name: benchmark/ingest/add_files_small_files.benchmark
+# description: Benchmark adding many small parquet files using ducklake_add_data_files
+# group: [add_files_small]
+
+template benchmark/ingest/add_files_small_files.benchmark.in

--- a/benchmark/ingest/add_files_small_files.benchmark.in
+++ b/benchmark/ingest/add_files_small_files.benchmark.in
@@ -1,0 +1,59 @@
+# name: ${FILE_PATH}
+# description: Benchmark adding many small parquet files using ducklake_add_data_files
+# group: [add_files_small]
+
+argument file_count 10000
+
+name DuckLake Add Small Files
+group ducklake_add_files
+subgroup small_files
+
+require ducklake
+require parquet
+
+cache_file ducklake_add_files_small_files_ready_${file_count}_${column_count}.marker
+
+load
+CREATE TABLE src AS
+SELECT
+  i::INTEGER AS col_long_name_001,
+  (i + 1)::INTEGER AS col_long_name_002,
+  (i + 2)::INTEGER AS col_long_name_003,
+  (i + 3)::INTEGER AS col_long_name_004,
+  (i + 4)::INTEGER AS col_long_name_005,
+  (i + 5)::INTEGER AS col_long_name_006,
+  (i + 6)::INTEGER AS col_long_name_007,
+  (i + 7)::INTEGER AS col_long_name_008,
+  (i + 8)::INTEGER AS col_long_name_009,
+  (i + 9)::INTEGER AS col_long_name_010,
+  (i + 10)::INTEGER AS col_long_name_011,
+  (i + 11)::INTEGER AS col_long_name_012,
+  (i + 12)::INTEGER AS col_long_name_013,
+  (i + 13)::INTEGER AS col_long_name_014,
+  (i + 14)::INTEGER AS col_long_name_015,
+  (i + 15)::INTEGER AS col_long_name_016,
+  (i + 16)::INTEGER AS col_long_name_017,
+  (i + 17)::INTEGER AS col_long_name_018,
+  (i + 18)::INTEGER AS col_long_name_019,
+  (i + 19)::INTEGER AS col_long_name_020,
+FROM range(${file_count}) t(i);
+COPY src TO '${BENCHMARK_DIR}/ducklake_add_files_small_files_source_parquet'
+  (FORMAT PARQUET, PARTITION_BY (col_long_name_001), WRITE_PARTITION_COLUMNS true, OVERWRITE);
+COPY (SELECT 1) TO '${BENCHMARK_DIR}/ducklake_add_files_small_files_ready_${file_count}.marker' (FORMAT CSV, HEADER);
+ATTACH 'ducklake:${BENCHMARK_DIR}/ducklake_add_files_small_files.db' AS ducklake
+  (DATA_PATH '${BENCHMARK_DIR}/ducklake_add_files_small_files_data_files', METADATA_CATALOG 'metadata');
+USE ducklake;
+
+reload
+ATTACH 'ducklake:${BENCHMARK_DIR}/ducklake_add_files_small_files.db' AS ducklake
+  (METADATA_CATALOG 'metadata');
+USE ducklake;
+
+run
+CREATE TABLE ducklake.big_files AS
+SELECT * FROM read_parquet('${BENCHMARK_DIR}/ducklake_add_files_small_files_source_parquet/**/*.parquet')
+LIMIT 0;
+CALL ducklake_add_data_files('ducklake', 'big_files', '${BENCHMARK_DIR}/ducklake_add_files_small_files_source_parquet/**/*.parquet');
+
+cleanup
+DROP TABLE IF EXISTS ducklake.big_files;

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -22,6 +22,9 @@ public:
 
 	bool TypeIsNativelySupported(const LogicalType &type) override;
 	bool SupportsInlining(const LogicalType &type) override;
+	bool SupportsAppender() const override {
+		return false;
+	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
 

--- a/src/include/metadata_manager/sqlite_metadata_manager.hpp
+++ b/src/include/metadata_manager/sqlite_metadata_manager.hpp
@@ -22,6 +22,9 @@ public:
 
 	bool TypeIsNativelySupported(const LogicalType &type) override;
 	bool SupportsInlining(const LogicalType &type) override;
+	bool SupportsAppender() const override {
+		return false;
+	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
 };

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -158,7 +158,7 @@ struct DuckLakeFileInfo {
 	optional_idx max_partial_file_snapshot;
 	string encryption_key;
 	MappingIndex mapping_id;
-	vector<DuckLakeColumnStatsInfo> column_stats;
+	map<FieldIndex, DuckLakeColumnStats> column_stats;
 	vector<DuckLakeFilePartitionInfo> partition_values;
 };
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -106,6 +106,11 @@ public:
 	virtual bool TypeIsNativelySupported(const LogicalType &type);
 	//! Check if a type supports data inlining on this metadata backend
 	virtual bool SupportsInlining(const LogicalType &type);
+	//! Check if this metadata manager supports the DuckDB Appender API for fast inserts
+	//! Returns true for DuckDB metadata, false for external databases (Postgres, SQLite)
+	virtual bool SupportsAppender() const {
+		return true;
+	}
 	//! Check if a set of LogicalTypes supports data inlining, recursing into nested types
 	bool SupportsInliningTypes(const vector<LogicalType> &types);
 	//! Check if columns (stored as DuckLakeColumnInfo) support inlining, recursing into children
@@ -164,7 +169,7 @@ public:
 	virtual string WriteNewColumns(const vector<DuckLakeNewColumn> &new_columns);
 	virtual string WriteNewTags(const vector<DuckLakeTagInfo> &new_tags);
 	virtual string WriteNewColumnTags(const vector<DuckLakeColumnTagInfo> &new_tags);
-	virtual string WriteNewDataFiles(const vector<DuckLakeFileInfo> &new_files,
+	virtual string WriteNewDataFiles(DuckLakeSnapshot &commit_snapshot, const vector<DuckLakeFileInfo> &new_files,
 	                                 const vector<DuckLakeTableInfo> &new_tables,
 	                                 vector<DuckLakeSchemaInfo> &new_schemas_result);
 	virtual string WriteNewInlinedData(DuckLakeSnapshot &commit_snapshot,
@@ -255,6 +260,11 @@ protected:
 protected:
 	string GetInlinedTableQuery(const DuckLakeTableInfo &table, const string &table_name);
 	string GetColumnType(const DuckLakeColumnInfo &col);
+
+	//! Optimized data file writing using DuckDB Appender API (only for DuckDB metadata manager)
+	string WriteNewDataFilesWithAppender(DuckLakeSnapshot &commit_snapshot, const vector<DuckLakeFileInfo> &new_files,
+	                                     const vector<DuckLakeTableInfo> &new_tables,
+	                                     vector<DuckLakeSchemaInfo> &new_schemas_result);
 
 	//! Get path relative to catalog path
 	DuckLakePath GetRelativePath(const string &path);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1,5 +1,6 @@
 #include "storage/ducklake_metadata_manager.hpp"
 #include "storage/ducklake_transaction.hpp"
+#include "storage/ducklake_variant_stats.hpp"
 #include "common/ducklake_util.hpp"
 #include "duckdb/planner/tableref/bound_at_clause.hpp"
 #include "duckdb/common/types/blob.hpp"
@@ -9,6 +10,7 @@
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "duckdb.hpp"
+#include "duckdb/main/appender.hpp"
 #include "metadata_manager/postgres_metadata_manager.hpp"
 #include "metadata_manager/sqlite_metadata_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
@@ -2816,12 +2818,216 @@ string DuckLakeMetadataManager::FromRelativePath(TableIndex table_id, const Duck
 	return FromRelativePath(path, GetPath(table_id, {}, {}));
 }
 
-string DuckLakeMetadataManager::WriteNewDataFiles(const vector<DuckLakeFileInfo> &new_files,
+
+// Optimized version using DuckDB Appender API for much faster inserts
+string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &commit_snapshot,
+                                                              const vector<DuckLakeFileInfo> &new_files,
+                                                              const vector<DuckLakeTableInfo> &new_tables,
+                                                              vector<DuckLakeSchemaInfo> &new_schemas_result) {
+	auto &catalog = transaction.GetCatalog();
+	auto &connection = transaction.GetConnection();
+	const auto &db_name = catalog.MetadataDatabaseName();
+	auto schema_name = catalog.MetadataSchemaName();
+	if (schema_name.empty()) {
+		schema_name = "main";
+	}
+
+	// Create appenders for each table
+	Appender data_file_appender(connection, db_name, schema_name, "ducklake_data_file");
+	Appender column_stats_appender(connection, db_name, schema_name, "ducklake_file_column_stats");
+	Appender partition_value_appender(connection, db_name, schema_name, "ducklake_file_partition_value");
+	Appender variant_stats_appender(connection, db_name, schema_name, "ducklake_file_variant_stats");
+
+	for (auto &file : new_files) {
+		auto data_file_index = static_cast<int64_t>(file.id.index);
+		auto table_id = static_cast<int64_t>(file.table_id.index);
+		int64_t begin_snapshot_val = file.begin_snapshot.IsValid()
+			? static_cast<int64_t>(file.begin_snapshot.GetIndex())
+			: static_cast<int64_t>(commit_snapshot.snapshot_id);
+		auto path = GetRelativePath(file.table_id, file.file_name, new_tables, new_schemas_result);
+
+		// ducklake_data_file columns:
+		// data_file_id, table_id, begin_snapshot, end_snapshot, file_order, path, path_is_relative,
+		// file_format, record_count, file_size_bytes, footer_size, row_id_start, partition_id,
+		// encryption_key, mapping_id, partial_max
+		data_file_appender.BeginRow();
+		data_file_appender.Append<int64_t>(data_file_index);                    // data_file_id
+		data_file_appender.Append<int64_t>(table_id);                           // table_id
+		data_file_appender.Append<int64_t>(begin_snapshot_val);                 // begin_snapshot
+		data_file_appender.Append(Value());                                     // end_snapshot (NULL)
+		data_file_appender.Append(Value());                                     // file_order (NULL)
+		data_file_appender.Append<string_t>(string_t(path.path));               // path
+		data_file_appender.Append<bool>(path.path_is_relative);                 // path_is_relative
+		data_file_appender.Append<string_t>(string_t("parquet"));               // file_format
+		data_file_appender.Append<int64_t>(static_cast<int64_t>(file.row_count));  // record_count
+		data_file_appender.Append<int64_t>(static_cast<int64_t>(file.file_size_bytes)); // file_size_bytes
+		if (file.footer_size.IsValid()) {
+			data_file_appender.Append<int64_t>(static_cast<int64_t>(file.footer_size.GetIndex())); // footer_size
+		} else {
+			data_file_appender.Append(Value());
+		}
+		if (file.row_id_start.IsValid()) {
+			data_file_appender.Append<int64_t>(static_cast<int64_t>(file.row_id_start.GetIndex())); // row_id_start
+		} else {
+			data_file_appender.Append(Value());
+		}
+		if (file.partition_id.IsValid()) {
+			data_file_appender.Append<int64_t>(static_cast<int64_t>(file.partition_id.GetIndex())); // partition_id
+		} else {
+			data_file_appender.Append(Value());
+		}
+		if (!file.encryption_key.empty()) {
+			data_file_appender.Append<string_t>(string_t(Blob::ToBase64(string_t(file.encryption_key)))); // encryption_key
+		} else {
+			data_file_appender.Append(Value());
+		}
+		if (file.mapping_id.IsValid()) {
+			data_file_appender.Append<int64_t>(static_cast<int64_t>(file.mapping_id.index)); // mapping_id
+		} else {
+			data_file_appender.Append(Value());
+		}
+		if (file.max_partial_file_snapshot.IsValid()) {
+			data_file_appender.Append<int64_t>(static_cast<int64_t>(file.max_partial_file_snapshot.GetIndex())); // partial_max
+		} else {
+			data_file_appender.Append(Value());
+		}
+		data_file_appender.EndRow();
+
+		// Column stats - using typed values directly
+		for (auto &column_stats_entry : file.column_stats) {
+			auto column_id = static_cast<int64_t>(column_stats_entry.first.index);
+			auto &stats = column_stats_entry.second;
+
+			// ducklake_file_column_stats columns:
+			// data_file_id, table_id, column_id, column_size_bytes, value_count, null_count,
+			// min_value, max_value, contains_nan, extra_stats
+			column_stats_appender.BeginRow();
+			column_stats_appender.Append<int64_t>(data_file_index);
+			column_stats_appender.Append<int64_t>(table_id);
+			column_stats_appender.Append<int64_t>(column_id);
+			column_stats_appender.Append<int64_t>(static_cast<int64_t>(stats.column_size_bytes));
+
+			// value_count and null_count
+			if (stats.has_null_count && stats.has_num_values && stats.null_count <= stats.num_values) {
+				column_stats_appender.Append<int64_t>(static_cast<int64_t>(stats.num_values - stats.null_count));
+				column_stats_appender.Append<int64_t>(static_cast<int64_t>(stats.null_count));
+			} else {
+				column_stats_appender.Append(Value());
+				column_stats_appender.Append(Value());
+			}
+
+			// min_value and max_value
+			if (stats.has_min) {
+				column_stats_appender.Append<string_t>(string_t(stats.min));
+			} else {
+				column_stats_appender.Append(Value());
+			}
+			if (stats.has_max) {
+				column_stats_appender.Append<string_t>(string_t(stats.max));
+			} else {
+				column_stats_appender.Append(Value());
+			}
+
+			// contains_nan
+			if (stats.has_contains_nan) {
+				column_stats_appender.Append<bool>(stats.contains_nan);
+			} else {
+				column_stats_appender.Append(Value());
+			}
+
+			// extra_stats
+			string extra_stats_str;
+			if (stats.extra_stats && stats.extra_stats->TrySerialize(extra_stats_str)) {
+				column_stats_appender.Append<string_t>(string_t(extra_stats_str));
+			} else {
+				column_stats_appender.Append(Value());
+			}
+			column_stats_appender.EndRow();
+
+			// Variant stats from extra_stats
+			if (stats.extra_stats && stats.extra_stats->GetStatsType() == DuckLakeExtraStatsType::VARIANT) {
+				auto &variant_extra = static_cast<DuckLakeColumnVariantStats &>(*stats.extra_stats);
+				for (auto &variant_entry : variant_extra.shredded_field_stats) {
+					auto &field_stats = variant_entry.second.field_stats;
+
+					// ducklake_file_variant_stats columns:
+					// data_file_id, table_id, column_id, variant_path, shredded_type, column_size_bytes,
+					// value_count, null_count, min_value, max_value, contains_nan, extra_stats
+					variant_stats_appender.BeginRow();
+					variant_stats_appender.Append<int64_t>(data_file_index);
+					variant_stats_appender.Append<int64_t>(table_id);
+					variant_stats_appender.Append<int64_t>(column_id);
+					variant_stats_appender.Append<string_t>(string_t(variant_entry.first));
+					variant_stats_appender.Append<string_t>(string_t(DuckLakeTypes::ToString(variant_entry.second.shredded_type)));
+					variant_stats_appender.Append<int64_t>(static_cast<int64_t>(field_stats.column_size_bytes));
+
+					if (field_stats.has_null_count && field_stats.has_num_values && field_stats.null_count <= field_stats.num_values) {
+						variant_stats_appender.Append<int64_t>(static_cast<int64_t>(field_stats.num_values - field_stats.null_count));
+						variant_stats_appender.Append<int64_t>(static_cast<int64_t>(field_stats.null_count));
+					} else {
+						variant_stats_appender.Append(Value());
+						variant_stats_appender.Append(Value());
+					}
+
+					if (field_stats.has_min) {
+						variant_stats_appender.Append<string_t>(string_t(field_stats.min));
+					} else {
+						variant_stats_appender.Append(Value());
+					}
+					if (field_stats.has_max) {
+						variant_stats_appender.Append<string_t>(string_t(field_stats.max));
+					} else {
+						variant_stats_appender.Append(Value());
+					}
+
+					if (field_stats.has_contains_nan) {
+						variant_stats_appender.Append<bool>(field_stats.contains_nan);
+					} else {
+						variant_stats_appender.Append(Value());
+					}
+
+					string field_extra_stats_str;
+					if (field_stats.extra_stats && field_stats.extra_stats->TrySerialize(field_extra_stats_str)) {
+						variant_stats_appender.Append<string_t>(string_t(field_extra_stats_str));
+					} else {
+						variant_stats_appender.Append(Value());
+					}
+					variant_stats_appender.EndRow();
+				}
+			}
+		}
+
+		// Partition values
+		if (file.partition_id.IsValid() == file.partition_values.empty()) {
+			throw InternalException("File should either not be partitioned, or have partition values");
+		}
+		for (auto &part_val : file.partition_values) {
+			// ducklake_file_partition_value columns:
+			// data_file_id, table_id, partition_key_index, partition_value
+			partition_value_appender.BeginRow();
+			partition_value_appender.Append<int64_t>(data_file_index);
+			partition_value_appender.Append<int64_t>(table_id);
+			partition_value_appender.Append<int64_t>(static_cast<int64_t>(part_val.partition_column_idx));
+			partition_value_appender.Append<string_t>(string_t(part_val.partition_value));
+			partition_value_appender.EndRow();
+		}
+	}
+
+	// Appenders will flush on destruction
+	return "";
+}
+
+string DuckLakeMetadataManager::WriteNewDataFiles(DuckLakeSnapshot &commit_snapshot,
+                                                  const vector<DuckLakeFileInfo> &new_files,
                                                   const vector<DuckLakeTableInfo> &new_tables,
                                                   vector<DuckLakeSchemaInfo> &new_schemas_result) {
 	string batch_query;
 	if (new_files.empty()) {
 		return batch_query;
+	}
+	// Use optimized appender path for DuckDB metadata (much faster for large inserts)
+	if (SupportsAppender()) {
+		return WriteNewDataFilesWithAppender(commit_snapshot, new_files, new_tables, new_schemas_result);
 	}
 	string data_file_insert_query;
 	string column_stats_insert_query;
@@ -2849,7 +3055,9 @@ string DuckLakeMetadataManager::WriteNewDataFiles(const vector<DuckLakeFileInfo>
 		    "(%d, %d, %s, NULL, NULL, %s, %s, 'parquet', %d, %d, %s, %s, %s, %s, %s, %s)", data_file_index, table_id,
 		    begin_snapshot, SQLString(path.path), path.path_is_relative ? "true" : "false", file.row_count,
 		    file.file_size_bytes, footer_size, row_id, partition_id, encryption_key, mapping, partial_max);
-		for (auto &column_stats : file.column_stats) {
+		for (auto &raw_stats : file.column_stats) {
+			// Stringify stats to construct insert queries
+			auto column_stats = DuckLakeColumnStatsInfo::FromColumnStats(raw_stats.first, raw_stats.second);
 			if (!column_stats_insert_query.empty()) {
 				column_stats_insert_query += ",";
 			}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3016,7 +3016,11 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 			partition_value_appender.Append<int64_t>(data_file_index);
 			partition_value_appender.Append<int64_t>(table_id);
 			partition_value_appender.Append<int64_t>(static_cast<int64_t>(part_val.partition_column_idx));
-			partition_value_appender.Append<string_t>(string_t(part_val.partition_value));
+			if (part_val.partition_value.IsNull()) {
+				partition_value_appender.Append(Value());
+			} else {
+				partition_value_appender.Append(part_val.partition_value);
+			}
 			partition_value_appender.EndRow();
 		}
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3021,7 +3021,12 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 		}
 	}
 
-	// Appenders will flush on destruction
+	// Explicitly close appenders
+	data_file_appender.Close();
+	column_stats_appender.Close();
+	partition_value_appender.Close();
+	variant_stats_appender.Close();
+
 	return "";
 }
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2938,6 +2938,10 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 			// extra_stats
 			string extra_stats_str;
 			if (stats.extra_stats && stats.extra_stats->TrySerialize(extra_stats_str)) {
+				// TrySerialize wraps the JSON in single quotes for SQL - strip them for Appender
+				if (extra_stats_str.size() >= 2 && extra_stats_str.front() == '\'' && extra_stats_str.back() == '\'') {
+					extra_stats_str = extra_stats_str.substr(1, extra_stats_str.size() - 2);
+				}
 				column_stats_appender.Append<string_t>(string_t(extra_stats_str));
 			} else {
 				column_stats_appender.Append(Value());
@@ -2988,6 +2992,10 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 
 					string field_extra_stats_str;
 					if (field_stats.extra_stats && field_stats.extra_stats->TrySerialize(field_extra_stats_str)) {
+						// TrySerialize wraps the JSON in single quotes for SQL - strip them for Appender
+						if (field_extra_stats_str.size() >= 2 && field_extra_stats_str.front() == '\'' && field_extra_stats_str.back() == '\'') {
+							field_extra_stats_str = field_extra_stats_str.substr(1, field_extra_stats_str.size() - 2);
+						}
 						variant_stats_appender.Append<string_t>(string_t(field_extra_stats_str));
 					} else {
 						variant_stats_appender.Append(Value());

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1331,12 +1331,7 @@ DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(DuckLakeDataFile &file, Duc
 	data_file.mapping_id = file.mapping_id;
 	data_file.begin_snapshot = file.begin_snapshot;
 	data_file.max_partial_file_snapshot = file.max_partial_file_snapshot;
-	// gather the column statistics for this file
-	for (auto &column_stats_entry : file.column_stats) {
-		auto column_stats =
-		    DuckLakeColumnStatsInfo::FromColumnStats(column_stats_entry.first, column_stats_entry.second);
-		data_file.column_stats.push_back(std::move(column_stats));
-	}
+	data_file.column_stats = file.column_stats;
 	for (auto &partition_entry : file.partition_values) {
 		DuckLakeFilePartitionInfo partition_info;
 		partition_info.partition_column_idx = partition_entry.partition_column_idx;
@@ -1646,7 +1641,7 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 	// write new data / data files
 	if (!table_data_changes.empty()) {
 		auto result = GetNewDataFiles(batch_queries, commit_state, stats);
-		batch_queries += metadata_manager->WriteNewDataFiles(result.new_files, new_tables_result, new_schemas_result);
+		batch_queries += metadata_manager->WriteNewDataFiles(commit_snapshot, result.new_files, new_tables_result, new_schemas_result);
 		batch_queries += metadata_manager->WriteNewInlinedData(commit_snapshot, result.new_inlined_data,
 		                                                       new_tables_result, new_inlined_data_tables_result);
 	}
@@ -1680,11 +1675,11 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 		    GetCompactionChanges(commit_snapshot, CompactionType::MERGE_ADJACENT_TABLES);
 		batch_queries += metadata_manager->WriteCompactions(compaction_merge_adjacent_changes.compacted_files,
 		                                                    CompactionType::MERGE_ADJACENT_TABLES);
-		batch_queries += metadata_manager->WriteNewDataFiles(compaction_merge_adjacent_changes.new_files,
+		batch_queries += metadata_manager->WriteNewDataFiles(commit_snapshot, compaction_merge_adjacent_changes.new_files,
 		                                                     new_tables_result, new_schemas_result);
 
 		auto compaction_rewrite_delete_changes = GetCompactionChanges(commit_snapshot, CompactionType::REWRITE_DELETES);
-		batch_queries += metadata_manager->WriteNewDataFiles(compaction_rewrite_delete_changes.new_files,
+		batch_queries += metadata_manager->WriteNewDataFiles(commit_snapshot, compaction_rewrite_delete_changes.new_files,
 		                                                     new_tables_result, new_schemas_result);
 		batch_queries += metadata_manager->WriteCompactions(compaction_rewrite_delete_changes.compacted_files,
 		                                                    CompactionType::REWRITE_DELETES);

--- a/test/sql/metadata/appender_data_files.test
+++ b/test/sql/metadata/appender_data_files.test
@@ -1,0 +1,180 @@
+# name: test/sql/metadata/appender_data_files.test
+# description: Test that the DuckDB Appender API for metadata inserts works correctly
+# group: [metadata]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_appender_test', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
+
+# ------------------------------------------
+# Basic insert - verify data file is recorded correctly
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.basic_test(id INTEGER, value VARCHAR);
+
+statement ok
+INSERT INTO ducklake.basic_test VALUES (1, 'hello'), (2, 'world'), (3, 'test');
+
+# Verify the data file was created
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'basic_test')
+----
+1
+
+# Verify the data can be read back correctly
+query II
+SELECT * FROM ducklake.basic_test ORDER BY id
+----
+1	hello
+2	world
+3	test
+
+# Verify column stats were recorded
+query I
+SELECT COUNT(*) FROM dl.ducklake_file_column_stats 
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'basic_test')
+----
+2
+
+# ------------------------------------------
+# Multiple inserts - verify multiple data files
+# ------------------------------------------
+statement ok
+INSERT INTO ducklake.basic_test VALUES (4, 'foo'), (5, 'bar');
+
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'basic_test')
+----
+2
+
+query II
+SELECT * FROM ducklake.basic_test ORDER BY id
+----
+1	hello
+2	world
+3	test
+4	foo
+5	bar
+
+# ------------------------------------------
+# Column stats min/max values
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.stats_test(i INTEGER, s VARCHAR);
+
+statement ok
+INSERT INTO ducklake.stats_test SELECT i, printf('%06d', i) FROM range(1000) t(i);
+
+# Check column stats contain min/max
+query IIII
+SELECT column_id, min_value, max_value, value_count FROM dl.ducklake_file_column_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'stats_test')
+ORDER BY column_id
+----
+1	0	999	1000
+2	000000	000999	1000
+
+# Verify filter pushdown still works with appender-written stats
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.stats_test WHERE i > 900
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+query I
+SELECT COUNT(*) FROM ducklake.stats_test WHERE i > 900
+----
+99
+
+# ------------------------------------------
+# NULL values in data
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.null_test(id INTEGER, value VARCHAR);
+
+statement ok
+INSERT INTO ducklake.null_test VALUES (1, 'a'), (2, NULL), (3, 'c'), (4, NULL);
+
+query II
+SELECT * FROM ducklake.null_test ORDER BY id
+----
+1	a
+2	NULL
+3	c
+4	NULL
+
+# Check null counts are recorded
+query II
+SELECT column_id, null_count FROM dl.ducklake_file_column_stats 
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'null_test')
+ORDER BY column_id
+----
+1	0
+2	2
+
+# ------------------------------------------
+# Filter pushdown with explicit multi-file setup
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.pruning_test(id INTEGER, value VARCHAR);
+
+# Create 3 separate files with known ranges
+statement ok
+INSERT INTO ducklake.pruning_test SELECT i, printf('%06d', i) FROM range(0, 1000) t(i);
+
+statement ok
+INSERT INTO ducklake.pruning_test SELECT i, printf('%06d', i) FROM range(1000, 2000) t(i);
+
+statement ok
+INSERT INTO ducklake.pruning_test SELECT i, printf('%06d', i) FROM range(2000, 3000) t(i);
+
+# Verify we have 3 data files
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'pruning_test')
+----
+3
+
+# Verify each file has column stats
+query I
+SELECT COUNT(*) FROM dl.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'pruning_test')
+----
+6
+
+# Query that should only hit the first file (id: 0-999)
+query I
+SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 500
+----
+500
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 500
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# Query that should hit first two files (id: 0-1999)
+query I
+SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 1500
+----
+1500
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 1500
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+
+# Query that should hit all three files
+query I
+SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 2500
+----
+2500
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.pruning_test WHERE id < 2500
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 3.*

--- a/test/sql/metadata/appender_partition_values.test
+++ b/test/sql/metadata/appender_partition_values.test
@@ -1,0 +1,202 @@
+# name: test/sql/metadata/appender_partition_values.test
+# description: Test partition values are correctly written via the DuckDB Appender API
+# group: [metadata]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_appender_partition_test', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
+
+# ------------------------------------------
+# Single partition column with multiple files
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.single_partition(id INTEGER, category VARCHAR, value INTEGER);
+ALTER TABLE ducklake.single_partition SET PARTITIONED BY (category);
+
+# Create multiple files for partition 'A' (two separate inserts)
+statement ok
+INSERT INTO ducklake.single_partition VALUES (1, 'A', 100), (2, 'A', 200);
+
+statement ok
+INSERT INTO ducklake.single_partition VALUES (3, 'A', 300);
+
+# Create files for other partitions
+statement ok
+INSERT INTO ducklake.single_partition VALUES (4, 'B', 400), (5, 'B', 500);
+
+statement ok
+INSERT INTO ducklake.single_partition VALUES (6, 'C', 600);
+
+# Verify we have 4 data files total
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'single_partition')
+----
+4
+
+# Verify partition values were recorded (should have entries for each file)
+query I
+SELECT COUNT(*) FROM dl.ducklake_file_partition_value
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'single_partition')
+----
+4
+
+# Verify 3 distinct partition values
+query I
+SELECT COUNT(DISTINCT partition_value) FROM dl.ducklake_file_partition_value
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'single_partition')
+----
+3
+
+# Verify data can be read back
+query III
+SELECT * FROM ducklake.single_partition ORDER BY id
+----
+1	A	100
+2	A	200
+3	A	300
+4	B	400
+5	B	500
+6	C	600
+
+# Verify partition pruning works - should read only 2 files for partition 'A'
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.single_partition WHERE category = 'A'
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+
+query III
+SELECT * FROM ducklake.single_partition WHERE category = 'A' ORDER BY id
+----
+1	A	100
+2	A	200
+3	A	300
+
+# Pruning for partition 'B' should read 1 file
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.single_partition WHERE category = 'B'
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+query III
+SELECT * FROM ducklake.single_partition WHERE category = 'B' ORDER BY id
+----
+4	B	400
+5	B	500
+
+# ------------------------------------------
+# Multiple partition columns with multiple files
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.multi_partition(id INTEGER, year INTEGER, month INTEGER, value VARCHAR);
+ALTER TABLE ducklake.multi_partition SET PARTITIONED BY (year, month);
+
+# Create separate files with different partition combinations
+statement ok
+INSERT INTO ducklake.multi_partition VALUES (1, 2023, 1, 'jan2023_a');
+
+statement ok
+INSERT INTO ducklake.multi_partition VALUES (2, 2023, 1, 'jan2023_b');
+
+statement ok
+INSERT INTO ducklake.multi_partition VALUES (3, 2023, 2, 'feb2023');
+
+statement ok
+INSERT INTO ducklake.multi_partition VALUES (4, 2024, 1, 'jan2024');
+
+# Verify we have 4 data files
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'multi_partition')
+----
+4
+
+# Each file has 2 partition columns, so 8 partition values total
+query I
+SELECT COUNT(*) FROM dl.ducklake_file_partition_value
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'multi_partition')
+----
+8
+
+# Data can be read back correctly
+query IIII
+SELECT * FROM ducklake.multi_partition ORDER BY id
+----
+1	2023	1	jan2023_a
+2	2023	1	jan2023_b
+3	2023	2	feb2023
+4	2024	1	jan2024
+
+# Partition pruning with multiple columns - year=2023 AND month=1 should read 2 files
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.multi_partition WHERE year = 2023 AND month = 1
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+
+query IIII
+SELECT * FROM ducklake.multi_partition WHERE year = 2023 AND month = 1 ORDER BY id
+----
+1	2023	1	jan2023_a
+2	2023	1	jan2023_b
+
+# Pruning for year=2024 should read 1 file
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.multi_partition WHERE year = 2024
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+query IIII
+SELECT * FROM ducklake.multi_partition WHERE year = 2024 ORDER BY id
+----
+4	2024	1	jan2024
+
+# ------------------------------------------
+# Adding more data to existing partitions
+# ------------------------------------------
+statement ok
+INSERT INTO ducklake.single_partition VALUES (7, 'A', 700);
+
+statement ok
+INSERT INTO ducklake.single_partition VALUES (8, 'D', 800);
+
+# Should now have 6 data files (4 original + 2 new)
+query I
+SELECT COUNT(*) FROM dl.ducklake_data_file WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'single_partition')
+----
+6
+
+# Data integrity check
+query I
+SELECT COUNT(*) FROM ducklake.single_partition
+----
+8
+
+# Partition 'A' should now have 3 files and all data
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.single_partition WHERE category = 'A'
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 3.*
+
+query III
+SELECT * FROM ducklake.single_partition WHERE category = 'A' ORDER BY id
+----
+1	A	100
+2	A	200
+3	A	300
+7	A	700
+
+# New partition 'D' should have 1 file
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.single_partition WHERE category = 'D'
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+query III
+SELECT * FROM ducklake.single_partition WHERE category = 'D' ORDER BY id
+----
+8	D	800

--- a/test/sql/metadata/appender_variant_stats.test
+++ b/test/sql/metadata/appender_variant_stats.test
@@ -1,0 +1,132 @@
+# name: test/sql/metadata/appender_variant_stats.test
+# description: Test variant stats are correctly written via the DuckDB Appender API
+# group: [metadata]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_appender_variant_test', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
+
+# ------------------------------------------
+# Variant column with primitive values
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.variant_primitive AS
+SELECT COLUMNS(*)::VARIANT FROM (VALUES
+    (10::VARIANT),
+    (20::VARIANT),
+    (30::VARIANT)
+) t(col);
+
+# Verify variant stats are recorded
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM dl.ducklake_file_variant_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'variant_primitive')
+----
+root	int32	10	30
+
+# Verify data can be read back
+query I
+FROM ducklake.variant_primitive
+----
+10
+20
+30
+
+# ------------------------------------------
+# Variant column with mixed values including nulls
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.variant_with_nulls AS
+SELECT COLUMNS(*)::VARIANT FROM (VALUES
+    (100::VARIANT),
+    (NULL::VARIANT),
+    (200::VARIANT),
+    (NULL::VARIANT)
+) t(col);
+
+# Variant stats should include null count
+query IIIII
+SELECT variant_path, shredded_type, min_value, max_value, null_count FROM dl.ducklake_file_variant_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'variant_with_nulls')
+----
+root	int32	100	200	2
+
+query I
+FROM ducklake.variant_with_nulls
+----
+100
+NULL
+200
+NULL
+
+# ------------------------------------------
+# Variant column with string values
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.variant_strings AS
+SELECT COLUMNS(*)::VARIANT FROM (VALUES
+    ('apple'::VARIANT),
+    ('banana'::VARIANT),
+    ('cherry'::VARIANT)
+) t(col);
+
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM dl.ducklake_file_variant_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'variant_strings')
+----
+root	varchar	apple	cherry
+
+query I
+FROM ducklake.variant_strings
+----
+apple
+banana
+cherry
+
+# ------------------------------------------
+# Variant column with nested array values
+# ------------------------------------------
+statement ok
+CREATE TABLE ducklake.variant_arrays AS
+SELECT COLUMNS(*)::VARIANT FROM (VALUES
+    (['a', 'b', 'c']::VARIANT),
+    (['x', 'y', 'z']::VARIANT)
+) t(col);
+
+# Array element stats
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM dl.ducklake_file_variant_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'variant_arrays')
+----
+element	varchar	a	z
+
+query I
+FROM ducklake.variant_arrays
+----
+[a, b, c]
+[x, y, z]
+
+# ------------------------------------------
+# Multiple inserts with variant data
+# ------------------------------------------
+statement ok
+INSERT INTO ducklake.variant_primitive SELECT (i * 10)::VARIANT FROM range(4, 11) t(i);
+
+query I
+SELECT COUNT(*) FROM ducklake.variant_primitive
+----
+10
+
+# Verify stats are recorded for multiple data files
+query I
+SELECT COUNT(*) FROM dl.ducklake_file_variant_stats
+WHERE table_id = (SELECT table_id FROM dl.ducklake_table WHERE table_name = 'variant_primitive')
+----
+2


### PR DESCRIPTION
The metadata manager currently constructs SQL strings to insert new metadata when writing new data files. If using DuckDB as the catalog, the Appender API eliminates most of that overhead and greatly improves bulk insert performance.

This makes a very big difference when using `ducklake_add_data_files` to bulk import tens to hundreds of thousands of existing Parquet files. Even beyond the performance improvement, peak memory usage also goes down significantly using this approach (no more massive SQL strings that have to be parsed into an AST).