### PR TITLE
Eagerly process metadata when importing Parquet files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "storage/ducklake_geo_stats.hpp"
+#include <unordered_set>
 
 namespace duckdb {
 
@@ -134,7 +135,7 @@ public:
 	vector<DuckLakeDataFile> AddFiles(const vector<string> &globs);
 
 private:
-	void ReadParquetFullMetadata(const string &glob);
+	void ReadParquetFullMetadata(const string &glob, vector<DuckLakeDataFile> &result);
 	DuckLakeDataFile AddFileToTable(ParquetFileMetadata &file);
 	unique_ptr<DuckLakeNameMapEntry> MapColumn(ParquetFileMetadata &file_metadata, ParquetColumn &column,
 	                                           const DuckLakeFieldId &field_id, string prefix);
@@ -157,10 +158,10 @@ private:
 	bool ignore_extra_columns;
 	map<string, string> hive_partitions;
 	HivePartitioningType hive_partitioning;
-	unordered_map<string, unique_ptr<ParquetFileMetadata>> parquet_files;
+	unordered_set<string> processed_files;
 };
 
-void DuckLakeFileProcessor::ReadParquetFullMetadata(const string &glob) {
+void DuckLakeFileProcessor::ReadParquetFullMetadata(const string &glob, vector<DuckLakeDataFile> &written_files) {
 	auto result = transaction.Query(StringUtil::Format(R"(
 SELECT 
     list_transform(parquet_file_metadata, x -> struct_pack(
@@ -231,16 +232,14 @@ FROM parquet_full_metadata(%s)
 		    FlatVector::GetData<string_t>(*struct_children[0])[struct_idx].GetString(); // struct field: file_name
 
 		// Check if we've already processed this file (can happen with overlapping globs)
-		auto &file_metadata_ptr = parquet_files[filename];
-		if (file_metadata_ptr) {
+		if (processed_files.count(filename)) {
 			// File already processed in a previous glob, skip
 			continue;
 		}
+		processed_files.insert(filename);
 
-		// Initialize new file metadata entry
-		file_metadata_ptr = make_uniq<ParquetFileMetadata>();
-		auto &file = *file_metadata_ptr;
-		file.filename = filename;
+		ParquetFileMetadata file;
+		file.filename = std::move(filename);
 
 		file.row_count = FlatVector::GetData<int64_t>(*struct_children[1])[struct_idx]; // struct field: num_rows
 		file.file_size_bytes =
@@ -482,6 +481,11 @@ FROM parquet_full_metadata(%s)
 			}
 
 			column.column_stats.push_back(std::move(stats));
+		}
+		auto data_file = AddFileToTable(file);
+		data_file.created_by_ducklake = false;
+		if (data_file.row_count > 0) {
+			written_files.push_back(std::move(data_file));
 		}
 	}
 }
@@ -1209,23 +1213,11 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 }
 
 vector<DuckLakeDataFile> DuckLakeFileProcessor::AddFiles(const vector<string> &globs) {
-	// fetch the metadata, stats and columns from the various files
-	for (auto &glob : globs) {
-		ReadParquetFullMetadata(glob);
-	}
-
-	// now we have obtained a list of files to add together with the relevant information (statistics, file size, ...)
-	// we need to create a mapping from the columns in the file to the columns in the table
+	// Process files directly to DuckLakeDataFile format to minimize peak memory usage
+	// Each file's intermediate metadata is discarded immediately after processing
 	vector<DuckLakeDataFile> written_files;
-	for (auto &entry : parquet_files) {
-		auto file = AddFileToTable(*entry.second);
-		// File being called by 'add files' is not created by ducklake
-		file.created_by_ducklake = false;
-		if (file.row_count == 0) {
-			// skip adding empty files
-			continue;
-		}
-		written_files.push_back(std::move(file));
+	for (auto &glob : globs) {
+		ReadParquetFullMetadata(glob, written_files);
 	}
 	return written_files;
 }

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -231,12 +231,15 @@ FROM parquet_full_metadata(%s)
 		auto filename =
 		    FlatVector::GetData<string_t>(*struct_children[0])[struct_idx].GetString(); // struct field: file_name
 
+		// Normalize path separators for consistent deduplication across platforms (Windows uses backslashes)
+		auto normalized_filename = StringUtil::Replace(filename, "\\", "/");
+
 		// Check if we've already processed this file (can happen with overlapping globs)
-		if (processed_files.count(filename)) {
+		if (processed_files.count(normalized_filename)) {
 			// File already processed in a previous glob, skip
 			continue;
 		}
-		processed_files.insert(filename);
+		processed_files.insert(normalized_filename);
 
 		ParquetFileMetadata file;
 		file.filename = std::move(filename);

--- a/test/sql/add_files/add_files_overlapping_globs.test
+++ b/test/sql/add_files/add_files_overlapping_globs.test
@@ -1,0 +1,129 @@
+# name: test/sql/add_files/add_files_overlapping_globs.test
+# description: test ducklake adding files with overlapping globs (same file matched by multiple globs)
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_overlapping_globs/', METADATA_CATALOG 'metadata');
+
+statement ok
+CREATE TABLE ducklake.test(col1 INTEGER, col2 VARCHAR);
+
+# Insert initial data to create the directory structure
+statement ok
+INSERT INTO ducklake.test VALUES (0, 'initial');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Create multiple parquet files in the table data directory (created by INSERT/flush)
+statement ok
+COPY (SELECT 1 col1, 'a' col2) TO '${DATA_PATH}/ducklake_overlapping_globs/main/test/file1.parquet';
+
+statement ok
+COPY (SELECT 2 col1, 'b' col2) TO '${DATA_PATH}/ducklake_overlapping_globs/main/test/file2.parquet';
+
+statement ok
+COPY (SELECT 3 col1, 'c' col2) TO '${DATA_PATH}/ducklake_overlapping_globs/main/test/file3.parquet';
+
+# Test 1: Add files using overlapping globs - the wildcard should match all 3 files,
+# and we also explicitly add file1.parquet - it should only be added once
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test', [
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file*.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file1.parquet'
+])
+
+# Each file should appear exactly once (3 new + 1 initial = 4 total rows)
+query II rowsort
+FROM ducklake.test
+----
+0	initial
+1	a
+2	b
+3	c
+
+# Verify the count is exactly 4 (no duplicates from overlapping globs)
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+4
+
+
+# Test 2: Create a new table and test with same glob listed twice
+statement ok
+CREATE TABLE ducklake.test2(col1 INTEGER, col2 VARCHAR);
+
+# Same glob listed twice - each file should only be added once
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test2', [
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file*.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file*.parquet'
+])
+
+query II rowsort
+FROM ducklake.test2
+----
+1	a
+2	b
+3	c
+
+query I
+SELECT COUNT(*) FROM ducklake.test2
+----
+3
+
+
+# Test 3: Create another table and add the same file multiple times explicitly
+statement ok
+CREATE TABLE ducklake.test3(col1 INTEGER, col2 VARCHAR);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test3', [
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file1.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file1.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file1.parquet'
+])
+
+# file1 should only be added once, not three times
+query II
+FROM ducklake.test3
+----
+1	a
+
+query I
+SELECT COUNT(*) FROM ducklake.test3
+----
+1
+
+
+# Test 4: Test with explicit file paths and wildcard that overlap
+statement ok
+CREATE TABLE ducklake.test4(col1 INTEGER, col2 VARCHAR);
+
+# Add file2 and file3 explicitly, plus wildcard that matches all files including file2 and file3
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test4', [
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file2.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file3.parquet',
+    '${DATA_PATH}/ducklake_overlapping_globs/main/test/file*.parquet'
+])
+
+query II rowsort
+FROM ducklake.test4
+----
+1	a
+2	b
+3	c
+
+query I
+SELECT COUNT(*) FROM ducklake.test4
+----
+3


### PR DESCRIPTION
Currently, `ducklake_add_data_files` reads all Parquet metadata into a vector of memory-intensive `ParquetFileMetadata` objects before adding them to the table. This PR processes metadata eagerly to reduce peak memory consumption.

This makes a difference when using `ducklake_add_data_files` to import tens or hundreds of thousands of existing Parquet files.

I also added a test for importing overlapping globs, a previously untested feature of `ducklake_add_data_files`. It turns out there is an issue specifically on Windows systems ([failing test log](https://github.com/thalassemia/ducklake/actions/runs/22649255427/job/65645759704)) that is resolved by replacing backslashes with forward slashes (aadf6ad).