### PR TITLE
Implicit type casting and null handling for Hive partition keys when importing Parquet files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1147,9 +1147,13 @@ void DuckLakeFileProcessor::MapPartitionColumns(ParquetFileMetadata &file) {
 			// key not found in the file path
 			continue;
 		}
-		auto hive_value = HivePartitioning::GetValue(context, partition_key_name, hive_entry->second, field_id->Type());
+		// Get the correct type for the partition key based on the transform
+		// For YEAR/MONTH/DAY/HOUR transforms, the type is BIGINT, not the source column type
+		auto partition_key_type =
+		    DuckLakePartitionUtils::GetPartitionKeyType(partition_field.transform.type, field_id->Type());
+		auto hive_value = HivePartitioning::GetValue(context, partition_key_name, hive_entry->second, partition_key_type);
 		file.hive_partition_values.emplace_back(
-		    HivePartition {partition_field.field_id, field_id->Type(), hive_value});
+		    HivePartition {partition_field.field_id, partition_key_type, hive_value});
 	}
 }
 

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1097,7 +1097,9 @@ DuckLakeFileProcessor::MapColumns(ParquetFileMetadata &file_metadata,
 		}
 		auto hive_entry = hive_partitions.find(col->name);
 		if (hive_entry != hive_partitions.end()) {
-			column_maps.push_back(MapHiveColumn(file_metadata, entry->second.get(), Value(hive_entry->second)));
+			auto hive_value =
+			    HivePartitioning::GetValue(context, col->name, hive_entry->second, entry->second.get().Type());
+			column_maps.push_back(MapHiveColumn(file_metadata, entry->second.get(), hive_value));
 			field_id_map.erase(entry);
 			continue;
 		}

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -5,6 +5,7 @@
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_insert.hpp"
 #include "duckdb/common/constants.hpp"
+#include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/common/types/vector.hpp"
@@ -126,9 +127,11 @@ struct ParquetFileMetadata {
 
 struct DuckLakeFileProcessor {
 public:
-	DuckLakeFileProcessor(DuckLakeTransaction &transaction, const DuckLakeAddDataFilesData &bind_data)
-	    : transaction(transaction), table(bind_data.table), allow_missing(bind_data.allow_missing),
-	      ignore_extra_columns(bind_data.ignore_extra_columns), hive_partitioning(bind_data.hive_partitioning) {
+	DuckLakeFileProcessor(DuckLakeTransaction &transaction, ClientContext &context,
+	                      const DuckLakeAddDataFilesData &bind_data)
+	    : transaction(transaction), context(context), table(bind_data.table),
+	      allow_missing(bind_data.allow_missing), ignore_extra_columns(bind_data.ignore_extra_columns),
+	      hive_partitioning(bind_data.hive_partitioning) {
 	}
 
 	vector<DuckLakeDataFile> AddFiles(const vector<string> &globs);
@@ -152,6 +155,7 @@ private:
 
 private:
 	DuckLakeTransaction &transaction;
+	ClientContext &context;
 	DuckLakeTableEntry &table;
 	bool allow_missing;
 	bool ignore_extra_columns;
@@ -1051,9 +1055,12 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 		auto &hive_value = entry.hive_value;
 
 		DuckLakeColumnStats column_stats(field_type);
-		column_stats.min = column_stats.max = hive_value.ToString();
-		column_stats.has_min = column_stats.has_max = true;
-		column_stats.has_null_count = true;
+		column_stats.has_null_count = false;
+		if (!hive_value.IsNull()) {
+			column_stats.has_null_count = true;
+			column_stats.min = column_stats.max = hive_value.ToString();
+			column_stats.has_min = column_stats.has_max = true;
+		}
 
 		result.column_stats.emplace(field_index, std::move(column_stats));
 	}
@@ -1096,7 +1103,8 @@ DuckLakeFileProcessor::MapColumns(ParquetFileMetadata &file_metadata,
 		auto hive_entry = hive_partitions.find(field_id.Name());
 		if (hive_entry != hive_partitions.end()) {
 			// the column exists in the hive partitions - check if the type matches
-			column_maps.push_back(MapHiveColumn(file_metadata, field_id, Value(hive_entry->second)));
+			auto hive_value = HivePartitioning::GetValue(context, field_id.Name(), hive_entry->second, field_id.Type());
+			column_maps.push_back(MapHiveColumn(file_metadata, field_id, hive_value));
 			continue;
 		}
 		// column does not exist - check if we are ignoring missing columns
@@ -1139,9 +1147,9 @@ void DuckLakeFileProcessor::MapPartitionColumns(ParquetFileMetadata &file) {
 			// key not found in the file path
 			continue;
 		}
-
+		auto hive_value = HivePartitioning::GetValue(context, partition_key_name, hive_entry->second, field_id->Type());
 		file.hive_partition_values.emplace_back(
-		    HivePartition {partition_field.field_id, field_id->Type(), Value(hive_entry->second)});
+		    HivePartition {partition_field.field_id, field_id->Type(), hive_value});
 	}
 }
 
@@ -1238,7 +1246,7 @@ static void DuckLakeAddDataFilesExecute(ClientContext &context, TableFunctionInp
 	if (state.finished) {
 		return;
 	}
-	DuckLakeFileProcessor processor(transaction, bind_data);
+	DuckLakeFileProcessor processor(transaction, context, bind_data);
 	auto files_to_add = processor.AddFiles(bind_data.globs);
 	// add the files
 	transaction.AppendFiles(bind_data.table.GetTableId(), std::move(files_to_add));

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1055,12 +1055,15 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 		auto &hive_value = entry.hive_value;
 
 		DuckLakeColumnStats column_stats(field_type);
-		column_stats.has_null_count = false;
+		column_stats.has_null_count = true;
 		if (!hive_value.IsNull()) {
-			column_stats.has_null_count = true;
 			column_stats.min = column_stats.max = hive_value.ToString();
 			column_stats.has_min = column_stats.has_max = true;
-		}
+		} else {
+			// All rows in this file have NULL for this partition column
+			column_stats.null_count = file_metadata.row_count.GetIndex();
+			column_stats.any_valid = false;
+		};
 
 		result.column_stats.emplace(field_index, std::move(column_stats));
 	}

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1055,6 +1055,10 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 		auto &hive_value = entry.hive_value;
 
 		DuckLakeColumnStats column_stats(field_type);
+		// num_values and null_count both needed to write count
+		// metadata in DuckLakeColumnStatsInfo::FromColumnStats
+		column_stats.has_num_values = true;
+		column_stats.num_values = file_metadata.row_count.GetIndex();
 		column_stats.has_null_count = true;
 		if (!hive_value.IsNull()) {
 			column_stats.min = column_stats.max = hive_value.ToString();

--- a/src/include/storage/ducklake_partition_data.hpp
+++ b/src/include/storage/ducklake_partition_data.hpp
@@ -61,6 +61,23 @@ struct DuckLakePartitionUtils {
 		}
 		return prefix + "_" + field_name;
 	}
+
+	//! Get the partition key type for a partition field based on its transform
+	//! For IDENTITY transforms, returns the source column type
+	//! For YEAR, MONTH, DAY, HOUR transforms, returns BIGINT (the result type of those functions)
+	static LogicalType GetPartitionKeyType(DuckLakeTransformType transform_type, const LogicalType &source_type) {
+		switch (transform_type) {
+		case DuckLakeTransformType::IDENTITY:
+			return source_type;
+		case DuckLakeTransformType::YEAR:
+		case DuckLakeTransformType::MONTH:
+		case DuckLakeTransformType::DAY:
+		case DuckLakeTransformType::HOUR:
+			return LogicalType::BIGINT;
+		default:
+			throw NotImplementedException("Unsupported partition transform type");
+		}
+	}
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -402,7 +402,7 @@ shared_ptr<BaseFileReader> DuckLakeMultiFileReader::CreateReader(ClientContext &
 	return MultiFileReader::CreateReader(context, file, options, file_options, interface);
 }
 
-vector<MultiFileColumnDefinition> MapColumns(MultiFileReaderData &reader_data,
+vector<MultiFileColumnDefinition> MapColumns(ClientContext &context, MultiFileReaderData &reader_data,
                                              const vector<MultiFileColumnDefinition> &global_map,
                                              const vector<unique_ptr<DuckLakeNameMapEntry>> &column_maps,
                                              bool parent_is_list = false) {
@@ -442,8 +442,9 @@ vector<MultiFileColumnDefinition> MapColumns(MultiFileReaderData &reader_data,
 				                            "found in filename \"%s\"",
 				                            column_map->source_name, reader_data.reader->file.path);
 			}
-			Value partition_val(entry->second);
-			result_col.default_expression = make_uniq<ConstantExpression>(partition_val.DefaultCastAs(result_col.type));
+			// Use GetValue to handle NULL values (__HIVE_DEFAULT_PARTITION__) and type casting
+			Value partition_val = HivePartitioning::GetValue(context, column_map->source_name, entry->second, result_col.type);
+			result_col.default_expression = make_uniq<ConstantExpression>(std::move(partition_val));
 			continue;
 		}
 
@@ -456,16 +457,16 @@ vector<MultiFileColumnDefinition> MapColumns(MultiFileReaderData &reader_data,
 		// recursively process any child nodes
 		if (!column_map->child_entries.empty()) {
 			bool is_list = result_col.type.id() == LogicalTypeId::LIST;
-			result_col.children = MapColumns(reader_data, result_col.children, column_map->child_entries, is_list);
+			result_col.children = MapColumns(context, reader_data, result_col.children, column_map->child_entries, is_list);
 		}
 	}
 	return result;
 }
 
-vector<MultiFileColumnDefinition> CreateNewMapping(MultiFileReaderData &reader_data,
+vector<MultiFileColumnDefinition> CreateNewMapping(ClientContext &context, MultiFileReaderData &reader_data,
                                                    const vector<MultiFileColumnDefinition> &global_map,
                                                    const DuckLakeNameMap &name_map) {
-	return MapColumns(reader_data, global_map, name_map.column_maps);
+	return MapColumns(context, reader_data, global_map, name_map.column_maps);
 }
 
 ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
@@ -509,7 +510,7 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 			auto transaction = read_info.transaction.lock();
 			auto &mapping = transaction->GetMappingById(mapping_id);
 			// use the mapping to generate a new set of global columns for this file
-			auto mapped_columns = CreateNewMapping(reader_data, global_columns, mapping);
+			auto mapped_columns = CreateNewMapping(context, reader_data, global_columns, mapping);
 			return MultiFileReader::CreateMapping(context, reader_data, mapped_columns, column_ids_to_use, filters,
 			                                      multi_file_list, bind_data, virtual_columns,
 			                                      MultiFileColumnMappingMode::BY_NAME);

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -126,6 +126,10 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 			// for other types we can compare the strings directly
 			min = new_stats.min;
 		}
+	} else {
+		// current stats don't have min but new_stats does
+		has_min = true;
+		min = new_stats.min;
 	}
 
 	if (!new_stats.has_max) {
@@ -143,6 +147,10 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 			// for other types we can compare the strings directly
 			max = new_stats.max;
 		}
+	} else {
+		// current stats don't have max but new_stats does
+		has_max = true;
+		max = new_stats.max;
 	}
 
 	if (new_stats.extra_stats) {

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -126,10 +126,6 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 			// for other types we can compare the strings directly
 			min = new_stats.min;
 		}
-	} else {
-		// current stats don't have min but new_stats does
-		has_min = true;
-		min = new_stats.min;
 	}
 
 	if (!new_stats.has_max) {
@@ -147,10 +143,6 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 			// for other types we can compare the strings directly
 			max = new_stats.max;
 		}
-	} else {
-		// current stats don't have max but new_stats does
-		has_max = true;
-		max = new_stats.max;
 	}
 
 	if (new_stats.extra_stats) {
@@ -239,6 +231,10 @@ unique_ptr<BaseStatistics> DuckLakeColumnStats::CreateStringStats() const {
 	} else if (has_max) {
 		stats = StringStats::CreateUnknown(type);
 		StringStats::SetMax(stats, string_t(max));
+	} else {
+		// No min/max stats available - use unknown stats to avoid
+		// false claims about max_string_length (CreateEmpty sets it to 0)
+		stats = StringStats::CreateUnknown(type);
 	}
 
 	// set null count

--- a/test/sql/add_files/add_files_hive_mismatch.test
+++ b/test/sql/add_files/add_files_hive_mismatch.test
@@ -30,7 +30,7 @@ CREATE TABLE ducklake.test(part_key INT, part_key2 INT, val VARCHAR);
 statement error
 CALL ducklake_add_data_files('ducklake', 'test', '${DATA_PATH}/ducklake_add_files_hive_mismatch/**/*.parquet', hive_partitioning => true)
 ----
-cannot be cast to the column type
+Unable to cast 'p1' (from hive partition column 'PART_KEY') to: 'INTEGER'
 
 statement ok
 CREATE OR REPLACE TABLE ducklake.test(part_key VARCHAR, part_key2 INT, val VARCHAR);

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -259,6 +259,10 @@ SELECT id, value, partition_col FROM ducklake.test_null_stats WHERE partition_co
 # Verify internal metadata stats are correctly written for NULL partition columns
 # Query the file stats for the partition column (column_id=3)
 # Join with data_file to match by record_count to identify which file is which
+# Note: disable verification for this query to work around sqlite_scanner serialization issue
+statement ok
+PRAGMA disable_verification
+
 query IIII
 SELECT df.record_count, cs.null_count, cs.min_value, cs.max_value
 FROM "__ducklake_metadata_ducklake".ducklake_file_column_stats cs
@@ -270,6 +274,9 @@ ORDER BY df.record_count DESC, cs.min_value NULLS LAST;
 3	0	a	a
 2	2	NULL	NULL
 1	0	b	b
+
+statement ok
+PRAGMA enable_verification
 
 # Test that when a column exists both in parquet data AND as hive partition,
 # the hive partition value takes precedence and is properly handled

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -148,3 +148,67 @@ SELECT id, name FROM ducklake.test_special ORDER BY id;
 2	test&value
 3	with=equals
 
+# Test that NULL partition column statistics are correctly tracked
+statement ok
+CREATE TABLE ducklake.test_null_stats(id INTEGER, value INTEGER, partition_col VARCHAR);
+
+statement ok
+COPY (SELECT 1 AS id, 100 AS value, 'a' AS partition_col
+    UNION ALL
+    SELECT 2 AS id, 200 AS value, 'a' AS partition_col
+    UNION ALL
+    SELECT 3 AS id, 300 AS value, 'a' AS partition_col
+    UNION ALL
+    SELECT 4 AS id, 400 AS value, NULL AS partition_col
+    UNION ALL
+    SELECT 5 AS id, 500 AS value, NULL AS partition_col
+    UNION ALL
+    SELECT 6 AS id, 600 AS value, 'b' AS partition_col)
+TO '${DATA_PATH}/null_stats' (FORMAT parquet, PARTITION_BY (partition_col));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_null_stats',
+    '${DATA_PATH}/null_stats/*/*.parquet',
+    hive_partitioning => true)
+
+# Verify all data is returned correctly
+query III
+SELECT id, value, partition_col FROM ducklake.test_null_stats ORDER BY id;
+----
+1	100	a
+2	200	a
+3	300	a
+4	400	NULL
+5	500	NULL
+6	600	b
+
+# Verify filtering on NULL partition values works correctly
+query III
+SELECT id, value, partition_col FROM ducklake.test_null_stats WHERE partition_col IS NULL ORDER BY id;
+----
+4	400	NULL
+5	500	NULL
+
+# Verify filtering on non-NULL partition values works correctly
+query III
+SELECT id, value, partition_col FROM ducklake.test_null_stats WHERE partition_col IS NOT NULL ORDER BY id;
+----
+1	100	a
+2	200	a
+3	300	a
+6	600	b
+
+# Verify internal metadata stats are correctly written for NULL partition columns
+# Query the file stats for the partition column (column_id=3)
+# Join with data_file to match by record_count to identify which file is which
+query IIII
+SELECT df.record_count, cs.null_count, cs.min_value, cs.max_value
+FROM "__ducklake_metadata_ducklake".ducklake_file_column_stats cs
+JOIN "__ducklake_metadata_ducklake".ducklake_data_file df ON cs.data_file_id = df.data_file_id
+JOIN "__ducklake_metadata_ducklake".ducklake_table t ON cs.table_id = t.table_id
+WHERE t.table_name = 'test_null_stats' AND cs.column_id = 3
+ORDER BY df.record_count DESC, cs.min_value NULLS LAST;
+----
+3	0	a	a
+2	2	NULL	NULL
+1	0	b	b

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -270,3 +270,40 @@ ORDER BY df.record_count DESC, cs.min_value NULLS LAST;
 3	0	a	a
 2	2	NULL	NULL
 1	0	b	b
+
+# Test that when a column exists both in parquet data AND as hive partition,
+# the hive partition value takes precedence and is properly handled
+statement ok
+CREATE TABLE ducklake.test_hive_precedence(id INTEGER, category DOUBLE);
+
+# First create the directory structure using a dummy partition write
+statement ok
+COPY (SELECT 1 AS id, 3.14 AS category UNION ALL SELECT 2 AS id, NULL AS category)
+TO '${DATA_PATH}/ducklake_hive_precedence' (FORMAT parquet, PARTITION_BY (category));
+
+# Now overwrite those files with parquet files that contain 'from_parquet' as category value
+# but keep the same hive directory structure
+statement ok
+COPY (SELECT 1 AS id, '3.14' AS category) TO '${DATA_PATH}/ducklake_hive_precedence/category=3.14/data.parquet' (FORMAT parquet, OVERWRITE true);
+
+statement ok
+COPY (SELECT 2 AS id, NULL AS category) TO '${DATA_PATH}/ducklake_hive_precedence/category=__HIVE_DEFAULT_PARTITION__/data.parquet' (FORMAT parquet, OVERWRITE true);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_hive_precedence',
+    '${DATA_PATH}/ducklake_hive_precedence/*/data.parquet',
+    hive_partitioning => true)
+
+# The category values should come from the hive partition path (alpha, beta),
+# NOT from the parquet file data (from_parquet)
+query II
+SELECT id, category FROM ducklake.test_hive_precedence ORDER BY id;
+----
+1	3.14
+2	NULL
+
+# Verify typeof() for timestamp columns
+query I
+SELECT typeof(category) FROM ducklake.test_hive_precedence LIMIT 1;
+----
+DOUBLE

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -1,0 +1,150 @@
+# name: test/sql/add_files/add_files_hive_partition_cast.test
+# description: test ducklake hive partition implicit casting
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive')
+
+statement ok
+CREATE TABLE ducklake.test(id INTEGER, year INTEGER, month INTEGER, day DATE);
+
+statement ok
+COPY (SELECT 1 AS id, 2024 AS year, 1 AS month, DATE '2024-01-02' AS day
+    UNION ALL
+    SELECT 2 AS id, 2024 AS year, 2 AS month, NULL AS day)
+TO '${DATA_PATH}/ducklake_add_files_hive' (FORMAT parquet, PARTITION_BY (year, month, day));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test',
+    '${DATA_PATH}/ducklake_add_files_hive/*/*/*/*.parquet',
+    hive_partitioning => true)
+
+query IIII
+SELECT id, year, month, day FROM ducklake.test ORDER BY id;
+----
+1	2024	1	2024-01-02
+2	2024	2	NULL
+
+# Test null partitions
+statement ok
+CREATE TABLE ducklake.test_null(id INTEGER, category VARCHAR, amount DECIMAL(10,2));
+
+statement ok
+COPY (SELECT 1 AS id, 'electronics' AS category, 99.99::DECIMAL(10,2) AS amount
+    UNION ALL
+    SELECT 2 AS id, NULL AS category, 50.00::DECIMAL(10,2) AS amount
+    UNION ALL
+    SELECT 3 AS id, 'home appliances' AS category, NULL AS amount)
+TO '${DATA_PATH}/hive_null' (FORMAT parquet, PARTITION_BY (category, amount));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_null',
+    '${DATA_PATH}/hive_null/*/*/*.parquet',
+    hive_partitioning => true)
+
+query III
+SELECT id, category, amount FROM ducklake.test_null ORDER BY id;
+----
+1	electronics	99.99
+2	NULL	50.00
+3	home appliances	NULL
+
+# Test boolean casting
+statement ok
+CREATE TABLE ducklake.test_bool(id INTEGER, active BOOLEAN, verified BOOLEAN);
+
+statement ok
+COPY (SELECT 1 AS id, true AS active, false AS verified
+    UNION ALL
+    SELECT 2 AS id, false AS active, true AS verified)
+TO '${DATA_PATH}/bool_test' (FORMAT parquet, PARTITION_BY (active, verified));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_bool',
+    '${DATA_PATH}/bool_test/*/*/*.parquet',
+    hive_partitioning => true)
+
+query III
+SELECT id, active, verified FROM ducklake.test_bool ORDER BY id;
+----
+1	true	false
+2	false	true
+
+# Test floating point values
+statement ok
+CREATE TABLE ducklake.test_float(id INTEGER, ratio DOUBLE, percentage FLOAT);
+
+statement ok
+COPY (SELECT 1 AS id, 3.14159 AS ratio, 99.5::FLOAT AS percentage
+    UNION ALL
+    SELECT 2 AS id, -0.001 AS ratio, 0.0::FLOAT AS percentage)
+TO '${DATA_PATH}/float_test' (FORMAT parquet, PARTITION_BY (ratio, percentage));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_float',
+    '${DATA_PATH}/float_test/*/*/*.parquet',
+    hive_partitioning => true)
+
+query III
+SELECT id, ratio, percentage FROM ducklake.test_float ORDER BY id;
+----
+1	3.14159	99.5
+2	-0.001	0.0
+
+# Test timestamp values with NULL
+statement ok
+CREATE TABLE ducklake.test_ts(id INTEGER, created_at TIMESTAMP);
+
+statement ok
+COPY (SELECT 1 AS id, TIMESTAMP '2024-01-15 10:30:00' AS created_at
+    UNION ALL
+    SELECT 2 AS id, NULL AS created_at)
+TO '${DATA_PATH}/ts_test' (FORMAT parquet, PARTITION_BY (created_at));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_ts',
+    '${DATA_PATH}/ts_test/*/*.parquet',
+    hive_partitioning => true)
+
+query II
+SELECT id, created_at FROM ducklake.test_ts ORDER BY id;
+----
+1	2024-01-15 10:30:00
+2	NULL
+
+# Test URL-encoded special characters in VARCHAR (spaces via partition)
+statement ok
+CREATE TABLE ducklake.test_special(id INTEGER, name VARCHAR);
+
+statement ok
+COPY (SELECT 1 AS id, 'hello world' AS name
+    UNION ALL
+    SELECT 2 AS id, 'test&value' AS name
+    UNION ALL
+    SELECT 3 AS id, 'with=equals' AS name)
+TO '${DATA_PATH}/special_test' (FORMAT parquet, PARTITION_BY (name));
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'test_special',
+    '${DATA_PATH}/special_test/*/*.parquet',
+    hive_partitioning => true)
+
+query II
+SELECT id, name FROM ducklake.test_special ORDER BY id;
+----
+1	hello world
+2	test&value
+3	with=equals
+

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -15,7 +15,7 @@ statement ok
 PRAGMA enable_verification
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_add_files_hive_cast')
 
 statement ok
 CREATE TABLE ducklake.test(id INTEGER, year INTEGER, month INTEGER, day DATE);
@@ -24,11 +24,11 @@ statement ok
 COPY (SELECT 1 AS id, 2024 AS year, 1 AS month, DATE '2024-01-02' AS day
     UNION ALL
     SELECT 2 AS id, 2024 AS year, 2 AS month, NULL AS day)
-TO '${DATA_PATH}/ducklake_add_files_hive' (FORMAT parquet, PARTITION_BY (year, month, day));
+TO '${DATA_PATH}/ducklake_add_files_hive_cast' (FORMAT parquet, PARTITION_BY (year, month, day));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test',
-    '${DATA_PATH}/ducklake_add_files_hive/*/*/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_cast/*/*/*/*.parquet',
     hive_partitioning => true)
 
 query IIII
@@ -47,11 +47,11 @@ COPY (SELECT 1 AS id, 'electronics' AS category, 99.99::DECIMAL(10,2) AS amount
     SELECT 2 AS id, NULL AS category, 50.00::DECIMAL(10,2) AS amount
     UNION ALL
     SELECT 3 AS id, 'home appliances' AS category, NULL AS amount)
-TO '${DATA_PATH}/hive_null' (FORMAT parquet, PARTITION_BY (category, amount));
+TO '${DATA_PATH}/ducklake_add_files_hive_null' (FORMAT parquet, PARTITION_BY (category, amount));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_null',
-    '${DATA_PATH}/hive_null/*/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_null/*/*/*.parquet',
     hive_partitioning => true)
 
 query III
@@ -69,11 +69,11 @@ statement ok
 COPY (SELECT 1 AS id, true AS active, false AS verified
     UNION ALL
     SELECT 2 AS id, false AS active, true AS verified)
-TO '${DATA_PATH}/bool_test' (FORMAT parquet, PARTITION_BY (active, verified));
+TO '${DATA_PATH}/ducklake_add_files_hive_bool' (FORMAT parquet, PARTITION_BY (active, verified));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_bool',
-    '${DATA_PATH}/bool_test/*/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_bool/*/*/*.parquet',
     hive_partitioning => true)
 
 query III
@@ -90,11 +90,11 @@ statement ok
 COPY (SELECT 1 AS id, 3.14159 AS ratio, 99.5::FLOAT AS percentage
     UNION ALL
     SELECT 2 AS id, -0.001 AS ratio, 0.0::FLOAT AS percentage)
-TO '${DATA_PATH}/float_test' (FORMAT parquet, PARTITION_BY (ratio, percentage));
+TO '${DATA_PATH}/ducklake_add_files_hive_float' (FORMAT parquet, PARTITION_BY (ratio, percentage));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_float',
-    '${DATA_PATH}/float_test/*/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_float/*/*/*.parquet',
     hive_partitioning => true)
 
 query III
@@ -111,11 +111,11 @@ statement ok
 COPY (SELECT 1 AS id, TIMESTAMP '2024-01-15 10:30:00' AS created_at
     UNION ALL
     SELECT 2 AS id, NULL AS created_at)
-TO '${DATA_PATH}/ts_test' (FORMAT parquet, PARTITION_BY (created_at));
+TO '${DATA_PATH}/ducklake_add_files_hive_ts' (FORMAT parquet, PARTITION_BY (created_at));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_ts',
-    '${DATA_PATH}/ts_test/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_ts/*/*.parquet',
     hive_partitioning => true)
 
 query II
@@ -134,11 +134,11 @@ COPY (SELECT 1 AS id, 'hello world' AS name
     SELECT 2 AS id, 'test&value' AS name
     UNION ALL
     SELECT 3 AS id, 'with=equals' AS name)
-TO '${DATA_PATH}/special_test' (FORMAT parquet, PARTITION_BY (name));
+TO '${DATA_PATH}/ducklake_add_files_hive_special' (FORMAT parquet, PARTITION_BY (name));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_special',
-    '${DATA_PATH}/special_test/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_special/*/*.parquet',
     hive_partitioning => true)
 
 query II
@@ -164,11 +164,11 @@ COPY (SELECT 1 AS id, 100 AS value, 'a' AS partition_col
     SELECT 5 AS id, 500 AS value, NULL AS partition_col
     UNION ALL
     SELECT 6 AS id, 600 AS value, 'b' AS partition_col)
-TO '${DATA_PATH}/null_stats' (FORMAT parquet, PARTITION_BY (partition_col));
+TO '${DATA_PATH}/ducklake_add_files_hive_null_stats' (FORMAT parquet, PARTITION_BY (partition_col));
 
 statement ok
 CALL ducklake_add_data_files('ducklake', 'test_null_stats',
-    '${DATA_PATH}/null_stats/*/*.parquet',
+    '${DATA_PATH}/ducklake_add_files_hive_null_stats/*/*.parquet',
     hive_partitioning => true)
 
 # Verify all data is returned correctly

--- a/test/sql/add_files/add_files_hive_partition_cast.test
+++ b/test/sql/add_files/add_files_hive_partition_cast.test
@@ -37,6 +37,26 @@ SELECT id, year, month, day FROM ducklake.test ORDER BY id;
 1	2024	1	2024-01-02
 2	2024	2	NULL
 
+# Verify types are correct - these queries would fail or give wrong results if values were VARCHAR
+# Test INTEGER arithmetic on hive partition columns
+query II
+SELECT id, year + 1 AS next_year FROM ducklake.test ORDER BY id;
+----
+1	2025
+2	2025
+
+# Verify typeof() returns the actual column type, not VARCHAR
+query IIII
+SELECT typeof(id), typeof(year), typeof(month), typeof(day) FROM ducklake.test LIMIT 1;
+----
+INTEGER	INTEGER	INTEGER	DATE
+
+# Test DATE operations on hive partition column
+query II
+SELECT id, day + INTERVAL 1 DAY AS next_day FROM ducklake.test WHERE day IS NOT NULL ORDER BY id;
+----
+1	2024-01-03 00:00:00
+
 # Test null partitions
 statement ok
 CREATE TABLE ducklake.test_null(id INTEGER, category VARCHAR, amount DECIMAL(10,2));
@@ -82,6 +102,19 @@ SELECT id, active, verified FROM ducklake.test_bool ORDER BY id;
 1	true	false
 2	false	true
 
+# Verify boolean operations work - would fail if values were VARCHAR strings
+query III
+SELECT id, NOT active AS inactive, active AND verified AS both FROM ducklake.test_bool ORDER BY id;
+----
+1	false	false
+2	true	false
+
+# Verify typeof() for boolean columns
+query III
+SELECT typeof(id), typeof(active), typeof(verified) FROM ducklake.test_bool LIMIT 1;
+----
+INTEGER	BOOLEAN	BOOLEAN
+
 # Test floating point values
 statement ok
 CREATE TABLE ducklake.test_float(id INTEGER, ratio DOUBLE, percentage FLOAT);
@@ -103,6 +136,19 @@ SELECT id, ratio, percentage FROM ducklake.test_float ORDER BY id;
 1	3.14159	99.5
 2	-0.001	0.0
 
+# Verify float arithmetic works - would fail if values were VARCHAR
+query II
+SELECT id, ratio * 2 AS doubled FROM ducklake.test_float ORDER BY id;
+----
+1	6.28318
+2	-0.002
+
+# Verify typeof() for float columns
+query III
+SELECT typeof(id), typeof(ratio), typeof(percentage) FROM ducklake.test_float LIMIT 1;
+----
+INTEGER	DOUBLE	FLOAT
+
 # Test timestamp values with NULL
 statement ok
 CREATE TABLE ducklake.test_ts(id INTEGER, created_at TIMESTAMP);
@@ -123,6 +169,18 @@ SELECT id, created_at FROM ducklake.test_ts ORDER BY id;
 ----
 1	2024-01-15 10:30:00
 2	NULL
+
+# Verify timestamp operations work - would fail if values were VARCHAR
+query II
+SELECT id, created_at + INTERVAL 1 HOUR AS later FROM ducklake.test_ts WHERE created_at IS NOT NULL ORDER BY id;
+----
+1	2024-01-15 11:30:00
+
+# Verify typeof() for timestamp columns
+query II
+SELECT typeof(id), typeof(created_at) FROM ducklake.test_ts LIMIT 1;
+----
+INTEGER	TIMESTAMP
 
 # Test URL-encoded special characters in VARCHAR (spaces via partition)
 statement ok


### PR DESCRIPTION
Currently, `MapHiveColumn` receives the raw output of `HivePartitioning::Parse`, which is a map of strings. These get interpreted as type `VARCHAR`, which cannot be cast to any other type. As a result, `ducklake_add_data_file` fails to load Parquet files into DuckLakes with non-`VARCHAR` partitioning keys.

This PR uses `HivePartitioning::GetValue` to gracefully cast parsed partition key strings to their target column types before invoking `MapHiveColumn`. This also improves handling of null partition keys, thanks to duckdb/duckdb#20512.

I added a test for the new casting logic. This test revealed an edge case where string columns with no min/max stats get assigned a maximum length of 0. This causes materialization compression to mangle these columns.
```
1. test/sql/add_files/add_files_hive_partition_cast.test:57
================================================================================
Query unexpectedly failed (test/sql/add_files/add_files_hive_partition_cast.test:57)
 (test/sql/add_files/add_files_hive_partition_cast.test:57)!
================================================================================
SELECT id, category, amount FROM ducklake.test_null ORDER BY id;
================================================================================
Actual result:
================================================================================
Invalid Error: Unoptimized statement differs from original result!
Original Result:
id	category	amount	
INTEGER	VARCHAR	DECIMAL(10,2)	
[ Rows: 3]
1	o	99.99
2	NULL	50.00
3	v	NULL

Unoptimized:
id	category	amount	
INTEGER	VARCHAR	DECIMAL(10,2)	
[ Rows: 3]
1	electronics	99.99
2	NULL	50.00
3	home appliances	NULL
```
I fixed this by using `StringStats::CreateUnknown` to handle this specific case, which leaves the max length unbounded instead of setting it to 0 like `StringStats::CreateEmpty`.

It's worth noting that I encountered [a weird internal error](https://github.com/thalassemia/ducklake/actions/runs/22658324324/job/65672761590) in one of the new tests using the SQLite catalog. It appears to be something in the `sqlite_scanner` extension and only shows up with `pragma enable_verification`. I turned off query verification for that one test to work around this.