### PR TITLE
Correctly handle NULL values in partitions

### DIFF
--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -11,12 +11,13 @@
 #include "storage/ducklake_stats.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "common/index.hpp"
+#include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
 
 struct DuckLakeFilePartition {
 	idx_t partition_column_idx;
-	string partition_value;
+	Value partition_value;
 };
 
 enum class DeleteFileSource : uint8_t {

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -142,7 +142,7 @@ struct DuckLakeVariantStatsInfo {
 
 struct DuckLakeFilePartitionInfo {
 	idx_t partition_column_idx;
-	string partition_value;
+	Value partition_value;
 };
 
 struct DuckLakeFileInfo {

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -191,11 +191,10 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 			auto &partition_children = MapValue::GetChildren(partition_info);
 			for (idx_t col_idx = 0; col_idx < partition_children.size(); col_idx++) {
 				auto &struct_children = StructValue::GetChildren(partition_children[col_idx]);
-				auto &part_value = StringValue::Get(struct_children[1]);
 
 				DuckLakeFilePartition file_partition_info;
 				file_partition_info.partition_column_idx = col_idx;
-				file_partition_info.partition_value = part_value;
+				file_partition_info.partition_value = struct_children[1];
 				data_file.partition_values.push_back(std::move(file_partition_info));
 			}
 		}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2877,9 +2877,14 @@ string DuckLakeMetadataManager::WriteNewDataFiles(const vector<DuckLakeFileInfo>
 			if (!partition_insert_query.empty()) {
 				partition_insert_query += ",";
 			}
-			partition_insert_query +=
-			    StringUtil::Format("(%d, %d, %d, %s)", data_file_index, table_id, part_val.partition_column_idx,
-			                       SQLString(part_val.partition_value));
+			string partition_val;
+			if (part_val.partition_value.IsNull()) {
+				partition_val = "NULL";
+			} else {
+				partition_val = StringUtil::Format("%s", SQLString(part_val.partition_value.ToString()));
+			}
+			partition_insert_query += StringUtil::Format("(%d, %d, %d, %s)", data_file_index, table_id,
+			                                             part_val.partition_column_idx, partition_val);
 		}
 	}
 	if (data_file_insert_query.empty()) {

--- a/test/sql/partitioning/partition_null.test
+++ b/test/sql/partitioning/partition_null.test
@@ -1,0 +1,56 @@
+# name: test/sql/partitioning/partition_null.test
+# description: Test partitioning with NULL values
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+# partitioning based on a column
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partitioning_null', METADATA_CATALOG 'ducklake_metadata')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE partitioned_tbl(part_key INTEGER, values VARCHAR);
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+INSERT INTO partitioned_tbl SELECT case when i%3=0 then NULL ELSE i%2 END part_key, concat('thisisastring_', i) FROM range(10000) t(i)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=0
+----
+3333
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key IS NULL
+----
+3334
+
+# verify files are partitioned
+query I
+SELECT regexp_extract(path, '.*(part_key=[_a-zA-Z0-9]*)[/\\].*', 1) AS path FROM ducklake_metadata.ducklake_data_file
+ORDER BY path
+----
+part_key=0
+part_key=1
+part_key=__HIVE_DEFAULT_PARTITION__
+
+# verify files are pruned when querying the partitions
+# FIXME: we are currently also reading the file with all NULL values
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=1
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 2.*


### PR DESCRIPTION
Currently inserting NULL values into partition columns result in an internal error being thrown. This PR fixes this and adds support for `NULL` partition keys.