### PR TITLE
Fix: rewrite_data_files skips large files with delete files

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -222,8 +222,9 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 	compaction_map_t<DuckLakeCompactionCandidates> candidates;
 	for (idx_t file_idx = 0; file_idx < files.size(); file_idx++) {
 		auto &candidate = files[file_idx];
-		if (candidate.file.data.file_size_bytes >= target_file_size) {
+		if (candidate.file.data.file_size_bytes >= target_file_size && type != CompactionType::REWRITE_DELETES) {
 			// this file by itself exceeds the threshold - skip merging
+			// (does not apply to REWRITE_DELETES - delete files must be rewritten regardless of data file size)
 			continue;
 		}
 		if ((!candidate.delete_files.empty() && type == CompactionType::MERGE_ADJACENT_TABLES) ||

--- a/test/sql/rewrite_data_files/test_rewrite_large_file_with_deletes.test
+++ b/test/sql/rewrite_data_files/test_rewrite_large_file_with_deletes.test
@@ -1,0 +1,89 @@
+# name: test/sql/rewrite_data_files/test_rewrite_large_file_with_deletes.test
+# description: Test that rewrite_data_files does not skip large files with delete files
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/rewrite_large_deletes', METADATA_CATALOG 'ducklake_metadata')
+
+statement ok
+USE ducklake
+
+# Set a very small target_file_size so that the data file exceeds it
+statement ok
+CALL ducklake.set_option('target_file_size', '1KB');
+
+statement ok
+CREATE TABLE test (key INTEGER, value VARCHAR);
+
+statement ok
+INSERT INTO test SELECT i, concat('thisisastring_', i) FROM range(1000) t(i)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Verify we have 1 data file, no delete files
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+# Delete some rows to create a delete file
+statement ok
+DELETE FROM test WHERE key < 500
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Verify we now have a delete file
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+1
+
+# The data file should be larger than target_file_size (1KB)
+# Without the fix, rewrite_data_files would skip this file
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0) ORDER BY ALL
+----
+test	1	1
+
+# After rewrite: delete files should be gone, data file should be rewritten
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+# Verify data correctness
+query I
+SELECT count(*) FROM test
+----
+500
+
+query I
+SELECT min(key) FROM test
+----
+500
+
+query I
+SELECT max(key) FROM test
+----
+999


### PR DESCRIPTION
## Summary

- `ducklake_rewrite_data_files` silently skips data files ≥ `target_file_size` (default 512 MB), even when they have associated delete files
- The file size check was intended only for `MERGE_ADJACENT_TABLES` but was incorrectly applied to `REWRITE_DELETES` as well
- One-line fix: guard the size check with `type != CompactionType::REWRITE_DELETES`

Fixes #821

## Test plan

- [ ] Existing compaction tests still pass
- [ ] Verify that `ducklake_rewrite_data_files` now rewrites data files larger than `target_file_size` when they have delete files