### PR TITLE
Avoid new schema version if partitions don't change

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -473,6 +473,26 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 	return field;
 }
 
+static bool PartitionFieldsMatch(optional_ptr<DuckLakePartition> current_partition,
+                                 const DuckLakePartition &requested_partition) {
+	if (!current_partition) {
+		return requested_partition.fields.empty();
+	}
+	if (current_partition->fields.size() != requested_partition.fields.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < current_partition->fields.size(); i++) {
+		auto &current_field = current_partition->fields[i];
+		auto &requested_field = requested_partition.fields[i];
+		if (current_field.partition_key_index != requested_field.partition_key_index ||
+		    current_field.field_id != requested_field.field_id ||
+		    current_field.transform.type != requested_field.transform.type) {
+			return false;
+		}
+	}
+	return true;
+}
+
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, SetPartitionedByInfo &info) {
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
@@ -484,6 +504,9 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 		auto partition_field = GetPartitionField(*this, expr);
 		partition_field.partition_key_index = expr_idx;
 		partition_data->fields.push_back(partition_field);
+	}
+	if (PartitionFieldsMatch(GetPartitionData(), *partition_data)) {
+		return nullptr;
 	}
 
 	auto new_entry = make_uniq<DuckLakeTableEntry>(*this, table_info, std::move(partition_data));

--- a/test/sql/partitioning/partition_nop_schema_version.test
+++ b/test/sql/partitioning/partition_nop_schema_version.test
@@ -1,0 +1,106 @@
+# name: test/sql/partitioning/partition_nop_schema_version.test
+# description: Verify repeated SET PARTITIONED BY does not increment schema_version or block compaction
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/partition_nop_schema_version')
+
+statement ok
+CREATE TABLE ducklake.test(part_key INTEGER, value VARCHAR);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+1
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+2
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 'before_1'), (1, 'before_2');
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+1
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+1
+
+# Setting the same partitioning again should be a no-op for schema versions too.
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+2
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 'after_1'), (1, 'after_2');
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+2
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+2
+
+query III
+SELECT table_name, files_processed, files_created
+FROM ducklake_merge_adjacent_files('ducklake', 'test')
+----
+test	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+1
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+1
+
+query II
+SELECT part_key, value FROM ducklake.test ORDER BY ALL
+----
+1	after_1
+1	after_2
+1	before_1
+1	before_2
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key, value);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+3


### PR DESCRIPTION
**Context**
It is common to have init scripts that look like this:

```sql
CREATE TABLE IF NOT EXISTS schema.table (
   field_1 VARCHAR,
   ....
);

ALTER TABLE schema.table
SET PARTITIONED BY (field_1)
```

Currently, each time this executes the table creation is skipped but the `ALTER TABLE` operation still creates a new table schema version.
This is undersirable because it prevents parquet file merging since the files have different schema versions.

**Proposed change**
Make the `ALTER TABLE` a no-op if the parititioning doesn't actually change.

