### PR TITLE
ducklake_delete_orphaned_files now only deletes parquet files

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3872,7 +3872,8 @@ vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup
                                                                                  const string &separator) {
 	auto query = R"(SELECT filename
 FROM read_blob({DATA_PATH} || '**')
-WHERE filename NOT IN (
+WHERE suffix(filename, '.parquet')
+AND filename NOT IN (
 SELECT REPLACE(
            CASE
                WHEN NOT file_relative THEN file_path

--- a/test/configs/minio.json
+++ b/test/configs/minio.json
@@ -29,7 +29,8 @@
         "test/sql/migration/v01_partitioned.test",
         "test/sql/delete/delete_ignore_extra_columns.test",
         "test/sql/add_files/add_file_with_three_level_list.test",
-        "test/sql/migration/test_compaction.test"
+        "test/sql/migration/test_compaction.test",
+        "test/sql/remove_orphans/metadata_in_data_path.test"
       ]
     }
   ]

--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -24,7 +24,8 @@
         "test/sql/general/default_path.test",
         "test/sql/autoloading/autoload_data_path.test",
         "test/sql/general/metadata_parameters.test",
-        "test/sql/metadata/ducklake_settings.test"
+        "test/sql/metadata/ducklake_settings.test",
+        "test/sql/remove_orphans/metadata_in_data_path.test"
       ]
     },
     {

--- a/test/sql/remove_orphans/metadata_in_data_path.test
+++ b/test/sql/remove_orphans/metadata_in_data_path.test
@@ -1,0 +1,53 @@
+# name: test/sql/remove_orphans/metadata_in_data_path.test
+# description: ducklake_delete_orphaned_files should not delete the metadata database when it resides in the data path
+# group: [remove_orphans]
+
+require ducklake
+
+require parquet
+
+# Place the metadata DB directly inside the data path directory
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}', METADATA_CATALOG 'ducklake_metadata')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE test (a integer)
+
+statement ok
+INSERT INTO test VALUES (1);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# The metadata DB and the parquet data file must exist before the call
+query I
+SELECT count(*) FROM GLOB('${DATA_PATH}/*.db')
+----
+1
+
+query I
+SELECT count(*) FROM GLOB('${DATA_PATH}/**/*.parquet')
+----
+1
+
+statement ok
+CALL ducklake_delete_orphaned_files('ducklake', cleanup_all => true);
+
+# Verify the metadata DB file was NOT deleted
+query I
+SELECT count(*) FROM GLOB('${DATA_PATH}/*.db')
+----
+1
+
+# Verify the parquet data file was NOT deleted
+query I
+SELECT count(*) FROM GLOB('${DATA_PATH}/**/*.parquet')
+----
+1


### PR DESCRIPTION
contains a fix for: https://github.com/duckdb/ducklake/issues/813

In case the ducklake catalog resides in the data path, it would be deleted by function `ducklake_delete_orphaned_files()`
We now prevent this by only deleting parquet files