### PR TITLE
Delete compactions might create 0 new files if the source data is fully deleted

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -93,11 +93,17 @@ SourceResultType DuckLakeCompaction::GetDataInternal(ExecutionContext &context, 
 	}
 	source_state.returned_result = true;
 
+	if (!this->sink_state) {
+		throw InternalException("DuckLakeCompaction - missing sink state while producing result");
+	}
+	auto &gstate = this->sink_state->Cast<DuckLakeInsertGlobalState>();
+	auto files_created = gstate.written_files.size();
+
 	chunk.SetCardinality(1);
 	chunk.SetValue(0, 0, Value(table.schema.name));
 	chunk.SetValue(1, 0, Value(table.name));
 	chunk.SetValue(2, 0, Value::BIGINT(static_cast<int64_t>(source_files.size())));
-	chunk.SetValue(3, 0, Value::BIGINT(1)); // Each compaction creates 1 output file
+	chunk.SetValue(3, 0, Value::BIGINT(static_cast<int64_t>(files_created)));
 	return SourceResultType::FINISHED;
 }
 
@@ -121,7 +127,10 @@ SinkFinalizeType DuckLakeCompaction::Finalize(Pipeline &pipeline, Event &event, 
                                               OperatorSinkFinalizeInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
 
-	if (global_state.written_files.size() != 1) {
+	if (global_state.written_files.size() > 1) {
+		throw InternalException("DuckLakeCompaction - expected at most a single output file");
+	}
+	if (global_state.written_files.empty() && type != CompactionType::REWRITE_DELETES) {
 		throw InternalException("DuckLakeCompaction - expected a single output file");
 	}
 	// set the partition values correctly
@@ -137,7 +146,9 @@ SinkFinalizeType DuckLakeCompaction::Finalize(Pipeline &pipeline, Event &event, 
 	DuckLakeCompactionEntry compaction_entry;
 	compaction_entry.row_id_start = row_id_start;
 	compaction_entry.source_files = source_files;
-	compaction_entry.written_file = global_state.written_files[0];
+	if (!global_state.written_files.empty()) {
+		compaction_entry.written_file = global_state.written_files[0];
+	}
 	compaction_entry.type = type;
 
 	auto &transaction = DuckLakeTransaction::Get(context, global_state.table.catalog);

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -108,6 +108,23 @@ SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chu
 //===--------------------------------------------------------------------===//
 using DeletesPerFile = unordered_map<string, set<PositionWithSnapshot>>;
 
+static void RemoveFullyDeletedWrittenFiles(ClientContext &context, vector<DuckLakeDataFile> &written_files,
+                                           DeletesPerFile &deletes_per_file) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	vector<DuckLakeDataFile> remaining_files;
+	remaining_files.reserve(written_files.size());
+	for (auto &written_file : written_files) {
+		auto delete_entry = deletes_per_file.find(written_file.file_name);
+		if (delete_entry != deletes_per_file.end() && delete_entry->second.size() >= written_file.row_count) {
+			fs.RemoveFile(written_file.file_name);
+			deletes_per_file.erase(delete_entry);
+			continue;
+		}
+		remaining_files.push_back(std::move(written_file));
+	}
+	written_files = std::move(remaining_files);
+}
+
 static DeletesPerFile GroupDeletesByFile(QueryResult &deleted_rows_result, vector<DuckLakeDataFile> &written_files,
                                          vector<idx_t> &file_start_row_ids) {
 	D_ASSERT(std::is_sorted(file_start_row_ids.begin(), file_start_row_ids.end()));
@@ -167,6 +184,7 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 
 		auto deletes_per_file =
 		    GroupDeletesByFile(*deleted_rows_result, global_state.written_files, file_start_row_ids);
+		RemoveFullyDeletedWrittenFiles(context, global_state.written_files, deletes_per_file);
 
 		if (!deletes_per_file.empty()) {
 			auto &fs = FileSystem::GetFileSystem(context);

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -108,23 +108,6 @@ SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chu
 //===--------------------------------------------------------------------===//
 using DeletesPerFile = unordered_map<string, set<PositionWithSnapshot>>;
 
-static void RemoveFullyDeletedWrittenFiles(ClientContext &context, vector<DuckLakeDataFile> &written_files,
-                                           DeletesPerFile &deletes_per_file) {
-	auto &fs = FileSystem::GetFileSystem(context);
-	vector<DuckLakeDataFile> remaining_files;
-	remaining_files.reserve(written_files.size());
-	for (auto &written_file : written_files) {
-		auto delete_entry = deletes_per_file.find(written_file.file_name);
-		if (delete_entry != deletes_per_file.end() && delete_entry->second.size() >= written_file.row_count) {
-			fs.RemoveFile(written_file.file_name);
-			deletes_per_file.erase(delete_entry);
-			continue;
-		}
-		remaining_files.push_back(std::move(written_file));
-	}
-	written_files = std::move(remaining_files);
-}
-
 static DeletesPerFile GroupDeletesByFile(QueryResult &deleted_rows_result, vector<DuckLakeDataFile> &written_files,
                                          vector<idx_t> &file_start_row_ids) {
 	D_ASSERT(std::is_sorted(file_start_row_ids.begin(), file_start_row_ids.end()));
@@ -184,7 +167,6 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 
 		auto deletes_per_file =
 		    GroupDeletesByFile(*deleted_rows_result, global_state.written_files, file_start_row_ids);
-		RemoveFullyDeletedWrittenFiles(context, global_state.written_files, deletes_per_file);
 
 		if (!deletes_per_file.empty()) {
 			auto &fs = FileSystem::GetFileSystem(context);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4049,13 +4049,15 @@ string DuckLakeMetadataManager::WriteDeleteRewrites(const vector<DuckLakeCompact
 		WHERE data_file_id = %llu;
 		)",
 		                       table_idx_last_snapshot[compaction.table_index.index], compaction.source_id.index);
-		// update the snapshot of our newly added file
-		batch_query +=
-		    StringUtil::Format(R"(
-			UPDATE {METADATA_CATALOG}.ducklake_data_file SET begin_snapshot = %llu
-			WHERE data_file_id = %llu;
-			)",
-		                       table_idx_last_snapshot[compaction.table_index.index], compaction.new_id.index);
+		// update the snapshot of our newly added file (if it was created)
+		if (compaction.new_id.IsValid()) {
+			batch_query +=
+			    StringUtil::Format(R"(
+				UPDATE {METADATA_CATALOG}.ducklake_data_file SET begin_snapshot = %llu
+				WHERE data_file_id = %llu;
+				)",
+			                       table_idx_last_snapshot[compaction.table_index.index], compaction.new_id.index);
+		}
 	}
 	return batch_query;
 }

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2310,33 +2310,42 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 			if (type != compaction.type) {
 				continue;
 			}
-			auto new_file = GetNewDataFile(compaction.written_file, commit_state, table_id, compaction.row_id_start);
-			switch (type) {
-			case CompactionType::REWRITE_DELETES:
-				new_file.begin_snapshot = commit_snapshot.snapshot_id;
-				break;
-			case CompactionType::MERGE_ADJACENT_TABLES: {
-				// For MERGE_ADJACENT_TABLES, track the max partial snapshot across all source files
-				optional_idx merged_max_partial_snapshot;
-				idx_t first_begin_snapshot = compaction.source_files[0].file.begin_snapshot;
-				for (auto &compacted_file : compaction.source_files) {
-					idx_t file_max_snapshot = compacted_file.max_partial_file_snapshot.IsValid()
-					                              ? compacted_file.max_partial_file_snapshot.GetIndex()
-					                              : compacted_file.file.begin_snapshot;
-					if (!merged_max_partial_snapshot.IsValid() ||
-					    file_max_snapshot > merged_max_partial_snapshot.GetIndex()) {
-						merged_max_partial_snapshot = file_max_snapshot;
+				bool has_new_file = !compaction.written_file.file_name.empty();
+				DuckLakeFileInfo new_file;
+
+				if (!has_new_file) {
+					if (type != CompactionType::REWRITE_DELETES) {
+						throw InternalException("Compaction error - expected output file for non-rewrite compaction");
 					}
+				} else {
+					new_file = GetNewDataFile(compaction.written_file, commit_state, table_id, compaction.row_id_start);
+					switch (type) {
+					case CompactionType::REWRITE_DELETES:
+						new_file.begin_snapshot = commit_snapshot.snapshot_id;
+						break;
+					case CompactionType::MERGE_ADJACENT_TABLES: {
+						// For MERGE_ADJACENT_TABLES, track the max partial snapshot across all source files
+						optional_idx merged_max_partial_snapshot;
+						idx_t first_begin_snapshot = compaction.source_files[0].file.begin_snapshot;
+						for (auto &compacted_file : compaction.source_files) {
+							idx_t file_max_snapshot = compacted_file.max_partial_file_snapshot.IsValid()
+							                              ? compacted_file.max_partial_file_snapshot.GetIndex()
+							                              : compacted_file.file.begin_snapshot;
+							if (!merged_max_partial_snapshot.IsValid() ||
+							    file_max_snapshot > merged_max_partial_snapshot.GetIndex()) {
+								merged_max_partial_snapshot = file_max_snapshot;
+							}
+					}
+					// Use the first source file's begin_snapshot for proper time travel support
+					new_file.begin_snapshot = first_begin_snapshot;
+					if (compaction.source_files.size() > 1) {
+						new_file.max_partial_file_snapshot = merged_max_partial_snapshot;
+					}
+					break;
 				}
-				// Use the first source file's begin_snapshot for proper time travel support
-				new_file.begin_snapshot = first_begin_snapshot;
-				if (compaction.source_files.size() > 1) {
-					new_file.max_partial_file_snapshot = merged_max_partial_snapshot;
+				default:
+					throw InternalException("DuckLakeTransaction::GetCompactionChanges Compaction type is invalid");
 				}
-				break;
-			}
-			default:
-				throw InternalException("DuckLakeTransaction::GetCompactionChanges Compaction type is invalid");
 			}
 
 			idx_t row_id_limit = 0;
@@ -2348,7 +2357,9 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 				DuckLakeCompactedFileInfo file_info;
 				file_info.path = compacted_file.file.data.path;
 				file_info.source_id = compacted_file.file.id;
-				file_info.new_id = new_file.id;
+				if (has_new_file) {
+					file_info.new_id = new_file.id;
+				}
 
 				if (!compacted_file.delete_files.empty()) {
 					file_info.delete_file_path = compacted_file.delete_files.back().data.path;
@@ -2358,12 +2369,18 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 					file_info.delete_file_start_snapshot = commit_snapshot.snapshot_id;
 					file_info.delete_file_end_snapshot = compacted_file.delete_files.back().end_snapshot;
 				}
-				if (row_id_limit > new_file.row_count) {
+				if (has_new_file && row_id_limit > new_file.row_count) {
 					throw InternalException("Compaction error - row id limit is larger than the row count of the file");
 				}
 				result.compacted_files.push_back(std::move(file_info));
 			}
-			result.new_files.push_back(std::move(new_file));
+			if (!has_new_file && row_id_limit != 0) {
+				throw InternalException(
+				    "Compaction error - rewrite compaction without output file must fully delete source files");
+			}
+			if (has_new_file) {
+				result.new_files.push_back(std::move(new_file));
+			}
 		}
 	}
 	return result;

--- a/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
+++ b/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
@@ -60,7 +60,7 @@ SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_delete'))
 query I
 SELECT COUNT(*) FROM ducklake_flush_inlined_data('ducklake');
 ----
-0
+1
 
 query I
 SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))
@@ -75,17 +75,17 @@ SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_delete'))
 query II
 SELECT COUNT(*), COALESCE(SUM(record_count), 0) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL;
 ----
-0	0
+1	20
 
 query II
 SELECT COUNT(*), COALESCE(SUM(delete_count), 0) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL;
 ----
-0	0
+1	20
 
-query I
-SELECT COUNT(*) FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0);
+query II
+SELECT COUNT(*), SUM(files_created) FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0);
 ----
-0
+1	0
 
 query I
 SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))

--- a/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
+++ b/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
@@ -62,6 +62,16 @@ SELECT COUNT(*) FROM ducklake_flush_inlined_data('ducklake');
 ----
 0
 
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))
+----
+20
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_delete'))
+----
+0
+
 query II
 SELECT COUNT(*), COALESCE(SUM(record_count), 0) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL;
 ----

--- a/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
+++ b/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
@@ -1,0 +1,62 @@
+# name: test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
+# description: rewrite_deletes should handle a fully deleted file created by ducklake_flush_inlined_data
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/rewrite_deletes_full_file_delete_after_flush', DATA_INLINING_ROW_LIMIT 100, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE t (id INTEGER);
+
+statement ok
+INSERT INTO t SELECT i FROM range(20) tbl(i);
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL;
+----
+0
+
+statement ok
+DELETE FROM t WHERE id < 20;
+
+query I
+SELECT COUNT(*) FROM t;
+----
+0
+
+query I
+SELECT COUNT(*) FROM ducklake_flush_inlined_data('ducklake');
+----
+0
+
+query II
+SELECT COUNT(*), COALESCE(SUM(record_count), 0) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL;
+----
+0	0
+
+query II
+SELECT COUNT(*), COALESCE(SUM(delete_count), 0) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL;
+----
+0	0
+
+query I
+SELECT COUNT(*) FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0);
+----
+0
+
+query I
+SELECT COUNT(*) FROM t;
+----
+0

--- a/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
+++ b/test/sql/compaction/rewrite_deletes_full_file_delete_after_flush.test
@@ -29,10 +29,31 @@ SELECT COUNT(*) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL
 0
 
 statement ok
+SET VARIABLE v_after_insert = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'));
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))
+----
+20
+
+statement ok
 DELETE FROM t WHERE id < 20;
+
+statement ok
+SET VARIABLE v_after_delete = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'));
 
 query I
 SELECT COUNT(*) FROM t;
+----
+0
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))
+----
+20
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_delete'))
 ----
 0
 
@@ -53,6 +74,16 @@ SELECT COUNT(*), COALESCE(SUM(delete_count), 0) FROM ducklake_meta.ducklake_dele
 
 query I
 SELECT COUNT(*) FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0);
+----
+0
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_insert'))
+----
+20
+
+query I
+SELECT COUNT(*) FROM t AT (VERSION => getvariable('v_after_delete'))
 ----
 0
 


### PR DESCRIPTION
In the normal path where data for a parquet file is fully deleted through a `DELETE` statement, ducklake doesn't create a delete file. `DuckLakeCompaction` is assuming that when merging a source and delete file, it must always create a new file because at least some live row must exist after compaction.

This is however not true after `ducklake_flush_inlined_data`.
This function writes the inlined data into a parquet file, and also writes inlined deletes to a delete file.
This delete file can delete all rows in the source data.

Note that an alternative approach where the source/delete parquet files are never created is not allowed, because we need to support time travel queries and `ducklake_flush_inlined_data` immediately deletes inline data.