### PR TITLE
Fix inlined file deletes lost on concurrent commit retry

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -311,9 +311,10 @@ private:
 public:
 	//! Read inlined file deletions for regular table scans (no snapshot info per row)
 	map<idx_t, set<idx_t>> ReadInlinedFileDeletions(TableIndex table_id, DuckLakeSnapshot snapshot);
+	//! Clear inlined table caches (needed after rollback so retry re-creates the tables)
+	void ClearInlinedTableCaches();
 
 private:
-	unordered_map<idx_t, string> inlined_table_name_cache;
 	static unordered_map<string /* name */, create_t> metadata_managers;
 	static mutex metadata_managers_lock;
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2428,6 +2428,11 @@ string DuckLakeMetadataManager::WriteNewInlinedFileDeletes(DuckLakeSnapshot &com
 	return batch_queries;
 }
 
+void DuckLakeMetadataManager::ClearInlinedTableCaches() {
+	insert_inlined_table_name_cache.clear();
+	delete_inlined_table_cache.clear();
+}
+
 map<idx_t, set<idx_t>> DuckLakeMetadataManager::ReadInlinedFileDeletions(TableIndex table_id,
                                                                          DuckLakeSnapshot snapshot) {
 	map<idx_t, set<idx_t>> result;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2495,6 +2495,8 @@ void DuckLakeTransaction::FlushChanges() {
 #endif
 
 			// retry the transaction (with a new snapshot id)
+			// clear the inlined table caches - the rollback undid any table creation from the previous attempt
+			metadata_manager->ClearInlinedTableCaches();
 			connection->BeginTransaction();
 			snapshot.reset();
 		}
@@ -2685,7 +2687,8 @@ DuckLakeTransaction::GetNewInlinedFileDeletes(DuckLakeCommitState &commit_state)
 		}
 		DuckLakeInlinedFileDeletionInfo info;
 		info.table_id = table_id;
-		info.file_deletions.file_deletes = std::move(table_changes.new_inlined_file_deletes->file_deletes);
+		// copy, not move - data must survive commit retries in FlushChanges
+		info.file_deletions.file_deletes = table_changes.new_inlined_file_deletes->file_deletes;
 		result.push_back(std::move(info));
 	}
 	return result;

--- a/test/sql/deletion_inlining/test_deletion_inlining_concurrent_retry.test
+++ b/test/sql/deletion_inlining/test_deletion_inlining_concurrent_retry.test
@@ -1,0 +1,59 @@
+# name: test/sql/deletion_inlining/test_deletion_inlining_concurrent_retry.test
+# description: test that inlined file deletes survive commit retries
+# group: [deletion_inlining]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/deletion_inlining_concurrent_retry', DATA_INLINING_ROW_LIMIT 10, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+SET ducklake_retry_wait_ms=100
+
+statement ok
+SET ducklake_retry_backoff=2.0
+
+# Create separate tables with data in parquet files (50 rows > inlining limit of 10).
+# Using separate tables avoids table-level conflicts in CheckForConflicts — the only
+# collision is on the snapshot primary key, which triggers the retry path.
+loop i 0 3
+
+statement ok
+CREATE TABLE ducklake.t${i} AS SELECT range a FROM range(50)
+
+endloop
+
+# Each thread owns one table and deletes rows one at a time in a loop.
+# Each single-row delete is its own transaction, causing many snapshot PK collisions
+# across threads and forcing retries. With the original bugs (std::move emptying
+# delete data, stale inlined table cache after rollback), retried deletes silently
+# lose their inlined file deletion metadata.
+concurrentloop tableid 0 3
+
+loop rowid 0 5
+
+statement maybe
+DELETE FROM ducklake.t${tableid} WHERE a = ${rowid}
+----
+
+endloop
+
+endloop
+
+# Every table should have rows 0-4 deleted.
+loop i 0 3
+
+query I
+SELECT COUNT(*) FROM ducklake.t${i} WHERE a < 5
+----
+0
+
+endloop


### PR DESCRIPTION
## Summary
- **Bug 1**: `GetNewInlinedFileDeletes()` used `std::move` on the source `file_deletes` map, emptying it on the first commit attempt. When `FlushChanges` retried, the inlined file deletion data was gone — the DELETE appeared to succeed but rows were not removed.
- **Bug 2**: `delete_inlined_table_cache` (and `insert_inlined_table_name_cache`) were not cleared after rollback. On retry, the stale cache caused `GetInlinedDeletionTableName` to skip `CREATE TABLE IF NOT EXISTS` for the inlined deletion table, so the subsequent INSERT silently failed.
- Also removes the unused `inlined_table_name_cache` field (dead code).
