### PR TITLE
fix: compaction should not inherit per_thread_output from lake config

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -574,7 +574,7 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	copy->filename_pattern = std::move(copy_options.filename_pattern);
 	copy->file_extension = std::move(copy_options.file_extension);
 	copy->overwrite_mode = copy_options.overwrite_mode;
-	copy->per_thread_output = copy_options.per_thread_output;
+	copy->per_thread_output = false;
 	copy->file_size_bytes = copy_options.file_size_bytes;
 	copy->rotate = copy_options.rotate;
 	copy->return_type = copy_options.return_type;

--- a/test/sql/compaction/compaction_per_thread_output.test
+++ b/test/sql/compaction/compaction_per_thread_output.test
@@ -1,0 +1,65 @@
+# name: test/sql/compaction/compaction_per_thread_output.test
+# description: test compaction with per_thread_output enabled
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_compaction_per_thread_output')
+
+statement ok
+CALL ducklake.set_option('per_thread_output', 'true');
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO ducklake.test VALUES (2);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO ducklake.test VALUES (3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# merge_adjacent_files should work with per_thread_output enabled
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake');
+
+# verify data integrity after merge
+query I
+SELECT * FROM ducklake.test ORDER BY ALL
+----
+1
+2
+3
+
+# delete from the merged file to create a delete file
+statement ok
+DELETE FROM ducklake.test WHERE i = 3;
+
+# rewrite_data_files should work with per_thread_output enabled
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+# verify data integrity after rewrite
+query I
+SELECT * FROM ducklake.test ORDER BY ALL
+----
+1
+2


### PR DESCRIPTION
## Summary

- Compaction (`ducklake_merge_adjacent_files` / `ducklake_rewrite_data_files`) crashes with `PRESERVE_ORDER is not supported with these parameters` when `per_thread_output` is enabled on the lake
- Root cause: `GenerateCompactionPlan` copies `per_thread_output` from lake config but unconditionally sets `PRESERVE_ORDER` — DuckDB rejects this combination
- Fix: override `per_thread_output` to `false` for compaction, same pattern as the existing `file_size_bytes` and `rotate` overrides

Fixes #864

## Test plan

- [x] New test `test/sql/compaction/compaction_per_thread_output.test` — verifies both `merge_adjacent_files` and `rewrite_data_files` succeed with `per_thread_output` enabled and data integrity is preserved
- [x] All existing compaction tests pass