### PR TITLE
Cache existence of GetInlinedDeletionTableName

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -171,6 +171,12 @@ public:
 	//! Return the schema for the given snapshot - loading it if it is not yet loaded
 	DuckLakeCatalogSet &GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
 
+	//! Check if an inlined deletion table is known to exist or not exist for the given table and snapshot
+	//! Returns: 1 = known to exist, -1 = known to not exist, 0 = unknown (need to query)
+	int CheckInlinedDeletionTableCache(TableIndex table_id, DuckLakeSnapshot snapshot);
+	//! Cache the result of an inlined deletion table existence check
+	void CacheInlinedDeletionTableResult(TableIndex table_id, DuckLakeSnapshot snapshot, bool exists);
+
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 	unique_ptr<DuckLakeCatalogSet> LoadSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
@@ -201,6 +207,13 @@ private:
 	string metadata_type;
 	//! Whether or not the catalog is initialized
 	bool initialized = false;
+	//! Cache for inlined deletion table existence checks
+	mutex inlined_deletion_cache_lock;
+	//! Table IDs where the inlined deletion table is known to exist (permanent - never invalidated)
+	unordered_set<idx_t> inlined_deletion_exists;
+	//! Table IDs where the inlined deletion table is known to NOT exist, with the snapshot_id at which we checked
+	//! Valid as long as current snapshot.snapshot_id <= cached snapshot_id
+	unordered_map<idx_t, idx_t> inlined_deletion_not_exists;
 	//! The id of the last committed snapshot, set at FlushChanges on a successful commit
 	mutable mutex commit_lock;
 	optional_idx last_committed_snapshot;

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -25,6 +25,8 @@ struct DuckLakeConfigOption;
 struct DeleteFileMap;
 class LogicalGet;
 
+enum class InlinedDeletionCacheResult { EXISTS, DOES_NOT_EXIST, UNKNOWN };
+
 class DuckLakeCatalog : public Catalog {
 public:
 	// default target file size: 512MB
@@ -172,8 +174,7 @@ public:
 	DuckLakeCatalogSet &GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
 
 	//! Check if an inlined deletion table is known to exist or not exist for the given table and snapshot
-	//! Returns: 1 = known to exist, -1 = known to not exist, 0 = unknown (need to query)
-	int CheckInlinedDeletionTableCache(TableIndex table_id, DuckLakeSnapshot snapshot);
+	InlinedDeletionCacheResult CheckInlinedDeletionTableCache(TableIndex table_id, DuckLakeSnapshot snapshot);
 	//! Cache the result of an inlined deletion table existence check
 	void CacheInlinedDeletionTableResult(TableIndex table_id, DuckLakeSnapshot snapshot, bool exists);
 

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -832,4 +832,26 @@ unique_ptr<LogicalOperator> DuckLakeCatalog::BindAlterAddIndex(Binder &binder, T
 	throw NotImplementedException("Adding indexes or constraints is not supported in DuckLake");
 }
 
+int DuckLakeCatalog::CheckInlinedDeletionTableCache(TableIndex table_id, DuckLakeSnapshot snapshot) {
+	lock_guard<mutex> guard(inlined_deletion_cache_lock);
+	if (inlined_deletion_exists.find(table_id.index) != inlined_deletion_exists.end()) {
+		return 1; // known to exist
+	}
+	auto it = inlined_deletion_not_exists.find(table_id.index);
+	if (it != inlined_deletion_not_exists.end() && snapshot.snapshot_id <= it->second) {
+		return -1; // known to not exist at this or earlier snapshot
+	}
+	return 0; // unknown
+}
+
+void DuckLakeCatalog::CacheInlinedDeletionTableResult(TableIndex table_id, DuckLakeSnapshot snapshot, bool exists) {
+	lock_guard<mutex> guard(inlined_deletion_cache_lock);
+	if (exists) {
+		inlined_deletion_exists.insert(table_id.index);
+		inlined_deletion_not_exists.erase(table_id.index);
+	} else {
+		inlined_deletion_not_exists[table_id.index] = snapshot.snapshot_id;
+	}
+}
+
 } // namespace duckdb

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -832,16 +832,17 @@ unique_ptr<LogicalOperator> DuckLakeCatalog::BindAlterAddIndex(Binder &binder, T
 	throw NotImplementedException("Adding indexes or constraints is not supported in DuckLake");
 }
 
-int DuckLakeCatalog::CheckInlinedDeletionTableCache(TableIndex table_id, DuckLakeSnapshot snapshot) {
+InlinedDeletionCacheResult DuckLakeCatalog::CheckInlinedDeletionTableCache(TableIndex table_id,
+                                                                           DuckLakeSnapshot snapshot) {
 	lock_guard<mutex> guard(inlined_deletion_cache_lock);
 	if (inlined_deletion_exists.find(table_id.index) != inlined_deletion_exists.end()) {
-		return 1; // known to exist
+		return InlinedDeletionCacheResult::EXISTS;
 	}
 	auto it = inlined_deletion_not_exists.find(table_id.index);
 	if (it != inlined_deletion_not_exists.end() && snapshot.snapshot_id <= it->second) {
-		return -1; // known to not exist at this or earlier snapshot
+		return InlinedDeletionCacheResult::DOES_NOT_EXIST;
 	}
-	return 0; // unknown
+	return InlinedDeletionCacheResult::UNKNOWN;
 }
 
 void DuckLakeCatalog::CacheInlinedDeletionTableResult(TableIndex table_id, DuckLakeSnapshot snapshot, bool exists) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2445,12 +2445,13 @@ map<idx_t, set<idx_t>> DuckLakeMetadataManager::ReadInlinedFileDeletions(TableIn
 	                                "{SNAPSHOT_ID}",
 	                                inlined_table_name);
 	auto query_result = transaction.Query(snapshot, query);
-	if (!query_result->HasError()) {
-		for (auto &row : *query_result) {
-			auto file_id = row.GetValue<idx_t>(0);
-			auto row_id = row.GetValue<idx_t>(1);
-			result[file_id].insert(row_id);
-		}
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw("Failed to read inlined file deletions from DuckLake: ");
+	}
+	for (auto &row : *query_result) {
+		auto file_id = row.GetValue<idx_t>(0);
+		auto row_id = row.GetValue<idx_t>(1);
+		result[file_id].insert(row_id);
 	}
 	return result;
 }
@@ -2479,10 +2480,11 @@ unordered_set<idx_t> DuckLakeMetadataManager::GetFileIdsWithInlinedDeletions(Tab
 	                                "begin_snapshot <= {SNAPSHOT_ID}",
 	                                inlined_table_name, file_id_list);
 	auto query_result = transaction.Query(snapshot, query);
-	if (!query_result->HasError()) {
-		for (auto &row : *query_result) {
-			result.insert(row.GetValue<idx_t>(0));
-		}
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw("Failed to read inlined file deletion IDs from DuckLake: ");
+	}
+	for (auto &row : *query_result) {
+		result.insert(row.GetValue<idx_t>(0));
 	}
 	return result;
 }
@@ -2499,13 +2501,14 @@ DuckLakeMetadataManager::ReadInlinedFileDeletionsForRange(TableIndex table_id, D
 	                                "WHERE begin_snapshot >= %d AND begin_snapshot <= {SNAPSHOT_ID}",
 	                                inlined_table_name, start_snapshot.snapshot_id);
 	auto query_result = transaction.Query(end_snapshot, query);
-	if (!query_result->HasError()) {
-		for (auto &row : *query_result) {
-			auto file_id = row.GetValue<idx_t>(0);
-			auto row_id = row.GetValue<idx_t>(1);
-			auto snapshot_id = row.GetValue<idx_t>(2);
-			result[file_id][row_id] = snapshot_id;
-		}
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw("Failed to read inlined file deletions for range from DuckLake: ");
+	}
+	for (auto &row : *query_result) {
+		auto file_id = row.GetValue<idx_t>(0);
+		auto row_id = row.GetValue<idx_t>(1);
+		auto snapshot_id = row.GetValue<idx_t>(2);
+		result[file_id][row_id] = snapshot_id;
 	}
 	return result;
 }
@@ -2515,13 +2518,22 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 	// The table name is always deterministic
 	string table_name = StringUtil::Format("ducklake_inlined_delete_%d", table_id.index);
 
-	// Check the cache first (tracks whether table exists)
+	// Check per-transaction cache first (covers tables created in this transaction)
 	if (delete_inlined_table_cache.find(table_id.index) != delete_inlined_table_cache.end()) {
 		return table_name;
 	}
 
+	// Check catalog-level cache (persists across transactions)
+	auto &catalog = transaction.GetCatalog();
+	auto cache_result = catalog.CheckInlinedDeletionTableCache(table_id, snapshot);
+	if (cache_result == 1) {
+		return table_name; // known to exist (committed)
+	}
+	if (cache_result == -1 && !create_if_not_exists) {
+		return string(); // known to not exist
+	}
+
 	if (create_if_not_exists) {
-		// Create the table if it doesn't exist
 		auto create_query = StringUtil::Format(
 		    "CREATE TABLE IF NOT EXISTS {METADATA_CATALOG}.%s(file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT);",
 		    table_name);
@@ -2529,17 +2541,23 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 		if (create_result->HasError()) {
 			create_result->GetErrorObject().Throw("Failed to create inlined deletion table: ");
 		}
+		// Only cache per-transaction — the CREATE is transactional and may be rolled back
 		delete_inlined_table_cache.insert(table_id.index);
 		return table_name;
 	}
 
-	// Check if the table exists by querying duckdb_tables()
+	// Read path: table visibility implies it was committed, safe to cache at catalog level
 	auto query = StringUtil::Format("SELECT NULL FROM {METADATA_CATALOG}.%s LIMIT 1", table_name);
 	auto result = transaction.Query(snapshot, query);
+	// TODO: Using the error state to check for existence here is fragile.
+	// Even if the table exists, a transient error in the catalog query would lead us to assume it does not exist.
+	// Maybe persist the existence of the deletion inlining table on the table metadata instead?
 	if (!result->HasError()) {
 		delete_inlined_table_cache.insert(table_id.index);
+		catalog.CacheInlinedDeletionTableResult(table_id, snapshot, true);
 		return table_name;
 	}
+	catalog.CacheInlinedDeletionTableResult(table_id, snapshot, false);
 	return string();
 }
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2526,10 +2526,10 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 	// Check catalog-level cache (persists across transactions)
 	auto &catalog = transaction.GetCatalog();
 	auto cache_result = catalog.CheckInlinedDeletionTableCache(table_id, snapshot);
-	if (cache_result == 1) {
+	if (cache_result == InlinedDeletionCacheResult::EXISTS) {
 		return table_name; // known to exist (committed)
 	}
-	if (cache_result == -1 && !create_if_not_exists) {
+	if (cache_result == InlinedDeletionCacheResult::DOES_NOT_EXIST && !create_if_not_exists) {
 		return string(); // known to not exist
 	}
 


### PR DESCRIPTION
Cache the existence of GetInlinedDeletionTables.

# Caching

Before this change, each query would check for the existence of the deletion inlining table using 
`SELECT NULL FROM {METADATA_CATALOG}.%s LIMIT 1`.
For catalogs like remote postgres, this is an additional roundtrip to the catalog.
This changes introduces a cache on the catalog to remember the existence or non-existence. 

The cache distinguishes "known to exist" (permanent — these tables are never dropped) from "known to not exist" (valid until the snapshot advances, since a new delete could create the table).
 
# Existence check and error handling

Separately, fix three callers ReadInlinedFileDeletions, GetFileIdsWithInlinedDeletions, ReadInlinedFileDeletionsForRange. These callers would swallow errors in their queries. These callers already know the inlining table exists when they issue their queries, so errors should always be unexpected at that point.

One issue remains with the approach of using an error check for the existence check in GetInlinedDeletionTableName: A transient error on the query could lead us to assume that the deletion inlining table does not exist, even if it does. This could lead to wrong results. 
This is a preexisting issue, but I think this needs to be addressed

# Benchmark

  ClickBench (43 queries, 100M rows) against a Postgres-backed DuckLake catalog with no inlined deletions:
```
  ┌─────────────┬───────────┐
  │             │ Total (s) │
  ├─────────────┼───────────┤
  │ With fix    │ ~20.2     │
  ├─────────────┼───────────┤
  │ Without fix │ ~21.4     │
  ├─────────────┼───────────┤
  │ Speedup     │ ~6%       │
  └─────────────┴───────────┘
```

The improvement is consistent across runs. Fast queries benefit most in relative terms since the fixed-cost metadata round-trip is a larger fraction of their total runtime.

Q7 Speedup 1.18x
Q17 Speedup 1.29x
Q26 Speedup 1.27x

All of these queries have a small compute time so the saved round-trip time is a bigger fraction of total runtime.

**Note:** I did not measure significant benefit when running against a local duckdb catalog, where the there is no network round-trip for querying the metadata 