### PR TITLE
refactor: replace IN subqueries with LEFT JOIN in table_changes macro

### DIFF
--- a/src/functions/ducklake_table_changes.cpp
+++ b/src/functions/ducklake_table_changes.cpp
@@ -6,15 +6,19 @@ namespace duckdb {
 // clang-format off
 static const DefaultTableMacro ducklake_table_macros[] = {
 	{DEFAULT_SCHEMA, "ducklake_table_changes", {"catalog", "schema_name", "table_name", "start_snapshot", "end_snapshot", nullptr}, {{nullptr, nullptr}},  R"(
-SELECT snapshot_id, rowid, CASE WHEN (snapshot_id, rowid) in (SELECT snapshot_id, rowid FROM ducklake_table_deletions(catalog, schema_name, table_name, start_snapshot, end_snapshot))
-       THEN 'update_postimage'
-       ELSE 'insert'
-       END AS change_type, * FROM ducklake_table_insertions(catalog, schema_name, table_name, start_snapshot, end_snapshot)
+SELECT i.snapshot_id, i.rowid,
+       CASE WHEN d.rowid IS NOT NULL THEN 'update_postimage' ELSE 'insert' END AS change_type,
+       i.*
+FROM ducklake_table_insertions(catalog, schema_name, table_name, start_snapshot, end_snapshot) i
+LEFT JOIN ducklake_table_deletions(catalog, schema_name, table_name, start_snapshot, end_snapshot) d
+ON i.snapshot_id = d.snapshot_id AND i.rowid = d.rowid
 UNION ALL
-SELECT snapshot_id, rowid, CASE WHEN (snapshot_id, rowid) in (SELECT snapshot_id, rowid FROM ducklake_table_insertions(catalog, schema_name, table_name, start_snapshot, end_snapshot))
-       THEN 'update_preimage'
-       ELSE 'delete'
-       END AS change_type, * FROM ducklake_table_deletions(catalog, schema_name, table_name, start_snapshot, end_snapshot)
+SELECT d.snapshot_id, d.rowid,
+       CASE WHEN i.rowid IS NOT NULL THEN 'update_preimage' ELSE 'delete' END AS change_type,
+       d.*
+FROM ducklake_table_deletions(catalog, schema_name, table_name, start_snapshot, end_snapshot) d
+LEFT JOIN ducklake_table_insertions(catalog, schema_name, table_name, start_snapshot, end_snapshot) i
+ON d.snapshot_id = i.snapshot_id AND d.rowid = i.rowid
 )"},
 	{nullptr, nullptr, {nullptr}, {{nullptr, nullptr}}, nullptr}
 	};


### PR DESCRIPTION
## Summary

- Replace `IN` subqueries with `LEFT JOIN` in the `ducklake_table_changes` macro
- Makes the join strategy explicit rather than relying on optimizer decorrelation
- More readable and easier to reason about

## Test plan

- [x] Existing `test/sql/table_changes/ducklake_table_changes.test` passes unchanged (same output, different execution plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)