### PR TITLE
Inline Insertions in Updates

### DIFF
--- a/src/include/common/index.hpp
+++ b/src/include/common/index.hpp
@@ -15,6 +15,11 @@ namespace duckdb {
 
 struct DuckLakeConstants {
 	static constexpr const idx_t TRANSACTION_LOCAL_ID_START = 9223372036854775808ULL;
+	static constexpr const idx_t TRANSACTION_LOCAL_ROW_ID_START = 1000000000000000000ULL;
+
+	static bool IsTransactionLocalRowId(int64_t rid) {
+		return rid >= 0 && static_cast<idx_t>(rid) >= TRANSACTION_LOCAL_ROW_ID_START;
+	}
 };
 
 struct SchemaIndex {

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -57,6 +57,8 @@ public:
 		return metadata_type;
 	}
 	idx_t DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const;
+	//! Returns the inlining limit (0 if the table is not eligible)
+	idx_t GetInliningLimit(ClientContext &context, DuckLakeTableEntry &table, const vector<LogicalType> &types);
 	string &Separator() {
 		return separator;
 	}

--- a/src/include/storage/ducklake_inlined_data.hpp
+++ b/src/include/storage/ducklake_inlined_data.hpp
@@ -17,6 +17,8 @@ namespace duckdb {
 struct DuckLakeInlinedData {
 	unique_ptr<ColumnDataCollection> data;
 	map<FieldIndex, DuckLakeColumnStats> column_stats;
+	//! Row Ids for update inlining
+	vector<int64_t> row_ids;
 };
 
 struct DuckLakeInlinedDataDeletes {

--- a/src/include/storage/ducklake_inlined_data.hpp
+++ b/src/include/storage/ducklake_inlined_data.hpp
@@ -19,6 +19,10 @@ struct DuckLakeInlinedData {
 	map<FieldIndex, DuckLakeColumnStats> column_stats;
 	//! Row Ids for update inlining
 	vector<int64_t> row_ids;
+
+	bool HasPreservedRowIds() const {
+		return !row_ids.empty();
+	}
 };
 
 struct DuckLakeInlinedDataDeletes {

--- a/src/include/storage/ducklake_inlined_data.hpp
+++ b/src/include/storage/ducklake_inlined_data.hpp
@@ -20,9 +20,13 @@ struct DuckLakeInlinedData {
 	//! Row Ids for update inlining
 	vector<int64_t> row_ids;
 
-	bool HasPreservedRowIds() const {
-		return !row_ids.empty();
-	}
+	bool HasPreservedRowIds() const;
+	//! Get the row_id for a given position in the data collection
+	idx_t GetRowId(idx_t position) const;
+	//! Get the output row_id for a surviving (non-deleted) row
+	int64_t GetOutputRowId(idx_t position) const;
+	//! Merge preserved row_ids from update inlining
+	void MergeRowIds(const DuckLakeInlinedData &new_data, idx_t new_data_count);
 };
 
 struct DuckLakeInlinedDataDeletes {

--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -24,7 +24,6 @@ class DuckLakeMultiFileList : public MultiFileList {
 	    "__ducklake_inlined_transaction_local_data";
 
 public:
-	static constexpr const idx_t TRANSACTION_LOCAL_ID_START = 1000000000000000000ULL;
 	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeDataFile> transaction_local_files,
 	                      shared_ptr<DuckLakeInlinedData> transaction_local_data,
 	                      unique_ptr<FilterPushdownInfo> filter_info = nullptr);
@@ -63,6 +62,8 @@ private:
 	void GetFilesForTable() const;
 	void GetTableInsertions() const;
 	void GetTableDeletions() const;
+	//! Get the row_id_start for transaction-local inlined data.
+	idx_t GetTransactionLocalRowIdStart(idx_t transaction_row_start) const;
 
 private:
 	mutable mutex file_lock;

--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -20,11 +20,11 @@ namespace duckdb {
 //! The DuckLakeMultiFileList implements the MultiFileList API to allow injecting it into the regular DuckDB parquet
 //! scan
 class DuckLakeMultiFileList : public MultiFileList {
-	static constexpr const idx_t TRANSACTION_LOCAL_ID_START = 1000000000000000000ULL;
 	static constexpr const char *DUCKLAKE_TRANSACTION_LOCAL_INLINED_FILENAME =
 	    "__ducklake_inlined_transaction_local_data";
 
 public:
+	static constexpr const idx_t TRANSACTION_LOCAL_ID_START = 1000000000000000000ULL;
 	DuckLakeMultiFileList(DuckLakeFunctionInfo &read_info, vector<DuckLakeDataFile> transaction_local_files,
 	                      shared_ptr<DuckLakeInlinedData> transaction_local_data,
 	                      unique_ptr<FilterPushdownInfo> filter_info = nullptr);

--- a/src/include/storage/ducklake_update.hpp
+++ b/src/include/storage/ducklake_update.hpp
@@ -15,8 +15,7 @@ namespace duckdb {
 class DuckLakeUpdate : public PhysicalOperator {
 public:
 	DuckLakeUpdate(PhysicalPlan &physical_plan, DuckLakeTableEntry &table, vector<PhysicalIndex> columns,
-	               PhysicalOperator &child, PhysicalOperator &delete_op,
-	               vector<unique_ptr<Expression>> &expressions);
+	               PhysicalOperator &child, PhysicalOperator &delete_op, vector<unique_ptr<Expression>> &expressions);
 
 	//! The table to update
 	DuckLakeTableEntry &table;
@@ -36,8 +35,8 @@ public:
 	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
 	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
 	                           GlobalOperatorState &gstate, OperatorState &state) const override;
-	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk,
-	                                        GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk, GlobalOperatorState &gstate,
+	                                        OperatorState &state) const override;
 	OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
 	                                         OperatorFinalizeInput &input) const override;
 
@@ -55,6 +54,9 @@ public:
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+	static DuckLakeUpdate &PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
+	                                          PhysicalOperator &child_plan, DuckLakeCopyInput &copy_input);
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_update.hpp
+++ b/src/include/storage/ducklake_update.hpp
@@ -11,6 +11,7 @@
 #include "storage/ducklake_insert.hpp"
 
 namespace duckdb {
+class DuckLakeInlineData;
 
 class DuckLakeUpdate : public PhysicalOperator {
 public:
@@ -31,6 +32,8 @@ public:
 	//! The row-id-index
 	idx_t row_id_index;
 	vector<unique_ptr<Expression>> expressions;
+	//! The (optional) inline data operator
+	optional_ptr<DuckLakeInlineData> inline_data_op;
 
 public:
 	// // Source interface

--- a/src/include/storage/ducklake_update.hpp
+++ b/src/include/storage/ducklake_update.hpp
@@ -65,6 +65,12 @@ public:
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+private:
+	//! Forward output from the inline data operator to the copy sink, draining HAVE_MORE_OUTPUT as needed.
+	void ForwardInlineOutputToCopy(ExecutionContext &context, DataChunk &inline_output,
+	                               GlobalOperatorState &inline_gstate, OperatorState &inline_lstate, DataChunk &input,
+	                               LocalSinkState &copy_lstate, InterruptState &interrupt_state) const;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_update.hpp
+++ b/src/include/storage/ducklake_update.hpp
@@ -11,66 +11,50 @@
 #include "storage/ducklake_insert.hpp"
 
 namespace duckdb {
-class DuckLakeInlineData;
 
 class DuckLakeUpdate : public PhysicalOperator {
 public:
 	DuckLakeUpdate(PhysicalPlan &physical_plan, DuckLakeTableEntry &table, vector<PhysicalIndex> columns,
-	               PhysicalOperator &child, PhysicalOperator &copy_op, PhysicalOperator &delete_op,
-	               PhysicalOperator &insert_op, vector<unique_ptr<Expression>> &expressions);
+	               PhysicalOperator &child, PhysicalOperator &delete_op,
+	               vector<unique_ptr<Expression>> &expressions);
 
 	//! The table to update
 	DuckLakeTableEntry &table;
 	//! The order of to-be-inserted columns
 	vector<PhysicalIndex> columns;
-	//! The copy operator for writing new data to files
-	PhysicalOperator &copy_op;
 	//! The delete operator for deleting the old data
 	PhysicalOperator &delete_op;
-	//! The (final) insert operator that registers inserted data
-	PhysicalOperator &insert_op;
 	//! The row-id-index
 	idx_t row_id_index;
 	vector<unique_ptr<Expression>> expressions;
-	//! The (optional) inline data operator
-	optional_ptr<DuckLakeInlineData> inline_data_op;
-
-public:
-	// // Source interface
-	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
-	                                 OperatorSourceInput &input) const override;
-
-	bool IsSource() const override {
-		return true;
-	}
 
 	static constexpr uint8_t DELETION_INFO_SIZE = 3;
 
 public:
-	// Sink interface
-	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
-	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
-	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-	                          OperatorSinkFinalizeInput &input) const override;
-	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
+	// Operator interface
+	unique_ptr<GlobalOperatorState> GetGlobalOperatorState(ClientContext &context) const override;
+	unique_ptr<OperatorState> GetOperatorState(ExecutionContext &context) const override;
+	OperatorResultType Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+	                           GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalizeResultType FinalExecute(ExecutionContext &context, DataChunk &chunk,
+	                                        GlobalOperatorState &gstate, OperatorState &state) const override;
+	OperatorFinalResultType OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                                         OperatorFinalizeInput &input) const override;
 
-	bool IsSink() const override {
+	bool ParallelOperator() const override {
 		return true;
 	}
 
-	bool ParallelSink() const override {
+	bool RequiresFinalExecute() const override {
+		return true;
+	}
+
+	bool RequiresOperatorFinalize() const override {
 		return true;
 	}
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
-
-private:
-	//! Forward output from the inline data operator to the copy sink, draining HAVE_MORE_OUTPUT as needed.
-	void ForwardInlineOutputToCopy(ExecutionContext &context, DataChunk &inline_output,
-	                               GlobalOperatorState &inline_gstate, OperatorState &inline_lstate, DataChunk &input,
-	                               LocalSinkState &copy_lstate, InterruptState &interrupt_state) const;
 };
 
 } // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   ducklake_delete_filter.cpp
   ducklake_field_data.cpp
   ducklake_inline_data.cpp
+  ducklake_inlined_data.cpp
   ducklake_inlined_data_reader.cpp
   ducklake_insert.cpp
   ducklake_merge_into.cpp

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/function/scalar_macro_function.hpp"
 #include "duckdb/function/table_macro_function.hpp"
 #include "storage/ducklake_macro_entry.hpp"
+#include "common/ducklake_util.hpp"
 
 namespace duckdb {
 
@@ -823,6 +824,26 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 
 idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
 	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 10);
+}
+
+idx_t DuckLakeCatalog::GetInliningLimit(ClientContext &context, DuckLakeTableEntry &table,
+                                        const vector<LogicalType> &types) {
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	idx_t limit = DataInliningRowLimit(schema.GetSchemaId(), table.GetTableId());
+	if (limit == 0) {
+		return 0;
+	}
+	if (DuckLakeUtil::HasInlinedSystemColumnConflict(table.GetColumns())) {
+		// We also return 0 if we have inline column conflicts
+		return 0;
+	}
+	auto &transaction = DuckLakeTransaction::Get(context, *this);
+	auto &metadata_manager = transaction.GetMetadataManager();
+	if (!metadata_manager.SupportsInliningTypes(types)) {
+		// Or of inline is not supported
+		return 0;
+	}
+	return limit;
 }
 
 unique_ptr<LogicalOperator> DuckLakeCatalog::BindAlterAddIndex(Binder &binder, TableCatalogEntry &table_entry,

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -840,7 +840,7 @@ idx_t DuckLakeCatalog::GetInliningLimit(ClientContext &context, DuckLakeTableEnt
 	auto &transaction = DuckLakeTransaction::Get(context, *this);
 	auto &metadata_manager = transaction.GetMetadataManager();
 	if (!metadata_manager.SupportsInliningTypes(types)) {
-		// Or of inline is not supported
+		// Or if inlining is not supported
 		return 0;
 	}
 	return limit;

--- a/src/storage/ducklake_inline_data.cpp
+++ b/src/storage/ducklake_inline_data.cpp
@@ -349,6 +349,15 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 		ColumnDataAppendState append_state;
 		phys_data->InitializeAppend(append_state);
 		for (auto &chunk : inlined_data.Chunks()) {
+			// extract row_ids from the row_id column
+			auto &row_id_vec = chunk.data[physical_col_count];
+			UnifiedVectorFormat row_id_format;
+			row_id_vec.ToUnifiedFormat(chunk.size(), row_id_format);
+			auto row_id_data = UnifiedVectorFormat::GetData<int64_t>(row_id_format);
+			for (idx_t r = 0; r < chunk.size(); r++) {
+				auto idx = row_id_format.sel->get_index(r);
+				result->row_ids.push_back(row_id_data[idx]);
+			}
 			DataChunk phys_chunk;
 			phys_chunk.InitializeEmpty(phys_types);
 			for (idx_t i = 0; i < physical_col_count; i++) {

--- a/src/storage/ducklake_inline_data.cpp
+++ b/src/storage/ducklake_inline_data.cpp
@@ -300,10 +300,10 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 		return OperatorFinalResultType::FINISHED;
 	}
 	{
-		auto cinsert = const_cast<DuckLakeInsert *>(insert.get());
-		lock_guard<mutex> lock(cinsert->lock);
-		if (!cinsert->sink_state) {
-			cinsert->sink_state = insert->GetGlobalSinkState(context);
+		auto mutable_insert = insert.get_mutable();
+		lock_guard<mutex> lock(mutable_insert->lock);
+		if (!mutable_insert->sink_state) {
+			mutable_insert->sink_state = insert->GetGlobalSinkState(context);
 		}
 	}
 	auto &insert_gstate = insert->sink_state->Cast<DuckLakeInsertGlobalState>();
@@ -317,7 +317,7 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 	insert_gstate.total_insert_count = inlined_data.Count();
 
 	// use physical column count for stats
-	// If we are inlining from updates, we might have extra columms (e.g., row_id, partitions)
+	// If we are inlining from updates, we might have extra columns (e.g., row_id, partitions)
 	auto physical_col_count = table.GetColumns().PhysicalColumnCount();
 
 	// compute the column stats for the data
@@ -343,7 +343,7 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 	}
 
 	if (inlined_data.Types().size() > physical_col_count) {
-		// If we have extra columns, we need to extract the pysical columns
+		// If we have extra columns, we need to extract the physical columns
 		vector<LogicalType> phys_types(inlined_data.Types().begin(), inlined_data.Types().begin() + physical_col_count);
 		auto phys_data = make_uniq<ColumnDataCollection>(context, phys_types);
 		ColumnDataAppendState append_state;

--- a/src/storage/ducklake_inline_data.cpp
+++ b/src/storage/ducklake_inline_data.cpp
@@ -313,15 +313,18 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 	auto &table = insert_gstate.table;
 	auto result = make_uniq<DuckLakeInlinedData>();
 	auto &inlined_data = *gstate.global_inlined_data;
-	result->data = std::move(gstate.global_inlined_data);
 	// set the insert count to the total number of inlined rows
 	insert_gstate.total_insert_count = inlined_data.Count();
+
+	// use physical column count for stats
+	// If we are inlining from updates, we might have extra columms (e.g., row_id, partitions)
+	auto physical_col_count = table.GetColumns().PhysicalColumnCount();
 
 	// compute the column stats for the data
 	vector<DuckLakeBaseColumnStats> new_stats;
 	auto &field_data = table.GetFieldData();
 	for (auto &chunk : inlined_data.Chunks()) {
-		for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
+		for (idx_t c = 0; c < physical_col_count; c++) {
 			UpdateStats(new_stats, c, chunk.data[c], chunk.size(), field_data.GetByRootIndex(PhysicalIndex(c)));
 		}
 	}
@@ -337,6 +340,27 @@ OperatorFinalResultType DuckLakeInlineData::OperatorFinalize(Pipeline &pipeline,
 				throw ConstraintException("NOT NULL constraint failed: %s.%s", table.name, column_name);
 			}
 		}
+	}
+
+	if (inlined_data.Types().size() > physical_col_count) {
+		// If we have extra columns, we need to extract the pysical columns
+		vector<LogicalType> phys_types(inlined_data.Types().begin(), inlined_data.Types().begin() + physical_col_count);
+		auto phys_data = make_uniq<ColumnDataCollection>(context, phys_types);
+		ColumnDataAppendState append_state;
+		phys_data->InitializeAppend(append_state);
+		for (auto &chunk : inlined_data.Chunks()) {
+			DataChunk phys_chunk;
+			phys_chunk.InitializeEmpty(phys_types);
+			for (idx_t i = 0; i < physical_col_count; i++) {
+				phys_chunk.data[i].Reference(chunk.data[i]);
+			}
+			phys_chunk.SetCardinality(chunk.size());
+			phys_data->Append(append_state, phys_chunk);
+		}
+		result->data = std::move(phys_data);
+	} else {
+		// Otherwise we just copy them
+		result->data = std::move(gstate.global_inlined_data);
 	}
 
 	// push the inlined data into the transaction

--- a/src/storage/ducklake_inlined_data.cpp
+++ b/src/storage/ducklake_inlined_data.cpp
@@ -1,0 +1,58 @@
+#include "storage/ducklake_inlined_data.hpp"
+
+#include <algorithm>
+
+namespace duckdb {
+
+bool DuckLakeInlinedData::HasPreservedRowIds() const {
+	return !row_ids.empty();
+}
+
+idx_t DuckLakeInlinedData::GetRowId(idx_t position) const {
+	if (HasPreservedRowIds()) {
+		return NumericCast<idx_t>(row_ids[position]);
+	}
+	return position;
+}
+
+int64_t DuckLakeInlinedData::GetOutputRowId(idx_t position) const {
+	if (HasPreservedRowIds()) {
+		return row_ids[position];
+	}
+	return NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START + position);
+}
+
+void DuckLakeInlinedData::MergeRowIds(const DuckLakeInlinedData &new_data, idx_t new_data_count) {
+	if (!new_data.HasPreservedRowIds() && !HasPreservedRowIds()) {
+		return;
+	}
+	if (!HasPreservedRowIds()) {
+		// if the existing data doesnt have preserved row ids, we assign them sequentially from
+		// transaction local id
+		idx_t existing_count = data->Count() - new_data_count;
+		row_ids.reserve(existing_count + new_data.row_ids.size());
+		auto next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
+		for (idx_t i = 0; i < existing_count; i++) {
+			row_ids.push_back(next_id + NumericCast<int64_t>(i));
+		}
+	}
+	if (new_data.HasPreservedRowIds()) {
+		// if this is already preserved we can just insert it
+		row_ids.insert(row_ids.end(), new_data.row_ids.begin(), new_data.row_ids.end());
+	} else {
+		// new data doesnt preserve row_ids, we need to use the TRANSACTION_LOCAL_ROW_ID_START
+		int64_t next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
+		if (!row_ids.empty()) {
+			// we only use max_id if it's guaranteed to be transactional (over next_id)
+			auto max_id = *std::max_element(row_ids.begin(), row_ids.end());
+			if (max_id >= next_id) {
+				next_id = max_id + 1;
+			}
+		}
+		for (idx_t i = 0; i < new_data_count; i++) {
+			row_ids.push_back(next_id + NumericCast<int64_t>(i));
+		}
+	}
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -224,18 +224,25 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
 				break;
 			}
 			case InlinedVirtualColumn::COLUMN_ROW_ID: {
-				// Generate ordinal data for row IDs
 				Vector ordinal_vector(LogicalType::BIGINT);
 				auto ordinal_data = FlatVector::GetData<int64_t>(ordinal_vector);
-				for (idx_t r = 0; r < scan_chunk.size(); r++) {
-					ordinal_data[r] = NumericCast<int64_t>(file_row_number + r);
+				if (!data->row_ids.empty()) {
+					// use preserved row_ids from update inlining
+					for (idx_t r = 0; r < scan_chunk.size(); r++) {
+						ordinal_data[r] = data->row_ids[file_row_number + r];
+					}
+				} else {
+					// use general orginal row id
+					for (idx_t r = 0; r < scan_chunk.size(); r++) {
+						ordinal_data[r] = NumericCast<int64_t>(file_row_number + r);
+					}
 				}
 				if (TryEvaluateExpression(context, c, ordinal_vector, LogicalType::BIGINT, chunk.data[c])) {
 					continue;
 				}
 				auto row_id_data = FlatVector::GetData<int64_t>(chunk.data[c]);
 				for (idx_t r = 0; r < scan_chunk.size(); r++) {
-					row_id_data[r] = NumericCast<int64_t>(file_row_number + r);
+					row_id_data[r] = ordinal_data[r];
 				}
 				continue;
 			}

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -226,13 +226,13 @@ AsyncResult DuckLakeInlinedDataReader::Scan(ClientContext &context, GlobalTableF
 			case InlinedVirtualColumn::COLUMN_ROW_ID: {
 				Vector ordinal_vector(LogicalType::BIGINT);
 				auto ordinal_data = FlatVector::GetData<int64_t>(ordinal_vector);
-				if (!data->row_ids.empty()) {
+				if (data->HasPreservedRowIds()) {
 					// use preserved row_ids from update inlining
 					for (idx_t r = 0; r < scan_chunk.size(); r++) {
 						ordinal_data[r] = data->row_ids[file_row_number + r];
 					}
 				} else {
-					// use general orginal row id
+					// use general ordinal row id
 					for (idx_t r = 0; r < scan_chunk.size(); r++) {
 						ordinal_data[r] = NumericCast<int64_t>(file_row_number + r);
 					}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -758,15 +758,10 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 		plan = planner.ResolveDefaultsProjection(op, *plan);
 	}
 	auto &ducklake_table = op.table.Cast<DuckLakeTableEntry>();
-	auto &ducklake_schema = ducklake_table.ParentSchema().Cast<DuckLakeSchemaEntry>();
 	optional_ptr<DuckLakeInlineData> inline_data;
 
-	idx_t data_inlining_row_limit = DataInliningRowLimit(ducklake_schema.GetSchemaId(), ducklake_table.GetTableId());
-	// FIXME: we are skipping columns that have conflicting names, we should resolve this
-	auto &duck_transaction = DuckLakeTransaction::Get(context, *this);
-	auto &metadata_manager = duck_transaction.GetMetadataManager();
-	if (data_inlining_row_limit > 0 && !DuckLakeUtil::HasInlinedSystemColumnConflict(ducklake_table.GetColumns()) &&
-	    metadata_manager.SupportsInliningTypes(plan->types)) {
+	idx_t data_inlining_row_limit = GetInliningLimit(context, ducklake_table, plan->types);
+	if (data_inlining_row_limit > 0) {
 		plan = planner.Make<DuckLakeInlineData>(*plan, data_inlining_row_limit);
 		inline_data = plan->Cast<DuckLakeInlineData>();
 	}

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -113,6 +113,51 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 	return copy.Combine(context, combine_input);
 }
 
+// Scan copy operator source and sink into insert operator — shared by MergeInsert and MergeUpdate
+static void FinalizeCopyToInsert(Pipeline &pipeline, Event &event, ClientContext &context,
+                                 PhysicalOperator &copy_op, PhysicalOperator &insert_op,
+                                 InterruptState &interrupt_state) {
+	DataChunk chunk;
+	chunk.Initialize(context, copy_op.types);
+
+	ThreadContext thread(context);
+	ExecutionContext exec_context(context, thread, nullptr);
+
+	auto copy_global = copy_op.GetGlobalSourceState(context);
+	auto copy_local = copy_op.GetLocalSourceState(exec_context, *copy_global);
+	OperatorSourceInput source_input {*copy_global, *copy_local, interrupt_state};
+
+	auto insert_global = insert_op.GetGlobalSinkState(context);
+	auto insert_local = insert_op.GetLocalSinkState(exec_context);
+	OperatorSinkInput sink_input {*insert_global, *insert_local, interrupt_state};
+	SourceResultType source_res = SourceResultType::HAVE_MORE_OUTPUT;
+	while (source_res == SourceResultType::HAVE_MORE_OUTPUT) {
+		chunk.Reset();
+		source_res = copy_op.GetData(exec_context, chunk, source_input);
+		if (chunk.size() == 0) {
+			continue;
+		}
+		if (source_res == SourceResultType::BLOCKED) {
+			throw InternalException("BLOCKED not supported in DuckLakeMerge");
+		}
+
+		auto sink_result = insert_op.Sink(exec_context, chunk, sink_input);
+		if (sink_result != SinkResultType::NEED_MORE_INPUT) {
+			throw InternalException("BLOCKED not supported in DuckLakeMerge");
+		}
+	}
+	OperatorSinkCombineInput combine_input {*insert_global, *insert_local, interrupt_state};
+	auto combine_res = insert_op.Combine(exec_context, combine_input);
+	if (combine_res == SinkCombineResultType::BLOCKED) {
+		throw InternalException("BLOCKED not supported in DuckLakeMerge");
+	}
+	OperatorSinkFinalizeInput finalize_input {*insert_global, interrupt_state};
+	auto finalize_res = insert_op.Finalize(pipeline, event, context, finalize_input);
+	if (finalize_res == SinkFinalizeType::BLOCKED) {
+		throw InternalException("BLOCKED not supported in DuckLakeMerge");
+	}
+}
+
 SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                                OperatorSinkFinalizeInput &input) const {
 	OperatorSinkFinalizeInput copy_finalize {*copy.sink_state, input.interrupt_state};
@@ -121,46 +166,7 @@ SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event,
 		return SinkFinalizeType::BLOCKED;
 	}
 
-	// now scan the copy
-	DataChunk chunk;
-	chunk.Initialize(context, copy.types);
-
-	ThreadContext thread(context);
-	ExecutionContext exec_context(context, thread, nullptr);
-
-	auto copy_global = copy.GetGlobalSourceState(context);
-	auto copy_local = copy.GetLocalSourceState(exec_context, *copy_global);
-	OperatorSourceInput source_input {*copy_global, *copy_local, input.interrupt_state};
-
-	auto insert_global = insert.GetGlobalSinkState(context);
-	auto insert_local = insert.GetLocalSinkState(exec_context);
-	OperatorSinkInput sink_input {*insert_global, *insert_local, input.interrupt_state};
-	SourceResultType source_res = SourceResultType::HAVE_MORE_OUTPUT;
-	while (source_res == SourceResultType::HAVE_MORE_OUTPUT) {
-		chunk.Reset();
-		source_res = copy.GetData(exec_context, chunk, source_input);
-		if (chunk.size() == 0) {
-			continue;
-		}
-		if (source_res == SourceResultType::BLOCKED) {
-			throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
-		}
-
-		auto sink_result = insert.Sink(exec_context, chunk, sink_input);
-		if (sink_result != SinkResultType::NEED_MORE_INPUT) {
-			throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
-		}
-	}
-	OperatorSinkCombineInput combine_input {*insert_global, *insert_local, input.interrupt_state};
-	auto combine_res = insert.Combine(exec_context, combine_input);
-	if (combine_res == SinkCombineResultType::BLOCKED) {
-		throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
-	}
-	OperatorSinkFinalizeInput finalize_input {*insert_global, input.interrupt_state};
-	auto finalize_res = insert.Finalize(pipeline, event, context, finalize_input);
-	if (finalize_res == SinkFinalizeType::BLOCKED) {
-		throw InternalException("BLOCKED not supported in DuckLakeMergeInsert");
-	}
+	FinalizeCopyToInsert(pipeline, event, context, copy, insert, input.interrupt_state);
 	return SinkFinalizeType::READY;
 }
 
@@ -354,35 +360,7 @@ SinkFinalizeType DuckLakeMergeUpdate::Finalize(Pipeline &pipeline, Event &event,
 	OperatorSinkFinalizeInput copy_finalize {*copy_op.sink_state, input.interrupt_state};
 	copy_op.Finalize(pipeline, event, context, copy_finalize);
 
-	DataChunk chunk;
-	chunk.Initialize(context, copy_op.types);
-	ThreadContext thread(context);
-	ExecutionContext exec_context(context, thread, nullptr);
-
-	auto copy_global = copy_op.GetGlobalSourceState(context);
-	auto copy_local = copy_op.GetLocalSourceState(exec_context, *copy_global);
-	OperatorSourceInput source_input {*copy_global, *copy_local, input.interrupt_state};
-
-	auto insert_global = insert_op.GetGlobalSinkState(context);
-	auto insert_local = insert_op.GetLocalSinkState(exec_context);
-	OperatorSinkInput sink_input {*insert_global, *insert_local, input.interrupt_state};
-
-	while (true) {
-		chunk.Reset();
-		auto source_res = copy_op.GetData(exec_context, chunk, source_input);
-		if (chunk.size() > 0) {
-			insert_op.Sink(exec_context, chunk, sink_input);
-		}
-		if (source_res == SourceResultType::FINISHED || chunk.size() == 0) {
-			break;
-		}
-	}
-
-	OperatorSinkCombineInput insert_combine {*insert_global, *insert_local, input.interrupt_state};
-	insert_op.Combine(exec_context, insert_combine);
-	OperatorSinkFinalizeInput insert_finalize {*insert_global, input.interrupt_state};
-	insert_op.Finalize(pipeline, event, context, insert_finalize);
-
+	FinalizeCopyToInsert(pipeline, event, context, copy_op, insert_op, input.interrupt_state);
 	return SinkFinalizeType::READY;
 }
 

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -4,6 +4,7 @@
 #include "storage/ducklake_update.hpp"
 #include "storage/ducklake_delete.hpp"
 #include "storage/ducklake_insert.hpp"
+#include "storage/ducklake_inline_data.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
@@ -185,6 +186,207 @@ unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionConte
 }
 
 //===--------------------------------------------------------------------===//
+// Merge Update
+//===--------------------------------------------------------------------===//
+class DuckLakeMergeUpdate : public PhysicalOperator {
+public:
+	DuckLakeMergeUpdate(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeUpdate &update_op,
+	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &copy_op,
+	                    PhysicalOperator &insert_op)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), update_op(update_op),
+	      inline_data_op(inline_data_op), copy_op(copy_op), insert_op(insert_op) {
+	}
+
+	DuckLakeUpdate &update_op;
+	optional_ptr<DuckLakeInlineData> inline_data_op;
+	PhysicalOperator &copy_op;
+	PhysicalOperator &insert_op;
+
+public:
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override {
+		return SourceResultType::FINISHED;
+	}
+	bool IsSource() const override {
+		return true;
+	}
+	bool IsSink() const override {
+		return true;
+	}
+	bool ParallelSink() const override {
+		return true;
+	}
+	string GetName() const override {
+		return "DUCKLAKE_MERGE_UPDATE";
+	}
+
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
+	unique_ptr<LocalSinkState> GetLocalSinkState(ExecutionContext &context) const override;
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	SinkCombineResultType Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const override;
+	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+	                          OperatorSinkFinalizeInput &input) const override;
+};
+
+class DuckLakeMergeUpdateGlobalState : public GlobalSinkState {
+public:
+	unique_ptr<GlobalOperatorState> update_gstate;
+	unique_ptr<GlobalOperatorState> inline_data_gstate;
+};
+
+class DuckLakeMergeUpdateLocalState : public LocalSinkState {
+public:
+	unique_ptr<OperatorState> update_lstate;
+	unique_ptr<OperatorState> inline_data_lstate;
+	unique_ptr<LocalSinkState> copy_lstate;
+	DataChunk update_output;
+	DataChunk inline_output;
+};
+
+unique_ptr<GlobalSinkState> DuckLakeMergeUpdate::GetGlobalSinkState(ClientContext &context) const {
+	auto result = make_uniq<DuckLakeMergeUpdateGlobalState>();
+	result->update_gstate = update_op.GetGlobalOperatorState(context);
+	if (inline_data_op) {
+		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
+	}
+	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
+	return std::move(result);
+}
+
+unique_ptr<LocalSinkState> DuckLakeMergeUpdate::GetLocalSinkState(ExecutionContext &context) const {
+	auto result = make_uniq<DuckLakeMergeUpdateLocalState>();
+	result->update_lstate = update_op.GetOperatorState(context);
+	if (inline_data_op) {
+		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
+		result->inline_output.Initialize(context.client, inline_data_op->types);
+	}
+	result->copy_lstate = copy_op.GetLocalSinkState(context);
+	result->update_output.Initialize(context.client, update_op.types);
+	return std::move(result);
+}
+
+// Forward output from inline data operator to copy sink, draining HAVE_MORE_OUTPUT
+static void ForwardInlineToCopy(ExecutionContext &context, const DuckLakeInlineData &inline_op,
+                                GlobalOperatorState &inline_gstate, OperatorState &inline_lstate,
+                                DataChunk &inline_output, DataChunk &input, PhysicalOperator &copy_op,
+                                LocalSinkState &copy_lstate, InterruptState &interrupt_state) {
+	inline_output.Reset();
+	auto result = inline_op.Execute(context, input, inline_output, inline_gstate, inline_lstate);
+	if (inline_output.size() > 0) {
+		OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
+		copy_op.Sink(context, inline_output, copy_input);
+	}
+	while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+		inline_output.Reset();
+		result = inline_op.Execute(context, input, inline_output, inline_gstate, inline_lstate);
+		if (inline_output.size() > 0) {
+			OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
+			copy_op.Sink(context, inline_output, copy_input);
+		}
+	}
+}
+
+SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeUpdateGlobalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeUpdateLocalState>();
+
+	lstate.update_output.Reset();
+	update_op.Execute(context, chunk, lstate.update_output, *gstate.update_gstate, *lstate.update_lstate);
+
+	if (lstate.update_output.size() == 0) {
+		return SinkResultType::NEED_MORE_INPUT;
+	}
+
+	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
+	// through to the CopyToFile sink
+	if (inline_data_op) {
+		ForwardInlineToCopy(context, *inline_data_op, *gstate.inline_data_gstate, *lstate.inline_data_lstate,
+		                    lstate.inline_output, lstate.update_output, copy_op, *lstate.copy_lstate,
+		                    input.interrupt_state);
+	} else {
+		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
+		copy_op.Sink(context, lstate.update_output, copy_input);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
+SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeUpdateGlobalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeUpdateLocalState>();
+
+	// drain inline data
+	if (inline_data_op) {
+		auto &inline_output = lstate.inline_output;
+		while (true) {
+			inline_output.Reset();
+			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
+			                                            *lstate.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
+				copy_op.Sink(context, inline_output, copy_input);
+			}
+			if (fresult == OperatorFinalizeResultType::FINISHED) {
+				break;
+			}
+		}
+	}
+
+	DataChunk dummy;
+	update_op.FinalExecute(context, dummy, *gstate.update_gstate, *lstate.update_lstate);
+
+	OperatorSinkCombineInput copy_combine {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
+	copy_op.Combine(context, copy_combine);
+	return SinkCombineResultType::FINISHED;
+}
+
+SinkFinalizeType DuckLakeMergeUpdate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                               OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeUpdateGlobalState>();
+
+	OperatorFinalizeInput update_finalize {*gstate.update_gstate, input.interrupt_state};
+	update_op.OperatorFinalize(pipeline, event, context, update_finalize);
+
+	if (inline_data_op) {
+		OperatorFinalizeInput inline_finalize {*gstate.inline_data_gstate, input.interrupt_state};
+		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize);
+	}
+
+	OperatorSinkFinalizeInput copy_finalize {*copy_op.sink_state, input.interrupt_state};
+	copy_op.Finalize(pipeline, event, context, copy_finalize);
+
+	DataChunk chunk;
+	chunk.Initialize(context, copy_op.types);
+	ThreadContext thread(context);
+	ExecutionContext exec_context(context, thread, nullptr);
+
+	auto copy_global = copy_op.GetGlobalSourceState(context);
+	auto copy_local = copy_op.GetLocalSourceState(exec_context, *copy_global);
+	OperatorSourceInput source_input {*copy_global, *copy_local, input.interrupt_state};
+
+	auto insert_global = insert_op.GetGlobalSinkState(context);
+	auto insert_local = insert_op.GetLocalSinkState(exec_context);
+	OperatorSinkInput sink_input {*insert_global, *insert_local, input.interrupt_state};
+
+	while (true) {
+		chunk.Reset();
+		auto source_res = copy_op.GetData(exec_context, chunk, source_input);
+		if (chunk.size() > 0) {
+			insert_op.Sink(exec_context, chunk, sink_input);
+		}
+		if (source_res == SourceResultType::FINISHED || chunk.size() == 0) {
+			break;
+		}
+	}
+
+	OperatorSinkCombineInput insert_combine {*insert_global, *insert_local, input.interrupt_state};
+	insert_op.Combine(exec_context, insert_combine);
+	OperatorSinkFinalizeInput insert_finalize {*insert_global, input.interrupt_state};
+	insert_op.Finalize(pipeline, event, context, insert_finalize);
+
+	return SinkFinalizeType::READY;
+}
+
+//===--------------------------------------------------------------------===//
 // Plan Merge Into
 //===--------------------------------------------------------------------===//
 static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog &catalog, ClientContext &context,
@@ -211,11 +413,38 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		update.expressions = std::move(action.expressions);
 		update.columns = std::move(action.columns);
 		update.update_is_del_and_insert = action.update_is_del_and_insert;
-		auto &update_plan = catalog.PlanUpdate(context, planner, update, child_plan);
-		result->op = update_plan;
-		auto &dl_update = result->op->Cast<DuckLakeUpdate>();
-		// The row_id comes before the deletion information, which is always the 3 last column of the chunk.
-		dl_update.row_id_index = child_plan.types.size() - DuckLakeUpdate::DELETION_INFO_SIZE - 1;
+
+		auto &ducklake_table = op.table.Cast<DuckLakeTableEntry>();
+		DuckLakeCopyInput copy_input(context, ducklake_table);
+		copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID;
+
+		auto &update_op = DuckLakeUpdate::PlanUpdateOperator(context, planner, update, child_plan, copy_input);
+
+		// The row_id comes before the deletion information, that is always the 3 last column of the chunk.
+		update_op.row_id_index = child_plan.types.size() - DuckLakeUpdate::DELETION_INFO_SIZE - 1;
+
+		// maybe wrap with InlineData if we hit the row limit
+		optional_ptr<DuckLakeInlineData> inline_data;
+		idx_t data_inlining_row_limit = catalog.GetInliningLimit(context, ducklake_table, update_op.types);
+		if (data_inlining_row_limit > 0) {
+			auto &inline_op =
+			    planner.Make<DuckLakeInlineData>(update_op, data_inlining_row_limit).Cast<DuckLakeInlineData>();
+			inline_data = &inline_op;
+		}
+
+		// plan copy and insert
+		auto &copy_op = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, nullptr);
+		auto &insert_op =
+		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
+		if (inline_data) {
+			inline_data->insert = insert_op.Cast<DuckLakeInsert>();
+		}
+		insert_op.children.push_back(copy_op);
+
+		// wrap in DuckLakeMergeUpdate
+		auto &merge_update = planner.Make<DuckLakeMergeUpdate>(return_types, update_op, inline_data, copy_op, insert_op)
+		                         .Cast<DuckLakeMergeUpdate>();
+		result->op = merge_update;
 		break;
 	}
 	case MergeActionType::MERGE_DELETE: {

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -70,6 +70,31 @@ SourceResultType DuckLakeMergeInsert::GetDataInternal(ExecutionContext &context,
 }
 
 //===--------------------------------------------------------------------===//
+// Shared helpers
+//===--------------------------------------------------------------------===//
+
+// Apply extra projections and casts before feeding a chunk to CopyToFile — shared by MergeInsert and MergeUpdate
+static void ProjectAndCastForCopy(ClientContext &context, DataChunk &input_chunk, PhysicalOperator &copy_op,
+                                  ExpressionExecutor *expression_executor, DataChunk &projected_chunk,
+                                  DataChunk &cast_chunk) {
+	reference<DataChunk> chunk_ref = input_chunk;
+	if (expression_executor) {
+		projected_chunk.Reset();
+		expression_executor->Execute(input_chunk, projected_chunk);
+		chunk_ref = projected_chunk;
+	}
+	auto &copy_types = copy_op.Cast<PhysicalCopyToFile>().expected_types;
+	for (idx_t i = 0; i < chunk_ref.get().ColumnCount(); i++) {
+		if (chunk_ref.get().data[i].GetType() != copy_types[i]) {
+			VectorOperations::Cast(context, chunk_ref.get().data[i], cast_chunk.data[i], chunk_ref.get().size());
+		} else {
+			cast_chunk.data[i].Reference(chunk_ref.get().data[i]);
+		}
+	}
+	cast_chunk.SetCardinality(chunk_ref.get().size());
+}
+
+//===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
 class DuckLakeMergeIntoLocalState : public LocalSinkState {
@@ -83,27 +108,9 @@ public:
 
 SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &local_state = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+	ProjectAndCastForCopy(context.client, chunk, copy, local_state.expression_executor.get(), local_state.chunk,
+	                      local_state.cast_chunk);
 	OperatorSinkInput sink_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-	reference<DataChunk> chunk_ref = chunk;
-	if (!extra_projections.empty()) {
-		// We have extra projections, we need to execute them
-		local_state.chunk.Reset();
-		local_state.expression_executor->Execute(chunk, local_state.chunk);
-		chunk_ref = local_state.chunk;
-	}
-
-	// Cast the chunk if needed
-	auto &copy_types = copy.Cast<PhysicalCopyToFile>().expected_types;
-	for (idx_t i = 0; i < chunk_ref.get().ColumnCount(); i++) {
-		if (chunk_ref.get().data[i].GetType() != copy_types[i]) {
-			VectorOperations::Cast(context.client, chunk_ref.get().data[i], local_state.cast_chunk.data[i],
-			                       chunk_ref.get().size());
-		} else {
-			local_state.cast_chunk.data[i].Reference(chunk_ref.get().data[i]);
-		}
-	}
-	local_state.cast_chunk.SetCardinality(chunk_ref.get().size());
-
 	return copy.Sink(context, local_state.cast_chunk, sink_input);
 }
 
@@ -114,9 +121,8 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 }
 
 // Scan copy operator source and sink into insert operator — shared by MergeInsert and MergeUpdate
-static void FinalizeCopyToInsert(Pipeline &pipeline, Event &event, ClientContext &context,
-                                 PhysicalOperator &copy_op, PhysicalOperator &insert_op,
-                                 InterruptState &interrupt_state) {
+static void FinalizeCopyToInsert(Pipeline &pipeline, Event &event, ClientContext &context, PhysicalOperator &copy_op,
+                                 PhysicalOperator &insert_op, InterruptState &interrupt_state) {
 	DataChunk chunk;
 	chunk.Initialize(context, copy_op.types);
 
@@ -207,6 +213,8 @@ public:
 	optional_ptr<DuckLakeInlineData> inline_data_op;
 	PhysicalOperator &copy_op;
 	PhysicalOperator &insert_op;
+	//! Extra projections for partition columns
+	vector<unique_ptr<Expression>> extra_projections;
 
 public:
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
@@ -247,6 +255,10 @@ public:
 	unique_ptr<LocalSinkState> copy_lstate;
 	DataChunk update_output;
 	DataChunk inline_output;
+	//! Projection and cast chunks for partition columns (same pattern as DuckLakeMergeInsert)
+	unique_ptr<ExpressionExecutor> expression_executor;
+	DataChunk projected_chunk;
+	DataChunk cast_chunk;
 };
 
 unique_ptr<GlobalSinkState> DuckLakeMergeUpdate::GetGlobalSinkState(ClientContext &context) const {
@@ -268,28 +280,16 @@ unique_ptr<LocalSinkState> DuckLakeMergeUpdate::GetLocalSinkState(ExecutionConte
 	}
 	result->copy_lstate = copy_op.GetLocalSinkState(context);
 	result->update_output.Initialize(context.client, update_op.types);
-	return std::move(result);
-}
-
-// Forward output from inline data operator to copy sink, draining HAVE_MORE_OUTPUT
-static void ForwardInlineToCopy(ExecutionContext &context, const DuckLakeInlineData &inline_op,
-                                GlobalOperatorState &inline_gstate, OperatorState &inline_lstate,
-                                DataChunk &inline_output, DataChunk &input, PhysicalOperator &copy_op,
-                                LocalSinkState &copy_lstate, InterruptState &interrupt_state) {
-	inline_output.Reset();
-	auto result = inline_op.Execute(context, input, inline_output, inline_gstate, inline_lstate);
-	if (inline_output.size() > 0) {
-		OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
-		copy_op.Sink(context, inline_output, copy_input);
-	}
-	while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
-		inline_output.Reset();
-		result = inline_op.Execute(context, input, inline_output, inline_gstate, inline_lstate);
-		if (inline_output.size() > 0) {
-			OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
-			copy_op.Sink(context, inline_output, copy_input);
+	if (!extra_projections.empty()) {
+		result->expression_executor = make_uniq<ExpressionExecutor>(context.client, extra_projections);
+		vector<LogicalType> projected_types;
+		for (auto &expr : result->expression_executor->expressions) {
+			projected_types.push_back(expr->return_type);
 		}
+		result->projected_chunk.Initialize(context.client, projected_types);
 	}
+	result->cast_chunk.Initialize(context.client, copy_op.Cast<PhysicalCopyToFile>().expected_types);
+	return std::move(result);
 }
 
 SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
@@ -306,12 +306,32 @@ SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &c
 	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
 	// through to the CopyToFile sink
 	if (inline_data_op) {
-		ForwardInlineToCopy(context, *inline_data_op, *gstate.inline_data_gstate, *lstate.inline_data_lstate,
-		                    lstate.inline_output, lstate.update_output, copy_op, *lstate.copy_lstate,
-		                    input.interrupt_state);
+		auto &inline_output = lstate.inline_output;
+		inline_output.Reset();
+		auto result = inline_data_op->Execute(context, lstate.update_output, inline_output, *gstate.inline_data_gstate,
+		                                      *lstate.inline_data_lstate);
+		if (inline_output.size() > 0) {
+			ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
+			                      lstate.projected_chunk, lstate.cast_chunk);
+			OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
+			copy_op.Sink(context, lstate.cast_chunk, copy_input);
+		}
+		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+			inline_output.Reset();
+			result = inline_data_op->Execute(context, lstate.update_output, inline_output, *gstate.inline_data_gstate,
+			                                 *lstate.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
+				                      lstate.projected_chunk, lstate.cast_chunk);
+				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
+				copy_op.Sink(context, lstate.cast_chunk, copy_input);
+			}
+		}
 	} else {
+		ProjectAndCastForCopy(context.client, lstate.update_output, copy_op, lstate.expression_executor.get(),
+		                      lstate.projected_chunk, lstate.cast_chunk);
 		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-		copy_op.Sink(context, lstate.update_output, copy_input);
+		copy_op.Sink(context, lstate.cast_chunk, copy_input);
 	}
 	return SinkResultType::NEED_MORE_INPUT;
 }
@@ -328,8 +348,10 @@ SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, Op
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
 			                                            *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
+				ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
+				                      lstate.projected_chunk, lstate.cast_chunk);
 				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-				copy_op.Sink(context, inline_output, copy_input);
+				copy_op.Sink(context, lstate.cast_chunk, copy_input);
 			}
 			if (fresult == OperatorFinalizeResultType::FINISHED) {
 				break;
@@ -411,6 +433,7 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		}
 
 		// plan copy and insert
+		auto copy_options = DuckLakeInsert::GetCopyOptions(context, copy_input);
 		auto &copy_op = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, nullptr);
 		auto &insert_op =
 		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
@@ -422,6 +445,7 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		// wrap in DuckLakeMergeUpdate
 		auto &merge_update = planner.Make<DuckLakeMergeUpdate>(return_types, update_op, inline_data, copy_op, insert_op)
 		                         .Cast<DuckLakeMergeUpdate>();
+		merge_update.extra_projections = std::move(copy_options.projection_list);
 		result->op = merge_update;
 		break;
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2585,7 +2585,8 @@ unique_ptr<QueryResult> DuckLakeMetadataManager::ReadInlinedData(DuckLakeSnapsho
 	auto result = transaction.Query(snapshot, StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s inlined_data
-WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL);)",
+WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
+ORDER BY row_id;)",
 	                                                             projection, inlined_table_name));
 	return result;
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2347,21 +2347,28 @@ WHERE table_id = %d AND schema_version=(
 		// append the data
 		// FIXME: we can do a much faster append than this
 		string values;
+		bool has_preserved_row_ids = !entry.data->row_ids.empty();
 		idx_t row_id = entry.row_id_start;
+		idx_t global_row_idx = 0;
 		for (auto &chunk : entry.data->data->Chunks()) {
 			for (idx_t r = 0; r < chunk.size(); r++) {
 				if (!values.empty()) {
 					values += ", ";
 				}
 				values += "(";
-				values += to_string(row_id);
+				if (has_preserved_row_ids) {
+					values += to_string(entry.data->row_ids[global_row_idx]);
+				} else {
+					values += to_string(row_id);
+					row_id++;
+				}
 				values += ", {SNAPSHOT_ID}, NULL";
 				for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
 					values += ", ";
 					values += DuckLakeUtil::ValueToSQL(*this, context, chunk.GetValue(c, r));
 				}
 				values += ")";
-				row_id++;
+				global_row_idx++;
 			}
 		}
 		if (!values.empty()) {
@@ -2395,7 +2402,7 @@ VALUES %s
 UPDATE {METADATA_CATALOG}.%s
 SET end_snapshot = {SNAPSHOT_ID}
 FROM deleted_row_list
-WHERE row_id=deleted_row_id;
+WHERE row_id=deleted_row_id AND end_snapshot IS NULL AND begin_snapshot != {SNAPSHOT_ID};
 )",
 		                                    row_id_list, entry.table_name);
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -6,7 +6,6 @@
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "storage/ducklake_catalog.hpp"
-#include "storage/ducklake_multi_file_list.hpp"
 #include "common/ducklake_types.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
@@ -2349,7 +2348,7 @@ WHERE table_id = %d AND schema_version=(
 		// append the data
 		// FIXME: we can do a much faster append than this
 		string values;
-		bool has_preserved_row_ids = !entry.data->row_ids.empty();
+		bool has_preserved_row_ids = entry.data->HasPreservedRowIds();
 		idx_t row_id = entry.row_id_start;
 		idx_t global_row_idx = 0;
 		for (auto &chunk : entry.data->data->Chunks()) {
@@ -2360,7 +2359,7 @@ WHERE table_id = %d AND schema_version=(
 				values += "(";
 				if (has_preserved_row_ids) {
 					auto rid = entry.data->row_ids[global_row_idx];
-					if (NumericCast<idx_t>(rid) >= DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START) {
+					if (DuckLakeConstants::IsTransactionLocalRowId(rid)) {
 						// This is a INSERT row w a placeholder id, we assign sequential row_id
 						values += to_string(row_id);
 						row_id++;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/blob.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_multi_file_list.hpp"
 #include "common/ducklake_types.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
@@ -2357,7 +2358,15 @@ WHERE table_id = %d AND schema_version=(
 				}
 				values += "(";
 				if (has_preserved_row_ids) {
-					values += to_string(entry.data->row_ids[global_row_idx]);
+					auto rid = entry.data->row_ids[global_row_idx];
+					if (NumericCast<idx_t>(rid) >= DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START) {
+						// This is a INSERT row w a placeholder id, we assign sequential row_id
+						values += to_string(row_id);
+						row_id++;
+					} else {
+						// This is a UPDATE row, we use preserved row_id
+						values += to_string(rid);
+					}
 				} else {
 					values += to_string(row_id);
 					row_id++;

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -248,7 +248,7 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 			transaction.GetLocalDeleteForFile(read_info.table_id, file_entry.file.path, file_entry.delete_file);
 		}
 	}
-	idx_t transaction_row_start = TRANSACTION_LOCAL_ID_START;
+	idx_t transaction_row_start = DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START;
 	for (auto &file : transaction_local_files) {
 		DuckLakeFileListExtendedEntry file_entry;
 		file_entry.file_id = DataFileIndex();
@@ -278,12 +278,7 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 		file_entry.file_id = DataFileIndex();
 		file_entry.delete_file_id = DataFileIndex();
 		file_entry.row_count = transaction_local_data->data->Count();
-		if (!transaction_local_data->row_ids.empty()) {
-			// preserved row_ids are absolute, so row_id_start must be 0
-			file_entry.row_id_start = 0;
-		} else {
-			file_entry.row_id_start = transaction_row_start;
-		}
+		file_entry.row_id_start = GetTransactionLocalRowIdStart(transaction_row_start);
 		file_entry.data_type = DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA;
 		result.push_back(std::move(file_entry));
 	}
@@ -353,7 +348,7 @@ void DuckLakeMultiFileList::GetFilesForTable() const {
 			}
 		}
 	}
-	idx_t transaction_row_start = TRANSACTION_LOCAL_ID_START;
+	idx_t transaction_row_start = DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START;
 	for (auto &file : transaction_local_files) {
 		DuckLakeFileListEntry file_entry;
 		file_entry.file = GetFileData(file);
@@ -375,12 +370,7 @@ void DuckLakeMultiFileList::GetFilesForTable() const {
 		// we have transaction local inlined data - create the dummy file entry
 		DuckLakeFileListEntry file_entry;
 		file_entry.file.path = DUCKLAKE_TRANSACTION_LOCAL_INLINED_FILENAME;
-		if (!transaction_local_data->row_ids.empty()) {
-			// preserved row_ids are absolute, so row_id_start must be 0
-			file_entry.row_id_start = 0;
-		} else {
-			file_entry.row_id_start = transaction_row_start;
-		}
+		file_entry.row_id_start = GetTransactionLocalRowIdStart(transaction_row_start);
 		file_entry.data_type = DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA;
 		files.push_back(std::move(file_entry));
 	}
@@ -460,6 +450,14 @@ const vector<DuckLakeFileListEntry> &DuckLakeMultiFileList::GetFiles() const {
 		read_file_list = true;
 	}
 	return files;
+}
+
+idx_t DuckLakeMultiFileList::GetTransactionLocalRowIdStart(idx_t transaction_row_start) const {
+	if (transaction_local_data && transaction_local_data->HasPreservedRowIds()) {
+		// preserved row_ids are absolute, so row_id_start must be 0
+		return 0;
+	}
+	return transaction_row_start;
 }
 
 } // namespace duckdb

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -278,7 +278,12 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 		file_entry.file_id = DataFileIndex();
 		file_entry.delete_file_id = DataFileIndex();
 		file_entry.row_count = transaction_local_data->data->Count();
-		file_entry.row_id_start = transaction_row_start;
+		if (!transaction_local_data->row_ids.empty()) {
+			// preserved row_ids are absolute, so row_id_start must be 0
+			file_entry.row_id_start = 0;
+		} else {
+			file_entry.row_id_start = transaction_row_start;
+		}
 		file_entry.data_type = DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA;
 		result.push_back(std::move(file_entry));
 	}
@@ -370,7 +375,12 @@ void DuckLakeMultiFileList::GetFilesForTable() const {
 		// we have transaction local inlined data - create the dummy file entry
 		DuckLakeFileListEntry file_entry;
 		file_entry.file.path = DUCKLAKE_TRANSACTION_LOCAL_INLINED_FILENAME;
-		file_entry.row_id_start = transaction_row_start;
+		if (!transaction_local_data->row_ids.empty()) {
+			// preserved row_ids are absolute, so row_id_start must be 0
+			file_entry.row_id_start = 0;
+		} else {
+			file_entry.row_id_start = transaction_row_start;
+		}
 		file_entry.data_type = DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA;
 		files.push_back(std::move(file_entry));
 	}

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1208,7 +1208,8 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transact
 		    info.alter_table_type != AlterTableType::RENAME_COLUMN &&
 		    info.alter_table_type != AlterTableType::ALTER_COLUMN_TYPE &&
 		    info.alter_table_type != AlterTableType::SET_NOT_NULL &&
-		    info.alter_table_type != AlterTableType::DROP_NOT_NULL) {
+		    info.alter_table_type != AlterTableType::DROP_NOT_NULL &&
+		    info.alter_table_type != AlterTableType::SET_DEFAULT) {
 			throw NotImplementedException("ALTER on a table with transaction-local inlined data is not supported %s",
 			                              EnumUtil::ToString(info.alter_table_type));
 		}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -16,6 +16,7 @@
 #include "storage/ducklake_macro_entry.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
+#include "storage/ducklake_multi_file_list.hpp"
 #include "storage/ducklake_transaction_changes.hpp"
 #include "storage/ducklake_transaction_manager.hpp"
 #include "storage/ducklake_view_entry.hpp"
@@ -211,9 +212,29 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 			existing_data.data->Append(chunk);
 		}
 		// merge preserved row_ids from update inlining
-		if (!new_data->row_ids.empty()) {
-			existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
-			                             new_data->row_ids.end());
+		if (!new_data->row_ids.empty() || !existing_data.row_ids.empty()) {
+			if (existing_data.row_ids.empty()) {
+				idx_t existing_count = existing_data.data->Count() - new_data->data->Count();
+				existing_data.row_ids.reserve(existing_count + new_data->row_ids.size());
+				auto next_id = NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START);
+				for (idx_t i = 0; i < existing_count; i++) {
+					existing_data.row_ids.push_back(next_id + NumericCast<int64_t>(i));
+				}
+			}
+			if (!new_data->row_ids.empty()) {
+				existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
+				                             new_data->row_ids.end());
+			} else {
+				int64_t next_id = NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START);
+				for (auto &rid : existing_data.row_ids) {
+					if (rid >= next_id) {
+						next_id = rid + 1;
+					}
+				}
+				for (idx_t i = 0; i < new_data->data->Count(); i++) {
+					existing_data.row_ids.push_back(next_id + NumericCast<int64_t>(i));
+				}
+			}
 		}
 		for (auto &entry : new_data->column_stats) {
 			auto stats_entry = existing_data.column_stats.find(entry.first);
@@ -284,7 +305,9 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 			if (has_preserved_row_ids) {
 				new_row_ids.push_back(preserved_row_ids[base_row_id + r]);
 			} else {
-				new_row_ids.push_back(NumericCast<int64_t>(row_id));
+				// generate transaction local row ids w a placeholder
+				new_row_ids.push_back(
+				    NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START + row_id));
 			}
 		}
 		base_row_id += chunk.size();
@@ -2035,6 +2058,13 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 			if (inlined_data.row_ids.empty()) {
 				// regular insert, we advance next_row_id
 				new_stats.next_row_id += record_count;
+			} else {
+				// mixed insert and updates, we only advance inserted row_ids
+				for (auto &rid : inlined_data.row_ids) {
+					if (NumericCast<idx_t>(rid) >= DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START) {
+						new_stats.next_row_id++;
+					}
+				}
 			}
 			// add the file to the to-be-written inlined data list
 			new_inlined_data.data = table_changes.new_inlined_data.get();

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -211,36 +211,7 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 			existing_data.data->Append(chunk);
 		}
 		// merge preserved row_ids from update inlining
-		if (new_data->HasPreservedRowIds() || existing_data.HasPreservedRowIds()) {
-			if (!existing_data.HasPreservedRowIds()) {
-				// if the existing data doesnt have preserved row ids, we sign them off sequentially from
-				// transaction local id
-				idx_t existing_count = existing_data.data->Count() - new_data->data->Count();
-				existing_data.row_ids.reserve(existing_count + new_data->row_ids.size());
-				auto next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
-				for (idx_t i = 0; i < existing_count; i++) {
-					existing_data.row_ids.push_back(next_id + NumericCast<int64_t>(i));
-				}
-			}
-			if (new_data->HasPreservedRowIds()) {
-				// if this is already preserved we can just insert it
-				existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
-				                             new_data->row_ids.end());
-			} else {
-				// new data doesnt preserve row_ids, we need to use the TRANSACTION_LOCAL_ROW_ID_START
-				int64_t next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
-				if (!existing_data.row_ids.empty()) {
-					auto max_id = *std::max_element(existing_data.row_ids.begin(), existing_data.row_ids.end());
-					if (max_id >= next_id) {
-						// we only use max_id if it's guaranteed to be transactional (over next_id)
-						next_id = max_id + 1;
-					}
-				}
-				for (idx_t i = 0; i < new_data->data->Count(); i++) {
-					existing_data.row_ids.push_back(next_id + NumericCast<int64_t>(i));
-				}
-			}
-		}
+		existing_data.MergeRowIds(*new_data, new_data->data->Count());
 		for (auto &entry : new_data->column_stats) {
 			auto stats_entry = existing_data.column_stats.find(entry.first);
 			if (stats_entry == existing_data.column_stats.end()) {
@@ -280,9 +251,8 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 		throw InternalException("DeleteFromLocalInlinedData called but no transaction-local data exists for table");
 	}
 	auto &table_changes = entry->second;
-	auto &existing = *table_changes.new_inlined_data->data;
-	auto &preserved_row_ids = table_changes.new_inlined_data->row_ids;
-	bool has_preserved_row_ids = table_changes.new_inlined_data->HasPreservedRowIds();
+	auto &inlined_data = *table_changes.new_inlined_data;
+	auto &existing = *inlined_data.data;
 	// construct a new collection from the existing data minus the deletes
 	auto new_data = make_uniq<ColumnDataCollection>(context, existing.Types());
 
@@ -296,23 +266,14 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 		idx_t selected_rows = 0;
 
 		for (idx_t r = 0; r < chunk.size(); r++) {
-			idx_t row_id;
-			if (has_preserved_row_ids) {
-				row_id = NumericCast<idx_t>(preserved_row_ids[base_row_id + r]);
-			} else {
-				row_id = base_row_id + r;
-			}
+			idx_t position = base_row_id + r;
+			auto row_id = inlined_data.GetRowId(position);
 			if (new_deletes.find(row_id) != new_deletes.end()) {
 				// deleted - skip
 				continue;
 			}
 			sel.set_index(selected_rows++, r);
-			if (has_preserved_row_ids) {
-				new_row_ids.push_back(preserved_row_ids[base_row_id + r]);
-			} else {
-				// generate transaction-local placeholder row_ids
-				new_row_ids.push_back(NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START + row_id));
-			}
+			new_row_ids.push_back(inlined_data.GetOutputRowId(position));
 		}
 		base_row_id += chunk.size();
 		if (selected_rows == 0) {
@@ -323,8 +284,8 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 	}
 
 	// override the existing collection and row_ids
-	table_changes.new_inlined_data->data = std::move(new_data);
-	table_changes.new_inlined_data->row_ids = std::move(new_row_ids);
+	inlined_data.data = std::move(new_data);
+	inlined_data.row_ids = std::move(new_row_ids);
 }
 
 static void RemoveFieldStats(map<FieldIndex, DuckLakeColumnStats> &column_stats, const DuckLakeFieldId &field_id) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -213,6 +213,8 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 		// merge preserved row_ids from update inlining
 		if (new_data->HasPreservedRowIds() || existing_data.HasPreservedRowIds()) {
 			if (!existing_data.HasPreservedRowIds()) {
+				// if the existing data doesnt have preserved row ids, we sign them off sequentially from
+				// transaction local id
 				idx_t existing_count = existing_data.data->Count() - new_data->data->Count();
 				existing_data.row_ids.reserve(existing_count + new_data->row_ids.size());
 				auto next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
@@ -221,14 +223,17 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 				}
 			}
 			if (new_data->HasPreservedRowIds()) {
+				// if this is already preserved we can just insert it
 				existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
 				                             new_data->row_ids.end());
 			} else {
-				// new data is insert-only — assign sequential placeholder ids after the max existing id
+				// new data doesnt preserve row_ids, we need to use the TRANSACTION_LOCAL_ROW_ID_START
 				int64_t next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
-				for (auto &rid : existing_data.row_ids) {
-					if (rid >= next_id) {
-						next_id = rid + 1;
+				if (!existing_data.row_ids.empty()) {
+					auto max_id = *std::max_element(existing_data.row_ids.begin(), existing_data.row_ids.end());
+					if (max_id >= next_id) {
+						// we only use max_id if it's guaranteed to be transactional (over next_id)
+						next_id = max_id + 1;
 					}
 				}
 				for (idx_t i = 0; i < new_data->data->Count(); i++) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -255,10 +255,13 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 	}
 	auto &table_changes = entry->second;
 	auto &existing = *table_changes.new_inlined_data->data;
+	auto &preserved_row_ids = table_changes.new_inlined_data->row_ids;
+	bool has_preserved_row_ids = !preserved_row_ids.empty();
 	// construct a new collection from the existing data minus the deletes
 	auto new_data = make_uniq<ColumnDataCollection>(context, existing.Types());
 
 	idx_t base_row_id = 0;
+	vector<int64_t> new_row_ids;
 	ColumnDataAppendState append_state;
 	new_data->InitializeAppend(append_state);
 	for (auto &chunk : existing.Chunks()) {
@@ -267,12 +270,20 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 		idx_t selected_rows = 0;
 
 		for (idx_t r = 0; r < chunk.size(); r++) {
-			auto row_id = base_row_id + r;
+			idx_t row_id;
+			if (has_preserved_row_ids) {
+				row_id = NumericCast<idx_t>(preserved_row_ids[base_row_id + r]);
+			} else {
+				row_id = base_row_id + r;
+			}
 			if (new_deletes.find(row_id) != new_deletes.end()) {
 				// deleted - skip
 				continue;
 			}
 			sel.set_index(selected_rows++, r);
+			if (has_preserved_row_ids) {
+				new_row_ids.push_back(preserved_row_ids[base_row_id + r]);
+			}
 		}
 		base_row_id += chunk.size();
 		if (selected_rows == 0) {
@@ -282,8 +293,11 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 		new_data->Append(append_state, chunk);
 	}
 
-	// override the existing collection
+	// override the existing collection and row_ids
 	table_changes.new_inlined_data->data = std::move(new_data);
+	if (has_preserved_row_ids) {
+		table_changes.new_inlined_data->row_ids = std::move(new_row_ids);
+	}
 }
 
 static void RemoveFieldStats(map<FieldIndex, DuckLakeColumnStats> &column_stats, const DuckLakeFieldId &field_id) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -283,6 +283,8 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 			sel.set_index(selected_rows++, r);
 			if (has_preserved_row_ids) {
 				new_row_ids.push_back(preserved_row_ids[base_row_id + r]);
+			} else {
+				new_row_ids.push_back(NumericCast<int64_t>(row_id));
 			}
 		}
 		base_row_id += chunk.size();
@@ -295,9 +297,7 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 
 	// override the existing collection and row_ids
 	table_changes.new_inlined_data->data = std::move(new_data);
-	if (has_preserved_row_ids) {
-		table_changes.new_inlined_data->row_ids = std::move(new_row_ids);
-	}
+	table_changes.new_inlined_data->row_ids = std::move(new_row_ids);
 }
 
 static void RemoveFieldStats(map<FieldIndex, DuckLakeColumnStats> &column_stats, const DuckLakeFieldId &field_id) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -16,7 +16,6 @@
 #include "storage/ducklake_macro_entry.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
-#include "storage/ducklake_multi_file_list.hpp"
 #include "storage/ducklake_transaction_changes.hpp"
 #include "storage/ducklake_transaction_manager.hpp"
 #include "storage/ducklake_view_entry.hpp"
@@ -127,7 +126,7 @@ shared_ptr<DuckLakeInlinedData> LocalTableChanges::GetTransactionLocalInlinedDat
 	for (auto &chunk : local_changes.data->Chunks()) {
 		result->data->Append(chunk);
 	}
-	result->row_ids = local_changes.row_ids;
+	result->row_ids = local_changes.row_ids; // propagate preserved row_ids if any
 	return result;
 }
 
@@ -212,20 +211,21 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 			existing_data.data->Append(chunk);
 		}
 		// merge preserved row_ids from update inlining
-		if (!new_data->row_ids.empty() || !existing_data.row_ids.empty()) {
-			if (existing_data.row_ids.empty()) {
+		if (new_data->HasPreservedRowIds() || existing_data.HasPreservedRowIds()) {
+			if (!existing_data.HasPreservedRowIds()) {
 				idx_t existing_count = existing_data.data->Count() - new_data->data->Count();
 				existing_data.row_ids.reserve(existing_count + new_data->row_ids.size());
-				auto next_id = NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START);
+				auto next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
 				for (idx_t i = 0; i < existing_count; i++) {
 					existing_data.row_ids.push_back(next_id + NumericCast<int64_t>(i));
 				}
 			}
-			if (!new_data->row_ids.empty()) {
+			if (new_data->HasPreservedRowIds()) {
 				existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
 				                             new_data->row_ids.end());
 			} else {
-				int64_t next_id = NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START);
+				// new data is insert-only — assign sequential placeholder ids after the max existing id
+				int64_t next_id = NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START);
 				for (auto &rid : existing_data.row_ids) {
 					if (rid >= next_id) {
 						next_id = rid + 1;
@@ -277,7 +277,7 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 	auto &table_changes = entry->second;
 	auto &existing = *table_changes.new_inlined_data->data;
 	auto &preserved_row_ids = table_changes.new_inlined_data->row_ids;
-	bool has_preserved_row_ids = !preserved_row_ids.empty();
+	bool has_preserved_row_ids = table_changes.new_inlined_data->HasPreservedRowIds();
 	// construct a new collection from the existing data minus the deletes
 	auto new_data = make_uniq<ColumnDataCollection>(context, existing.Types());
 
@@ -305,9 +305,8 @@ void LocalTableChanges::DeleteFromLocalInlinedData(ClientContext &context, Table
 			if (has_preserved_row_ids) {
 				new_row_ids.push_back(preserved_row_ids[base_row_id + r]);
 			} else {
-				// generate transaction local row ids w a placeholder
-				new_row_ids.push_back(
-				    NumericCast<int64_t>(DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START + row_id));
+				// generate transaction-local placeholder row_ids
+				new_row_ids.push_back(NumericCast<int64_t>(DuckLakeConstants::TRANSACTION_LOCAL_ROW_ID_START + row_id));
 			}
 		}
 		base_row_id += chunk.size();
@@ -2055,13 +2054,13 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 
 			// update global stats
 			new_stats.record_count += record_count;
-			if (inlined_data.row_ids.empty()) {
+			if (!inlined_data.HasPreservedRowIds()) {
 				// regular insert, we advance next_row_id
 				new_stats.next_row_id += record_count;
 			} else {
 				// mixed insert and updates, we only advance inserted row_ids
 				for (auto &rid : inlined_data.row_ids) {
-					if (NumericCast<idx_t>(rid) >= DuckLakeMultiFileList::TRANSACTION_LOCAL_ID_START) {
+					if (DuckLakeConstants::IsTransactionLocalRowId(rid)) {
 						new_stats.next_row_id++;
 					}
 				}
@@ -2362,31 +2361,31 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 			if (type != compaction.type) {
 				continue;
 			}
-				bool has_new_file = !compaction.written_file.file_name.empty();
-				DuckLakeFileInfo new_file;
+			bool has_new_file = !compaction.written_file.file_name.empty();
+			DuckLakeFileInfo new_file;
 
-				if (!has_new_file) {
-					if (type != CompactionType::REWRITE_DELETES) {
-						throw InternalException("Compaction error - expected output file for non-rewrite compaction");
-					}
-				} else {
-					new_file = GetNewDataFile(compaction.written_file, commit_state, table_id, compaction.row_id_start);
-					switch (type) {
-					case CompactionType::REWRITE_DELETES:
-						new_file.begin_snapshot = commit_snapshot.snapshot_id;
-						break;
-					case CompactionType::MERGE_ADJACENT_TABLES: {
-						// For MERGE_ADJACENT_TABLES, track the max partial snapshot across all source files
-						optional_idx merged_max_partial_snapshot;
-						idx_t first_begin_snapshot = compaction.source_files[0].file.begin_snapshot;
-						for (auto &compacted_file : compaction.source_files) {
-							idx_t file_max_snapshot = compacted_file.max_partial_file_snapshot.IsValid()
-							                              ? compacted_file.max_partial_file_snapshot.GetIndex()
-							                              : compacted_file.file.begin_snapshot;
-							if (!merged_max_partial_snapshot.IsValid() ||
-							    file_max_snapshot > merged_max_partial_snapshot.GetIndex()) {
-								merged_max_partial_snapshot = file_max_snapshot;
-							}
+			if (!has_new_file) {
+				if (type != CompactionType::REWRITE_DELETES) {
+					throw InternalException("Compaction error - expected output file for non-rewrite compaction");
+				}
+			} else {
+				new_file = GetNewDataFile(compaction.written_file, commit_state, table_id, compaction.row_id_start);
+				switch (type) {
+				case CompactionType::REWRITE_DELETES:
+					new_file.begin_snapshot = commit_snapshot.snapshot_id;
+					break;
+				case CompactionType::MERGE_ADJACENT_TABLES: {
+					// For MERGE_ADJACENT_TABLES, track the max partial snapshot across all source files
+					optional_idx merged_max_partial_snapshot;
+					idx_t first_begin_snapshot = compaction.source_files[0].file.begin_snapshot;
+					for (auto &compacted_file : compaction.source_files) {
+						idx_t file_max_snapshot = compacted_file.max_partial_file_snapshot.IsValid()
+						                              ? compacted_file.max_partial_file_snapshot.GetIndex()
+						                              : compacted_file.file.begin_snapshot;
+						if (!merged_max_partial_snapshot.IsValid() ||
+						    file_max_snapshot > merged_max_partial_snapshot.GetIndex()) {
+							merged_max_partial_snapshot = file_max_snapshot;
+						}
 					}
 					// Use the first source file's begin_snapshot for proper time travel support
 					new_file.begin_snapshot = first_begin_snapshot;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -126,6 +126,7 @@ shared_ptr<DuckLakeInlinedData> LocalTableChanges::GetTransactionLocalInlinedDat
 	for (auto &chunk : local_changes.data->Chunks()) {
 		result->data->Append(chunk);
 	}
+	result->row_ids = local_changes.row_ids;
 	return result;
 }
 
@@ -208,6 +209,11 @@ void LocalTableChanges::AppendInlinedData(ClientContext &context, TableIndex tab
 		existing_data.data->InitializeAppend(append_state);
 		for (auto &chunk : new_data->data->Chunks()) {
 			existing_data.data->Append(chunk);
+		}
+		// merge preserved row_ids from update inlining
+		if (!new_data->row_ids.empty()) {
+			existing_data.row_ids.insert(existing_data.row_ids.end(), new_data->row_ids.begin(),
+			                             new_data->row_ids.end());
 		}
 		for (auto &entry : new_data->column_stats) {
 			auto stats_entry = existing_data.column_stats.find(entry.first);
@@ -2012,8 +2018,10 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 
 			// update global stats
 			new_stats.record_count += record_count;
-			new_stats.next_row_id += record_count;
-
+			if (inlined_data.row_ids.empty()) {
+				// regular insert, we advance next_row_id
+				new_stats.next_row_id += record_count;
+			}
 			// add the file to the to-be-written inlined data list
 			new_inlined_data.data = table_changes.new_inlined_data.get();
 			result.new_inlined_data.push_back(new_inlined_data);

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -89,7 +89,7 @@ unique_ptr<GlobalSinkState> DuckLakeUpdate::GetGlobalSinkState(ClientContext &co
 	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
 	delete_op.sink_state = delete_op.GetGlobalSinkState(context);
 	if (inline_data_op) {
-		// We need tto initialize data global state
+		// We need to initialize the inline data global state
 		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
 	}
 	return std::move(result);
@@ -131,6 +131,29 @@ unique_ptr<LocalSinkState> DuckLakeUpdate::GetLocalSinkState(ExecutionContext &c
 		result->inline_output_chunk.Initialize(context.client, inline_data_op->types);
 	}
 	return std::move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Inline data helpers
+//===--------------------------------------------------------------------===//
+void DuckLakeUpdate::ForwardInlineOutputToCopy(ExecutionContext &context, DataChunk &inline_output,
+                                               GlobalOperatorState &inline_gstate, OperatorState &inline_lstate,
+                                               DataChunk &input, LocalSinkState &copy_lstate,
+                                               InterruptState &interrupt_state) const {
+	inline_output.Reset();
+	auto result = inline_data_op->Execute(context, input, inline_output, inline_gstate, inline_lstate);
+	if (inline_output.size() > 0) {
+		OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
+		copy_op.Sink(context, inline_output, copy_input);
+	}
+	while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+		inline_output.Reset();
+		result = inline_data_op->Execute(context, input, inline_output, inline_gstate, inline_lstate);
+		if (inline_output.size() > 0) {
+			OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
+			copy_op.Sink(context, inline_output, copy_input);
+		}
+	}
 }
 
 //===--------------------------------------------------------------------===//
@@ -207,24 +230,9 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	if (inline_data_op) {
 		// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
 		// throuhg
-		auto &inline_output = lstate.inline_output_chunk;
-		inline_output.Reset();
-		auto inline_result = inline_data_op->Execute(context, insert_chunk, inline_output, *gstate.inline_data_gstate,
-		                                             *lstate.inline_data_lstate);
-		if (inline_output.size() > 0) {
-			OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
-			copy_op.Sink(context, inline_output, copy_input);
-		}
-		// handle HAVE_MORE_OUTPUT
-		while (inline_result == OperatorResultType::HAVE_MORE_OUTPUT) {
-			inline_output.Reset();
-			inline_result = inline_data_op->Execute(context, insert_chunk, inline_output, *gstate.inline_data_gstate,
-			                                        *lstate.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
-				copy_op.Sink(context, inline_output, copy_input);
-			}
-		}
+		ForwardInlineOutputToCopy(context, lstate.inline_output_chunk, *gstate.inline_data_gstate,
+		                          *lstate.inline_data_lstate, insert_chunk, *lstate.copy_local_state,
+		                          input.interrupt_state);
 	} else {
 		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 		copy_op.Sink(context, insert_chunk, copy_input);
@@ -267,6 +275,7 @@ SinkCombineResultType DuckLakeUpdate::Combine(ExecutionContext &context, Operato
 			}
 		}
 	}
+
 	OperatorSinkCombineInput copy_combine_input {*copy_op.sink_state, *local_state.copy_local_state,
 	                                             input.interrupt_state};
 	auto result = copy_op.Combine(context, copy_combine_input);

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -8,8 +8,12 @@
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "storage/ducklake_delete.hpp"
+#include "storage/ducklake_inline_data.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_schema_entry.hpp"
+#include "storage/ducklake_transaction.hpp"
+#include "common/ducklake_util.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
@@ -337,6 +341,31 @@ static unique_ptr<Expression> GetPartitionExpressionForUpdate(ClientContext &con
 	}
 }
 
+static optional_ptr<DuckLakeInlineData>
+PlanInlineDataForUpdate(ClientContext &context, DuckLakeCatalog &catalog, PhysicalPlanGenerator &planner,
+                        DuckLakeTableEntry &table, const vector<unique_ptr<Expression>> &expressions,
+                        idx_t physical_count, PhysicalOperator &child_plan, PhysicalOperator &insert_op) {
+	vector<LogicalType> physical_types;
+	for (idx_t i = 0; i < physical_count; i++) {
+		physical_types.push_back(expressions[i]->return_type);
+	}
+	idx_t limit = catalog.GetInliningLimit(context, table, physical_types);
+	if (limit == 0) {
+		return nullptr;
+	}
+	// compute insert_chunk types: [physical (casted)] [BIGINT row_id] [partition (casted)]
+	vector<LogicalType> insert_types;
+	for (auto &expr : expressions) {
+		insert_types.push_back(expr->return_type);
+	}
+	insert_types.insert(insert_types.begin() + physical_count, LogicalType::BIGINT);
+
+	auto &inline_op = planner.Make<DuckLakeInlineData>(child_plan, limit).Cast<DuckLakeInlineData>();
+	inline_op.types = insert_types;
+	inline_op.insert = insert_op.Cast<DuckLakeInsert>();
+	return &inline_op;
+}
+
 PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                               PhysicalOperator &child_plan) {
 	if (op.return_chunk) {
@@ -348,8 +377,7 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 		}
 	}
 	auto &table = op.table.Cast<DuckLakeTableEntry>();
-	// FIXME: we should take the inlining limit into account here and write new updates to the inline data tables if
-	// possible updates are executed as a delete + insert - generate the two nodes (delete and insert) plan the copy for
+	// updates are executed as a delete + insert - generate the two nodes (delete and insert) plan the copy for
 	// the insert
 	DuckLakeCopyInput copy_input(context, table);
 	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID;
@@ -401,7 +429,15 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 		}
 	}
 
-	return planner.Make<DuckLakeUpdate>(table, op.columns, child_plan, copy_op, delete_op, insert_op, expressions);
+	// plan inline data before creating update (update constructor moves expressions)
+	auto inline_data =
+	    PlanInlineDataForUpdate(context, *this, planner, table, expressions, op.columns.size(), child_plan, insert_op);
+
+	auto &update_op =
+	    planner.Make<DuckLakeUpdate>(table, op.columns, child_plan, copy_op, delete_op, insert_op, expressions)
+	        .Cast<DuckLakeUpdate>();
+	update_op.inline_data_op = inline_data;
+	return update_op;
 }
 
 void DuckLakeTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj,

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -41,11 +41,10 @@ struct FileRowIdHash {
 };
 
 DuckLakeUpdate::DuckLakeUpdate(PhysicalPlan &physical_plan, DuckLakeTableEntry &table, vector<PhysicalIndex> columns_p,
-                               PhysicalOperator &child, PhysicalOperator &copy_op, PhysicalOperator &delete_op,
-                               PhysicalOperator &insert_op, vector<unique_ptr<Expression>> &expressions)
-    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, 1), table(table),
-      columns(std::move(columns_p)), copy_op(copy_op), delete_op(delete_op), insert_op(insert_op),
-      expressions(std::move(expressions)) {
+                               PhysicalOperator &child, PhysicalOperator &delete_op,
+                               vector<unique_ptr<Expression>> &expressions)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {}, 1), table(table),
+      columns(std::move(columns_p)), delete_op(delete_op), expressions(std::move(expressions)) {
 	children.push_back(child);
 	row_id_index = columns.size();
 }
@@ -53,7 +52,7 @@ DuckLakeUpdate::DuckLakeUpdate(PhysicalPlan &physical_plan, DuckLakeTableEntry &
 //===--------------------------------------------------------------------===//
 // States
 //===--------------------------------------------------------------------===//
-class DuckLakeUpdateGlobalState : public GlobalSinkState {
+class DuckLakeUpdateGlobalState : public GlobalOperatorState {
 public:
 	DuckLakeUpdateGlobalState() : total_updated_count(0) {
 	}
@@ -63,14 +62,10 @@ public:
 	//! Duplicate row detection (first-write-wins)
 	mutex seen_rows_lock;
 	unordered_set<FileRowId, FileRowIdHash> seen_rows;
-
-	//! Inline data global state
-	unique_ptr<GlobalOperatorState> inline_data_gstate;
 };
 
-class DuckLakeUpdateLocalState : public LocalSinkState {
+class DuckLakeUpdateLocalState : public OperatorState {
 public:
-	unique_ptr<LocalSinkState> copy_local_state;
 	unique_ptr<LocalSinkState> delete_local_state;
 	unique_ptr<ExpressionExecutor> expression_executor;
 	//! Chunk where the updated expressions are executed.
@@ -78,26 +73,17 @@ public:
 	DataChunk insert_chunk;
 	DataChunk delete_chunk;
 	idx_t updated_count = 0;
-
-	//! Inline data local state and output buffer
-	unique_ptr<OperatorState> inline_data_lstate;
-	DataChunk inline_output_chunk;
 };
 
-unique_ptr<GlobalSinkState> DuckLakeUpdate::GetGlobalSinkState(ClientContext &context) const {
+unique_ptr<GlobalOperatorState> DuckLakeUpdate::GetGlobalOperatorState(ClientContext &context) const {
 	auto result = make_uniq<DuckLakeUpdateGlobalState>();
-	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
+	// init delete_op sink state
 	delete_op.sink_state = delete_op.GetGlobalSinkState(context);
-	if (inline_data_op) {
-		// We need to initialize the inline data global state
-		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
-	}
 	return std::move(result);
 }
 
-unique_ptr<LocalSinkState> DuckLakeUpdate::GetLocalSinkState(ExecutionContext &context) const {
+unique_ptr<OperatorState> DuckLakeUpdate::GetOperatorState(ExecutionContext &context) const {
 	auto result = make_uniq<DuckLakeUpdateLocalState>();
-	result->copy_local_state = copy_op.GetLocalSinkState(context);
 	result->delete_local_state = delete_op.GetLocalSinkState(context);
 
 	vector<LogicalType> delete_types;
@@ -111,74 +97,37 @@ unique_ptr<LocalSinkState> DuckLakeUpdate::GetLocalSinkState(ExecutionContext &c
 		expression_types.push_back(expr->return_type);
 	}
 
-	for (auto &type : expression_types) {
-		if (DuckLakeTypes::RequiresCast(type)) {
-			type = DuckLakeTypes::GetCastedType(type);
-		}
-	}
 	result->update_expression_chunk.Initialize(context.client, expression_types);
-	// updates also write the row id to the file, so the final version needs the row_id placed
-	// right after the physical columns (before computed partition columns).
-	vector<LogicalType> insert_types = expression_types;
-	auto physical_column_count = columns.size();
-	D_ASSERT(physical_column_count <= insert_types.size());
-	insert_types.insert(insert_types.begin() + physical_column_count, LogicalType::BIGINT);
-	result->insert_chunk.Initialize(context.client, insert_types);
+	result->insert_chunk.Initialize(context.client, types);
 
 	result->delete_chunk.Initialize(context.client, delete_types);
-	if (inline_data_op) {
-		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
-		result->inline_output_chunk.Initialize(context.client, inline_data_op->types);
-	}
 	return std::move(result);
 }
 
 //===--------------------------------------------------------------------===//
-// Inline data helpers
+// Execute
 //===--------------------------------------------------------------------===//
-void DuckLakeUpdate::ForwardInlineOutputToCopy(ExecutionContext &context, DataChunk &inline_output,
-                                               GlobalOperatorState &inline_gstate, OperatorState &inline_lstate,
-                                               DataChunk &input, LocalSinkState &copy_lstate,
-                                               InterruptState &interrupt_state) const {
-	inline_output.Reset();
-	auto result = inline_data_op->Execute(context, input, inline_output, inline_gstate, inline_lstate);
-	if (inline_output.size() > 0) {
-		OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
-		copy_op.Sink(context, inline_output, copy_input);
-	}
-	while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
-		inline_output.Reset();
-		result = inline_data_op->Execute(context, input, inline_output, inline_gstate, inline_lstate);
-		if (inline_output.size() > 0) {
-			OperatorSinkInput copy_input {*copy_op.sink_state, copy_lstate, interrupt_state};
-			copy_op.Sink(context, inline_output, copy_input);
-		}
-	}
-}
-
-//===--------------------------------------------------------------------===//
-// Sink
-//===--------------------------------------------------------------------===//
-SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-	auto &gstate = input.global_state.Cast<DuckLakeUpdateGlobalState>();
-	auto &lstate = input.local_state.Cast<DuckLakeUpdateLocalState>();
+OperatorResultType DuckLakeUpdate::Execute(ExecutionContext &context, DataChunk &input, DataChunk &chunk,
+                                           GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = gstate_p.Cast<DuckLakeUpdateGlobalState>();
+	auto &lstate = state_p.Cast<DuckLakeUpdateLocalState>();
 
 	// filter duplicate row IDs using deletion info (last 3 columns)
-	idx_t delete_idx_start = chunk.ColumnCount() - DELETION_INFO_SIZE;
-	auto &file_index_vec = chunk.data[delete_idx_start + 1];
-	auto &row_number_vec = chunk.data[delete_idx_start + 2];
+	idx_t delete_idx_start = input.ColumnCount() - DELETION_INFO_SIZE;
+	auto &file_index_vec = input.data[delete_idx_start + 1];
+	auto &row_number_vec = input.data[delete_idx_start + 2];
 
 	UnifiedVectorFormat file_index_data, row_number_data;
-	file_index_vec.ToUnifiedFormat(chunk.size(), file_index_data);
-	row_number_vec.ToUnifiedFormat(chunk.size(), row_number_data);
+	file_index_vec.ToUnifiedFormat(input.size(), file_index_data);
+	row_number_vec.ToUnifiedFormat(input.size(), row_number_data);
 	auto file_indices = UnifiedVectorFormat::GetData<uint64_t>(file_index_data);
 	auto row_numbers = UnifiedVectorFormat::GetData<int64_t>(row_number_data);
 
-	SelectionVector sel(chunk.size());
+	SelectionVector sel(input.size());
 	idx_t sel_count = 0;
 	{
 		lock_guard<mutex> guard(gstate.seen_rows_lock);
-		for (idx_t i = 0; i < chunk.size(); i++) {
+		for (idx_t i = 0; i < input.size(); i++) {
 			auto file_idx = file_index_data.sel->get_index(i);
 			auto row_idx = row_number_data.sel->get_index(i);
 			FileRowId key {file_indices[file_idx], row_numbers[row_idx]};
@@ -190,186 +139,68 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 
 	if (sel_count == 0) {
 		// all rows were duplicates
-		return SinkResultType::NEED_MORE_INPUT;
+		return OperatorResultType::NEED_MORE_INPUT;
 	}
 
 	// slice to non-duplicate rows only
-	chunk.Slice(sel, sel_count);
+	input.Slice(sel, sel_count);
 
-	// push the to-be-inserted data into the copy
+	// evaluate update expressions
 	auto &update_expression_chunk = lstate.update_expression_chunk;
 	auto &insert_chunk = lstate.insert_chunk;
 
-	update_expression_chunk.SetCardinality(chunk.size());
-	insert_chunk.SetCardinality(chunk.size());
-	lstate.expression_executor->Execute(chunk, update_expression_chunk);
+	update_expression_chunk.SetCardinality(input.size());
+	insert_chunk.SetCardinality(input.size());
+	lstate.expression_executor->Execute(input, update_expression_chunk);
 
 	const idx_t physical_column_count = columns.size();
-	const idx_t expression_column_count = update_expression_chunk.ColumnCount();
-	D_ASSERT(expression_column_count >= physical_column_count);
-	const idx_t partition_column_count = expression_column_count - physical_column_count;
-	const idx_t insert_column_count = insert_chunk.ColumnCount();
-	D_ASSERT(insert_column_count >= expression_column_count);
-	// virtual columns (PlanUpdate sets WRITE_ROW_ID, so there is exactly one: the row id) must sit between the physical
-	// and partition columns
-	const idx_t virtual_column_count = insert_column_count - expression_column_count;
-	D_ASSERT(virtual_column_count == 1);
 
-	// copy the physical columns directly
+	// build output, physical columns + row_id
 	for (idx_t i = 0; i < physical_column_count; i++) {
 		insert_chunk.data[i].Reference(update_expression_chunk.data[i]);
 	}
-	// reference the row id right after the physical columns
-	insert_chunk.data[physical_column_count].Reference(chunk.data[row_id_index]);
-	// place computed partition columns after the virtual columns
-	for (idx_t part_idx = 0; part_idx < partition_column_count; part_idx++) {
-		insert_chunk.data[physical_column_count + virtual_column_count + part_idx].Reference(
-		    update_expression_chunk.data[physical_column_count + part_idx]);
-	}
+	// we place row_id right after physical columns
+	insert_chunk.data[physical_column_count].Reference(input.data[row_id_index]);
 
-	if (inline_data_op) {
-		// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
-		// throuhg
-		ForwardInlineOutputToCopy(context, lstate.inline_output_chunk, *gstate.inline_data_gstate,
-		                          *lstate.inline_data_lstate, insert_chunk, *lstate.copy_local_state,
-		                          input.interrupt_state);
-	} else {
-		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
-		copy_op.Sink(context, insert_chunk, copy_input);
-	}
+	chunk.Reference(insert_chunk);
 
-	// push the rowids into the delete
 	auto &delete_chunk = lstate.delete_chunk;
-	delete_chunk.SetCardinality(chunk.size());
+	delete_chunk.SetCardinality(input.size());
 	for (idx_t i = 0; i < DELETION_INFO_SIZE; i++) {
-		delete_chunk.data[i].Reference(chunk.data[delete_idx_start + i]);
+		delete_chunk.data[i].Reference(input.data[delete_idx_start + i]);
 	}
 
-	OperatorSinkInput delete_input {*delete_op.sink_state, *lstate.delete_local_state, input.interrupt_state};
+	InterruptState interrupt_state;
+	OperatorSinkInput delete_input {*delete_op.sink_state, *lstate.delete_local_state, interrupt_state};
 	delete_op.Sink(context, delete_chunk, delete_input);
 
-	lstate.updated_count += chunk.size();
-	return SinkResultType::NEED_MORE_INPUT;
+	lstate.updated_count += input.size();
+	return OperatorResultType::NEED_MORE_INPUT;
 }
 
-//===--------------------------------------------------------------------===//
-// Combine
-//===--------------------------------------------------------------------===//
-SinkCombineResultType DuckLakeUpdate::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
-	auto &global_state = input.global_state.Cast<DuckLakeUpdateGlobalState>();
-	auto &local_state = input.local_state.Cast<DuckLakeUpdateLocalState>();
-	// drain inline data FinalExecute — flushes local→global or emits on overflow
-	if (inline_data_op) {
-		auto &inline_output = local_state.inline_output_chunk;
-		while (true) {
-			inline_output.Reset();
-			auto fresult = inline_data_op->FinalExecute(context, inline_output, *global_state.inline_data_gstate,
-			                                            *local_state.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				OperatorSinkInput copy_input {*copy_op.sink_state, *local_state.copy_local_state,
-				                              input.interrupt_state};
-				copy_op.Sink(context, inline_output, copy_input);
-			}
-			if (fresult == OperatorFinalizeResultType::FINISHED) {
-				break;
-			}
-		}
-	}
+OperatorFinalizeResultType DuckLakeUpdate::FinalExecute(ExecutionContext &context, DataChunk &chunk,
+                                                        GlobalOperatorState &gstate_p, OperatorState &state_p) const {
+	auto &gstate = gstate_p.Cast<DuckLakeUpdateGlobalState>();
+	auto &lstate = state_p.Cast<DuckLakeUpdateLocalState>();
 
-	OperatorSinkCombineInput copy_combine_input {*copy_op.sink_state, *local_state.copy_local_state,
-	                                             input.interrupt_state};
-	auto result = copy_op.Combine(context, copy_combine_input);
+	InterruptState interrupt_state;
+	OperatorSinkCombineInput del_combine_input {*delete_op.sink_state, *lstate.delete_local_state, interrupt_state};
+	auto result = delete_op.Combine(context, del_combine_input);
 	if (result != SinkCombineResultType::FINISHED) {
-		throw InternalException("DuckLakeUpdate::Combine does not support async child operators");
+		throw InternalException("DuckLakeUpdate::FinalExecute does not support async child operators");
 	}
-	OperatorSinkCombineInput del_combine_input {*delete_op.sink_state, *local_state.delete_local_state,
-	                                            input.interrupt_state};
-	result = delete_op.Combine(context, del_combine_input);
-	if (result != SinkCombineResultType::FINISHED) {
-		throw InternalException("DuckLakeUpdate::Combine does not support async child operators");
-	}
-	global_state.total_updated_count += local_state.updated_count;
-	return SinkCombineResultType::FINISHED;
+	gstate.total_updated_count += lstate.updated_count;
+	return OperatorFinalizeResultType::FINISHED;
 }
 
-//===--------------------------------------------------------------------===//
-// Finalize
-//===--------------------------------------------------------------------===//
-SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-                                          OperatorSinkFinalizeInput &input) const {
-	auto &gstate = input.global_state.Cast<DuckLakeUpdateGlobalState>();
-
+OperatorFinalResultType DuckLakeUpdate::OperatorFinalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                                         OperatorFinalizeInput &input) const {
 	OperatorSinkFinalizeInput del_finalize_input {*delete_op.sink_state, input.interrupt_state};
 	auto result = delete_op.Finalize(pipeline, event, context, del_finalize_input);
 	if (result != SinkFinalizeType::READY) {
-		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
+		throw InternalException("DuckLakeUpdate::OperatorFinalize does not support async child operators");
 	}
-
-	if (inline_data_op) {
-		// call OperatorFinalize on inline data
-		OperatorFinalizeInput inline_finalize_input {*gstate.inline_data_gstate, input.interrupt_state};
-		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize_input);
-	}
-
-	OperatorSinkFinalizeInput copy_finalize_input {*copy_op.sink_state, input.interrupt_state};
-	result = copy_op.Finalize(pipeline, event, context, copy_finalize_input);
-	if (result != SinkFinalizeType::READY) {
-		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
-	}
-
-	// scan the copy operator and sink into the insert operator
-	ThreadContext thread_context(context);
-	ExecutionContext execution_context(context, thread_context, nullptr);
-	auto global_source = copy_op.GetGlobalSourceState(context);
-	auto local_source = copy_op.GetLocalSourceState(execution_context, *global_source);
-
-	DataChunk copy_source_chunk;
-	copy_source_chunk.Initialize(context, copy_op.types);
-
-	if (!insert_op.sink_state) {
-		// use existing sink_state if OperatorFinalize already created it
-		insert_op.sink_state = insert_op.GetGlobalSinkState(context);
-	}
-	auto local_sink = insert_op.GetLocalSinkState(execution_context);
-
-	OperatorSourceInput source_input {*global_source, *local_source, input.interrupt_state};
-	OperatorSinkInput sink_input {*insert_op.sink_state, *local_sink, input.interrupt_state};
-	while (true) {
-		auto source_result = copy_op.GetData(execution_context, copy_source_chunk, source_input);
-		if (copy_source_chunk.size() == 0) {
-			break;
-		}
-		if (source_result == SourceResultType::BLOCKED) {
-			throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
-		}
-
-		auto sink_result = insert_op.Sink(execution_context, copy_source_chunk, sink_input);
-		if (sink_result == SinkResultType::BLOCKED) {
-			throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
-		}
-		if (source_result == SourceResultType::FINISHED) {
-			break;
-		}
-	}
-
-	OperatorSinkFinalizeInput insert_finalize_input {*insert_op.sink_state, input.interrupt_state};
-	result = insert_op.Finalize(pipeline, event, context, insert_finalize_input);
-	if (result != SinkFinalizeType::READY) {
-		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
-	}
-	return SinkFinalizeType::READY;
-}
-
-//===--------------------------------------------------------------------===//
-// GetData
-//===--------------------------------------------------------------------===//
-SourceResultType DuckLakeUpdate::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
-                                                 OperatorSourceInput &input) const {
-	auto &global_state = sink_state->Cast<DuckLakeUpdateGlobalState>();
-	auto value = Value::BIGINT(NumericCast<int64_t>(global_state.total_updated_count.load()));
-	chunk.SetCardinality(1);
-	chunk.SetValue(0, 0, value);
-	return SourceResultType::FINISHED;
+	return OperatorFinalResultType::FINISHED;
 }
 
 //===--------------------------------------------------------------------===//
@@ -385,63 +216,6 @@ InsertionOrderPreservingMap<string> DuckLakeUpdate::ParamsToString() const {
 	return result;
 }
 
-static unique_ptr<Expression> GetFunction(ClientContext &context, unique_ptr<BoundReferenceExpression> column_reference,
-                                          const string &function_name) {
-	vector<unique_ptr<Expression>> children;
-	children.emplace_back(std::move(column_reference));
-	ErrorData error;
-	FunctionBinder binder(context);
-	auto function = binder.BindScalarFunction(DEFAULT_SCHEMA, function_name, std::move(children), error, false);
-	if (!function) {
-		error.Throw();
-	}
-	return function;
-}
-
-static unique_ptr<Expression> GetPartitionExpressionForUpdate(ClientContext &context,
-                                                              unique_ptr<BoundReferenceExpression> column_reference,
-                                                              const DuckLakePartitionField &field) {
-	switch (field.transform.type) {
-	case DuckLakeTransformType::IDENTITY:
-		return std::move(column_reference);
-	case DuckLakeTransformType::YEAR:
-		return GetFunction(context, std::move(column_reference), "year");
-	case DuckLakeTransformType::MONTH:
-		return GetFunction(context, std::move(column_reference), "month");
-	case DuckLakeTransformType::DAY:
-		return GetFunction(context, std::move(column_reference), "day");
-	case DuckLakeTransformType::HOUR:
-		return GetFunction(context, std::move(column_reference), "hour");
-	default:
-		throw NotImplementedException("Unsupported partition transform type in GetPartitionExpressionForUpdate");
-	}
-}
-
-static optional_ptr<DuckLakeInlineData>
-PlanInlineDataForUpdate(ClientContext &context, DuckLakeCatalog &catalog, PhysicalPlanGenerator &planner,
-                        DuckLakeTableEntry &table, const vector<unique_ptr<Expression>> &expressions,
-                        idx_t physical_count, PhysicalOperator &child_plan, PhysicalOperator &insert_op) {
-	vector<LogicalType> physical_types;
-	for (idx_t i = 0; i < physical_count; i++) {
-		physical_types.push_back(expressions[i]->return_type);
-	}
-	idx_t limit = catalog.GetInliningLimit(context, table, physical_types);
-	if (limit == 0) {
-		return nullptr;
-	}
-	// compute insert_chunk types: [physical (casted)] [BIGINT row_id] [partition (casted)]
-	vector<LogicalType> insert_types;
-	for (auto &expr : expressions) {
-		insert_types.push_back(expr->return_type);
-	}
-	insert_types.insert(insert_types.begin() + physical_count, LogicalType::BIGINT);
-
-	auto &inline_op = planner.Make<DuckLakeInlineData>(child_plan, limit).Cast<DuckLakeInlineData>();
-	inline_op.types = insert_types;
-	inline_op.insert = insert_op.Cast<DuckLakeInsert>();
-	return &inline_op;
-}
-
 PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
                                               PhysicalOperator &child_plan) {
 	if (op.return_chunk) {
@@ -453,67 +227,54 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 		}
 	}
 	auto &table = op.table.Cast<DuckLakeTableEntry>();
-	// updates are executed as a delete + insert - generate the two nodes (delete and insert) plan the copy for
-	// the insert
+
 	DuckLakeCopyInput copy_input(context, table);
 	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID;
-	auto &copy_op = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, nullptr);
-	// plan the delete
 	vector<idx_t> row_id_indexes;
 	for (idx_t i = 0; i < DuckLakeUpdate::DELETION_INFO_SIZE; i++) {
 		row_id_indexes.push_back(i);
 	}
 	auto &delete_op = DuckLakeDelete::PlanDelete(context, planner, table, child_plan, std::move(row_id_indexes),
 	                                             copy_input.encryption_key, false);
-	// plan the actual insert
-	auto &insert_op = DuckLakeInsert::PlanInsert(context, planner, table, copy_input.encryption_key);
 
+	// build update expressions (physical columns only, no partition cols, no casts)
 	vector<unique_ptr<Expression>> expressions;
 	unordered_map<idx_t, idx_t> expression_map;
-
 	for (idx_t i = 0; i < op.columns.size(); i++) {
 		expression_map[op.columns[i].index] = i;
 	}
 	for (idx_t i = 0; i < op.columns.size(); i++) {
 		expressions.push_back(op.expressions[expression_map[i]]->Copy());
 	}
-	if (copy_input.partition_data) {
-		bool all_identity = true;
-		for (auto &field : copy_input.partition_data->fields) {
-			if (field.transform.type != DuckLakeTransformType::IDENTITY) {
-				all_identity = false;
-				break;
-			}
-		}
-		if (!all_identity) {
-			for (auto &field : copy_input.partition_data->fields) {
-				optional_idx col_idx;
-				DuckLakeInsert::GetTopLevelColumn(copy_input, field.field_id, col_idx);
-				D_ASSERT(col_idx.IsValid());
-				auto &child_expression = expressions[col_idx.GetIndex()]->Cast<BoundReferenceExpression>();
-				auto column_reference =
-				    make_uniq<BoundReferenceExpression>(child_expression.return_type, child_expression.index);
-				expressions.push_back(GetPartitionExpressionForUpdate(context, std::move(column_reference), field));
-			}
-		}
-	}
-
-	for (auto &expr : expressions) {
-		if (DuckLakeTypes::RequiresCast(expr->return_type)) {
-			auto target_type = DuckLakeTypes::GetCastedType(expr->return_type);
-			expr = BoundCastExpression::AddCastToType(context, std::move(expr), std::move(target_type));
-		}
-	}
-
-	// plan inline data before creating update (update constructor moves expressions)
-	auto inline_data =
-	    PlanInlineDataForUpdate(context, *this, planner, table, expressions, op.columns.size(), child_plan, insert_op);
 
 	auto &update_op =
-	    planner.Make<DuckLakeUpdate>(table, op.columns, child_plan, copy_op, delete_op, insert_op, expressions)
-	        .Cast<DuckLakeUpdate>();
-	update_op.inline_data_op = inline_data;
-	return update_op;
+	    planner.Make<DuckLakeUpdate>(table, op.columns, child_plan, delete_op, expressions).Cast<DuckLakeUpdate>();
+
+	// set output types we use physical column types + BIGINT row_id
+	vector<LogicalType> update_output_types;
+	for (auto &expr : update_op.expressions) {
+		update_output_types.push_back(expr->return_type);
+	}
+	update_output_types.push_back(LogicalType::BIGINT);
+	update_op.types = std::move(update_output_types);
+
+	// follow the insert path for inlining:
+	optional_ptr<PhysicalOperator> plan = &update_op;
+	optional_ptr<DuckLakeInlineData> inline_data;
+
+	idx_t data_inlining_row_limit = GetInliningLimit(context, table, plan->types);
+	if (data_inlining_row_limit > 0) {
+		plan = planner.Make<DuckLakeInlineData>(*plan, data_inlining_row_limit);
+		inline_data = plan->Cast<DuckLakeInlineData>();
+	}
+
+	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
+	auto &insert_op = DuckLakeInsert::PlanInsert(context, planner, table, std::move(copy_input.encryption_key));
+	if (inline_data) {
+		inline_data->insert = insert_op.Cast<DuckLakeInsert>();
+	}
+	insert_op.children.push_back(physical_copy);
+	return insert_op;
 }
 
 void DuckLakeTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj,

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -216,20 +216,11 @@ InsertionOrderPreservingMap<string> DuckLakeUpdate::ParamsToString() const {
 	return result;
 }
 
-PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
-                                              PhysicalOperator &child_plan) {
-	if (op.return_chunk) {
-		throw BinderException("RETURNING clause not yet supported for updates of a DuckLake table");
-	}
-	for (auto &expr : op.expressions) {
-		if (expr->type == ExpressionType::VALUE_DEFAULT) {
-			throw BinderException("SET DEFAULT is not yet supported for updates of a DuckLake table");
-		}
-	}
+DuckLakeUpdate &DuckLakeUpdate::PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                   LogicalUpdate &op, PhysicalOperator &child_plan,
+                                                   DuckLakeCopyInput &copy_input) {
 	auto &table = op.table.Cast<DuckLakeTableEntry>();
 
-	DuckLakeCopyInput copy_input(context, table);
-	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID;
 	vector<idx_t> row_id_indexes;
 	for (idx_t i = 0; i < DuckLakeUpdate::DELETION_INFO_SIZE; i++) {
 		row_id_indexes.push_back(i);
@@ -257,8 +248,26 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 	}
 	update_output_types.push_back(LogicalType::BIGINT);
 	update_op.types = std::move(update_output_types);
+	return update_op;
+}
 
-	// follow the insert path for inlining:
+PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
+                                              PhysicalOperator &child_plan) {
+	if (op.return_chunk) {
+		throw BinderException("RETURNING clause not yet supported for updates of a DuckLake table");
+	}
+	for (auto &expr : op.expressions) {
+		if (expr->type == ExpressionType::VALUE_DEFAULT) {
+			throw BinderException("SET DEFAULT is not yet supported for updates of a DuckLake table");
+		}
+	}
+	auto &table = op.table.Cast<DuckLakeTableEntry>();
+
+	DuckLakeCopyInput copy_input(context, table);
+	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID;
+	auto &update_op = DuckLakeUpdate::PlanUpdateOperator(context, planner, op, child_plan, copy_input);
+
+	// follow the insert path for inlining
 	optional_ptr<PhysicalOperator> plan = &update_op;
 	optional_ptr<DuckLakeInlineData> inline_data;
 

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -290,6 +290,12 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
                                           OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<DuckLakeUpdateGlobalState>();
 
+	OperatorSinkFinalizeInput del_finalize_input {*delete_op.sink_state, input.interrupt_state};
+	auto result = delete_op.Finalize(pipeline, event, context, del_finalize_input);
+	if (result != SinkFinalizeType::READY) {
+		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
+	}
+
 	if (inline_data_op) {
 		// call OperatorFinalize on inline data
 		OperatorFinalizeInput inline_finalize_input {*gstate.inline_data_gstate, input.interrupt_state};
@@ -297,12 +303,7 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
 	}
 
 	OperatorSinkFinalizeInput copy_finalize_input {*copy_op.sink_state, input.interrupt_state};
-	auto result = copy_op.Finalize(pipeline, event, context, copy_finalize_input);
-	if (result != SinkFinalizeType::READY) {
-		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
-	}
-	OperatorSinkFinalizeInput del_finalize_input {*delete_op.sink_state, input.interrupt_state};
-	result = delete_op.Finalize(pipeline, event, context, del_finalize_input);
+	result = copy_op.Finalize(pipeline, event, context, copy_finalize_input);
 	if (result != SinkFinalizeType::READY) {
 		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");
 	}

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -89,7 +89,7 @@ unique_ptr<GlobalSinkState> DuckLakeUpdate::GetGlobalSinkState(ClientContext &co
 	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
 	delete_op.sink_state = delete_op.GetGlobalSinkState(context);
 	if (inline_data_op) {
-	    // We need tto initialize data global state
+		// We need tto initialize data global state
 		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
 	}
 	return std::move(result);
@@ -205,11 +205,12 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 	}
 
 	if (inline_data_op) {
-		// if we have an inline data operator, we need to execute through it, it will either inline it or pass it throuhg
+		// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
+		// throuhg
 		auto &inline_output = lstate.inline_output_chunk;
 		inline_output.Reset();
-		auto inline_result = inline_data_op->Execute(context, insert_chunk, inline_output,
-		                                             *gstate.inline_data_gstate, *lstate.inline_data_lstate);
+		auto inline_result = inline_data_op->Execute(context, insert_chunk, inline_output, *gstate.inline_data_gstate,
+		                                             *lstate.inline_data_lstate);
 		if (inline_output.size() > 0) {
 			OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 			copy_op.Sink(context, inline_output, copy_input);
@@ -217,8 +218,8 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		// handle HAVE_MORE_OUTPUT
 		while (inline_result == OperatorResultType::HAVE_MORE_OUTPUT) {
 			inline_output.Reset();
-			inline_result = inline_data_op->Execute(context, insert_chunk, inline_output,
-			                                        *gstate.inline_data_gstate, *lstate.inline_data_lstate);
+			inline_result = inline_data_op->Execute(context, insert_chunk, inline_output, *gstate.inline_data_gstate,
+			                                        *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
 				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
 				copy_op.Sink(context, inline_output, copy_input);
@@ -289,7 +290,6 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
                                           OperatorSinkFinalizeInput &input) const {
 	auto &gstate = input.global_state.Cast<DuckLakeUpdateGlobalState>();
 
-
 	if (inline_data_op) {
 		// call OperatorFinalize on inline data
 		OperatorFinalizeInput inline_finalize_input {*gstate.inline_data_gstate, input.interrupt_state};
@@ -315,7 +315,6 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
 
 	DataChunk copy_source_chunk;
 	copy_source_chunk.Initialize(context, copy_op.types);
-
 
 	if (!insert_op.sink_state) {
 		// use existing sink_state if OperatorFinalize already created it

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -219,6 +219,11 @@ InsertionOrderPreservingMap<string> DuckLakeUpdate::ParamsToString() const {
 DuckLakeUpdate &DuckLakeUpdate::PlanUpdateOperator(ClientContext &context, PhysicalPlanGenerator &planner,
                                                    LogicalUpdate &op, PhysicalOperator &child_plan,
                                                    DuckLakeCopyInput &copy_input) {
+	for (auto &expr : op.expressions) {
+		if (expr->type == ExpressionType::VALUE_DEFAULT) {
+			throw BinderException("SET DEFAULT is not yet supported for updates of a DuckLake table");
+		}
+	}
 	auto &table = op.table.Cast<DuckLakeTableEntry>();
 
 	vector<idx_t> row_id_indexes;
@@ -255,11 +260,6 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
                                               PhysicalOperator &child_plan) {
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for updates of a DuckLake table");
-	}
-	for (auto &expr : op.expressions) {
-		if (expr->type == ExpressionType::VALUE_DEFAULT) {
-			throw BinderException("SET DEFAULT is not yet supported for updates of a DuckLake table");
-		}
 	}
 	auto &table = op.table.Cast<DuckLakeTableEntry>();
 

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -63,6 +63,9 @@ public:
 	//! Duplicate row detection (first-write-wins)
 	mutex seen_rows_lock;
 	unordered_set<FileRowId, FileRowIdHash> seen_rows;
+
+	//! Inline data global state
+	unique_ptr<GlobalOperatorState> inline_data_gstate;
 };
 
 class DuckLakeUpdateLocalState : public LocalSinkState {
@@ -75,12 +78,20 @@ public:
 	DataChunk insert_chunk;
 	DataChunk delete_chunk;
 	idx_t updated_count = 0;
+
+	//! Inline data local state and output buffer
+	unique_ptr<OperatorState> inline_data_lstate;
+	DataChunk inline_output_chunk;
 };
 
 unique_ptr<GlobalSinkState> DuckLakeUpdate::GetGlobalSinkState(ClientContext &context) const {
 	auto result = make_uniq<DuckLakeUpdateGlobalState>();
 	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
 	delete_op.sink_state = delete_op.GetGlobalSinkState(context);
+	if (inline_data_op) {
+	    // We need tto initialize data global state
+		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
+	}
 	return std::move(result);
 }
 
@@ -115,6 +126,10 @@ unique_ptr<LocalSinkState> DuckLakeUpdate::GetLocalSinkState(ExecutionContext &c
 	result->insert_chunk.Initialize(context.client, insert_types);
 
 	result->delete_chunk.Initialize(context.client, delete_types);
+	if (inline_data_op) {
+		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
+		result->inline_output_chunk.Initialize(context.client, inline_data_op->types);
+	}
 	return std::move(result);
 }
 
@@ -189,8 +204,30 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 		    update_expression_chunk.data[physical_column_count + part_idx]);
 	}
 
-	OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
-	copy_op.Sink(context, insert_chunk, copy_input);
+	if (inline_data_op) {
+		// if we have an inline data operator, we need to execute through it, it will either inline it or pass it throuhg
+		auto &inline_output = lstate.inline_output_chunk;
+		inline_output.Reset();
+		auto inline_result = inline_data_op->Execute(context, insert_chunk, inline_output,
+		                                             *gstate.inline_data_gstate, *lstate.inline_data_lstate);
+		if (inline_output.size() > 0) {
+			OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
+			copy_op.Sink(context, inline_output, copy_input);
+		}
+		// handle HAVE_MORE_OUTPUT
+		while (inline_result == OperatorResultType::HAVE_MORE_OUTPUT) {
+			inline_output.Reset();
+			inline_result = inline_data_op->Execute(context, insert_chunk, inline_output,
+			                                        *gstate.inline_data_gstate, *lstate.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
+				copy_op.Sink(context, inline_output, copy_input);
+			}
+		}
+	} else {
+		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_local_state, input.interrupt_state};
+		copy_op.Sink(context, insert_chunk, copy_input);
+	}
 
 	// push the rowids into the delete
 	auto &delete_chunk = lstate.delete_chunk;
@@ -212,6 +249,23 @@ SinkResultType DuckLakeUpdate::Sink(ExecutionContext &context, DataChunk &chunk,
 SinkCombineResultType DuckLakeUpdate::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeUpdateGlobalState>();
 	auto &local_state = input.local_state.Cast<DuckLakeUpdateLocalState>();
+	// drain inline data FinalExecute — flushes local→global or emits on overflow
+	if (inline_data_op) {
+		auto &inline_output = local_state.inline_output_chunk;
+		while (true) {
+			inline_output.Reset();
+			auto fresult = inline_data_op->FinalExecute(context, inline_output, *global_state.inline_data_gstate,
+			                                            *local_state.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				OperatorSinkInput copy_input {*copy_op.sink_state, *local_state.copy_local_state,
+				                              input.interrupt_state};
+				copy_op.Sink(context, inline_output, copy_input);
+			}
+			if (fresult == OperatorFinalizeResultType::FINISHED) {
+				break;
+			}
+		}
+	}
 	OperatorSinkCombineInput copy_combine_input {*copy_op.sink_state, *local_state.copy_local_state,
 	                                             input.interrupt_state};
 	auto result = copy_op.Combine(context, copy_combine_input);
@@ -233,6 +287,15 @@ SinkCombineResultType DuckLakeUpdate::Combine(ExecutionContext &context, Operato
 //===--------------------------------------------------------------------===//
 SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                           OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeUpdateGlobalState>();
+
+
+	if (inline_data_op) {
+		// call OperatorFinalize on inline data
+		OperatorFinalizeInput inline_finalize_input {*gstate.inline_data_gstate, input.interrupt_state};
+		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize_input);
+	}
+
 	OperatorSinkFinalizeInput copy_finalize_input {*copy_op.sink_state, input.interrupt_state};
 	auto result = copy_op.Finalize(pipeline, event, context, copy_finalize_input);
 	if (result != SinkFinalizeType::READY) {
@@ -253,11 +316,15 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
 	DataChunk copy_source_chunk;
 	copy_source_chunk.Initialize(context, copy_op.types);
 
-	auto global_sink = insert_op.GetGlobalSinkState(context);
+
+	if (!insert_op.sink_state) {
+		// use existing sink_state if OperatorFinalize already created it
+		insert_op.sink_state = insert_op.GetGlobalSinkState(context);
+	}
 	auto local_sink = insert_op.GetLocalSinkState(execution_context);
 
 	OperatorSourceInput source_input {*global_source, *local_source, input.interrupt_state};
-	OperatorSinkInput sink_input {*global_sink, *local_sink, input.interrupt_state};
+	OperatorSinkInput sink_input {*insert_op.sink_state, *local_sink, input.interrupt_state};
 	while (true) {
 		auto source_result = copy_op.GetData(execution_context, copy_source_chunk, source_input);
 		if (copy_source_chunk.size() == 0) {
@@ -276,7 +343,7 @@ SinkFinalizeType DuckLakeUpdate::Finalize(Pipeline &pipeline, Event &event, Clie
 		}
 	}
 
-	OperatorSinkFinalizeInput insert_finalize_input {*global_sink, input.interrupt_state};
+	OperatorSinkFinalizeInput insert_finalize_input {*insert_op.sink_state, input.interrupt_state};
 	result = insert_op.Finalize(pipeline, event, context, insert_finalize_input);
 	if (result != SinkFinalizeType::READY) {
 		throw InternalException("DuckLakeUpdate::Finalize does not support async child operators");

--- a/test/sql/data_inlining/data_inlining_interleaved_update.test
+++ b/test/sql/data_inlining/data_inlining_interleaved_update.test
@@ -55,13 +55,14 @@ SELECT * FROM ducklake.test ORDER BY id
 4	d
 
 # verify rowids - the updated row (id=1) should preserve its original rowid (0)
+# INSERT rows get sequential row_ids from next_row_id (2), UPDATE rows keep preserved row_ids
 query III
 SELECT rowid, * FROM ducklake.test ORDER BY id
 ----
 0	1	aa
 1	2	b
-3	3	c
-4	4	d
+2	3	c
+3	4	d
 
 # verify table_changes shows the update correctly (not as separate delete+insert)
 query IIIII
@@ -69,5 +70,5 @@ FROM ducklake.table_changes('test', 3, 3) ORDER BY ALL
 ----
 3	0	update_postimage	1	aa
 3	0	update_preimage	1	a
-3	3	insert	3	c
-3	4	insert	4	d
+3	2	insert	3	c
+3	3	insert	4	d

--- a/test/sql/data_inlining/data_inlining_interleaved_update.test
+++ b/test/sql/data_inlining/data_inlining_interleaved_update.test
@@ -72,3 +72,29 @@ FROM ducklake.table_changes('test', 3, 3) ORDER BY ALL
 3	0	update_preimage	1	a
 3	2	insert	3	c
 3	3	insert	4	d
+
+# UPDATE -> INSERT in one transaction (update-only existing data, then insert)
+# this tests the case where existing_data has only preserved row_ids (from the update)
+# and the new insert data needs TRANSACTION_LOCAL_ROW_ID_START-based ids
+statement ok
+BEGIN
+
+query I
+UPDATE ducklake.test SET val='bb' WHERE id=2
+----
+1
+
+statement ok
+INSERT INTO ducklake.test VALUES (5, 'e')
+
+statement ok
+COMMIT
+
+query III
+SELECT rowid, * FROM ducklake.test ORDER BY id
+----
+0	1	aa
+1	2	bb
+2	3	c
+3	4	d
+4	5	e

--- a/test/sql/data_inlining/data_inlining_update_inline_verification.test
+++ b/test/sql/data_inlining/data_inlining_update_inline_verification.test
@@ -1,0 +1,109 @@
+# name: test/sql/data_inlining/data_inlining_update_inline_verification.test
+# description: verify that a small update on file-backed data gets inlined (insert + delete tables, no new file)
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_update_inline_verify_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i, 'val_' || i::VARCHAR AS j FROM range(20) t(i)
+
+statement ok
+SELECT COUNT(*) cnt FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
+
+query I
+SELECT COUNT(*) = 1 cnt FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
+----
+true
+
+query I
+UPDATE ducklake.test SET j='updated' WHERE i=5
+----
+1
+
+query I
+SELECT COUNT(*) = 1 FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
+----
+true
+
+# verify the data is correct
+query II
+SELECT * FROM ducklake.test WHERE i=5
+----
+5	updated
+
+# the inlined insert table should have the new row from the update
+query II
+SELECT i, j FROM ducklake_meta.ducklake_inlined_data_1_1
+----
+5	updated
+
+# the inlined delete table should track the old row that was removed from the file
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_delete_1
+----
+1
+
+# verify rowids are preserved
+query III
+SELECT rowid, * FROM ducklake.test WHERE i=5
+----
+5	5	updated
+
+# do another update
+query I
+UPDATE ducklake.test SET j='changed' WHERE i=10
+----
+1
+
+# still no new files
+query I
+SELECT COUNT(*) = 1FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
+----
+true
+
+# inlined insert table now has 2 rows
+query II
+SELECT i, j FROM ducklake_meta.ducklake_inlined_data_1_1 ORDER BY i
+----
+5	updated
+10	changed
+
+# inlined delete table now has 2 entries
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_delete_1
+----
+2
+
+# verify all data is correct
+query II
+SELECT * FROM ducklake.test ORDER BY i
+----
+0	val_0
+1	val_1
+2	val_2
+3	val_3
+4	val_4
+5	updated
+6	val_6
+7	val_7
+8	val_8
+9	val_9
+10	changed
+11	val_11
+12	val_12
+13	val_13
+14	val_14
+15	val_15
+16	val_16
+17	val_17
+18	val_18
+19	val_19

--- a/test/sql/data_inlining/data_inlining_update_inline_verification.test
+++ b/test/sql/data_inlining/data_inlining_update_inline_verification.test
@@ -16,9 +16,6 @@ ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/du
 statement ok
 CREATE TABLE ducklake.test AS SELECT i, 'val_' || i::VARCHAR AS j FROM range(20) t(i)
 
-statement ok
-SELECT COUNT(*) cnt FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
-
 query I
 SELECT COUNT(*) = 1 cnt FROM GLOB('${DATA_PATH}/ducklake_update_inline_verify_files/**')
 ----

--- a/test/sql/macros/test_snapshots_after_macro.test
+++ b/test/sql/macros/test_snapshots_after_macro.test
@@ -1,6 +1,6 @@
 # name: test/sql/macros/test_snapshots_after_macro.test
 # description: test that snapshots() works after creating a macro
-# group: [macro]
+# group: [macros]
 
 require ducklake
 

--- a/test/sql/merge/merge_partition_update.test
+++ b/test/sql/merge/merge_partition_update.test
@@ -39,6 +39,10 @@ MERGE INTO my_timeseries
     ON my_timeseries.ts = timeseries_updates.ts
     WHEN MATCHED THEN UPDATE;
 
+# flush inlined data from the MERGE update
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/merge_partition_update/**/year=2025/*')
 ----
@@ -50,6 +54,10 @@ statement ok
 UPDATE my_timeseries
 SET x = 43::DOUBLE PRECISION
 WHERE ts = '2025-09-17'::TIMESTAMP;
+
+# flush inlined data from the UPDATE
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
 
 query I
 SELECT COUNT(*) FROM GLOB('${DATA_PATH}/merge_partition_update/**/year=2025/*')


### PR DESCRIPTION
This PR implements inline insertions for Update operations, with them now generating inlined data with preserved row ids instead of generating new files.

The row id management is implemented in the DuckLakeInlinedData and is stored for updates. We not only store it but we also merge and maintain them between multiple update (and insert) operations in the same transaction.

We also transform DuckLakeUpdate to feed its output into the inlined operator, behaving with a similar pipeline as the INSERT, while the old code was moved to DuckLakeMergeUpdate since MERGE requires direct access to Sink calls.

In practice the update basically evaluates the updates, triggers the deletes, and passes on the transformed chunks for the inserts.

```sql
EXPLAIN UPDATE ducklake.test SET val='x' WHERE id=1;
```

```
 ┌───────────────────────────┐
│      DUCKLAKE_INSERT      │
│    ────────────────────   │
│      Table Name: test     │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│        COPY_TO_FILE       │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│    DUCKLAKE_INLINE_DATA   │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      DUCKLAKE_UPDATE      │
│    ────────────────────   │
│      Table Name: test     │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         PROJECTION        │
│    ────────────────────   │
│            'x'            │
│             #0            │
│           rowid           │
│          filename         │
│         file_index        │
│      file_row_number      │
│                           │
│           ~1 row          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│       DUCKLAKE_SCAN       │
│    ────────────────────   │
│        Table: test        │
│      Projections: id      │
│       Filters: id=1       │
│                           │
│           ~1 row          │
└───────────────────────────┘
```