### PR TITLE
Log type for metadata queries

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -5,14 +5,19 @@
 #include "storage/ducklake_storage.hpp"
 #include "functions/ducklake_table_functions.hpp"
 #include "storage/ducklake_secret.hpp"
+#include "duckdb/logging/log_manager.hpp"
 #include "duckdb/storage/storage_extension.hpp"
+#include "storage/ducklake_log_type.hpp"
 
 namespace duckdb {
 
 static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("Adds support for DuckLake, SQL as a Lakehouse Format");
 
-	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+	auto &instance = loader.GetDatabaseInstance();
+	instance.GetLogManager().RegisterLogType(make_uniq<DuckLakeMetadataLogType>());
+
+	auto &config = DBConfig::GetConfig(instance);
 	StorageExtension::Register(config, "ducklake", make_shared_ptr<DuckLakeStorageExtension>());
 
 	config.AddExtensionOption("ducklake_max_retry_count",

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -16,6 +16,9 @@
 #include "storage/ducklake_partition_data.hpp"
 #include "storage/ducklake_stats.hpp"
 
+#include <chrono>
+#include <functional>
+
 namespace duckdb {
 struct DuckLakeGlobalStatsInfo;
 class ColumnList;
@@ -171,6 +174,16 @@ public:
 	//! Return the schema for the given snapshot - loading it if it is not yet loaded
 	DuckLakeCatalogSet &GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
 
+	//! Callback type for instrumenting metadata queries
+	using QueryCallback = std::function<void(const string &query, std::chrono::steady_clock::duration elapsed)>;
+
+	void SetQueryCallback(QueryCallback callback) {
+		query_callback = std::move(callback);
+	}
+	const QueryCallback &GetQueryCallback() const {
+		return query_callback;
+	}
+
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 	unique_ptr<DuckLakeCatalogSet> LoadSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
@@ -204,6 +217,8 @@ private:
 	//! The id of the last committed snapshot, set at FlushChanges on a successful commit
 	mutable mutex commit_lock;
 	optional_idx last_committed_snapshot;
+	//! Optional callback for instrumenting metadata queries
+	QueryCallback query_callback;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_log_type.hpp
+++ b/src/include/storage/ducklake_log_type.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_log_type.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/logging/log_type.hpp"
+
+namespace duckdb {
+
+class DuckLakeMetadataLogType : public LogType {
+public:
+	static constexpr const char *NAME = "DuckLakeMetadata";
+	static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG;
+
+	DuckLakeMetadataLogType();
+
+	static LogicalType GetLogType();
+	static string ConstructLogMessage(const string &catalog_name, const string &query, int64_t elapsed_ms);
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   ducklake_inline_data.cpp
   ducklake_inlined_data_reader.cpp
   ducklake_insert.cpp
+  ducklake_log_type.cpp
   ducklake_merge_into.cpp
   ducklake_schema_entry.cpp
   ducklake_transaction_manager.cpp

--- a/src/storage/ducklake_log_type.cpp
+++ b/src/storage/ducklake_log_type.cpp
@@ -1,0 +1,31 @@
+#include "storage/ducklake_log_type.hpp"
+
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+constexpr LogLevel DuckLakeMetadataLogType::LEVEL;
+
+DuckLakeMetadataLogType::DuckLakeMetadataLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType DuckLakeMetadataLogType::GetLogType() {
+	child_list_t<LogicalType> child_list = {
+	    {"catalog", LogicalType::VARCHAR},
+	    {"query", LogicalType::VARCHAR},
+	    {"elapsed_ms", LogicalType::BIGINT},
+	};
+	return LogicalType::STRUCT(child_list);
+}
+
+string DuckLakeMetadataLogType::ConstructLogMessage(const string &catalog_name, const string &query,
+                                                    int64_t elapsed_ms) {
+	child_list_t<Value> child_list = {
+	    {"catalog", Value(catalog_name)},
+	    {"query", Value(query)},
+	    {"elapsed_ms", Value::BIGINT(elapsed_ms)},
+	};
+	return Value::STRUCT(std::move(child_list)).ToString();
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -20,6 +20,8 @@
 #include "storage/ducklake_transaction_manager.hpp"
 #include "storage/ducklake_view_entry.hpp"
 #include "duckdb/common/printer.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "storage/ducklake_log_type.hpp"
 #include "duckdb/main/settings.hpp"
 #include "duckdb/main/client_config.hpp"
 
@@ -2543,7 +2545,18 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	query = StringUtil::Replace(query, "{METADATA_SCHEMA_ESCAPED}", schema_identifier_escaped);
 	query = StringUtil::Replace(query, "{METADATA_PATH}", metadata_path);
 	query = StringUtil::Replace(query, "{DATA_PATH}", data_path);
-	return connection.Query(query);
+	auto start = std::chrono::steady_clock::now();
+	auto result = connection.Query(query);
+	auto end = std::chrono::steady_clock::now();
+	auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+	DUCKDB_LOG(db, DuckLakeMetadataLogType, ducklake_catalog.GetName(), query, elapsed_ms);
+
+	auto &cb = ducklake_catalog.GetQueryCallback();
+	if (cb) {
+		cb(query, end - start);
+	}
+	return result;
 }
 
 unique_ptr<QueryResult> DuckLakeTransaction::Query(DuckLakeSnapshot snapshot, string query) {


### PR DESCRIPTION
Add a new log type for ducklake metadata queries. 

Metadata queries can be an important factor in performance, especially for remote catalogs. This changes adds a log type with fields catalog, query and elapsed_ms to debug metadata queries.

The log can be enabled like this
```
CALL enable_logging('DuckLakeMetadata', storage='shell_log_storage');
```

Note that on the INFO level, there is already a QueryLog, which logs every query on every connection including metadata queries. I think it's still worthwhile to have a separate log type for metadata queries, so you can filter on those alone (and have timing information in the elapsed_ms field).

This change also adds a small hook to DuckLakeCatalog that applications that embed ducklake can use to receive the metadata queries with their time, for example in order to add them to their observability pipelines.