### PR TITLE
Copy the delete data to avoid corruption of snapshot_ids borking delete merges

### DIFF
--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -253,6 +253,10 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			if (!file_entry.delete_file.path.empty()) {
 				delete_filter->Initialize(context, file_entry.delete_file);
 			}
+			if (delete_map && !file_entry.delete_file.path.empty()) {
+				auto delete_data_copy = make_shared_ptr<DuckLakeDeleteData>(*delete_filter->delete_data);
+				delete_map->AddDeleteData(reader.GetFileName(), std::move(delete_data_copy));
+			}
 			// Apply inlined file deletions (stored in metadata database instead of delete file)
 			if (!file_entry.inlined_file_deletions.empty()) {
 				DuckLakeInlinedDataDeletes inlined_deletes;
@@ -264,10 +268,6 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			}
 			// set the snapshot id so we know what to skip from deletion files
 			delete_filter->SetSnapshotFilter(read_info.snapshot.snapshot_id);
-			// Only add to delete_map if there's an actual delete file and not just inlined deletions
-			if (delete_map && !file_entry.delete_file.path.empty()) {
-				delete_map->AddDeleteData(reader.GetFileName(), delete_filter->delete_data);
-			}
 			reader.deletion_filter = std::move(delete_filter);
 		}
 	} else {

--- a/test/sql/issues/issue_865_update_wrong_result.test
+++ b/test/sql/issues/issue_865_update_wrong_result.test
@@ -1,0 +1,60 @@
+# name: test/sql/issues/issue_865_update_wrong_result.test
+# description: UPDATE on ducklake table produces duplicate rows when a data file has both a committed delete file and committed inlined file deletions
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/issue_865', DATA_INLINING_ROW_LIMIT 10)
+
+# Create table with enough rows to NOT be inlined
+statement ok
+CREATE TABLE ducklake.test AS SELECT i AS id, 'original' AS val FROM range(100) t(i)
+
+# Create delete file
+statement ok
+DELETE FROM ducklake.test WHERE id >= 80
+
+query I
+SELECT count(*) FROM ducklake.test
+----
+80
+
+# Inline deletes
+statement ok
+DELETE FROM ducklake.test WHERE id >= 75
+
+query I
+SELECT count(*) FROM ducklake.test
+----
+75
+
+# If we update more than the inline value, inlined deletion merge will corrupt de delete data
+query I
+UPDATE ducklake.test SET val = 'updated' WHERE id < 20
+----
+20
+
+# After update: should still have 75 rows
+query I
+SELECT count(*) FROM ducklake.test
+----
+75
+
+# The 20 updated rows should exist exactly once with 'updated'
+query I
+SELECT count(*) FROM ducklake.test WHERE val = 'updated'
+----
+20
+
+# No duplicate ids
+query I
+SELECT count(*) FROM (SELECT id, count(*) cnt FROM ducklake.test GROUP BY id HAVING count(*) > 1)
+----
+0


### PR DESCRIPTION
Fix: #865