### PR TITLE
Fix single quote escaping in variant stats TrySerialize

### DIFF
--- a/src/storage/statistics/ducklake_variant_stats.cpp
+++ b/src/storage/statistics/ducklake_variant_stats.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parser/keyword_helper.hpp"
 #include "storage/ducklake_metadata_info.hpp"
 #include "yyjson.hpp"
+#include "common/ducklake_util.hpp"
 
 namespace duckdb {
 
@@ -208,7 +209,7 @@ bool DuckLakeColumnVariantStats::TrySerialize(string &result) const {
 	string out(json, len);
 	free(json);
 	yyjson_mut_doc_free(doc);
-	result = "'" + out + "'";
+	result = DuckLakeUtil::SQLLiteralToString(out);
 	return true;
 }
 

--- a/test/sql/stats/variant_stats_special_chars.test
+++ b/test/sql/stats/variant_stats_special_chars.test
@@ -1,0 +1,50 @@
+# name: test/sql/stats/variant_stats_special_chars.test
+# description: test that single quotes in variant string stats don't break serialization
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS db2 (DATA_PATH '${DATA_PATH}/ducklake_variant_stats_special', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+use db2;
+
+statement ok
+CREATE TABLE t (v VARIANT)
+
+statement ok
+INSERT INTO t VALUES ({'text': 'hello'}::VARIANT)
+
+# second insert: the apostrophe becomes the new max in the table-level extra_stats
+# TrySerialize wraps the JSON in single quotes for SQL - the apostrophe must be escaped
+statement ok
+INSERT INTO t VALUES ({'text': 'it''s fine'}::VARIANT)
+
+query I
+SELECT COUNT(*) FROM t
+----
+2
+
+# check per-file stats
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM dl.ducklake_file_variant_stats WHERE data_file_id=0
+----
+"text"	varchar	hello	hello
+
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM dl.ducklake_file_variant_stats WHERE data_file_id=1
+----
+"text"	varchar	it's fine	it's fine
+
+# table-level extra_stats should have survived serialization with the single quote
+query I
+SELECT extra_stats IS NOT NULL FROM dl.ducklake_table_column_stats
+----
+true


### PR DESCRIPTION
`TrySerialize()` in `ducklake_variant_stats.cpp` wraps the serialized JSON in plain single quotes:

```cpp
result = "'" + out + "'";
```

When a shredded string field's min/max contains a single quote (e.g. `"max":"it's broken"`), this produces broken SQL for PostgreSQL catalogs. The per-file stats in `ducklake_file_variant_stats` already escape correctly via `StatsToString()`, so this was just missed in the table-level stats path.

Fix: use `DuckLakeUtil::SQLLiteralToString(out)` which does `Replace("'", "''")`.

Also adds a regression test with a single quote in variant string data.

Fixes #902