### PR TITLE
Don't scan duckdb_tables() during Initialize

### DIFF
--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -76,6 +76,7 @@ void DuckLakeInitializer::Initialize() {
 	// check if we are loading an existing DuckLake or creating a new one
 	// directly query a known ducklake metadata table to avoid scanning all attached catalogs via duckdb_tables()
 	// this prevents a corrupted ducklake catalog from blocking initialization of unrelated ducklake databases
+	// FIXME: verify that all ducklake tables are in the correct format
 	result = transaction.Query("SELECT NULL FROM {METADATA_CATALOG}.ducklake_metadata LIMIT 1");
 	if (result->HasError()) {
 		auto &error_obj = result->GetErrorObject();

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -74,22 +74,23 @@ void DuckLakeInitializer::Initialize() {
 	}
 	// after the metadata database is attached initialize the ducklake
 	// check if we are loading an existing DuckLake or creating a new one
-	// FIXME: verify that all tables are in the correct format instead
-	result = transaction.Query(
-	    "SELECT COUNT(*) FROM duckdb_tables() WHERE database_name={METADATA_CATALOG_NAME_LITERAL} AND "
-	    "schema_name={METADATA_SCHEMA_NAME_LITERAL} AND table_name LIKE 'ducklake_%'");
+	// directly query a known ducklake metadata table to avoid scanning all attached catalogs via duckdb_tables()
+	// this prevents a corrupted ducklake catalog from blocking initialization of unrelated ducklake databases
+	result = transaction.Query("SELECT NULL FROM {METADATA_CATALOG}.ducklake_metadata LIMIT 1");
 	if (result->HasError()) {
 		auto &error_obj = result->GetErrorObject();
-		error_obj.Throw("Failed to load DuckLake table data");
-	}
-	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
-	if (count == 0) {
-		if (!options.create_if_not_exists) {
-			throw InvalidInputException("Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a "
-			                            "new DuckLake is explicitly disabled",
-			                            options.metadata_path);
+		if (error_obj.Type() == ExceptionType::CATALOG) {
+			// table does not exist - this is a new ducklake
+			if (!options.create_if_not_exists) {
+				throw InvalidInputException(
+				    "Existing DuckLake at metadata catalog \"%s\" does not exist - and creating a "
+				    "new DuckLake is explicitly disabled",
+				    options.metadata_path);
+			}
+			InitializeNewDuckLake(transaction, has_explicit_schema);
+		} else {
+			error_obj.Throw("Failed to load DuckLake table data");
 		}
-		InitializeNewDuckLake(transaction, has_explicit_schema);
 	} else {
 		LoadExistingDuckLake(transaction);
 	}

--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -24,6 +24,7 @@
         "test/sql/general/default_path.test",
         "test/sql/autoloading/autoload_data_path.test",
         "test/sql/general/metadata_parameters.test",
+        "test/sql/issues/corrupted_catalog_fault_isolation.test",
         "test/sql/metadata/ducklake_settings.test",
         "test/sql/remove_orphans/metadata_in_data_path.test"
       ]

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -68,6 +68,7 @@
       "paths": [
         "test/sql/general/missing_parquet.test",
         "test/sql/general/paths.test",
+        "test/sql/issues/corrupted_catalog_fault_isolation.test",
         "test/sql/secrets/ducklake_secrets.test"
       ]
     },

--- a/test/sql/issues/corrupted_catalog_fault_isolation.test
+++ b/test/sql/issues/corrupted_catalog_fault_isolation.test
@@ -6,24 +6,22 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
-
 test-env DATA_PATH __TEST_DIR__
 
 # Create a ducklake catalog with a table
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS corrupt_dl (DATA_PATH '${DATA_PATH}/corrupt_dl/')
+ATTACH 'ducklake:__TEST_DIR__/corrupted.db' AS corrupt_dl (DATA_PATH '${DATA_PATH}/corrupted')
 
 statement ok
 CREATE TABLE corrupt_dl.t1 AS SELECT 1 AS id, 'hello' AS name
 
 # Corrupt the metadata: set an invalid column type
 statement ok
-UPDATE __ducklake_metadata_corrupt_dl.ducklake_column SET column_type = 'int32varcharvarchar' WHERE column_name = 'id'
+UPDATE __ducklake_metadata_corrupt_dl.main.ducklake_column SET column_type = 'int32varcharvarchar' WHERE column_name = 'id'
 
 # Attach a second ducklake catalog - this should succeed despite the corrupted sibling
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS good_dl (DATA_PATH '${DATA_PATH}/good_dl/')
+ATTACH 'ducklake:__TEST_DIR__/good.db' AS good_dl (DATA_PATH '${DATA_PATH}/good')
 
 statement ok
 CREATE TABLE good_dl.t2 AS SELECT 42 AS val
@@ -32,3 +30,16 @@ query I
 SELECT val FROM good_dl.t2
 ----
 42
+
+statement ok
+DETACH corrupt_dl
+
+# Reattach the corrupted catalog - attach itself should succeed (lazy loading)
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/corrupted.db' AS corrupt_dl (DATA_PATH '${DATA_PATH}/corrupted')
+
+# Verify the corruption survives detach/reattach
+statement error
+SELECT * FROM corrupt_dl.t1
+----
+unsupported type 'int32varcharvarchar'

--- a/test/sql/issues/corrupted_catalog_fault_isolation.test
+++ b/test/sql/issues/corrupted_catalog_fault_isolation.test
@@ -1,6 +1,7 @@
 # name: test/sql/issues/corrupted_catalog_fault_isolation.test
 # description: A corrupted ducklake catalog should not prevent attaching other ducklake catalogs
 # group: [issues]
+# note: skipped in SQLite/Postgres CI configs - this test requires multiple independent metadata databases
 
 require ducklake
 

--- a/test/sql/issues/corrupted_catalog_fault_isolation.test
+++ b/test/sql/issues/corrupted_catalog_fault_isolation.test
@@ -1,0 +1,34 @@
+# name: test/sql/issues/corrupted_catalog_fault_isolation.test
+# description: A corrupted ducklake catalog should not prevent attaching other ducklake catalogs
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+# Create a ducklake catalog with a table
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS corrupt_dl (DATA_PATH '${DATA_PATH}/corrupt_dl/')
+
+statement ok
+CREATE TABLE corrupt_dl.t1 AS SELECT 1 AS id, 'hello' AS name
+
+# Corrupt the metadata: set an invalid column type
+statement ok
+UPDATE __ducklake_metadata_corrupt_dl.ducklake_column SET column_type = 'int32varcharvarchar' WHERE column_name = 'id'
+
+# Attach a second ducklake catalog - this should succeed despite the corrupted sibling
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS good_dl (DATA_PATH '${DATA_PATH}/good_dl/')
+
+statement ok
+CREATE TABLE good_dl.t2 AS SELECT 42 AS val
+
+query I
+SELECT val FROM good_dl.t2
+----
+42


### PR DESCRIPTION
Problem: We use a duckdb_tables() scan during ducklake initialize to verify whether the ducklake is initialozed. This loads all schemas of all attached ducklakes. This will prevent a ducklake attach if another unrelated ducklake database is corrupted. This also has negative performance impact, we might load more schemas than needed. 

Solution: Directly check for the existence of a ducklake metadata table we always expect to be there to check if the ducklake is initialized. 
