### PR TITLE
fix: detect concurrent insert and delete transactions on the same table

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1236,16 +1236,22 @@ void DuckLakeTransaction::CheckForConflicts(const TransactionChangeInformation &
 	for (auto &table_id : changes.tables_inserted_into) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "insert into table", "dropped it");
 		ConflictCheck(table_id, other_changes.altered_tables, "insert into table", "altered it");
+		ConflictCheck(table_id, other_changes.tables_deleted_from, "insert into table", "deleted from it");
+		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table", "deleted inlined data from it");
 	}
 	for (auto &table_id : changes.tables_inserted_inlined) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "insert into table", "dropped it");
 		ConflictCheck(table_id, other_changes.altered_tables, "insert into table", "altered it");
+		ConflictCheck(table_id, other_changes.tables_deleted_from, "insert into table", "deleted from it");
+		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table", "deleted inlined data from it");
 	}
 	for (auto &table_id : changes.tables_deleted_from) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "delete from table", "dropped it");
 		ConflictCheck(table_id, other_changes.altered_tables, "delete from table", "altered it");
 		ConflictCheck(table_id, other_changes.tables_merge_adjacent, "delete from table", "compacted it");
 		ConflictCheck(table_id, other_changes.tables_rewrite_delete, "delete from table", "compacted it");
+		ConflictCheck(table_id, other_changes.inserted_tables, "delete from table", "inserted into it");
+		ConflictCheck(table_id, other_changes.tables_inserted_inlined, "delete from table", "inserted into it");
 	}
 	if (!changes.tables_deleted_from.empty()) {
 		bool check_for_matches = false;
@@ -1277,6 +1283,8 @@ void DuckLakeTransaction::CheckForConflicts(const TransactionChangeInformation &
 		ConflictCheck(table_id, other_changes.altered_tables, "delete from table", "altered it");
 		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "delete from table", "deleted from it");
 		ConflictCheck(table_id, other_changes.tables_flushed_inlined, "delete from table", "flushed the inlined data");
+		ConflictCheck(table_id, other_changes.inserted_tables, "delete from table", "inserted into it");
+		ConflictCheck(table_id, other_changes.tables_inserted_inlined, "delete from table", "inserted into it");
 	}
 	for (auto &table_id : changes.tables_flushed_inlined) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "flush inline data", "dropped it");

--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -172,8 +172,9 @@
         "test/sql/update/test_update_same_value.test",
         "test/sql/delete/cleanup_delete_on_conflict.test",
         "test/sql/alter/add_col/test_add_col_transactions.test",
-        "test/sql/alter/drop_col/test_drop_col_transactions.test"
-
+        "test/sql/alter/drop_col/test_drop_col_transactions.test",
+        "test/sql/transactions/transaction_insert_mixed_deletes.test",
+        "test/sql/transactions/transaction_insert_delete_chunks.test"
       ]
     },
     {

--- a/test/sql/concurrent/concurrent_insert_delete_conflict.test
+++ b/test/sql/concurrent/concurrent_insert_delete_conflict.test
@@ -1,0 +1,55 @@
+# name: test/sql/concurrent/concurrent_insert_delete_conflict.test
+# description: test that concurrent insert + delete on the same table triggers a conflict
+# group: [concurrent]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_concurrent_insert_delete_files', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+SET ducklake_retry_wait_ms=100
+
+statement ok
+SET ducklake_retry_backoff=2.0
+
+statement ok
+SET ducklake_max_retry_count=100
+
+statement ok
+CREATE TABLE ducklake.tbl(key INTEGER);
+
+statement ok
+INSERT INTO ducklake.tbl SELECT i FROM range(10) t(i);
+
+query II
+SELECT COUNT(*), SUM(key) FROM ducklake.tbl
+----
+10	45
+
+# one thread inserts, the other deletes; cross-conflict should be detected
+concurrentloop i 0 2
+
+statement maybe
+DELETE FROM ducklake.tbl WHERE key = ${i}
+----
+
+statement maybe
+INSERT INTO ducklake.tbl VALUES (100 + ${i})
+----
+
+endloop
+
+# the table should not have duplicate keys regardless of which statements succeeded
+query I
+SELECT COUNT(*) FROM (SELECT key, COUNT(*) as cnt FROM ducklake.tbl GROUP BY key HAVING cnt > 1)
+----
+0


### PR DESCRIPTION
**tl;dr**: Concurrent transactions that insert into and delete from the same table now conflict, preventing silent duplicate rows in upsert workloads. Both delete-and-insert & merge into. Inserts without deletes are unaffected

### Problem

`CheckForConflicts` had no cross-checks between insert and delete operations. Two concurrent transactions could both  read the same snapshot, both decide a row doesn't exist, and both insert it. This creates duplicates. Any concurrent upsert patterns are affected.

### Fix

Addition of bi-directional `ConflictCheck`s; inserts now conflict with concurrent deletes and vice versa

This happens at the table-level similar to the `tables_deleted_inlined` check. To do something similar at the file or row level would be a much larger change (from what I can tell) but could be the way the way to go if table-levvel is thought ot be too coarse.