### PR TITLE
fix: return move projection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ include_directories(src/include)
 find_package(roaring CONFIG REQUIRED)
 include_directories(${roaring_DIR}/../../include)
 
+# Warn when returning unique_ptr<Derived> as unique_ptr<Base> without std::move
+# (Clang-specific; GCC does not need an explicit flag for this pattern)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wreturn-std-move)
+endif()
+
 add_subdirectory(src)
 set(EXTENSION_SOURCES ${ALL_OBJECT_FILES})
 

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -739,7 +739,7 @@ static unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context, 
 	auto projection = make_uniq<LogicalProjection>(bind_index, std::move(proj_exprs));
 	projection->children.push_back(std::move(filter));
 
-	return projection;
+	return std::move(projection);
 }
 
 DuckLakeFlushInlinedDataFunction::DuckLakeFlushInlinedDataFunction()


### PR DESCRIPTION
use std::move to convert unique_ptr<Derive> to unique_ptr<Base>.

This pattern has been fixed once in #689. Enabling the warning makes the compiler enforce it going forward.