### PR TITLE
Adding reading and writing of Iceberg V3 Deletion Vectors (i.e., puffin files)

### DIFF
--- a/.github/workflows/DeletionVectors.yml
+++ b/.github/workflows/DeletionVectors.yml
@@ -1,0 +1,62 @@
+name: Deletion Vector Tests
+on: [push, pull_request,repository_dispatch]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ducklake-deletion-vector-tests:
+    name: DuckLake Tests (Deletion Vectors)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ['linux_amd64']
+        vcpkg_version: [ '2023.04.15' ]
+        include:
+          - arch: 'linux_amd64'
+            vcpkg_triplet: 'x64-linux'
+
+    env:
+      VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+      GEN: Ninja
+      VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    steps:
+    - name: Install required ubuntu packages
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt-get install -y -qq build-essential cmake ninja-build ccache python3
+
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: 'true'
+
+    - name: Checkout DuckDB to version
+      run: |
+        cd duckdb
+        git checkout $(cat ../.github/duckdb-version)
+
+    - name: Setup Ccache
+      uses: hendrikmuhs/ccache-action@main
+      with:
+        key: ${{ github.job }}
+        save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/ducklake' }}
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11.1
+      with:
+        vcpkgGitCommitId: a42af01b72c28a8e1d7b48107b33e4f286a55ef6
+
+    - name: Build extension
+      env:
+        GEN: ninja
+      run: |
+        make release
+
+    - name: Test extension (deletion vectors)
+      run: |
+        build/release/test/unittest --test-config test/configs/deletion_vectors.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,15 @@ set(EXTENSION_SOURCES ${ALL_OBJECT_FILES})
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
+# Roaring is installed via vcpkg and used for deletion vectors
+find_package(roaring CONFIG)
+if(roaring_FOUND)
+    target_link_libraries(${EXTENSION_NAME} roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
+    target_link_libraries(${TARGET_NAME}_loadable_extension roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE DUCKLAKE_HAVE_ROARING)
+    target_compile_definitions(${TARGET_NAME}_loadable_extension PRIVATE DUCKLAKE_HAVE_ROARING)
+endif()
+
 install(
   TARGETS ${EXTENSION_NAME}
   EXPORT "${DUCKDB_EXPORT_SET}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,20 +9,18 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
+# Roaring is installed via vcpkg and used for deletion vectors
+find_package(roaring CONFIG REQUIRED)
+include_directories(${roaring_DIR}/../../include)
+
 add_subdirectory(src)
 set(EXTENSION_SOURCES ${ALL_OBJECT_FILES})
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
-# Roaring is installed via vcpkg and used for deletion vectors
-find_package(roaring CONFIG)
-if(roaring_FOUND)
-    target_link_libraries(${EXTENSION_NAME} roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
-    target_link_libraries(${TARGET_NAME}_loadable_extension roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
-    target_compile_definitions(${EXTENSION_NAME} PRIVATE DUCKLAKE_HAVE_ROARING)
-    target_compile_definitions(${TARGET_NAME}_loadable_extension PRIVATE DUCKLAKE_HAVE_ROARING)
-endif()
+target_link_libraries(${EXTENSION_NAME} roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
+target_link_libraries(${TARGET_NAME}_loadable_extension roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/common/ducklake_data_file.cpp
+++ b/src/common/ducklake_data_file.cpp
@@ -1,6 +1,27 @@
 #include "common/ducklake_data_file.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
+
+string DeleteFileFormatToString(DeleteFileFormat format) {
+	switch (format) {
+	case DeleteFileFormat::PARQUET:
+		return "parquet";
+	case DeleteFileFormat::PUFFIN:
+		return "puffin";
+	default:
+		throw InternalException("Unknown DeleteFileFormat");
+	}
+}
+
+DeleteFileFormat DeleteFileFormatFromString(const string &str) {
+	if (StringUtil::CIEquals(str, "parquet")) {
+		return DeleteFileFormat::PARQUET;
+	} else if (StringUtil::CIEquals(str, "puffin")) {
+		return DeleteFileFormat::PUFFIN;
+	}
+	throw InvalidInputException("Unknown delete file format: %s", str);
+}
 
 DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 	file_name = other.file_name;

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -31,6 +31,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("ducklake_default_data_inlining_row_limit",
 	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
 	                          Value::UBIGINT(10), nullptr, SetScope::GLOBAL);
+	config.AddExtensionOption(
+	    "ducklake_default_write_deletion_vectors",
+	    "[EXPERIMENTAL] Write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false), nullptr, SetScope::GLOBAL);
 
 	DuckLakeSnapshotsFunction snapshots;
 	loader.RegisterFunction(snapshots);

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -32,7 +32,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
 	                          Value::UBIGINT(10), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption(
-	    "ducklake_default_write_deletion_vectors",
+	    "ducklake_write_deletion_vectors",
 	    "[EXPERIMENTAL] Write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false), nullptr, SetScope::GLOBAL);
 

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -404,6 +404,7 @@ struct FileDeleteInfo {
 	bool existing_delete_path_is_relative = false;
 	idx_t existing_delete_begin_snapshot = 0;
 	string existing_delete_encryption_key;
+	DeleteFileFormat existing_delete_format = DeleteFileFormat::PARQUET;
 };
 
 static void FlushInlinedFileDeletions(ClientContext &context, DuckLakeCatalog &catalog,
@@ -423,7 +424,8 @@ static void FlushInlinedFileDeletions(ClientContext &context, DuckLakeCatalog &c
 	auto deletions_result = transaction.Query(snapshot, StringUtil::Format(R"(
 SELECT del.file_id, data.path, data.path_is_relative, del.row_id, del.begin_snapshot,
        existing_del.delete_file_id, existing_del.path as del_path, existing_del.path_is_relative as del_path_is_relative,
-       existing_del.begin_snapshot as del_begin_snapshot, existing_del.encryption_key as del_encryption_key
+       existing_del.begin_snapshot as del_begin_snapshot, existing_del.encryption_key as del_encryption_key,
+       existing_del.format as del_format
 FROM {METADATA_CATALOG}.%s del
 JOIN {METADATA_CATALOG}.ducklake_data_file data ON del.file_id = data.data_file_id
 LEFT JOIN (
@@ -468,6 +470,10 @@ LEFT JOIN (
 					file_info.existing_delete_begin_snapshot = chunk->GetValue(8, row_idx).GetValue<idx_t>();
 					if (!chunk->GetValue(9, row_idx).IsNull()) {
 						file_info.existing_delete_encryption_key = chunk->GetValue(9, row_idx).GetValue<string>();
+					}
+					if (!chunk->GetValue(10, row_idx).IsNull()) {
+						file_info.existing_delete_format =
+						    DeleteFileFormatFromString(chunk->GetValue(10, row_idx).GetValue<string>());
 					}
 				}
 			} else {
@@ -515,6 +521,7 @@ LEFT JOIN (
 			                                     ? table.DataPath() + file_info.existing_delete_path
 			                                     : file_info.existing_delete_path;
 			existing_delete_file_data.encryption_key = file_info.existing_delete_encryption_key;
+			existing_delete_file_data.format = file_info.existing_delete_format;
 
 			auto existing_deletions = DuckLakeDeleteFilter::ScanDeleteFile(context, existing_delete_file_data);
 

--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -12,7 +12,7 @@ struct DuckLakeOptionMetadata {
 	const char *description;
 };
 
-using ducklake_option_array = std::array<DuckLakeOptionMetadata, 19>;
+using ducklake_option_array = std::array<DuckLakeOptionMetadata, 20>;
 
 static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
     {{"data_inlining_row_limit", "Maximum amount of rows to inline in a single insert"},
@@ -37,7 +37,8 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
                       "'ducklake_flush_inlined_data','ducklake_merge_adjacent_files', "
                       "'ducklake_rewrite_data_files', 'ducklake_delete_orphaned_files'"},
      {"encrypted", "Whether or not to encrypt Parquet files written to the data path"},
-     {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"}}};
+     {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"},
+     {"write_deletion_vectors", "Whether to write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -38,7 +38,7 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
                       "'ducklake_rewrite_data_files', 'ducklake_delete_orphaned_files'"},
      {"encrypted", "Whether or not to encrypt Parquet files written to the data path"},
      {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"},
-     {"write_deletion_vectors", "Whether to write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)"}}};
+     {"write_deletion_vectors", "[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -38,7 +38,8 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
                       "'ducklake_rewrite_data_files', 'ducklake_delete_orphaned_files'"},
      {"encrypted", "Whether or not to encrypt Parquet files written to the data path"},
      {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"},
-     {"write_deletion_vectors", "[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)"}}};
+     {"write_deletion_vectors", "[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion "
+                                "vectors (puffin) instead of positional delete files (parquet)"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -96,6 +96,8 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else if (option == "per_thread_output") {
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
+	} else if (option == "write_deletion_vectors") {
+		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -20,6 +20,14 @@ struct DuckLakeFilePartition {
 	Value partition_value;
 };
 
+enum class DeleteFileFormat : uint8_t {
+	PARQUET, //! Positional delete file in Parquet format
+	PUFFIN   //! Deletion vector in Puffin format (Iceberg V3)
+};
+
+string DeleteFileFormatToString(DeleteFileFormat format);
+DeleteFileFormat DeleteFileFormatFromString(const string &str);
+
 enum class DeleteFileSource : uint8_t {
 	REGULAR, //! Regular delete file created during a DELETE operation
 	FLUSH    //! Delete file created during a flush operation (flushing inlined data)
@@ -34,6 +42,7 @@ struct DuckLakeDeleteFile {
 	DataFileIndex data_file_id;
 	string data_file_path;
 	string file_name;
+	DeleteFileFormat format = DeleteFileFormat::PARQUET;
 	idx_t delete_count;
 	idx_t file_size_bytes;
 	idx_t footer_size;

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -143,6 +143,11 @@ public:
 		return hive_file_pattern == "true";
 	}
 
+	bool WriteDeletionVectors(SchemaIndex schema_id, TableIndex table_id) const {
+		auto write_dv = GetConfigOption<string>("write_deletion_vectors", schema_id, table_id, "false");
+		return write_dv == "true";
+	}
+
 	void SetEncryption(DuckLakeEncryption encryption);
 	// Generate an encryption key for writing (or empty if encryption is disabled)
 	string GenerateEncryptionKey(ClientContext &context) const;

--- a/src/include/storage/ducklake_delete.hpp
+++ b/src/include/storage/ducklake_delete.hpp
@@ -80,6 +80,8 @@ struct DuckLakeDeleteFileWriter {
 	static DuckLakeDeleteFile WriteDeleteFile(ClientContext &context, WriteDeleteFileInput &input);
 	static DuckLakeDeleteFile WriteDeleteFileWithSnapshots(ClientContext &context,
 	                                                       WriteDeleteFileWithSnapshotsInput &input);
+	//! Write a deletion vector file (puffin format) instead of a parquet delete file
+	static DuckLakeDeleteFile WriteDeletionVectorFile(ClientContext &context, WriteDeleteFileInput &input);
 };
 
 struct DuckLakeDeleteMap {

--- a/src/include/storage/ducklake_delete.hpp
+++ b/src/include/storage/ducklake_delete.hpp
@@ -190,6 +190,12 @@ private:
 	                              const DuckLakeFileListExtendedEntry &data_file_info,
 	                              DuckLakeDeleteData &existing_delete_data, const set<idx_t> &sorted_deletes,
 	                              DuckLakeDeleteFile &delete_file) const;
+	//! Merge existing + new deletes into a single deletion vector (puffin) file
+	void FlushMergedDeletionVector(DuckLakeTransaction &transaction, ClientContext &context,
+	                               DuckLakeDeleteGlobalState &global_state, const string &filename,
+	                               const DuckLakeFileListExtendedEntry &data_file_info,
+	                               DuckLakeDeleteData &existing_delete_data, const set<idx_t> &sorted_deletes,
+	                               DuckLakeDeleteFile &delete_file) const;
 	//! Try to drop a file if all rows are deleted. Returns true if the file was dropped.
 	bool TryDropFullyDeletedFile(DuckLakeTransaction &transaction, const DuckLakeDeleteFile &delete_file,
 	                             const DuckLakeFileListExtendedEntry &data_file_info, idx_t delete_count) const;

--- a/src/include/storage/ducklake_delete_filter.hpp
+++ b/src/include/storage/ducklake_delete_filter.hpp
@@ -59,6 +59,8 @@ public:
 	static DeleteFileScanResult ScanDeleteFile(ClientContext &context, const DuckLakeFileData &delete_file,
 	                                           optional_idx snapshot_filter_min = optional_idx(),
 	                                           optional_idx snapshot_filter_max = optional_idx());
+	//! Scan a puffin deletion vector file and return the deleted row positions
+	static DeleteFileScanResult ScanDeletionVectorFile(ClientContext &context, const DuckLakeFileData &delete_file);
 
 private:
 	//! Scan the data file to get the global row_ids at specific file positions

--- a/src/include/storage/ducklake_deletion_vector.hpp
+++ b/src/include/storage/ducklake_deletion_vector.hpp
@@ -21,6 +21,8 @@ struct DuckLakeDeletionVectorData {
 public:
 	//! Deserialize a deletion vector from a puffin blob
 	static unique_ptr<DuckLakeDeletionVectorData> FromBlob(data_ptr_t blob_start, idx_t blob_length);
+	//! Serialize bitmaps into a deletion-vector-v1 puffin blob
+	static vector<data_t> ToBlob(const unordered_map<int32_t, roaring::Roaring> &bitmaps);
 
 	//! Convert the bitmaps to a sorted set of deleted row positions
 	void ToSet(set<idx_t> &out) const;

--- a/src/include/storage/ducklake_deletion_vector.hpp
+++ b/src/include/storage/ducklake_deletion_vector.hpp
@@ -21,8 +21,8 @@ struct DuckLakeDeletionVectorData {
 public:
 	//! Deserialize a deletion vector from a puffin blob
 	static unique_ptr<DuckLakeDeletionVectorData> FromBlob(data_ptr_t blob_start, idx_t blob_length);
-	//! Serialize bitmaps into a deletion-vector-v1 puffin blob
-	static vector<data_t> ToBlob(const unordered_map<int32_t, roaring::Roaring> &bitmaps);
+	//! Serialize deleted row positions into a deletion-vector-v1 puffin blob
+	static vector<data_t> ToBlob(const set<idx_t> &positions);
 
 	//! Convert the bitmaps to a sorted set of deleted row positions
 	void ToSet(set<idx_t> &out) const;

--- a/src/include/storage/ducklake_deletion_vector.hpp
+++ b/src/include/storage/ducklake_deletion_vector.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_deletion_vector.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/set.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include <roaring/roaring.hh>
+
+namespace duckdb {
+
+//! DuckLakeDeletionVectorData holds the roaring bitmap representation of deleted row positions.
+//! Follows the Iceberg deletion-vector-v1 blob format (puffin spec).
+struct DuckLakeDeletionVectorData {
+public:
+	//! Deserialize a deletion vector from a puffin blob
+	static unique_ptr<DuckLakeDeletionVectorData> FromBlob(data_ptr_t blob_start, idx_t blob_length);
+
+	//! Convert the bitmaps to a sorted set of deleted row positions
+	void ToSet(set<idx_t> &out) const;
+
+public:
+	//! Map from high 32-bit key to roaring bitmap of low 32-bit values
+	unordered_map<int32_t, roaring::Roaring> bitmaps;
+};
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -186,6 +186,7 @@ struct DuckLakeDeleteFileInfo {
 	TableIndex table_id;
 	DataFileIndex data_file_id;
 	string path;
+	DeleteFileFormat format = DeleteFileFormat::PARQUET;
 	idx_t delete_count;
 	idx_t file_size_bytes;
 	idx_t footer_size;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -352,6 +352,7 @@ struct DuckLakeFileData {
 	string encryption_key;
 	idx_t file_size_bytes = 0;
 	optional_idx footer_size;
+	DeleteFileFormat format = DeleteFileFormat::PARQUET;
 };
 
 enum class DuckLakeDataType {

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -290,9 +290,12 @@ private:
 	string FlushDrop(const string &metadata_table_name, const string &id_name, const set<T> &dropped_entries);
 	template <class T>
 	DuckLakeFileData ReadDataFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted);
+	template <class T>
+	DuckLakeFileData ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted);
 
 	bool IsEncrypted() const;
 	string GetFileSelectList(const string &prefix);
+	string GetDeleteFileSelectList(const string &prefix);
 	FilterPushdownQueryComponents GenerateFilterPushdownComponents(const FilterPushdownInfo &filter_info,
 	                                                               TableIndex table_id);
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   ducklake_multi_file_list.cpp
   ducklake_storage.cpp
   ducklake_delete.cpp
+  ducklake_deletion_vector.cpp
   ducklake_multi_file_reader.cpp
   ducklake_secret.cpp
   ducklake_stats.cpp

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -71,6 +71,12 @@ void DuckLakeCatalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 			options.config_options["data_inlining_row_limit"] = to_string(limit);
 		}
 	}
+	if (options.config_options.find("write_deletion_vectors") == options.config_options.end()) {
+		Value setting_val;
+		if (context->TryGetCurrentSetting("ducklake_default_write_deletion_vectors", setting_val)) {
+			options.config_options["write_deletion_vectors"] = setting_val.GetValue<bool>() ? "true" : "false";
+		}
+	}
 	DuckLakeInitializer initializer(*context, *this, options);
 	initializer.Initialize();
 	db.tags["data_path"] = DataPath();

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -73,7 +73,7 @@ void DuckLakeCatalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 	}
 	if (options.config_options.find("write_deletion_vectors") == options.config_options.end()) {
 		Value setting_val;
-		if (context->TryGetCurrentSetting("ducklake_default_write_deletion_vectors", setting_val)) {
+		if (context->TryGetCurrentSetting("ducklake_write_deletion_vectors", setting_val)) {
 			options.config_options["write_deletion_vectors"] = setting_val.GetValue<bool>() ? "true" : "false";
 		}
 	}

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -133,6 +133,7 @@ static DuckLakeDeleteFile WriteDeleteFileInternal(ClientContext &context, InputT
 	DuckLakeDeleteFile delete_file;
 	delete_file.data_file_path = input.data_file_path;
 	delete_file.file_name = delete_file_path;
+	delete_file.format = DeleteFileFormat::PARQUET;
 	delete_file.delete_count = stats.row_count;
 	delete_file.file_size_bytes = stats.file_size_bytes;
 	delete_file.footer_size = stats.footer_size_bytes.GetValue<idx_t>();
@@ -154,21 +155,12 @@ DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeleteFileWithSnapshots(Client
 }
 
 DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeletionVectorFile(ClientContext &context,
-                                                                      WriteDeleteFileInput &input) {
+                                                                     WriteDeleteFileInput &input) {
 	auto delete_file_uuid = "ducklake-" + input.transaction.GenerateUUID() + "-delete.puffin";
 	string delete_file_path = DuckLakeUtil::JoinPath(input.fs, input.data_path, delete_file_uuid);
 
-	// Build roaring bitmaps grouped by high 32 bits
-	unordered_map<int32_t, roaring::Roaring> bitmaps;
-	for (auto row_idx : input.positions) {
-		int64_t row_id = static_cast<int64_t>(row_idx);
-		int32_t high_bits = static_cast<int32_t>(row_id >> 32);
-		uint32_t low_bits = static_cast<uint32_t>(row_id & 0xFFFFFFFF);
-		bitmaps[high_bits].add(low_bits);
-	}
-
-	// Serialize to blob
-	auto blob_data = DuckLakeDeletionVectorData::ToBlob(bitmaps);
+	// Serialize positions to puffin blob
+	auto blob_data = DuckLakeDeletionVectorData::ToBlob(input.positions);
 
 	// Write blob to file
 	auto &fs = FileSystem::GetFileSystem(context);
@@ -372,52 +364,60 @@ bool DuckLakeDelete::TryDropFullyDeletedFile(DuckLakeTransaction &transaction, c
 	return true;
 }
 
+void DuckLakeDelete::FlushMergedDeletionVector(DuckLakeTransaction &transaction, ClientContext &context,
+                                               DuckLakeDeleteGlobalState &global_state, const string &filename,
+                                               const DuckLakeFileListExtendedEntry &data_file_info,
+                                               DuckLakeDeleteData &existing_delete_data,
+                                               const set<idx_t> &sorted_deletes,
+                                               DuckLakeDeleteFile &delete_file) const {
+	// Deletion vectors don't support per-position snapshot tracking.
+	// Merge all positions (existing + new) into a flat set, like the old pre-snapshot code.
+	set<idx_t> all_deletes = sorted_deletes;
+	auto &existing_deletes = existing_delete_data.deleted_rows;
+	all_deletes.insert(existing_deletes.begin(), existing_deletes.end());
+
+	// clear the deletes from the map
+	delete_map->ClearDeletes(filename);
+
+	// set the delete file as overwriting existing deletes
+	delete_file.overwrites_existing_delete = true;
+
+	if (TryDropFullyDeletedFile(transaction, delete_file, data_file_info, all_deletes.size())) {
+		return;
+	}
+
+	auto &fs = FileSystem::GetFileSystem(context);
+	WriteDeleteFileInput input {context,        transaction, fs,          table.DataPath(),
+	                            encryption_key, filename,    all_deletes, DeleteFileSource::REGULAR};
+	auto written_file = DuckLakeDeleteFileWriter::WriteDeletionVectorFile(context, input);
+
+	written_file.data_file_id = delete_file.data_file_id;
+	written_file.overwrites_existing_delete = delete_file.overwrites_existing_delete;
+	// track the old delete file for deletion from metadata
+	written_file.overwritten_delete_file.delete_file_id = data_file_info.delete_file_id;
+	written_file.overwritten_delete_file.path = data_file_info.delete_file.path;
+
+	global_state.written_files.emplace(filename, std::move(written_file));
+}
+
 void DuckLakeDelete::FlushDeleteWithSnapshots(DuckLakeTransaction &transaction, ClientContext &context,
                                               DuckLakeDeleteGlobalState &global_state, const string &filename,
                                               const DuckLakeFileListExtendedEntry &data_file_info,
                                               DuckLakeDeleteData &existing_delete_data,
                                               const set<idx_t> &sorted_deletes, DuckLakeDeleteFile &delete_file) const {
+	auto &catalog = table.catalog.Cast<DuckLakeCatalog>();
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	if (catalog.WriteDeletionVectors(schema.GetSchemaId(), table.GetTableId())) {
+		FlushMergedDeletionVector(transaction, context, global_state, filename, data_file_info, existing_delete_data,
+		                          sorted_deletes, delete_file);
+		return;
+	}
+
 	auto existing_snapshot = data_file_info.delete_file_begin_snapshot;
 
 	// the commit snapshot for new deletes is current_snapshot + 1
 	const auto current_snapshot = transaction.GetSnapshot();
 	const idx_t new_delete_snapshot = current_snapshot.snapshot_id + 1;
-
-	auto &catalog = table.catalog.Cast<DuckLakeCatalog>();
-	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
-	bool use_deletion_vectors = catalog.WriteDeletionVectors(schema.GetSchemaId(), table.GetTableId());
-
-	if (use_deletion_vectors) {
-		// Deletion vectors don't support per-position snapshot tracking.
-		// Merge all positions (existing + new) into a flat set, like the old pre-snapshot code.
-		set<idx_t> all_deletes = sorted_deletes;
-		auto &existing_deletes = existing_delete_data.deleted_rows;
-		all_deletes.insert(existing_deletes.begin(), existing_deletes.end());
-
-		// clear the deletes from the map
-		delete_map->ClearDeletes(filename);
-
-		// set the delete file as overwriting existing deletes
-		delete_file.overwrites_existing_delete = true;
-
-		if (TryDropFullyDeletedFile(transaction, delete_file, data_file_info, all_deletes.size())) {
-			return;
-		}
-
-		auto &fs = FileSystem::GetFileSystem(context);
-		WriteDeleteFileInput input {context,   transaction,           fs,       table.DataPath(),
-		                            encryption_key, filename, all_deletes, DeleteFileSource::REGULAR};
-		auto written_file = DuckLakeDeleteFileWriter::WriteDeletionVectorFile(context, input);
-
-		written_file.data_file_id = delete_file.data_file_id;
-		written_file.overwrites_existing_delete = delete_file.overwrites_existing_delete;
-		// track the old delete file for deletion from metadata
-		written_file.overwritten_delete_file.delete_file_id = data_file_info.delete_file_id;
-		written_file.overwritten_delete_file.path = data_file_info.delete_file.path;
-
-		global_state.written_files.emplace(filename, std::move(written_file));
-		return;
-	}
 
 	set<PositionWithSnapshot> sorted_deletes_with_snapshots;
 	// add existing deletes with their snapshot IDs

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -383,6 +383,42 @@ void DuckLakeDelete::FlushDeleteWithSnapshots(DuckLakeTransaction &transaction, 
 	const auto current_snapshot = transaction.GetSnapshot();
 	const idx_t new_delete_snapshot = current_snapshot.snapshot_id + 1;
 
+	auto &catalog = table.catalog.Cast<DuckLakeCatalog>();
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	bool use_deletion_vectors = catalog.WriteDeletionVectors(schema.GetSchemaId(), table.GetTableId());
+
+	if (use_deletion_vectors) {
+		// Deletion vectors don't support per-position snapshot tracking.
+		// Merge all positions (existing + new) into a flat set, like the old pre-snapshot code.
+		set<idx_t> all_deletes = sorted_deletes;
+		auto &existing_deletes = existing_delete_data.deleted_rows;
+		all_deletes.insert(existing_deletes.begin(), existing_deletes.end());
+
+		// clear the deletes from the map
+		delete_map->ClearDeletes(filename);
+
+		// set the delete file as overwriting existing deletes
+		delete_file.overwrites_existing_delete = true;
+
+		if (TryDropFullyDeletedFile(transaction, delete_file, data_file_info, all_deletes.size())) {
+			return;
+		}
+
+		auto &fs = FileSystem::GetFileSystem(context);
+		WriteDeleteFileInput input {context,   transaction,           fs,       table.DataPath(),
+		                            encryption_key, filename, all_deletes, DeleteFileSource::REGULAR};
+		auto written_file = DuckLakeDeleteFileWriter::WriteDeletionVectorFile(context, input);
+
+		written_file.data_file_id = delete_file.data_file_id;
+		written_file.overwrites_existing_delete = delete_file.overwrites_existing_delete;
+		// track the old delete file for deletion from metadata
+		written_file.overwritten_delete_file.delete_file_id = data_file_info.delete_file_id;
+		written_file.overwritten_delete_file.path = data_file_info.delete_file.path;
+
+		global_state.written_files.emplace(filename, std::move(written_file));
+		return;
+	}
+
 	set<PositionWithSnapshot> sorted_deletes_with_snapshots;
 	// add existing deletes with their snapshot IDs
 	MergeDeletesWithSnapshots(existing_delete_data, existing_snapshot.GetIndex(), sorted_deletes_with_snapshots);

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -1,4 +1,5 @@
 #include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_deletion_vector.hpp"
 #include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/common/multi_file/multi_file_function.hpp"
@@ -150,6 +151,42 @@ DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeleteFile(ClientContext &cont
 DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeleteFileWithSnapshots(ClientContext &context,
                                                                           WriteDeleteFileWithSnapshotsInput &input) {
 	return WriteDeleteFileInternal(context, input);
+}
+
+DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeletionVectorFile(ClientContext &context,
+                                                                      WriteDeleteFileInput &input) {
+	auto delete_file_uuid = "ducklake-" + input.transaction.GenerateUUID() + "-delete.puffin";
+	string delete_file_path = DuckLakeUtil::JoinPath(input.fs, input.data_path, delete_file_uuid);
+
+	// Build roaring bitmaps grouped by high 32 bits
+	unordered_map<int32_t, roaring::Roaring> bitmaps;
+	for (auto row_idx : input.positions) {
+		int64_t row_id = static_cast<int64_t>(row_idx);
+		int32_t high_bits = static_cast<int32_t>(row_id >> 32);
+		uint32_t low_bits = static_cast<uint32_t>(row_id & 0xFFFFFFFF);
+		bitmaps[high_bits].add(low_bits);
+	}
+
+	// Serialize to blob
+	auto blob_data = DuckLakeDeletionVectorData::ToBlob(bitmaps);
+
+	// Write blob to file
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto file_handle =
+	    fs.OpenFile(delete_file_path, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
+	file_handle->Write(blob_data.data(), blob_data.size());
+	file_handle->Close();
+
+	DuckLakeDeleteFile delete_file;
+	delete_file.data_file_path = input.data_file_path;
+	delete_file.file_name = delete_file_path;
+	delete_file.format = DeleteFileFormat::PUFFIN;
+	delete_file.delete_count = input.positions.size();
+	delete_file.file_size_bytes = blob_data.size();
+	delete_file.footer_size = 0;
+	delete_file.encryption_key = input.encryption_key;
+	delete_file.source = input.source;
+	return delete_file;
 }
 
 //===--------------------------------------------------------------------===//
@@ -472,6 +509,10 @@ void DuckLakeDelete::FlushDelete(DuckLakeTransaction &transaction, ClientContext
 	}
 
 	auto &fs = FileSystem::GetFileSystem(context);
+	auto &catalog = table.catalog.Cast<DuckLakeCatalog>();
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	bool use_deletion_vectors = catalog.WriteDeletionVectors(schema.GetSchemaId(), table.GetTableId());
+
 	WriteDeleteFileInput input {context,
 	                            transaction,
 	                            fs,
@@ -480,7 +521,8 @@ void DuckLakeDelete::FlushDelete(DuckLakeTransaction &transaction, ClientContext
 	                            filename,
 	                            sorted_deletes,
 	                            DeleteFileSource::REGULAR};
-	auto written_file = DuckLakeDeleteFileWriter::WriteDeleteFile(context, input);
+	auto written_file = use_deletion_vectors ? DuckLakeDeleteFileWriter::WriteDeletionVectorFile(context, input)
+	                                         : DuckLakeDeleteFileWriter::WriteDeleteFile(context, input);
 
 	written_file.data_file_id = delete_file.data_file_id;
 	written_file.overwrites_existing_delete = delete_file.overwrites_existing_delete;

--- a/src/storage/ducklake_delete_filter.cpp
+++ b/src/storage/ducklake_delete_filter.cpp
@@ -1,9 +1,11 @@
 #include "storage/ducklake_delete_filter.hpp"
+#include "storage/ducklake_deletion_vector.hpp"
 #include "common/parquet_file_scanner.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
@@ -107,9 +109,36 @@ idx_t DuckLakeDeleteFilter::Filter(row_t start_row_index, idx_t count, Selection
 	return delete_data->Filter(start_row_index, count, result_sel, snapshot_filter);
 }
 
+DeleteFileScanResult DuckLakeDeleteFilter::ScanDeletionVectorFile(ClientContext &context,
+                                                                  const DuckLakeFileData &delete_file) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	auto file_handle = fs.OpenFile(delete_file.path, FileOpenFlags::FILE_FLAGS_READ);
+	auto file_size = file_handle->GetFileSize();
+
+	auto buffer = make_unsafe_uniq_array<data_t>(file_size);
+	file_handle->Read(buffer.get(), file_size);
+
+	auto dv_data = DuckLakeDeletionVectorData::FromBlob(buffer.get(), file_size);
+
+	DeleteFileScanResult result;
+	result.has_embedded_snapshots = false;
+
+	set<idx_t> deleted_set;
+	dv_data->ToSet(deleted_set);
+	for (auto &pos : deleted_set) {
+		result.deleted_rows.push_back(pos);
+	}
+	return result;
+}
+
 DeleteFileScanResult DuckLakeDeleteFilter::ScanDeleteFile(ClientContext &context, const DuckLakeFileData &delete_file,
                                                           optional_idx snapshot_filter_min,
                                                           optional_idx snapshot_filter_max) {
+	// Check if this is a puffin deletion vector file
+	if (StringUtil::EndsWith(delete_file.path, ".puffin")) {
+		return ScanDeletionVectorFile(context, delete_file);
+	}
+
 	// Set up custom MultiFileReader to avoid HEAD requests
 	auto function_info = make_shared_ptr<DeleteFileFunctionInfo>();
 	function_info->file_data = delete_file;

--- a/src/storage/ducklake_delete_filter.cpp
+++ b/src/storage/ducklake_delete_filter.cpp
@@ -135,7 +135,7 @@ DeleteFileScanResult DuckLakeDeleteFilter::ScanDeleteFile(ClientContext &context
                                                           optional_idx snapshot_filter_min,
                                                           optional_idx snapshot_filter_max) {
 	// Check if this is a puffin deletion vector file
-	if (StringUtil::EndsWith(delete_file.path, ".puffin")) {
+	if (delete_file.format == DeleteFileFormat::PUFFIN) {
 		return ScanDeletionVectorFile(context, delete_file);
 	}
 

--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -119,6 +119,59 @@ unique_ptr<DuckLakeDeletionVectorData> DuckLakeDeletionVectorData::FromBlob(data
 	return result;
 }
 
+vector<data_t> DuckLakeDeletionVectorData::ToBlob(const unordered_map<int32_t, roaring::Roaring> &bitmaps) {
+	//! https://iceberg.apache.org/puffin-spec/#deletion-vector-v1-blob-type
+
+	// Calculate total size needed
+	idx_t total_size = 0;
+	total_size += sizeof(uint32_t); // vector_size field
+	total_size += sizeof(uint32_t); // magic bytes
+	total_size += sizeof(uint64_t); // amount of bitmaps
+	for (const auto &entry : bitmaps) {
+		total_size += sizeof(int32_t);                   // key
+		total_size += entry.second.getSizeInBytes(true); // portable serialized bitmap
+	}
+	total_size += sizeof(uint32_t); // CRC checksum
+
+	vector<data_t> blob_output;
+	blob_output.resize(total_size);
+	data_ptr_t blob_ptr = blob_output.data();
+
+	// Write vector_size (total_size - (CRC checksum + vector_size field))
+	uint32_t vector_size = BSwap(static_cast<uint32_t>(total_size - sizeof(uint32_t) - sizeof(uint32_t)));
+	Store<uint32_t>(vector_size, blob_ptr);
+	blob_ptr += sizeof(uint32_t);
+
+	auto checksummed_data_start = blob_ptr;
+	constexpr uint8_t DELETION_VECTOR_MAGIC[4] = {0xD1, 0xD3, 0x39, 0x64};
+	memcpy(blob_ptr, DELETION_VECTOR_MAGIC, 4);
+	blob_ptr += sizeof(uint32_t);
+
+	// Write bitmap count
+	Store<uint64_t>(bitmaps.size(), blob_ptr);
+	blob_ptr += sizeof(uint64_t);
+
+	// Write each bitmap
+	for (const auto &entry : bitmaps) {
+		// Write key (high 32 bits)
+		Store<int32_t>(entry.first, blob_ptr);
+		blob_ptr += sizeof(int32_t);
+
+		// Write bitmap (portable format)
+		size_t bitmap_size = entry.second.write((char *)blob_ptr, true);
+		blob_ptr += bitmap_size;
+	}
+
+	// Compute and write CRC checksum
+	auto checksummed_data_length = blob_ptr - checksummed_data_start;
+	CRC32 crc;
+	crc.Update(checksummed_data_start, checksummed_data_length);
+	uint32_t checksum = crc.GetValue();
+
+	Store<uint32_t>(BSwap(checksum), blob_ptr);
+	return blob_output;
+}
+
 namespace {
 
 struct RoaringIterateContext {

--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -119,8 +119,16 @@ unique_ptr<DuckLakeDeletionVectorData> DuckLakeDeletionVectorData::FromBlob(data
 	return result;
 }
 
-vector<data_t> DuckLakeDeletionVectorData::ToBlob(const unordered_map<int32_t, roaring::Roaring> &bitmaps) {
+vector<data_t> DuckLakeDeletionVectorData::ToBlob(const set<idx_t> &positions) {
 	//! https://iceberg.apache.org/puffin-spec/#deletion-vector-v1-blob-type
+
+	// Group row positions by high 32 bits into roaring bitmaps
+	unordered_map<int32_t, roaring::Roaring> bitmaps;
+	for (auto row_idx : positions) {
+		int32_t high_bits = static_cast<int32_t>(static_cast<int64_t>(row_idx) >> 32);
+		uint32_t low_bits = static_cast<uint32_t>(row_idx & 0xFFFFFFFF);
+		bitmaps[high_bits].add(low_bits);
+	}
 
 	// Calculate total size needed
 	idx_t total_size = 0;

--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -1,0 +1,147 @@
+#include "storage/ducklake_deletion_vector.hpp"
+
+#include "duckdb/common/bswap.hpp"
+
+namespace duckdb {
+
+namespace {
+
+class CRC32 {
+public:
+	CRC32() : crc(0xFFFFFFFF) {
+		InitTable();
+	}
+
+public:
+	static void InitTable() {
+		if (table_initialized)
+			return;
+
+		for (uint32_t i = 0; i < 256; i++) {
+			uint32_t c = i;
+			for (int j = 0; j < 8; j++) {
+				if (c & 1) {
+					c = 0xEDB88320 ^ (c >> 1);
+				} else {
+					c = c >> 1;
+				}
+			}
+			crc_table[i] = c;
+		}
+		table_initialized = true;
+	}
+
+public:
+	void Update(const data_t *data, idx_t length) {
+		for (idx_t i = 0; i < length; i++) {
+			crc = crc_table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+		}
+	}
+
+	uint32_t GetValue() const {
+		return crc ^ 0xFFFFFFFF;
+	}
+
+private:
+	uint32_t crc;
+	static uint32_t crc_table[256];
+	static bool table_initialized;
+};
+
+uint32_t CRC32::crc_table[256];
+bool CRC32::table_initialized = false;
+
+} // namespace
+
+unique_ptr<DuckLakeDeletionVectorData> DuckLakeDeletionVectorData::FromBlob(data_ptr_t blob_start, idx_t blob_length) {
+	//! https://iceberg.apache.org/puffin-spec/#deletion-vector-v1-blob-type
+
+	if (blob_length < 12) {
+		throw InvalidInputException("Blob is too small (length of %d bytes) to be a deletion-vector-v1", blob_length);
+	}
+
+	auto blob_end = blob_start + blob_length;
+	auto vector_size = Load<uint32_t>(blob_start);
+	vector_size = BSwap(vector_size);
+	blob_start += sizeof(uint32_t);
+	D_ASSERT(blob_start < blob_end);
+
+	constexpr char DELETION_VECTOR_MAGIC[] = {'\xD1', '\xD3', '\x39', '\x64'};
+	char magic_bytes[4];
+
+	auto checksummed_data_start = blob_start;
+	memcpy(magic_bytes, blob_start, 4);
+	blob_start += 4;
+	vector_size -= 4;
+	D_ASSERT(blob_start < blob_end);
+
+	auto memcmp_res = memcmp(DELETION_VECTOR_MAGIC, magic_bytes, 4);
+	if (memcmp_res != 0) {
+		throw InvalidInputException("Magic bytes mismatch, deletion vector is corrupt!");
+	}
+
+	int64_t amount_of_bitmaps = Load<int64_t>(blob_start);
+	blob_start += sizeof(int64_t);
+	vector_size -= sizeof(int64_t);
+	D_ASSERT(blob_start < blob_end);
+
+	auto result = make_uniq<DuckLakeDeletionVectorData>();
+	result->bitmaps.reserve(amount_of_bitmaps);
+	for (int64_t i = 0; i < amount_of_bitmaps; i++) {
+		auto key = Load<int32_t>(blob_start);
+		blob_start += sizeof(int32_t);
+		vector_size -= sizeof(int32_t);
+		D_ASSERT(blob_start < blob_end);
+
+		size_t bitmap_size =
+		    roaring::api::roaring_bitmap_portable_deserialize_size((const char *)blob_start, vector_size);
+		auto bitmap = roaring::Roaring::readSafe((const char *)blob_start, bitmap_size);
+		blob_start += bitmap_size;
+		vector_size -= bitmap_size;
+		D_ASSERT(blob_start < blob_end);
+		result->bitmaps.emplace(key, std::move(bitmap));
+	}
+
+	//! Compute and compare the checksum
+	auto checksummed_data_length = blob_start - checksummed_data_start;
+	auto stored_checksum = BSwap(Load<uint32_t>(blob_start));
+	blob_start += sizeof(uint32_t);
+	D_ASSERT(blob_start == blob_end);
+
+	CRC32 crc;
+	crc.Update(checksummed_data_start, checksummed_data_length);
+	uint32_t checksum = crc.GetValue();
+	if (checksum != stored_checksum) {
+		throw InvalidInputException(
+		    "Stored checksum (%d) does not match computed checksum (%d), the DeletionVector is corrupted",
+		    stored_checksum, checksum);
+	}
+	return result;
+}
+
+namespace {
+
+struct RoaringIterateContext {
+	set<idx_t> *out;
+	idx_t high;
+};
+
+} // namespace
+
+void DuckLakeDeletionVectorData::ToSet(set<idx_t> &out) const {
+	for (auto &entry : bitmaps) {
+		RoaringIterateContext ctx {&out, static_cast<idx_t>(entry.first)};
+		auto &bitmap = entry.second;
+
+		bitmap.iterate(
+		    [](uint32_t value, void *ptr) -> bool {
+			    auto *ctx = static_cast<RoaringIterateContext *>(ptr);
+			    idx_t full_value = (ctx->high << 32) | static_cast<idx_t>(value);
+			    ctx->out->insert(full_value);
+			    return true;
+		    },
+		    &ctx);
+	}
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3268,9 +3268,10 @@ string DuckLakeMetadataManager::WriteNewDeleteFiles(const vector<DuckLakeDeleteF
 		    file.begin_snapshot.IsValid() ? std::to_string(file.begin_snapshot.GetIndex()) : "{SNAPSHOT_ID}";
 		string partial_max = file.max_snapshot.IsValid() ? to_string(file.max_snapshot.GetIndex()) : "NULL";
 		delete_file_insert_query += StringUtil::Format(
-		    "(%d, %d, %s, NULL,  %d, %s, %s, 'parquet', %d, %d, %d, %s, %s)", delete_file_index, table_id,
+		    "(%d, %d, %s, NULL,  %d, %s, %s, %s, %d, %d, %d, %s, %s)", delete_file_index, table_id,
 		    begin_snapshot_str, data_file_index, SQLString(path.path), path.path_is_relative ? "true" : "false",
-		    file.delete_count, file.file_size_bytes, file.footer_size, encryption_key, partial_max);
+		    SQLString(DeleteFileFormatToString(file.format)), file.delete_count, file.file_size_bytes, file.footer_size,
+		    encryption_key, partial_max);
 	}
 
 	// insert the data files

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -887,6 +887,10 @@ string DuckLakeMetadataManager::GetFileSelectList(const string &prefix) {
 	return result;
 }
 
+string DuckLakeMetadataManager::GetDeleteFileSelectList(const string &prefix) {
+	return GetFileSelectList(prefix) + ", " + prefix + ".format AS " + prefix + "_format";
+}
+
 template <class T>
 DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx,
                                                        bool is_encrypted) {
@@ -916,6 +920,17 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table
 		}
 		data.encryption_key = Blob::FromBase64(row.template GetValue<string>(col_idx++));
 	}
+	return data;
+}
+
+template <class T>
+DuckLakeFileData DuckLakeMetadataManager::ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx,
+                                                         bool is_encrypted) {
+	auto data = ReadDataFile(table, row, col_idx, is_encrypted);
+	if (!row.IsNull(col_idx)) {
+		data.format = DeleteFileFormatFromString(row.template GetValue<string>(col_idx));
+	}
+	col_idx++;
 	return data;
 }
 
@@ -1354,7 +1369,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 
 	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
 	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
-	                     GetFileSelectList("del") + stats_select_list;
+	                     GetDeleteFileSelectList("del") + stats_select_list;
 
 	string query;
 	string where_clause;
@@ -1415,7 +1430,7 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 			file_entry.mapping_id = MappingIndex(row.GetValue<idx_t>(col_idx));
 		}
 		col_idx++;
-		file_entry.delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
+		file_entry.delete_file = ReadDeleteFile(table, row, col_idx, IsEncrypted());
 		for (auto &dfc : dynamic_filter_columns) {
 			string min_val;
 			string max_val;
@@ -1448,7 +1463,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetTableInsertions(DuckLa
 	auto table_id = table.GetTableId();
 	string select_list = GetFileSelectList("data") +
 	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
-	                     GetFileSelectList("del");
+	                     GetDeleteFileSelectList("del");
 	// Files either match the exact snapshot range
 	// Or they have partial_max set, which means they are a file with many snapshot ids, and might contain
 	// the snapshot we need
@@ -1461,7 +1476,8 @@ FROM {METADATA_CATALOG}.ducklake_data_file data, (
 		CAST(NULL AS BOOLEAN) path_is_relative,
 		CAST(NULL AS BIGINT) file_size_bytes,
 		CAST(NULL AS BIGINT) footer_size,
-		CAST(NULL AS VARCHAR) encryption_key
+		CAST(NULL AS VARCHAR) encryption_key,
+		CAST(NULL AS VARCHAR) format
 ) del
 WHERE data.table_id=%d AND data.begin_snapshot <= {SNAPSHOT_ID} AND (
 	(data.begin_snapshot >= %d) OR
@@ -1500,7 +1516,7 @@ WHERE data.table_id=%d AND data.begin_snapshot <= {SNAPSHOT_ID} AND (
 			file_entry.mapping_id = MappingIndex(row.GetValue<idx_t>(col_idx));
 		}
 		col_idx++;
-		file_entry.delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
+		file_entry.delete_file = ReadDeleteFile(table, row, col_idx, IsEncrypted());
 		files.push_back(std::move(file_entry));
 	}
 	return files;
@@ -1512,7 +1528,7 @@ vector<DuckLakeDeleteScanEntry> DuckLakeMetadataManager::GetTableDeletions(DuckL
 	auto table_id = table.GetTableId();
 	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
 	                     ", data.row_id_start, data.record_count, data.mapping_id, " +
-	                     GetFileSelectList("current_delete") + ", " + GetFileSelectList("previous_delete");
+	                     GetDeleteFileSelectList("current_delete") + ", " + GetDeleteFileSelectList("previous_delete");
 
 	// Check if we have an inlined deletion table for this table (usually cached, no DB hit)
 	auto inlined_table_name = GetInlinedDeletionTableName(table_id, end_snapshot);
@@ -1547,7 +1563,7 @@ main_results AS (
 	// Main query: partial deletes from delete_file table and full file deletes
 	query += StringUtil::Format(R"(
 SELECT %s, current_delete.begin_snapshot FROM (
-	SELECT data_file_id, begin_snapshot, path, path_is_relative, file_size_bytes, footer_size, encryption_key
+	SELECT data_file_id, begin_snapshot, path, path_is_relative, file_size_bytes, footer_size, encryption_key, format
 	FROM {METADATA_CATALOG}.ducklake_delete_file
 	WHERE table_id = %d AND begin_snapshot <= {SNAPSHOT_ID}
 ) AS current_delete
@@ -1558,7 +1574,8 @@ LEFT JOIN LATERAL (
 		path_is_relative,
 		file_size_bytes,
 		footer_size,
-		encryption_key
+		encryption_key,
+		format
 	FROM {METADATA_CATALOG}.ducklake_delete_file
 	WHERE table_id = %d AND begin_snapshot < %d
 	ORDER BY data_file_id, begin_snapshot DESC
@@ -1585,13 +1602,14 @@ LEFT JOIN LATERAL (
 		path_is_relative,
 		file_size_bytes,
 		footer_size,
-		encryption_key
+		encryption_key,
+		format
 	FROM {METADATA_CATALOG}.ducklake_delete_file
 	WHERE table_id = %d AND begin_snapshot < data.end_snapshot
 	ORDER BY data_file_id, begin_snapshot DESC
 ) AS previous_delete
 USING (data_file_id), (
-	SELECT NULL path, NULL path_is_relative, NULL file_size_bytes, NULL footer_size, NULL encryption_key
+	SELECT NULL path, NULL path_is_relative, NULL file_size_bytes, NULL footer_size, NULL encryption_key, NULL format
 ) current_delete
 )",
 	                            select_list, table_id.index, table_id.index, start_snapshot.snapshot_id, table_id.index,
@@ -1602,6 +1620,7 @@ USING (data_file_id), (
 		if (IsEncrypted()) {
 			null_file_cols += ", NULL encryption_key";
 		}
+		null_file_cols += ", NULL format";
 		query += StringUtil::Format(R"(
 UNION ALL
 
@@ -1660,8 +1679,8 @@ FROM main_results
 			entry.mapping_id = MappingIndex(row.GetValue<idx_t>(col_idx));
 		}
 		col_idx++;
-		entry.delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
-		entry.previous_delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
+		entry.delete_file = ReadDeleteFile(table, row, col_idx, IsEncrypted());
+		entry.previous_delete_file = ReadDeleteFile(table, row, col_idx, IsEncrypted());
 		entry.snapshot_id = row.GetValue<idx_t>(col_idx++);
 		// store the snapshot range for filtering embedded snapshot IDs
 		entry.start_snapshot = start_snapshot.snapshot_id;
@@ -1690,7 +1709,7 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
                                                   const FilterPushdownInfo *filter_info) {
 	auto table_id = table.GetTableId();
 	string select_list =
-	    GetFileSelectList("data") + ", data.row_id_start, " + GetFileSelectList("del") + ", del.begin_snapshot";
+	    GetFileSelectList("data") + ", data.row_id_start, " + GetDeleteFileSelectList("del") + ", del.begin_snapshot";
 
 	string query;
 	string where_clause;
@@ -1739,7 +1758,7 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 			file_entry.row_id_start = row.GetValue<idx_t>(col_idx);
 		}
 		col_idx++;
-		file_entry.delete_file = ReadDataFile(table, row, col_idx, IsEncrypted());
+		file_entry.delete_file = ReadDeleteFile(table, row, col_idx, IsEncrypted());
 		if (!row.IsNull(col_idx)) {
 			file_entry.delete_file_begin_snapshot = row.GetValue<idx_t>(col_idx);
 		}
@@ -1768,7 +1787,7 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	                            "del.begin_snapshot AS del_begin_snapshot, "
 	                            "del.end_snapshot AS del_end_snapshot, "
 	                            "del.partial_max AS del_partial_max, " +
-	                            GetFileSelectList("del");
+	                            GetDeleteFileSelectList("del");
 	string select_list = data_select_list + ", " + delete_select_list;
 	string deletion_threshold_clause;
 	if (type == CompactionType::REWRITE_DELETES) {
@@ -1875,7 +1894,7 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 			delete_file.max_snapshot = row.GetValue<idx_t>(col_idx);
 		}
 		col_idx++;
-		delete_file.data = ReadDataFile(table, row, col_idx, IsEncrypted());
+		delete_file.data = ReadDeleteFile(table, row, col_idx, IsEncrypted());
 		file_entry.delete_files.push_back(std::move(delete_file));
 	}
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3268,8 +3268,8 @@ string DuckLakeMetadataManager::WriteNewDeleteFiles(const vector<DuckLakeDeleteF
 		    file.begin_snapshot.IsValid() ? std::to_string(file.begin_snapshot.GetIndex()) : "{SNAPSHOT_ID}";
 		string partial_max = file.max_snapshot.IsValid() ? to_string(file.max_snapshot.GetIndex()) : "NULL";
 		delete_file_insert_query += StringUtil::Format(
-		    "(%d, %d, %s, NULL,  %d, %s, %s, %s, %d, %d, %d, %s, %s)", delete_file_index, table_id,
-		    begin_snapshot_str, data_file_index, SQLString(path.path), path.path_is_relative ? "true" : "false",
+		    "(%d, %d, %s, NULL,  %d, %s, %s, %s, %d, %d, %d, %s, %s)", delete_file_index, table_id, begin_snapshot_str,
+		    data_file_index, SQLString(path.path), path.path_is_relative ? "true" : "false",
 		    SQLString(DeleteFileFormatToString(file.format)), file.delete_count, file.file_size_bytes, file.footer_size,
 		    encryption_key, partial_max);
 	}

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -221,6 +221,7 @@ DuckLakeFileData GetDeleteData(const DuckLakeDataFile &file) {
 	result.encryption_key = delete_file.encryption_key;
 	result.file_size_bytes = delete_file.file_size_bytes;
 	result.footer_size = delete_file.footer_size;
+	result.format = delete_file.format;
 	return result;
 }
 

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -47,6 +47,9 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 	} else if (StringUtil::StartsWith(lcase, "meta_")) {
 		auto parameter_name = lcase.substr(5);
 		options.metadata_parameters[parameter_name] = value;
+	} else if (lcase == "write_deletion_vectors") {
+		options.config_options["write_deletion_vectors"] =
+		    BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN)) ? "true" : "false";
 	} else if (lcase == "create_if_not_exists") {
 		options.create_if_not_exists = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "automatic_migration") {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2056,6 +2056,7 @@ DuckLakeDeleteFileInfo DuckLakeTransaction::GetNewDeleteFile(TableIndex table_id
 	delete_file.table_id = table_id;
 	delete_file.data_file_id = file.data_file_id;
 	delete_file.path = file.file_name;
+	delete_file.format = file.format;
 	delete_file.delete_count = file.delete_count;
 	delete_file.file_size_bytes = file.file_size_bytes;
 	delete_file.footer_size = file.footer_size;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -486,6 +486,7 @@ void LocalTableChanges::GetLocalDeleteForFile(TableIndex table_id, const string 
 	result.file_size_bytes = delete_file.file_size_bytes;
 	result.footer_size = delete_file.footer_size;
 	result.encryption_key = delete_file.encryption_key;
+	result.format = delete_file.format;
 }
 
 bool LocalTableChanges::HasLocalInlinedFileDeletes(TableIndex table_id) const {

--- a/test/configs/deletion_vectors.json
+++ b/test/configs/deletion_vectors.json
@@ -1,0 +1,35 @@
+{
+  "description": "Run DuckLake tests with deletion vectors enabled (puffin format instead of parquet delete files).",
+  "on_init": "SET ducklake_default_write_deletion_vectors = true;",
+  "statically_loaded_extensions": [
+    "core_functions",
+    "parquet",
+    "ducklake",
+    "icu"
+  ],
+  "skip_tests": [
+    {
+      "reason": "Parquet is statically loaded in this config, test requires missing parquet",
+      "paths": [
+        "test/sql/general/missing_parquet.test"
+      ]
+    },
+    {
+      "reason": "Deletion vectors do not support per-position snapshot tracking, breaking tests that rely on precise time travel across multiple deletes or parquet-specific delete file metadata",
+      "paths": [
+        "test/sql/delete/delete_file_stats.test",
+        "test/sql/delete/delete_same_transaction.test",
+        "test/sql/delete/multi_deletes.test",
+        "test/sql/table_changes/ducklake_table_deletions_compacted.test",
+        "test/sql/table_changes/ducklake_table_deletions_large.test",
+        "test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test",
+        "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
+        "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",
+        "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
+        "test/sql/rewrite_data_files/test_rewrite_db.test",
+        "test/sql/alter/alter_timestamptz_promotion.test",
+        "test/sql/alter/test_insert_select_alter_column_persistence.test"
+      ]
+    }
+  ]
+}

--- a/test/configs/deletion_vectors.json
+++ b/test/configs/deletion_vectors.json
@@ -1,6 +1,6 @@
 {
   "description": "Run DuckLake tests with deletion vectors enabled (puffin format instead of parquet delete files).",
-  "on_init": "SET ducklake_default_write_deletion_vectors = true;",
+  "on_init": "SET ducklake_write_deletion_vectors = true;",
   "statically_loaded_extensions": [
     "core_functions",
     "parquet",
@@ -15,10 +15,8 @@
       ]
     },
     {
-      "reason": "Deletion vectors do not support per-position snapshot tracking, breaking tests that rely on precise time travel across multiple deletes or parquet-specific delete file metadata",
+      "reason": "Deletion vectors do not support per-position snapshot tracking, breaking tests that rely on precise time travel across multiple deletes",
       "paths": [
-        "test/sql/delete/delete_file_stats.test",
-        "test/sql/delete/delete_same_transaction.test",
         "test/sql/delete/multi_deletes.test",
         "test/sql/table_changes/ducklake_table_deletions_compacted.test",
         "test/sql/table_changes/ducklake_table_deletions_large.test",
@@ -26,9 +24,7 @@
         "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
         "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",
         "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
-        "test/sql/rewrite_data_files/test_rewrite_db.test",
-        "test/sql/alter/alter_timestamptz_promotion.test",
-        "test/sql/alter/test_insert_select_alter_column_persistence.test"
+        "test/sql/rewrite_data_files/test_rewrite_db.test"
       ]
     }
   ]

--- a/test/sql/delete/delete_file_stats.test
+++ b/test/sql/delete/delete_file_stats.test
@@ -25,7 +25,7 @@ DELETE FROM ducklake.test WHERE id%2=0
 1500
 
 query II
-SELECT  file_size_bytes > 0, footer_size > 0 FROM __ducklake_metadata_ducklake.ducklake_delete_file
+SELECT  file_size_bytes > 0, footer_size >= 0 FROM __ducklake_metadata_ducklake.ducklake_delete_file
 ----
 true	true
 true	true

--- a/test/sql/delete/delete_same_transaction.test
+++ b/test/sql/delete/delete_same_transaction.test
@@ -50,7 +50,7 @@ COMMIT
 
 # verify that we only have one delete file written after the commit (i.e. we cleaned up the first file
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_delete_same_transaction_files/main/test/*-delete.parquet')
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_delete_same_transaction_files/main/test/*-delete.*')
 ----
 1
 

--- a/test/sql/delete/deletion_vector.test
+++ b/test/sql/delete/deletion_vector.test
@@ -1,0 +1,61 @@
+# name: test/sql/delete/deletion_vector.test
+# description: Test writing and reading deletion vectors (puffin format)
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/deletion_vector_files', WRITE_DELETION_VECTORS true)
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i id FROM range(1000) t(i);
+
+statement ok
+INSERT INTO ducklake.test SELECT i id FROM range(15000, 16000) t(i)
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+2000
+
+# delete even rows
+query I
+DELETE FROM ducklake.test WHERE id%2=0
+----
+1000
+
+# verify the delete file is in puffin format
+query I
+SELECT format FROM __ducklake_metadata_ducklake.ducklake_delete_file
+----
+puffin
+puffin
+
+# verify data is correct after delete
+query II
+SELECT COUNT(*), COUNT(*) FILTER(WHERE id%2=0) FROM ducklake.test
+----
+1000	0
+
+# we can time travel to see the state of the table before deletes
+query II
+SELECT COUNT(*), COUNT(*) FILTER(WHERE id%2=0) FROM ducklake.test AT (VERSION => 2)
+----
+2000	1000
+
+# delete some more rows (this will go through the snapshot merge path and fall back to parquet)
+query I
+DELETE FROM ducklake.test WHERE id < 100
+----
+50
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+950

--- a/test/sql/delete/deletion_vector.test
+++ b/test/sql/delete/deletion_vector.test
@@ -30,9 +30,9 @@ DELETE FROM ducklake.test WHERE id%2=0
 ----
 1000
 
-# verify the delete file is in puffin format
+# verify the delete files are in puffin format
 query I
-SELECT format FROM __ducklake_metadata_ducklake.ducklake_delete_file
+SELECT format FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE end_snapshot IS NULL
 ----
 puffin
 puffin
@@ -49,7 +49,7 @@ SELECT COUNT(*), COUNT(*) FILTER(WHERE id%2=0) FROM ducklake.test AT (VERSION =>
 ----
 2000	1000
 
-# delete some more rows (this will go through the snapshot merge path and fall back to parquet)
+# delete some more rows - this goes through FlushDeleteWithSnapshots but should still write puffin
 query I
 DELETE FROM ducklake.test WHERE id < 100
 ----
@@ -59,3 +59,26 @@ query I
 SELECT COUNT(*) FROM ducklake.test
 ----
 950
+
+# all active delete files should still be puffin (old ones get overwritten)
+query I
+SELECT DISTINCT format FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+puffin
+
+# verify the actual data is correct
+query I
+SELECT COUNT(*) FILTER(WHERE id < 100) FROM ducklake.test
+----
+0
+
+# delete all remaining rows from one file to test full file drop
+query I
+DELETE FROM ducklake.test WHERE id >= 0 AND id < 1000
+----
+450
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+500

--- a/test/sql/delete/multi_deletes.test
+++ b/test/sql/delete/multi_deletes.test
@@ -51,7 +51,7 @@ SELECT COUNT(*), SUM(id) FROM ducklake.test
 
 # verify that we only have one delete file written after the commit (i.e. we cleaned up the first file)
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_multi_deletes_files/main/test/*-delete.parquet')
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_multi_deletes_files/main/test/*-delete.*')
 ----
 1
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,4 +1,5 @@
 {
   "dependencies": [
+    "roaring"
   ]
 }


### PR DESCRIPTION
This PR adds support for deletion vectors (roaring bitmaps) to ducklake.

This PR adds support to both read and write of these files (mostly by adapting the code from [duckdb/iceberg](https://github.com/duckdb/duckdb-iceberg/blob/main/src/core/deletes/iceberg_deletion_vector.cpp), and by bringing our old merge delete code back.

The writing of these files is currently only focused on testing, so we have added a  `write_deletion_vectors` option that defaults to `False` with the following description: `[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)`.

We should eventually converge to also write these by default, but that is a bit more involved, as it will require them to be able to write deletes of multiple snapshots in the same file.

The tests we are skipping are related to the way we now write deletion files with multiple snapshot information. Since we now only need to preserve one file for multi-snapshots, old files are eagerly deleted, which does not work with the merge style of single-snapshot deletions. This should not affect the read path, and implementing it would increase code complexity for an unrealistic test path.