### PR TITLE
Fix rename failure exception message

### DIFF
--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -205,7 +205,7 @@ void DuckLakeSchemaEntry::Alter(CatalogTransaction catalog_transaction, AlterInf
 			auto existing_table = GetEntry(catalog_transaction, CatalogType::TABLE_ENTRY, new_table->name);
 			if (StringUtil::Lower(alter.name) != StringUtil::Lower(new_table->name) && existing_table) {
 				throw BinderException("Cannot rename table %s to %s, since %s already exists.", alter.name,
-				                      new_table->name, alter.name);
+				                      new_table->name, new_table->name);
 			}
 		}
 		transaction.AlterEntry(table, std::move(new_table));


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/938

In the updated version after my PR
```sql
memory D ATTACH ':memory:' AS ducklake (TYPE ducklake, DATA_PATH '/tmp/rename_bug');
memory D CREATE TABLE ducklake.tb1(val INT1);
memory D CREATE TABLE ducklake.tb2(val INT1);
memory D ALTER TABLE ducklake.tb1 RENAME TO tb2;
Binder Error:
Cannot rename table tb1 to tb2, since tb2 already exists.
```