### PR TITLE
Fix SET NOT NULL error message

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -517,22 +517,24 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto stats = GetTableStats(transaction);
 	if (!stats) {
 		throw CatalogException(
-		    "Cannot SET NULL on table %s - the table has transaction-local changes or no stats are available", name);
+		    "Cannot SET NOT NULL on table %s - the table has transaction-local changes or no stats are available",
+		    name);
 	}
 
 	auto column_stats = stats->column_stats.find(field_id.GetFieldIndex());
 	if (column_stats == stats->column_stats.end()) {
-		throw CatalogException("Cannot SET NULL on table %s - no column stats are available", name);
+		throw CatalogException("Cannot SET NOT NULL on table %s - no column stats are available", name);
 	}
 	auto &col_stats = column_stats->second;
 	if (col_stats.has_null_count && col_stats.null_count > 0) {
-		throw CatalogException("Cannot SET NULL on column %s - the column has NULL values", col.GetName());
+		throw CatalogException("Cannot SET NOT NULL on column %s - the column has NULL values", col.GetName());
 	}
 
 	// check if there is an existing constraint
 	auto existing_idx = FindNotNullConstraint(table_info, col.Logical());
 	if (existing_idx.IsValid()) {
-		throw CatalogException("Cannot SET NULL on column %s - it already has a NOT NULL constraint", col.GetName());
+		throw CatalogException("Cannot SET NOT NULL on column %s - it already has a NOT NULL constraint",
+		                       col.GetName());
 	}
 	table_info.constraints.push_back(make_uniq<NotNullConstraint>(col.Logical()));
 


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/940

The `AlterTable` function is working on `SetNotNull`, all error messages should be updated.
Exception after this PR
```sql
memory D ATTACH ':memory:' AS ducklake (TYPE ducklake, DATA_PATH '/tmp/rename_bug');
memory D CREATE TABLE ducklake.tbl(val INT);
memory D INSERT INTO ducklake.tbl VALUES(NULL);
memory D ALTER TABLE ducklake.tbl ALTER COLUMN val SET NOT NULL; 
Catalog Error:
Cannot SET NOT NULL on column val - the column has NULL values
```