### PR TITLE
Fix schema creation exception

### DIFF
--- a/src/include/storage/ducklake_schema_entry.hpp
+++ b/src/include/storage/ducklake_schema_entry.hpp
@@ -34,6 +34,7 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateTableExtended(CatalogTransaction transaction, BoundCreateTableInfo &info,
 	                                               string table_uuid, string table_data_path);
+	unique_ptr<CreateInfo> GetInfo() const override;
 	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;
 	optional_ptr<CatalogEntry> CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) override;
 	optional_ptr<CatalogEntry> CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -105,7 +105,7 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::CreateSchema(CatalogTransaction tran
 			return nullptr;
 		}
 		if (info.on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-			return nullptr;
+			throw CatalogException("Schema %s already exists", info.schema);
 		}
 		// drop the existing entry
 		DropInfo drop_info;

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -105,7 +105,7 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::CreateSchema(CatalogTransaction tran
 			return nullptr;
 		}
 		if (info.on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-			throw CatalogException("Schema %s already exists", info.schema);
+			throw CatalogException::EntryAlreadyExists(CatalogType::SCHEMA_ENTRY, info.schema);
 		}
 		// drop the existing entry
 		DropInfo drop_info;

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -23,6 +23,12 @@ DuckLakeSchemaEntry::DuckLakeSchemaEntry(Catalog &catalog, CreateSchemaInfo &inf
       data_path(std::move(data_path_p)) {
 }
 
+unique_ptr<CreateInfo> DuckLakeSchemaEntry::GetInfo() const {
+	auto result = SchemaCatalogEntry::GetInfo();
+	result->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+	return result;
+}
+
 bool DuckLakeSchemaEntry::HandleCreateConflict(CatalogTransaction transaction, CatalogType catalog_type,
                                                const string &entry_name, OnCreateConflict on_conflict) {
 	auto existing_entry = GetEntry(transaction, catalog_type, entry_name);

--- a/test/sql/catalog/schema.test
+++ b/test/sql/catalog/schema.test
@@ -174,3 +174,13 @@ CREATE SCHEMA ducklake.schema_two
 
 statement ok
 COMMIT
+
+# creating a schema that already exists should error
+statement error
+CREATE SCHEMA ducklake.s1;
+----
+already exists
+
+# CREATE SCHEMA IF NOT EXISTS should succeed silently
+statement ok
+CREATE SCHEMA IF NOT EXISTS ducklake.s1;


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/942

After this PR SQL statements become
```sql
memory D ATTACH ':memory:' AS ducklake (TYPE ducklake, DATA_PATH '/tmp/rename_bug');
memory D CREATE SCHEMA ducklake.myschema;
memory D CREATE SCHEMA ducklake.myschema;
Catalog Error:
Schema myschema already exists
```