### PR TITLE
Disallow column name to be internal name

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1,4 +1,5 @@
 #include "common/ducklake_types.hpp"
+#include "common/ducklake_util.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_scan.hpp"
@@ -561,6 +562,9 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 }
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, RenameColumnInfo &info) {
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name)) {
+		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use", info.new_name);
+	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	if (!table_info.columns.ColumnExists(info.old_name)) {
@@ -597,6 +601,9 @@ void DuckLakeTableEntry::RequireNextColumnId(DuckLakeTransaction &transaction) {
 }
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, AddColumnInfo &info) {
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name())) {
+		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use", info.new_column.Name());
+	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	if (info.if_column_not_exists && ColumnExists(info.new_column.Name())) {

--- a/test/sql/alter/issue_944.test
+++ b/test/sql/alter/issue_944.test
@@ -1,0 +1,33 @@
+# name: test/sql/alter/issue_944.test
+# description: test ducklake cannot create, rename or rename a column to system colume name
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/issue_944', METADATA_CATALOG 'xx')
+
+statement error
+CREATE TABLE ducklake.test(row_id INTEGER);
+----
+Column name "row_id" is reserved by DuckLake for internal use
+
+statement ok
+CREATE TABLE ducklake.test(a INTEGER);
+
+statement error
+ALTER TABLE ducklake.test ADD COLUMN row_id INTEGER;
+----
+Column name "row_id" is reserved by DuckLake for internal use
+
+statement error
+ALTER TABLE ducklake.test RENAME COLUMN a TO row_id;
+----
+Column name "row_id" is reserved by DuckLake for internal use


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/944

This PR adds validation as what we did for table creation to keep a consistent behavior
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_schema_entry.cpp#L69-L71