### PR TITLE
Explicitly set C++17 for DuckLake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 include_directories(src/include)
 
 # Roaring is installed via vcpkg and used for deletion vectors


### PR DESCRIPTION
Seems like the build implicitly requires CXX 17 but it was not made explicit anywhere. This makes it explicit if that is the intention