### PR TITLE
Explicit unique pointer cast for projection operator for inlined data flush

### DIFF
--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -739,7 +739,7 @@ static unique_ptr<LogicalOperator> FlushInlinedDataBind(ClientContext &context, 
 	auto projection = make_uniq<LogicalProjection>(bind_index, std::move(proj_exprs));
 	projection->children.push_back(std::move(filter));
 
-	return projection;
+	return unique_ptr_cast<LogicalProjection, LogicalOperator>(std::move(projection));
 }
 
 DuckLakeFlushInlinedDataFunction::DuckLakeFlushInlinedDataFunction()


### PR DESCRIPTION
`unique_ptr` is a wrapper type, the compiler sees `LogicalProjection` -> `LogicalOperator` but the return type is `LogicalOperator` so we use DuckDB's existing pattern for `unique_ptr_cast` to make it guaranteed to compile correctly