### PR TITLE
Respect DuckDB's static extension build flag: EXTENSION_STATIC_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,16 @@ include_directories(${roaring_DIR}/../../include)
 add_subdirectory(src)
 set(EXTENSION_SOURCES ${ALL_OBJECT_FILES})
 
-build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
+if(EXTENSION_STATIC_BUILD)
+  build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
+  target_link_libraries(${EXTENSION_NAME} roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
+
+  install(
+    TARGETS ${EXTENSION_NAME}
+    EXPORT "${DUCKDB_EXPORT_SET}"
+    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
+endif()
+
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
-
-target_link_libraries(${EXTENSION_NAME} roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
 target_link_libraries(${TARGET_NAME}_loadable_extension roaring::roaring roaring::roaring-headers roaring::roaring-headers-cpp)
-
-install(
-  TARGETS ${EXTENSION_NAME}
-  EXPORT "${DUCKDB_EXPORT_SET}"
-  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
-  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")


### PR DESCRIPTION
DuckDB has an existing flag for extensions to opt in or out of static building separate from loadable extension building. This patch adds support for honoring that existing flag