### PR TITLE
Fix drop table in single transaction

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2844,7 +2844,9 @@ void DuckLakeTransaction::DropTable(DuckLakeTableEntry &table) {
 		// if we have written any files for this table - clean them up
 		auto context_ref = context.lock();
 		local_changes.CleanupFiles(*context_ref, table_id);
-		new_tables.erase(schema_entry);
+		if (schema_entry->second->GetEntries().empty()) {
+			new_tables.erase(schema_entry);
+		}
 	} else {
 		auto table_id = table.GetTableId();
 		dropped_tables.insert(table_id);
@@ -2859,7 +2861,9 @@ void DuckLakeTransaction::DropView(DuckLakeViewEntry &view) {
 			throw InternalException("Dropping a transaction local view that does not exist?");
 		}
 		schema_entry->second->DropEntry(view.name);
-		new_tables.erase(schema_entry);
+		if (schema_entry->second->GetEntries().empty()) {
+			new_tables.erase(schema_entry);
+		}
 	} else {
 		auto view_id = view.GetViewId();
 		dropped_views.insert(view_id);

--- a/test/sql/catalog/drop_entry_same_schema.test
+++ b/test/sql/catalog/drop_entry_same_schema.test
@@ -1,0 +1,155 @@
+# name: test/sql/catalog/drop_entry_same_schema.test
+# description: Test that dropping a transaction-local table/view does not remove other entries in the same schema
+# group: [catalog]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_drop_same_schema')
+
+# dropping one transaction-local table must not remove another table in the same schema
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.t1(x INTEGER);
+
+statement ok
+CREATE TABLE ducklake.t2(y INTEGER);
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (1);
+
+statement ok
+INSERT INTO ducklake.t2 VALUES (2);
+
+statement ok
+DROP TABLE ducklake.t1
+
+statement error
+SELECT * FROM ducklake.t1
+----
+does not exist
+
+query I
+SELECT * FROM ducklake.t2
+----
+2
+
+query I
+SELECT table_name FROM duckdb_tables() WHERE database_name = 'ducklake' ORDER BY table_name
+----
+t2
+
+statement ok
+COMMIT
+
+query I
+SELECT * FROM ducklake.t2
+----
+2
+
+statement ok
+DROP TABLE ducklake.t2
+
+# dropping one transaction-local view must not remove another view in the same schema
+statement ok
+BEGIN
+
+statement ok
+CREATE VIEW ducklake.va AS SELECT 10 AS a
+
+statement ok
+CREATE VIEW ducklake.vb AS SELECT 20 AS b
+
+statement ok
+DROP VIEW ducklake.va
+
+statement error
+FROM ducklake.va
+----
+does not exist
+
+query I
+FROM ducklake.vb
+----
+20
+
+statement ok
+COMMIT
+
+query I
+FROM ducklake.vb
+----
+20
+
+statement ok
+DROP VIEW ducklake.vb
+
+# dropping a transaction-local table must not remove a transaction-local view (mixed types)
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.mix_t(x INTEGER);
+
+statement ok
+CREATE VIEW ducklake.mix_v AS SELECT 99 AS v
+
+statement ok
+DROP TABLE ducklake.mix_t
+
+query I
+FROM ducklake.mix_v
+----
+99
+
+statement ok
+COMMIT
+
+query I
+FROM ducklake.mix_v
+----
+99
+
+statement ok
+DROP VIEW ducklake.mix_v
+
+# dropping a transaction-local view must not remove a transaction-local table (mixed types, reverse)
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.mix_t2(x INTEGER);
+
+statement ok
+INSERT INTO ducklake.mix_t2 VALUES (42);
+
+statement ok
+CREATE VIEW ducklake.mix_v2 AS SELECT 77 AS v
+
+statement ok
+DROP VIEW ducklake.mix_v2
+
+query I
+SELECT * FROM ducklake.mix_t2
+----
+42
+
+statement ok
+COMMIT
+
+query I
+SELECT * FROM ducklake.mix_t2
+----
+42
+
+statement ok
+DROP TABLE ducklake.mix_t2

--- a/test/sql/catalog/drop_entry_same_schema.test
+++ b/test/sql/catalog/drop_entry_same_schema.test
@@ -1,5 +1,5 @@
 # name: test/sql/catalog/drop_entry_same_schema.test
-# description: Test that dropping a transaction-local table/view does not remove other entries in the same schema
+# description: Test that dropping a transaction-local table/view does not remove other entries in the same schema, see issue https://github.com/duckdb/ducklake/issues/957
 # group: [catalog]
 
 require ducklake
@@ -14,7 +14,6 @@ test-env DATA_PATH __TEST_DIR__
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_drop_same_schema')
 
-# dropping one transaction-local table must not remove another table in the same schema
 statement ok
 BEGIN
 
@@ -93,7 +92,7 @@ FROM ducklake.vb
 statement ok
 DROP VIEW ducklake.vb
 
-# dropping a transaction-local table must not remove a transaction-local view (mixed types)
+# dropping a transaction-local table must not remove a transaction-local view
 statement ok
 BEGIN
 


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/957

If I don't mis-understand, when a new table/view is created inside of a transaction, it's inserted into `new_tables` map

This is where we find the `DuckLakeCatalogSet`
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L3048-L3052

And when we create a new entry, we add into the `CatalogSet` returned above
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L2803-L2807

The bug is somehow when we delete a table/view, we remove the whole catalog set from the transaction-local `new_tables`, even if it's not empty:
- table: https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L2839
- view: https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L2854
- In my PR, I check the emptiness of the catalog set before removing