### PR TITLE
Fix repeated column update in one transaction

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1533,6 +1533,8 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 	}
 
 	set<FieldIndex> columns_handled_by_later_ops;
+	// Maps from field index to the number of alter operations for that field.
+	map<FieldIndex, idx_t> field_alter_count;
 	for (idx_t table_idx = 0; table_idx < tables.size(); table_idx++) {
 		auto &table = tables[table_idx].get();
 		auto local_change = table.GetLocalChange();
@@ -1542,11 +1544,15 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 		case LocalChangeType::RENAME_COLUMN:
 		case LocalChangeType::SET_DEFAULT:
 			columns_handled_by_later_ops.insert(local_change.field_index);
+			field_alter_count[local_change.field_index]++;
 			break;
 		default:
 			break;
 		}
 	}
+
+	// Maps from field index to the number of alter operations remaining for that field.
+	map<FieldIndex, idx_t> field_alter_remaining(std::move(field_alter_count));
 
 	// traverse in reverse order
 	bool column_schema_change = false;
@@ -1595,6 +1601,13 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 		case LocalChangeType::DROP_NULL:
 		case LocalChangeType::RENAME_COLUMN:
 		case LocalChangeType::SET_DEFAULT: {
+			auto &remaining = field_alter_remaining[local_change.field_index];
+			remaining--;
+			// This is an older thus superseded entry for a field that is altered for multiple times in this
+			// transaction, so we skip it; the newest entry will emit the definitive value.
+			if (remaining > 0) {
+				break;
+			}
 			// drop the previous column
 			DuckLakeDroppedColumn dropped_col;
 			dropped_col.table_id = commit_state.GetTableId(table);

--- a/test/sql/alter/set_default_duplicate_in_transaction.test
+++ b/test/sql/alter/set_default_duplicate_in_transaction.test
@@ -1,0 +1,81 @@
+# name: test/sql/alter/set_default_duplicate_in_transaction.test
+# description: Regression test for duplicate SET DEFAULT on the same column within a single transaction
+# group: [alter]
+
+#
+# Bug: When SET DEFAULT is applied multiple times to the same column within a single
+# transaction, the commit generates a drop+add pair for EACH alteration. This inserts
+# duplicate rows in ducklake_column (both with end_snapshot IS NULL), causing a
+# "Column with name X already exists!" error on next table access.
+#
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_set_default_dup')
+
+statement ok
+CREATE TABLE ducklake.tbl (a INTEGER);
+
+# Two SET DEFAULT on the same column in one transaction
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 99
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 9
+
+statement ok
+COMMIT
+
+# This should succeed - but fails with "Column with name a already exists!"
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 8
+
+statement ok
+COMMIT
+
+# Verify the final default value is 8
+statement ok
+INSERT INTO ducklake.tbl DEFAULT VALUES
+
+query I
+SELECT a FROM ducklake.tbl
+----
+8
+
+# Also test three SET DEFAULTs in one transaction
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 100
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 200
+
+statement ok
+ALTER TABLE ducklake.tbl ALTER a SET DEFAULT 300
+
+statement ok
+COMMIT
+
+statement ok
+INSERT INTO ducklake.tbl DEFAULT VALUES
+
+query I
+SELECT a FROM ducklake.tbl ORDER BY a
+----
+8
+300


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/961

When I was debugging the issue, I used the dummy way to add logging for `ducklake_column` system table, for the failure sql.
```sql
memory D ATTACH ':memory:' AS dl (TYPE ducklake);
memory D CREATE TABLE dl.tbl (a INT);
memory D BEGIN;
memory D ALTER TABLE dl.tbl ALTER a SET DEFAULT 99;
memory D ALTER TABLE dl.tbl ALTER a SET DEFAULT 9;
memory D COMMIT;
memory D BEGIN;
memory D ALTER TABLE dl.tbl ALTER a SET DEFAULT 8;
Catalog Error:
Column with name a already exists!
```

Here's what I found [here](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L2241-L2250):
- At commit phase, the column `a` is dropped twice, and re-created twice
- The drop column SQL: 
```sql
WITH dropped_cols(tid, cid) AS (
VALUES (1, 1), (1, 1)
)
UPDATE {METADATA_CATALOG}.ducklake_column
SET end_snapshot = {SNAPSHOT_ID}
FROM dropped_cols
WHERE table_id=tid AND column_id=cid AND end_snapshot IS NULL;
```
- The append column SQL: 
```sql
INSERT INTO {METADATA_CATALOG}.ducklake_column VALUES (1, {SNAPSHOT_ID}, NULL, 1, 1, 'a', 'int32', NULL, '99', true, NULL, 'literal', 'duckdb'),(1, {SNAPSHOT_ID}, NULL, 1, 1, 'a', 'int32', NULL, '9', true, NULL, 'literal', 'duckdb');
```
- As we can easily tell, the column `a` is dropped twice and appended twice, all the them are recorded in the `ducklake_column`
- Next time when we reconstruct the latest snapshot [here](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_catalog.cpp#L326) inside of [MetadataManager](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_metadata_manager.cpp#L529-L555), we get two columns, [inserting both into the same table](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_catalog.cpp#L376) leads to crash

In this PR, the goal I want to achieve is to only insert one single row (the latest value) into `ducklake_column`, so later access won't access single column for multiple times. 