### PR TITLE
Fix sql string replacement for view

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -350,4 +350,46 @@ bool DuckLakeUtil::HasInlinedSystemColumnConflict(const vector<DuckLakeColumnInf
 	return false;
 }
 
+string DuckLakeUtil::ReplaceSkippingQuotes(const string &sql, const string &from, const string &to) {
+	if (from.empty()) {
+		return sql;
+	}
+	string result;
+	result.reserve(sql.size());
+	idx_t i = 0;
+	while (i < sql.size()) {
+		char c = sql[i];
+		if (c == '\'' || c == '"') {
+			// Now we're inside a quoted region, so copy everything until the matching close quote.
+			char quote = c;
+			result += c;
+			i++;
+			while (i < sql.size()) {
+				result += sql[i];
+				if (sql[i] == quote) {
+					i++;
+					// doubled quote is an escape, still stay inside the quoted region
+					if (i < sql.size() && sql[i] == quote) {
+						result += sql[i];
+						i++;
+						continue;
+					}
+					break;
+				}
+				i++;
+			}
+			continue;
+		}
+		// We're outside quotes, can now check for a match of `from`.
+		if (sql.compare(i, from.size(), from) == 0) {
+			result += to;
+			i += from.size();
+		} else {
+			result += c;
+			i++;
+		}
+	}
+	return result;
+}
+
 } // namespace duckdb

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -1,6 +1,7 @@
 #include "common/ducklake_util.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/parser/parser.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "storage/ducklake_metadata_manager.hpp"
 #include "storage/ducklake_metadata_info.hpp"
@@ -354,41 +355,55 @@ string DuckLakeUtil::ReplaceSkippingQuotes(const string &sql, const string &from
 	if (from.empty()) {
 		return sql;
 	}
-	string result;
-	result.reserve(sql.size());
-	idx_t i = 0;
-	while (i < sql.size()) {
-		char c = sql[i];
-		if (c == '\'' || c == '"') {
-			// Now we're inside a quoted region, so copy everything until the matching close quote.
-			char quote = c;
-			result += c;
-			i++;
-			while (i < sql.size()) {
-				result += sql[i];
-				if (sql[i] == quote) {
-					i++;
-					// doubled quote is an escape, still stay inside the quoted region
-					if (i < sql.size() && sql[i] == quote) {
-						result += sql[i];
-						i++;
-						continue;
-					}
-					break;
-				}
-				i++;
-			}
-			continue;
+
+	auto tokens = Parser::Tokenize(sql);
+
+	// Collect quoted ranges (string constants and double-quoted identifiers) where replacement doesn't happen
+	vector<pair<idx_t, idx_t>> no_replace_ranges;
+	for (idx_t i = 0; i < tokens.size(); i++) {
+		bool is_quoted = tokens[i].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_STRING_CONSTANT;
+		if (!is_quoted && tokens[i].type == SimplifiedTokenType::SIMPLIFIED_TOKEN_IDENTIFIER &&
+		    tokens[i].start < sql.size() && sql[tokens[i].start] == '"') {
+			is_quoted = true;
 		}
-		// We're outside quotes, can now check for a match of `from`.
-		if (sql.compare(i, from.size(), from) == 0) {
-			result += to;
-			i += from.size();
-		} else {
-			result += c;
-			i++;
+		if (is_quoted) {
+			const idx_t start = tokens[i].start;
+			const idx_t end = (i + 1 < tokens.size()) ? tokens[i + 1].start : sql.size();
+			no_replace_ranges.push_back({start, end});
 		}
 	}
+
+	string result;
+	result.reserve(sql.size());
+	idx_t pos = 0;
+	idx_t range_idx = 0;
+
+	while (pos < sql.size()) {
+		while (range_idx < no_replace_ranges.size() && pos >= no_replace_ranges[range_idx].second) {
+			range_idx++;
+		}
+
+		// If inside a quoted range, copy verbatim to its end
+		if (range_idx < no_replace_ranges.size() && pos >= no_replace_ranges[range_idx].first) {
+			idx_t end = no_replace_ranges[range_idx].second;
+			result += sql.substr(pos, end - pos);
+			pos = end;
+			range_idx++;
+			continue;
+		}
+
+		// If not inside a quoted range, check for a match of `from`
+		if (sql.compare(pos, from.size(), from) == 0) {
+			result += to;
+			pos += from.size();
+			continue;
+		}
+
+		// Otherwise, just copy the character at the current position
+		result += sql[pos];
+		pos++;
+	}
+
 	return result;
 }
 

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -40,6 +40,10 @@ public:
 
 	static DynamicFilter *GetOptionalDynamicFilter(const TableFilter &filter);
 
+	//! Replace occurrences of `from` with `to`, skipping content inside
+	//! single-quoted string literals and double-quoted identifiers.
+	static string ReplaceSkippingQuotes(const string &sql, const string &from, const string &to);
+
 	//! Returns true if the given column name conflicts with inlined data system columns
 	static bool IsInlinedSystemColumn(const string &name);
 	//! Returns true if any column name conflicts with inlined data system columns

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -156,7 +156,7 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateView(CatalogTransaction tr
 	// replace our catalog name with a generic {DUCKLAKE_CATALOG}.
 	auto query_sql = info.query->ToString();
 	auto &catalog_name = ParentCatalog().GetName();
-	query_sql = StringUtil::Replace(query_sql, catalog_name + ".", "{DUCKLAKE_CATALOG}.");
+	query_sql = DuckLakeUtil::ReplaceSkippingQuotes(query_sql, catalog_name + ".", "{DUCKLAKE_CATALOG}.");
 
 	auto view_entry = make_uniq<DuckLakeViewEntry>(ParentCatalog(), *this, info, view_id, std::move(view_uuid),
 	                                               query_sql, LocalChangeType::CREATED);

--- a/src/storage/ducklake_view_entry.cpp
+++ b/src/storage/ducklake_view_entry.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/parser/parsed_data/alter_table_info.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "common/ducklake_util.hpp"
 
 namespace duckdb {
 
@@ -69,7 +70,7 @@ string DuckLakeViewEntry::ToSQL() const {
 	}
 	result += " AS ";
 	// switcharoo of generic {DUCKLAKE_CATALOG}. with actual catalog name
-	result += StringUtil::Replace(query_sql, "{DUCKLAKE_CATALOG}.", catalog.GetName() + ".");
+	result += DuckLakeUtil::ReplaceSkippingQuotes(query_sql, "{DUCKLAKE_CATALOG}.", catalog.GetName() + ".");
 	result += ";";
 	return result;
 }
@@ -85,7 +86,7 @@ unique_ptr<CatalogEntry> DuckLakeViewEntry::Copy(ClientContext &context) const {
 unique_ptr<SelectStatement> DuckLakeViewEntry::ParseSelectStatement() const {
 	Parser parser;
 	// switcharoo of generic {DUCKLAKE_CATALOG}. with actual catalog name
-	auto resolved_sql = StringUtil::Replace(query_sql, "{DUCKLAKE_CATALOG}.", catalog.GetName() + ".");
+	auto resolved_sql = DuckLakeUtil::ReplaceSkippingQuotes(query_sql, "{DUCKLAKE_CATALOG}.", catalog.GetName() + ".");
 	parser.ParseQuery(resolved_sql);
 	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
 		throw InvalidInputException("Invalid input for view - view must have a single SELECT statement: \"%s\"",

--- a/test/sql/view/view_string_literal_catalog_replace.test
+++ b/test/sql/view/view_string_literal_catalog_replace.test
@@ -1,0 +1,38 @@
+# name: test/sql/view/view_string_literal_catalog_replace.test
+# description: Test that naive catalog name replacement does not corrupt string literals in views
+# group: [view]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/view_literal.db' AS dl (DATA_PATH '__TEST_DIR__/view_literal_data')
+
+statement ok
+CREATE TABLE dl.main.t(i INTEGER)
+
+statement ok
+INSERT INTO dl.main.t VALUES (1)
+
+# Create a view whose SELECT list contains a string literal with the catalog name in it
+statement ok
+CREATE VIEW dl.main.v AS SELECT 'dl.hello' AS val FROM dl.main.t
+
+query I
+SELECT * FROM dl.main.v
+----
+dl.hello
+
+statement ok
+DETACH dl
+
+# Re-attach under a different catalog name
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/view_literal.db' AS other_name (DATA_PATH '__TEST_DIR__/view_literal_data')
+
+# The string literal must still be 'dl.hello', NOT 'other_name.hello'
+query I
+SELECT * FROM other_name.main.v
+----
+dl.hello


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/967

The bug is:
- When a view is created, DuckLake replaces the catalog name with a placeholder `{DUCKLAKE_CATALOG}` [here](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_schema_entry.cpp#L153); when the view gets queries we replace it back [here](https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_view_entry.cpp#L88)
- But the thing is, if the original sql contains a catalog name (in detail, `dl` is part of the view creation sql, and it's also the catalog name), string-based replacement doesn't work

The fix I proposed in this PR is to create a quote-aware string replacement.
Disclaimer: the string replacement function is written by opus.