### PR TITLE
fix: deletion bugs (fixes issue #917)

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -238,9 +238,10 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 			// (does not apply to REWRITE_DELETES - delete files must be rewritten regardless of data file size)
 			continue;
 		}
-		if ((!candidate.delete_files.empty() && type == CompactionType::MERGE_ADJACENT_TABLES) ||
-		    candidate.file.end_snapshot.IsValid() || candidate.has_inlined_deletions) {
-			// Merge Adjacent Tables doesn't perform the merge if delete files are present
+		if (((!candidate.delete_files.empty() || !candidate.inlined_file_deletions.empty()) &&
+		     type == CompactionType::MERGE_ADJACENT_TABLES) ||
+		    candidate.file.end_snapshot.IsValid()) {
+			// Merge Adjacent Tables doesn't perform the merge if any deletes are present
 			continue;
 		}
 		// construct the compaction group for this file - i.e. the set of candidate files we can compact it with
@@ -415,9 +416,11 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	for (auto &source : source_files) {
 		DuckLakeFileListEntry result;
 		result.file = source.file.data;
+		result.file_id = source.file.id;
 		result.row_id_start = source.file.row_id_start;
 		result.snapshot_id = source.file.begin_snapshot;
 		result.mapping_id = source.file.mapping_id;
+		result.inlined_file_deletions = source.inlined_file_deletions;
 		switch (type) {
 		case CompactionType::REWRITE_DELETES: {
 			if (!source.delete_files.empty()) {

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "common/parquet_file_scanner.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
@@ -43,6 +44,106 @@ static void AttachDeleteFilesToWrittenFiles(vector<DuckLakeDeleteFile> &delete_f
 			it->second.get().delete_files.push_back(std::move(delete_file));
 		}
 	}
+}
+
+struct FlushedRowVersion {
+	idx_t row_id;
+	idx_t begin_snapshot;
+
+	bool operator==(const FlushedRowVersion &other) const {
+		return row_id == other.row_id && begin_snapshot == other.begin_snapshot;
+	}
+};
+
+struct FlushedRowVersionHash {
+	hash_t operator()(const FlushedRowVersion &row_version) const {
+		return CombineHash(std::hash<idx_t> {}(row_version.row_id),
+		                   std::hash<idx_t> {}(row_version.begin_snapshot));
+	}
+};
+
+using DeletedRowsByVersion = unordered_map<FlushedRowVersion, idx_t, FlushedRowVersionHash>;
+using FilePositionsByVersion = unordered_map<FlushedRowVersion, idx_t, FlushedRowVersionHash>;
+
+static DuckLakeFileData CreateWrittenFileScanEntry(const DuckLakeDataFile &written_file) {
+	DuckLakeFileData result;
+	result.path = written_file.file_name;
+	result.encryption_key = written_file.encryption_key;
+	result.file_size_bytes = written_file.file_size_bytes;
+	result.footer_size = written_file.footer_size;
+	return result;
+}
+
+static FilePositionsByVersion ScanWrittenFilePositions(ClientContext &context, const DuckLakeDataFile &written_file) {
+	auto file_entry = CreateWrittenFileScanEntry(written_file);
+	ParquetFileScanner scanner(context, file_entry);
+
+	auto row_id_col_idx = scanner.FindColumn("_ducklake_internal_row_id");
+	auto snapshot_id_col_idx = scanner.FindColumn("_ducklake_internal_snapshot_id");
+	if (!row_id_col_idx.IsValid() || !snapshot_id_col_idx.IsValid()) {
+		throw InternalException("Flushed file \"%s\" is missing internal row/snapshot columns required for delete "
+		                        "position tracking",
+		                        written_file.file_name);
+	}
+
+	scanner.SetColumnIds(
+	    {NumericCast<column_t>(row_id_col_idx.GetIndex()), NumericCast<column_t>(snapshot_id_col_idx.GetIndex())});
+
+	DataChunk scan_chunk;
+	scan_chunk.Initialize(context, {LogicalType::BIGINT, LogicalType::BIGINT});
+
+	FilePositionsByVersion result;
+	idx_t current_file_position = 0;
+	while (scanner.Scan(scan_chunk)) {
+		auto count = scan_chunk.size();
+
+		UnifiedVectorFormat row_id_data;
+		scan_chunk.data[0].ToUnifiedFormat(count, row_id_data);
+		auto row_ids = UnifiedVectorFormat::GetData<int64_t>(row_id_data);
+
+		UnifiedVectorFormat snapshot_data;
+		scan_chunk.data[1].ToUnifiedFormat(count, snapshot_data);
+		auto snapshot_ids = UnifiedVectorFormat::GetData<int64_t>(snapshot_data);
+
+		for (idx_t i = 0; i < count; i++) {
+			auto row_id_idx = row_id_data.sel->get_index(i);
+			auto snapshot_idx = snapshot_data.sel->get_index(i);
+			if (!row_id_data.validity.RowIsValid(row_id_idx) || !snapshot_data.validity.RowIsValid(snapshot_idx)) {
+				throw InvalidInputException("Flushed file \"%s\" has NULL internal row/snapshot columns",
+				                            written_file.file_name);
+			}
+
+			FlushedRowVersion row_version {NumericCast<idx_t>(row_ids[row_id_idx]),
+			                               NumericCast<idx_t>(snapshot_ids[snapshot_idx])};
+			auto insert_result = result.emplace(row_version, current_file_position);
+			if (!insert_result.second) {
+				throw InternalException("Flushed file \"%s\" contains duplicate row version (%d, %d)",
+				                        written_file.file_name, row_version.row_id, row_version.begin_snapshot);
+			}
+			current_file_position++;
+		}
+	}
+	return result;
+}
+
+static DeletedRowsByVersion LoadDeletedRowsForPartition(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
+                                                        const string &inlined_table_name,
+                                                        const string &partition_filter) {
+	string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
+	auto deleted_rows_result = transaction.Query(snapshot, StringUtil::Format(R"(
+		SELECT row_id, begin_snapshot, end_snapshot
+		FROM {METADATA_CATALOG}.%s
+		WHERE {SNAPSHOT_ID} >= begin_snapshot%s
+		  AND end_snapshot IS NOT NULL;)",
+	                                                           inlined_table_name, extra_filter));
+
+	DeletedRowsByVersion result;
+	for (auto &row : *deleted_rows_result) {
+		FlushedRowVersion row_version {NumericCast<idx_t>(row.GetValue<int64_t>(0)),
+		                               NumericCast<idx_t>(row.GetValue<int64_t>(1))};
+		result[row_version] = NumericCast<idx_t>(row.GetValue<int64_t>(2));
+	}
+	return result;
 }
 
 //===--------------------------------------------------------------------===//
@@ -117,9 +218,7 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 	if (!global_state.written_files.empty()) {
 		DeletesPerFile deletes_per_file;
 		auto partition_sql_exprs = table.GetPartitionSQLExpressions();
-
-		// Track cumulative row offset per partition so each file knows its range
-		unordered_map<string, idx_t> partition_row_offsets;
+		unordered_map<string, DeletedRowsByVersion> deleted_rows_by_partition;
 
 		for (auto &file : global_state.written_files) {
 			// Build partition filter (empty string for non-partitioned tables)
@@ -132,30 +231,25 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 				partition_filter = DuckLakePartitionUtils::BuildPartitionFilter(partition_sql_exprs, values);
 			}
 
-			idx_t file_offset = partition_row_offsets[partition_filter];
-			partition_row_offsets[partition_filter] += file.row_count;
+			auto deleted_partition_entry = deleted_rows_by_partition.find(partition_filter);
+			if (deleted_partition_entry == deleted_rows_by_partition.end()) {
+				auto deleted_rows =
+				    LoadDeletedRowsForPartition(transaction, snapshot, inlined_table.table_name, partition_filter);
+				deleted_partition_entry =
+				    deleted_rows_by_partition.emplace(partition_filter, std::move(deleted_rows)).first;
+			}
+			if (deleted_partition_entry->second.empty()) {
+				continue;
+			}
 
-			// Query deleted rows within this file's row range, filtered to its partition
-			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
-			auto deleted_rows_result =
-			    transaction.Query(snapshot, StringUtil::Format(R"(
-				WITH all_rows AS (
-					SELECT end_snapshot, ROW_NUMBER() OVER (ORDER BY row_id, begin_snapshot) - 1 AS output_position
-					FROM {METADATA_CATALOG}.%s
-					WHERE {SNAPSHOT_ID} >= begin_snapshot%s
-				)
-				SELECT end_snapshot, output_position
-				FROM all_rows
-				WHERE end_snapshot IS NOT NULL
-				AND output_position >= %d AND output_position < %d;)",
-			                                                   inlined_table.table_name, extra_filter, file_offset,
-			                                                   file_offset + file.row_count));
-
-			for (auto &row : *deleted_rows_result) {
-				auto end_snap = row.GetValue<int64_t>(0);
-				auto output_position = row.GetValue<int64_t>(1);
-				int64_t pos_in_file = output_position - static_cast<int64_t>(file_offset);
-				PositionWithSnapshot pos_with_snap {pos_in_file, end_snap};
+			auto file_positions = ScanWrittenFilePositions(context, file);
+			for (auto &entry : file_positions) {
+				auto delete_entry = deleted_partition_entry->second.find(entry.first);
+				if (delete_entry == deleted_partition_entry->second.end()) {
+					continue;
+				}
+				PositionWithSnapshot pos_with_snap {NumericCast<int64_t>(entry.second),
+				                                    NumericCast<int64_t>(delete_entry->second)};
 				deletes_per_file[file.file_name].insert(pos_with_snap);
 			}
 		}

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -446,7 +446,7 @@ struct DuckLakeCompactionFileEntry {
 	vector<DuckLakeCompactionDeleteFileData> delete_files;
 	optional_idx max_partial_file_snapshot;
 	idx_t schema_version;
-	//! Inlined file deletions stored in the metadata database rather than delete files.
+	//! Inlined file deletions stored in the metadata database rather than delete files
 	set<idx_t> inlined_file_deletions;
 };
 

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -446,8 +446,8 @@ struct DuckLakeCompactionFileEntry {
 	vector<DuckLakeCompactionDeleteFileData> delete_files;
 	optional_idx max_partial_file_snapshot;
 	idx_t schema_version;
-	//! Whether this file has inlined deletions (stored in metadata database rather than delete files)
-	bool has_inlined_deletions = false;
+	//! Inlined file deletions stored in the metadata database rather than delete files.
+	set<idx_t> inlined_file_deletions;
 };
 
 struct DuckLakeRewriteFileEntry {
@@ -468,6 +468,7 @@ struct DuckLakeCompactedFileInfo {
 	string path;
 	DataFileIndex source_id;
 	DataFileIndex new_id;
+	optional_idx rewrite_snapshot;
 	//! Info on delete files, in case the compaction is a delete-rewrite
 	string delete_file_path;
 	DataFileIndex delete_file_id;

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -209,6 +209,7 @@ public:
 	SnapshotDeletedFromFiles GetFilesDeletedOrDroppedAfterSnapshot(const DuckLakeSnapshot &start_snapshot) const;
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot();
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot(BoundAtClause &at_clause, SnapshotBound bound);
+	virtual unique_ptr<DuckLakeSnapshot> GetSnapshotById(idx_t snapshot_id);
 	virtual idx_t GetNextColumnId(TableIndex table_id);
 	virtual unique_ptr<QueryResult> ReadInlinedData(DuckLakeSnapshot snapshot, const string &inlined_table_name,
 	                                                const vector<string> &columns_to_read);

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -74,6 +74,13 @@ static DuckLakeDeleteFile WriteDeleteFileInternal(ClientContext &context, InputT
 		types_to_write.push_back(LogicalType::BIGINT);
 	}
 
+	if (!input.fs.IsRemoteFile(input.data_path)) {
+		try {
+			input.fs.CreateDirectoriesRecursive(input.data_path);
+		} catch (...) {
+		}
+	}
+
 	auto function_data = copy_fun.function.copy_to_bind(input.context, bind_input, names_to_write, types_to_write);
 	auto copy_global_state = copy_fun.function.copy_to_initialize_global(context, *function_data, delete_file_path);
 
@@ -164,6 +171,12 @@ DuckLakeDeleteFile DuckLakeDeleteFileWriter::WriteDeletionVectorFile(ClientConte
 
 	// Write blob to file
 	auto &fs = FileSystem::GetFileSystem(context);
+	if (!fs.IsRemoteFile(input.data_path)) {
+		try {
+			fs.CreateDirectoriesRecursive(input.data_path);
+		} catch (...) {
+		}
+	}
 	auto file_handle =
 	    fs.OpenFile(delete_file_path, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE);
 	file_handle->Write(blob_data.data(), blob_data.size());

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1795,7 +1795,7 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	string deletion_threshold_clause;
 	if (type == CompactionType::REWRITE_DELETES) {
 		// Filter current data files in SQL, then apply the delete threshold in C++ so we can include
-		// metadata-only inlined file deletions as rewrite candidates.
+		// metadata-only inlined file deletions as rewrite candidates
 		deletion_threshold_clause = " AND data.end_snapshot is null";
 	}
 	// Add file size filtering for MERGE_ADJACENT_TABLES compaction
@@ -1901,7 +1901,7 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 		file_entry.delete_files.push_back(std::move(delete_file));
 	}
 
-	// Load inlined deletions for active files so rewrite compaction can treat them the same as delete files.
+	// Load inlined deletions for active files so rewrite compaction can treat them the same as delete files
 	auto inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
 	for (auto &file : files) {
 		auto entry = inlined_deletions.find(file.file.id.index);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1794,9 +1794,9 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	string select_list = data_select_list + ", " + delete_select_list;
 	string deletion_threshold_clause;
 	if (type == CompactionType::REWRITE_DELETES) {
-		deletion_threshold_clause = StringUtil::Format(
-		    " AND CAST(del.delete_count AS FLOAT)/CAST(data.record_count AS FLOAT) >= %f and data.end_snapshot is null",
-		    deletion_threshold);
+		// Filter current data files in SQL, then apply the delete threshold in C++ so we can include
+		// metadata-only inlined file deletions as rewrite candidates.
+		deletion_threshold_clause = " AND data.end_snapshot is null";
 	}
 	// Add file size filtering for MERGE_ADJACENT_TABLES compaction
 	string file_size_filter_clause;
@@ -1901,17 +1901,31 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 		file_entry.delete_files.push_back(std::move(delete_file));
 	}
 
-	// Check for inlined deletions and mark affected files
-	// Gather file IDs first, then query only for existence
-	vector<idx_t> file_ids;
-	file_ids.reserve(files.size());
+	// Load inlined deletions for active files so rewrite compaction can treat them the same as delete files.
+	auto inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
 	for (auto &file : files) {
-		file_ids.push_back(file.file.id.index);
+		auto entry = inlined_deletions.find(file.file.id.index);
+		if (entry != inlined_deletions.end()) {
+			file.inlined_file_deletions = std::move(entry->second);
+		}
 	}
-	auto files_with_deletions = GetFileIdsWithInlinedDeletions(table_id, snapshot, file_ids);
-	for (auto &file : files) {
-		if (files_with_deletions.count(file.file.id.index)) {
-			file.has_inlined_deletions = true;
+
+	if (type == CompactionType::REWRITE_DELETES) {
+		for (idx_t file_idx = 0; file_idx < files.size(); file_idx++) {
+			auto &file = files[file_idx];
+			idx_t active_delete_count = 0;
+			if (!file.delete_files.empty() && !file.delete_files.back().end_snapshot.IsValid()) {
+				active_delete_count = file.delete_files.back().row_count;
+			}
+			auto total_delete_count = active_delete_count + file.inlined_file_deletions.size();
+			double delete_ratio = 0;
+			if (file.file.row_count > 0) {
+				delete_ratio = static_cast<double>(total_delete_count) / static_cast<double>(file.file.row_count);
+			}
+			if (total_delete_count == 0 || delete_ratio < deletion_threshold) {
+				files.erase_at(file_idx);
+				file_idx--;
+			}
 		}
 	}
 
@@ -3556,6 +3570,25 @@ WHERE snapshot_id = (
 	return snapshot;
 }
 
+unique_ptr<DuckLakeSnapshot> DuckLakeMetadataManager::GetSnapshotById(idx_t snapshot_id) {
+	auto query = StringUtil::Format(R"(
+SELECT snapshot_id, schema_version, next_catalog_id, next_file_id
+FROM {METADATA_CATALOG}.ducklake_snapshot
+WHERE snapshot_id = %llu;)",
+	                                snapshot_id);
+	DuckLakeSnapshot dummy_snapshot(0, 0, 0, 0);
+	auto result = Query(dummy_snapshot, query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw(
+		    StringUtil::Format("Failed to query snapshot %llu for DuckLake: ", snapshot_id));
+	}
+	auto snapshot = TryGetSnapshotInternal(*result);
+	if (!snapshot) {
+		throw InvalidInputException("Snapshot %llu not found in DuckLake", snapshot_id);
+	}
+	return snapshot;
+}
+
 static unordered_map<idx_t, DuckLakePartitionInfo>
 GetNewPartitions(const vector<DuckLakePartitionInfo> &old_partitions,
                  const vector<DuckLakePartitionInfo> &new_partitions) {
@@ -4112,7 +4145,7 @@ string DuckLakeMetadataManager::WriteDeleteRewrites(const vector<DuckLakeCompact
 	for (idx_t i = compactions.size(); i > 0; i--) {
 		auto &compaction = compactions[i - 1];
 		if (table_idx_last_snapshot.find(compaction.table_index.index) == table_idx_last_snapshot.end()) {
-			table_idx_last_snapshot[compaction.table_index.index] = compaction.delete_file_start_snapshot.GetIndex();
+			table_idx_last_snapshot[compaction.table_index.index] = compaction.rewrite_snapshot.GetIndex();
 		}
 	}
 
@@ -4120,12 +4153,12 @@ string DuckLakeMetadataManager::WriteDeleteRewrites(const vector<DuckLakeCompact
 	for (idx_t i = 0; i < compactions.size(); ++i) {
 		auto &compaction = compactions[i];
 		D_ASSERT(!compaction.path.empty());
-		if (!compaction.delete_file_end_snapshot.IsValid()) {
+		if (compaction.delete_file_id.IsValid() && !compaction.delete_file_end_snapshot.IsValid()) {
 			batch_query += StringUtil::Format(R"(
-			UPDATE {METADATA_CATALOG}.ducklake_delete_file SET end_snapshot = %llu
-			WHERE delete_file_id = %llu;
-			)",
-			                                  table_idx_last_snapshot[compaction.table_index.index],
+				UPDATE {METADATA_CATALOG}.ducklake_delete_file SET end_snapshot = %llu
+				WHERE delete_file_id = %llu;
+				)",
+				                                  table_idx_last_snapshot[compaction.table_index.index],
 			                                  compaction.delete_file_id.index);
 		}
 		// We must update the data file table

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -307,38 +307,6 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 		file_entry.data_type = DuckLakeDataType::TRANSACTION_LOCAL_INLINED_DATA;
 		result.push_back(std::move(file_entry));
 	}
-	if (!read_file_list) {
-		// we have not read the file list yet - construct it from the extended file list
-		// Read committed inlined file deletions from metadata
-		map<idx_t, set<idx_t>> committed_inlined_deletions;
-		if (!read_info.table_id.IsTransactionLocal()) {
-			auto &metadata_manager = transaction.GetMetadataManager();
-			committed_inlined_deletions =
-			    metadata_manager.ReadInlinedFileDeletions(read_info.table_id, read_info.snapshot);
-		}
-		for (auto &file : result) {
-			DuckLakeFileListEntry file_entry;
-			file_entry.file = file.file;
-			file_entry.row_id_start = file.row_id_start;
-			file_entry.delete_file = file.delete_file;
-			file_entry.file_id = file.file_id;
-			file_entry.data_type = file.data_type;
-			// Apply committed inlined file deletions from metadata
-			if (file.file_id.IsValid()) {
-				auto it = committed_inlined_deletions.find(file.file_id.index);
-				if (it != committed_inlined_deletions.end()) {
-					file_entry.inlined_file_deletions = std::move(it->second);
-				}
-			}
-			// Apply local inlined file deletes if any (merges into committed deletions)
-			if (file.file_id.IsValid() && transaction.HasLocalInlinedFileDeletes(read_info.table_id)) {
-				transaction.GetLocalInlinedFileDeletesForFile(read_info.table_id, file.file_id.index,
-				                                              file_entry.inlined_file_deletions);
-			}
-			files.emplace_back(std::move(file_entry));
-		}
-		read_file_list = true;
-	}
 	return result;
 }
 

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -80,8 +80,25 @@ static unique_ptr<DuckLakeNameMapEntry> CreateLegacyNameMapEntry(const DuckLakeF
 	return result;
 }
 
+static bool FileHasFieldIdIdentifiers(const vector<MultiFileColumnDefinition> &columns) {
+	for (auto &column : columns) {
+		if (!column.identifier.IsNull() && column.identifier.type().id() == LogicalTypeId::INTEGER) {
+			return true;
+		}
+		if (FileHasFieldIdIdentifiers(column.children)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 static unique_ptr<DuckLakeNameMap> TryCreateLegacyNameMap(DuckLakeFunctionInfo &read_info,
-                                                          const OpenFileInfo &opened_file) {
+                                                          const OpenFileInfo &opened_file,
+                                                          const vector<MultiFileColumnDefinition> &local_columns) {
+	if (FileHasFieldIdIdentifiers(local_columns)) {
+		// DuckLake-written files already carry field IDs and do not need a legacy name-map fallback.
+		return nullptr;
+	}
 	if (!opened_file.extended_info) {
 		return nullptr;
 	}
@@ -561,7 +578,7 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 			                                      multi_file_list, bind_data, virtual_columns,
 			                                      MultiFileColumnMappingMode::BY_NAME);
 		}
-		auto legacy_name_map = TryCreateLegacyNameMap(read_info, reader_data.reader->file);
+		auto legacy_name_map = TryCreateLegacyNameMap(read_info, reader_data.reader->file, reader_data.reader->columns);
 		if (legacy_name_map) {
 			auto mapped_columns = CreateNewMapping(context, reader_data, global_columns, *legacy_name_map);
 			return MultiFileReader::CreateMapping(context, reader_data, mapped_columns, column_ids_to_use, filters,

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -3,6 +3,7 @@
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_delete_filter.hpp"
+#include "common/ducklake_name_map.hpp"
 #include "common/ducklake_util.hpp"
 
 #include "duckdb/common/local_file_system.hpp"
@@ -67,6 +68,43 @@ static void NormalizeListChildNames(vector<MultiFileColumnDefinition> &columns, 
 			NormalizeListChildNames(col.children, is_list);
 		}
 	}
+}
+
+static unique_ptr<DuckLakeNameMapEntry> CreateLegacyNameMapEntry(const DuckLakeFieldId &field_id) {
+	auto result = make_uniq<DuckLakeNameMapEntry>();
+	result->source_name = field_id.Name();
+	result->target_field_id = field_id.GetFieldIndex();
+	for (auto &child : field_id.Children()) {
+		result->child_entries.push_back(CreateLegacyNameMapEntry(*child));
+	}
+	return result;
+}
+
+static unique_ptr<DuckLakeNameMap> TryCreateLegacyNameMap(DuckLakeFunctionInfo &read_info,
+                                                          const OpenFileInfo &opened_file) {
+	if (!opened_file.extended_info) {
+		return nullptr;
+	}
+	auto snapshot_entry = opened_file.extended_info->options.find("snapshot_id");
+	if (snapshot_entry == opened_file.extended_info->options.end() || snapshot_entry->second.IsNull()) {
+		return nullptr;
+	}
+
+	auto transaction = read_info.GetTransaction();
+	auto file_snapshot = transaction->GetMetadataManager().GetSnapshotById(snapshot_entry->second.GetValue<idx_t>());
+	auto &catalog = read_info.table.catalog.Cast<DuckLakeCatalog>();
+	auto historical_entry = catalog.GetEntryById(*transaction, *file_snapshot, read_info.table.GetTableId());
+	if (!historical_entry || historical_entry->type != CatalogType::TABLE_ENTRY) {
+		return nullptr;
+	}
+
+	auto result = make_uniq<DuckLakeNameMap>();
+	auto &historical_table = historical_entry->Cast<DuckLakeTableEntry>();
+	result->table_id = historical_table.GetTableId();
+	for (auto &field_id : historical_table.GetFieldData().GetFieldIds()) {
+		result->column_maps.push_back(CreateLegacyNameMapEntry(*field_id));
+	}
+	return result;
 }
 
 static bool CanSkipFileByTopNDynamicFilter(const DuckLakeFileListEntry &file_entry,
@@ -519,6 +557,13 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 			auto &mapping = transaction->GetMappingById(mapping_id);
 			// use the mapping to generate a new set of global columns for this file
 			auto mapped_columns = CreateNewMapping(context, reader_data, global_columns, mapping);
+			return MultiFileReader::CreateMapping(context, reader_data, mapped_columns, column_ids_to_use, filters,
+			                                      multi_file_list, bind_data, virtual_columns,
+			                                      MultiFileColumnMappingMode::BY_NAME);
+		}
+		auto legacy_name_map = TryCreateLegacyNameMap(read_info, reader_data.reader->file);
+		if (legacy_name_map) {
+			auto mapped_columns = CreateNewMapping(context, reader_data, global_columns, *legacy_name_map);
 			return MultiFileReader::CreateMapping(context, reader_data, mapped_columns, column_ids_to_use, filters,
 			                                      multi_file_list, bind_data, virtual_columns,
 			                                      MultiFileColumnMappingMode::BY_NAME);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2391,9 +2391,12 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 				if (!compacted_file.delete_files.empty()) {
 					row_id_limit -= compacted_file.delete_files.back().row_count;
 				}
+				row_id_limit -= compacted_file.inlined_file_deletions.size();
 				DuckLakeCompactedFileInfo file_info;
 				file_info.path = compacted_file.file.data.path;
 				file_info.source_id = compacted_file.file.id;
+				file_info.table_index = entry.GetTableIndex();
+				file_info.rewrite_snapshot = commit_snapshot.snapshot_id;
 				if (has_new_file) {
 					file_info.new_id = new_file.id;
 				}
@@ -2402,7 +2405,6 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 					file_info.delete_file_path = compacted_file.delete_files.back().data.path;
 					file_info.delete_file_id = compacted_file.delete_files.back().delete_file_id;
 					file_info.start_snapshot = compacted_file.file.begin_snapshot;
-					file_info.table_index = entry.GetTableIndex();
 					file_info.delete_file_start_snapshot = commit_snapshot.snapshot_id;
 					file_info.delete_file_end_snapshot = compacted_file.delete_files.back().end_snapshot;
 				}

--- a/test/sql/delete/delete_add_files_creates_delete_dir.test
+++ b/test/sql/delete/delete_add_files_creates_delete_dir.test
@@ -1,0 +1,44 @@
+# name: test/sql/delete/delete_add_files_creates_delete_dir.test
+# description: DELETE should create the table data directory before writing delete files for add_data_files tables
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/delete_add_files_creates_delete_dir', DATA_INLINING_ROW_LIMIT 5, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t(id INTEGER)
+
+statement ok
+COPY (SELECT i::INTEGER AS id FROM range(100) t(i)) TO '${DATA_PATH}/source.parquet'
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/source.parquet')
+
+query I
+SELECT count(*) FROM t
+----
+100
+
+statement ok
+DELETE FROM t WHERE id BETWEEN 10 AND 40
+
+query I
+SELECT count(*) FROM t
+----
+69
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+1

--- a/test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test
+++ b/test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test
@@ -1,0 +1,53 @@
+# name: test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test
+# description: Legacy files without mapping_id remain readable and deletable after column rename
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/delete_legacy_missing_mapping_after_rename_add_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t(old_id INTEGER, payload VARCHAR)
+
+statement ok
+COPY (
+    SELECT 42 AS old_id, 'old' AS payload
+    UNION ALL
+    SELECT 43 AS old_id, 'old2' AS payload
+) TO '${DATA_PATH}/delete_legacy_missing_mapping_after_rename_add_files_source.parquet'
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/delete_legacy_missing_mapping_after_rename_add_files_source.parquet')
+
+statement ok
+ALTER TABLE ducklake.t RENAME COLUMN old_id TO id
+
+# Model a legacy v0.3 file that never had a persisted name mapping.
+statement ok
+UPDATE ducklake_meta.ducklake_data_file SET mapping_id = NULL
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE id = 42
+----
+1
+
+query III
+SELECT rowid, id, payload FROM ducklake.t ORDER BY rowid
+----
+0	42	old
+1	43	old2
+
+statement ok
+DELETE FROM ducklake.t WHERE id = 42
+
+query II
+SELECT id, payload FROM ducklake.t ORDER BY id
+----
+43	old2

--- a/test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes.test
+++ b/test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes.test
@@ -1,0 +1,66 @@
+# name: test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes.test
+# description: rewrite_data_files should rewrite files that only have inlined file deletions
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/rewrite_inlined_file_deletes', DATA_INLINING_ROW_LIMIT 10, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t AS SELECT i AS a FROM range(50) t(i)
+
+statement ok
+DELETE FROM t WHERE a = 25
+
+query I
+SELECT count(*) FROM t
+----
+49
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_inlined_delete_1
+----
+1
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0)
+----
+t	1	1
+
+query I
+SELECT count(*) FROM t
+----
+49
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+statement ok
+SET VARIABLE rewrite_snap = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'))
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_data_file WHERE begin_snapshot = getvariable('rewrite_snap') AND end_snapshot IS NULL
+----
+1

--- a/test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes_add_files.test
+++ b/test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes_add_files.test
@@ -1,0 +1,72 @@
+# name: test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes_add_files.test
+# description: rewrite_data_files should rewrite imported files that only have inlined file deletions
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/rewrite_inlined_file_deletes_add_files', DATA_INLINING_ROW_LIMIT 10, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t(a INTEGER)
+
+statement ok
+COPY (SELECT i::INTEGER AS a FROM range(50) t(i)) TO '${DATA_PATH}/source.parquet'
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/source.parquet')
+
+query I
+SELECT count(*) FROM t
+----
+50
+
+statement ok
+DELETE FROM t WHERE a = 25
+
+query I
+SELECT count(*) FROM t
+----
+49
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_inlined_delete_1
+----
+1
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0)
+----
+t	1	1
+
+query I
+SELECT count(*) FROM t
+----
+49
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+statement ok
+SET VARIABLE rewrite_snap = (SELECT max(snapshot_id) FROM ducklake_snapshots('ducklake'))
+
+query I
+SELECT count(*) FROM ducklake_meta.ducklake_data_file WHERE begin_snapshot = getvariable('rewrite_snap') AND end_snapshot IS NULL
+----
+1

--- a/test/sql/sorted_table/data_inlining_flush_sorted_sequential_updates.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_sequential_updates.test
@@ -1,0 +1,57 @@
+# name: test/sql/sorted_table/data_inlining_flush_sorted_sequential_updates.test
+# description: sorted flush should build delete positions from actual file order, not row_id order
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_inlining_flush_sorted_sequential_updates', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+CREATE TABLE ducklake.t(id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO ducklake.t VALUES (2, 0), (1, 0), (3, 0);
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+statement ok
+ALTER TABLE ducklake.t SET SORTED BY (id ASC NULLS LAST);
+
+query II
+SELECT id, val FROM ducklake.t ORDER BY id
+----
+1	0
+2	3
+3	0
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+SELECT id, COUNT(*) FROM ducklake.t GROUP BY id ORDER BY id
+----
+1	1
+2	1
+3	1
+
+query II
+SELECT id, val FROM ducklake.t ORDER BY id
+----
+1	0
+2	3
+3	0


### PR DESCRIPTION
## Summary

This PR fixes four separate deletion bugs that showed up under the same [#917](https://github.com/duckdb/ducklake/issues/917) umbrella:

  - `ducklake_rewrite_data_files` skipped files whose deletes only existed in metadata-backed inlined delete tables
  - `DELETE` on some `ducklake_add_data_files` tables failed because the local delete-file directory was never created
  - legacy `v0.3 -> v0.4` files with `mapping_id = NULL` could break after later column renames
  - `ducklake_flush_inlined_data` could write wrong positional delete files for sorted tables

These were related in symptoms, but they were not the same bug.

## What was going wrong

### Rewrite path ignored metadata-only file deletes

`rewrite_data_files` only looked at rows in `ducklake_delete_file` when choosing rewrite candidates and validating output row counts.

If a file only had metadata-backed inlined file deletes, duckLake could treat it as if it had no deletes at all. That meant:

  - rewrite candidates got skipped
  - imported files from `ducklake_add_data_files` could stay stuck in the deleted-but-never-rewritten state
  - `merge_adjacent_files` could make decisions without seeing those deletes

### Delete writers assumed the table directory already existed

For local `ducklake_add_data_files` tables, the first write might actually be a delete file. If the table directory had never been created, writing the delete artifact failed.

### Legacy files without a mapping stopped surviving renames

Some `v0.3 -> v0.4` files can still have `mapping_id = NULL`. If those files also do not carry field IDs, and the table later goes through a rename, binding by current column names is wrong for the old file. That gives the "new rows delete, old rows do not" kind of failure.

There was also a secondary issue where `GetFilesExtended()` could seed the normal file list with partial metadata, which made mapping-related bugs easier to trigger.

### Sorted flush used the wrong row positions

`ducklake_flush_inlined_data` was building delete positions from:

```sql
ROW_NUMBER() OVER (ORDER BY row_id, begin_snapshot)
```

That only works if the written parquet file is also in row-id order. For sorted tables it is not. The file is in sort-key order, so the delete file could target the wrong rows.

## What this changes

  - treat metadata-backed inlined file deletes like regular delete files during rewrite planning and validation
  - pass inlined file deletions through the compaction scan path
  - count inlined deleted rows in rewrite row-count accounting
  - avoid merging files that still have any kind of delete state
  - create local delete directories before writing delete files or deletion vectors
  - add a legacy fallback name map based on the historical table schema at the file snapshot when mapping_id is missing
  - stop back-filling the normal file list from GetFilesExtended()
  - build flush delete positions from the actual written parquet file order by scanning _ducklake_internal_row_id and _ducklake_internal_snapshot_id

## Notes

  - The legacy mapping fix is about v0.3 -> v0.4 histories, not v0.2.
  - The sorted flush fix adds a readback of the written parquet file on the flush path. That is extra work, but it is the only safe way to build positional delete files once file order is no longer row-id order.
  - This PR does not finish the separate ducklake_table_deletions / ducklake_table_changes diagnostics issue for repeated row IDs in one partial file. That is a follow-up issue in the diagnostics path, not the normal read path.

  ## Tests

  - test/sql/delete/delete_add_files_creates_delete_dir.test
  - test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test
  - test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes.test
  - test/sql/rewrite_data_files/test_rewrite_inlined_file_deletes_add_files.test
  - test/sql/sorted_table/data_inlining_flush_sorted_sequential_updates.test
  - full DuckLake debug SQLLogicTest pass, including *.test_slow