### PR TITLE
Delete deletion files for local table change

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -570,6 +570,14 @@ void LocalTableChanges::CleanupFiles(ClientContext &context, TableIndex table_id
 		auto &fs = FileSystem::GetFileSystem(context);
 		for (auto &file : table_changes.new_data_files) {
 			fs.RemoveFile(file.file_name);
+			for (auto &del_file : file.delete_files) {
+				fs.TryRemoveFile(del_file.file_name);
+			}
+		}
+		for (auto &file : table_changes.new_delete_files) {
+			for (auto &delete_files : file.second) {
+				fs.TryRemoveFile(delete_files.file_name);
+			}
 		}
 		changes.erase(table_entry);
 	}

--- a/test/sql/cleanup/drop_table_cleans_delete_files.test
+++ b/test/sql/cleanup/drop_table_cleans_delete_files.test
@@ -1,0 +1,52 @@
+# name: test/sql/cleanup/drop_table_cleans_delete_files.test
+# description: Dropping a transaction-local table must clean up both deletion files and data files
+# group: [cleanup]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_drop_delete_cleanup', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.tbl AS SELECT i id FROM range(1000) t(i);
+
+# data file exists
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*.parquet')
+----
+1
+
+statement ok
+DELETE FROM ducklake.tbl WHERE id % 2 = 0;
+
+# delete file exists
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.parquet')
+----
+1
+
+statement ok
+DROP TABLE ducklake.tbl
+
+# both data files and delete files should be cleaned up
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*.parquet')
+----
+0
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.parquet')
+----
+0
+
+statement ok
+COMMIT

--- a/test/sql/cleanup/drop_table_cleans_delete_files.test
+++ b/test/sql/cleanup/drop_table_cleans_delete_files.test
@@ -30,7 +30,7 @@ DELETE FROM ducklake.tbl WHERE id % 2 = 0;
 
 # delete file exists
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.parquet')
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.*')
 ----
 1
 
@@ -44,7 +44,7 @@ SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*.
 0
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.parquet')
+SELECT COUNT(*) FROM glob('${DATA_PATH}/ducklake_drop_delete_cleanup/main/tbl/*-delete.*')
 ----
 0
 


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/975

The code change is borrowed from another file cleanup function here: https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_transaction.cpp#L67-L79