### PR TITLE
Fix migration issue of range tables from v0.3 to v0.4

### DIFF
--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -66,7 +66,8 @@ private:
 	void GetFilesForTable() const;
 	void GetTableInsertions() const;
 	void GetTableDeletions() const;
-	void AddFilterToPushdownInfo(FilterPushdownInfo &pushdown_info, column_t column_id, unique_ptr<TableFilter> filter) const;
+	void AddFilterToPushdownInfo(FilterPushdownInfo &pushdown_info, column_t column_id,
+	                             unique_ptr<TableFilter> filter) const;
 	//! Get the row_id_start for transaction-local inlined data.
 	idx_t GetTransactionLocalRowIdStart(idx_t transaction_row_start) const;
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -256,7 +256,7 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.4' WHERE key = 'versi
 
 	auto migrate_schema_versions = transaction.Query(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_schema_versions (table_id, begin_snapshot, schema_version)
-SELECT t.table_id, t.begin_snapshot, sv.schema_version
+SELECT t.table_id, sv.begin_snapshot, sv.schema_version
 FROM {METADATA_CATALOG}.ducklake_schema_versions sv
 JOIN {METADATA_CATALOG}.ducklake_table t
   ON sv.begin_snapshot BETWEEN t.begin_snapshot

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1248,13 +1248,15 @@ void DuckLakeTransaction::CheckForConflicts(const TransactionChangeInformation &
 		ConflictCheck(table_id, other_changes.dropped_tables, "insert into table", "dropped it");
 		ConflictCheck(table_id, other_changes.altered_tables, "insert into table", "altered it");
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "insert into table", "deleted from it");
-		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table", "deleted inlined data from it");
+		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table",
+		              "deleted inlined data from it");
 	}
 	for (auto &table_id : changes.tables_inserted_inlined) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "insert into table", "dropped it");
 		ConflictCheck(table_id, other_changes.altered_tables, "insert into table", "altered it");
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "insert into table", "deleted from it");
-		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table", "deleted inlined data from it");
+		ConflictCheck(table_id, other_changes.tables_deleted_inlined, "insert into table",
+		              "deleted inlined data from it");
 	}
 	for (auto &table_id : changes.tables_deleted_from) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "delete from table", "dropped it");

--- a/test/sql/migration/per_table_schema.test
+++ b/test/sql/migration/per_table_schema.test
@@ -13,20 +13,20 @@ ATTACH 'ducklake:__TEST_DIR__/per_table_schema.db' AS ducklake (DATA_PATH '__TES
 
 # Turning the global to local is basically an explosion within the table snapshot range.
 query III
-FROM __ducklake_metadata_ducklake.ducklake_schema_versions ORDER BY ALL;
+SELECT table_id, begin_snapshot, schema_version FROM __ducklake_metadata_ducklake.ducklake_schema_versions ORDER BY ALL;
 ----
 1	1	1
-1	2	1
-1	3	1
-1	4	1
-1	5	1
-1	6	1
+1	2	2
+1	3	3
+1	4	4
+1	5	5
+1	6	6
 2	2	2
-2	3	2
-2	4	2
-2	5	2
-2	6	2
+2	3	3
+2	4	4
+2	5	5
+2	6	6
 3	3	3
-3	4	3
-3	5	3
-3	6	3
+3	4	4
+3	5	5
+3	6	6


### PR DESCRIPTION
We need to use sv.begin_snapshot to preserve the original snapshot at which each schema version was introduced. 

I believe this should be a fix query for anyone that has already migrated:

```sql
  UPDATE ducklake_schema_versions AS sv
  SET begin_snapshot = (
      SELECT MIN(snapshot_id)
      FROM ducklake_snapshot s
      WHERE s.schema_version = sv.schema_version
  );
```