### PR TITLE
Fix multiple comments set in single transaction

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1538,6 +1538,9 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 	set<FieldIndex> columns_handled_by_later_ops;
 	// Maps from field index to the number of alter operations for that field.
 	map<FieldIndex, idx_t> field_alter_count;
+	idx_t comment_count = 0;
+	// Maps from field index to the number of column comment operations for that field.
+	map<FieldIndex, idx_t> column_comment_count;
 	for (idx_t table_idx = 0; table_idx < tables.size(); table_idx++) {
 		auto &table = tables[table_idx].get();
 		auto local_change = table.GetLocalChange();
@@ -1549,6 +1552,12 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 			columns_handled_by_later_ops.insert(local_change.field_index);
 			field_alter_count[local_change.field_index]++;
 			break;
+		case LocalChangeType::SET_COMMENT:
+			comment_count++;
+			break;
+		case LocalChangeType::SET_COLUMN_COMMENT:
+			column_comment_count[local_change.field_index]++;
+			break;
 		default:
 			break;
 		}
@@ -1556,6 +1565,9 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 
 	// Maps from field index to the number of alter operations remaining for that field.
 	map<FieldIndex, idx_t> field_alter_remaining(std::move(field_alter_count));
+	idx_t comment_remaining = comment_count;
+	// Maps from field index to the number of column comment operations remaining for that field.
+	map<FieldIndex, idx_t> column_comment_remaining(std::move(column_comment_count));
 
 	// traverse in reverse order
 	bool column_schema_change = false;
@@ -1580,6 +1592,10 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 			break;
 		}
 		case LocalChangeType::SET_COMMENT: {
+			comment_remaining--;
+			if (comment_remaining > 0) {
+				break;
+			}
 			DuckLakeTagInfo comment_info;
 			comment_info.id = commit_state.GetTableId(table).index;
 			comment_info.key = "comment";
@@ -1590,6 +1606,11 @@ void DuckLakeTransaction::GetNewTableInfo(DuckLakeCommitState &commit_state, Duc
 			break;
 		}
 		case LocalChangeType::SET_COLUMN_COMMENT: {
+			auto &col_comment_rem = column_comment_remaining[local_change.field_index];
+			col_comment_rem--;
+			if (col_comment_rem > 0) {
+				break;
+			}
 			DuckLakeColumnTagInfo comment_info;
 			comment_info.table_id = commit_state.GetTableId(table);
 			comment_info.field_index = local_change.field_index;
@@ -1798,11 +1819,23 @@ void DuckLakeTransaction::GetNewViewInfo(DuckLakeCommitState &commit_state, Duck
 		}
 		view_entry = view_entry.get().Child();
 	}
+	// count comment operations for deduplication
+	idx_t view_comment_count = 0;
+	for (idx_t view_idx = 0; view_idx < views.size(); view_idx++) {
+		if (views[view_idx].get().GetLocalChange().type == LocalChangeType::SET_COMMENT) {
+			view_comment_count++;
+		}
+	}
+	idx_t view_comment_remaining = view_comment_count;
 	// traverse in reverse order
 	for (idx_t view_idx = views.size(); view_idx > 0; view_idx--) {
 		auto &view = views[view_idx - 1].get();
 		switch (view.GetLocalChange().type) {
 		case LocalChangeType::SET_COMMENT: {
+			view_comment_remaining--;
+			if (view_comment_remaining > 0) {
+				break;
+			}
 			DuckLakeTagInfo comment_info;
 			comment_info.id = commit_state.GetViewId(view).index;
 			comment_info.key = "comment";

--- a/test/sql/comments/comment_duplicate_same_transaction.test
+++ b/test/sql/comments/comment_duplicate_same_transaction.test
@@ -59,3 +59,24 @@ query II
 SELECT key, value FROM __ducklake_metadata_ducklake.ducklake_column_tag WHERE end_snapshot IS NULL AND table_id = 1
 ----
 comment	col second
+
+# Check view-wise comment.
+statement ok
+CREATE VIEW ducklake.test_view AS SELECT * FROM ducklake.test
+
+statement ok
+BEGIN
+
+statement ok
+COMMENT ON VIEW ducklake.test_view IS 'view first'
+
+statement ok
+COMMENT ON VIEW ducklake.test_view IS 'view second'
+
+statement ok
+COMMIT
+
+query I
+SELECT comment FROM duckdb_views() WHERE view_name = 'test_view'
+----
+view second

--- a/test/sql/comments/comment_duplicate_same_transaction.test
+++ b/test/sql/comments/comment_duplicate_same_transaction.test
@@ -1,0 +1,61 @@
+# name: test/sql/comments/comment_duplicate_same_transaction.test
+# description: Verify that setting COMMENT multiple times in the same transaction only keeps the latest value
+# group: [comments]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/comment_dup_txn/')
+
+statement ok
+CREATE TABLE ducklake.test(a INTEGER);
+
+# Check table-wise comment.
+statement ok
+BEGIN
+
+statement ok
+COMMENT ON TABLE ducklake.test IS 'first'
+
+statement ok
+COMMENT ON TABLE ducklake.test IS 'second'
+
+statement ok
+COMMIT
+
+query I
+SELECT comment FROM duckdb_tables() WHERE table_name = 'test'
+----
+second
+
+query II
+SELECT key, value FROM __ducklake_metadata_ducklake.ducklake_tag WHERE end_snapshot IS NULL AND object_id = 1
+----
+comment	second
+
+# Check column-wise comment.
+statement ok
+BEGIN
+
+statement ok
+COMMENT ON COLUMN ducklake.test.a IS 'col first'
+
+statement ok
+COMMENT ON COLUMN ducklake.test.a IS 'col second'
+
+statement ok
+COMMIT
+
+query II
+SELECT column_name, comment FROM duckdb_columns() WHERE table_name = 'test' AND column_name = 'a'
+----
+a	col second
+
+query II
+SELECT key, value FROM __ducklake_metadata_ducklake.ducklake_column_tag WHERE end_snapshot IS NULL AND table_id = 1
+----
+comment	col second


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/980

Same issue as https://github.com/duckdb/ducklake/pull/962, we need to count table-wise/column-wise/view-wise comment as well, instead of blindly recording them all.