### PR TITLE
Fix macros cleanup on snapshot expiration

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4391,8 +4391,11 @@ WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
 	tables_to_delete_from = {"ducklake_macro_impl", "ducklake_macro_parameters"};
 	for (auto &delete_tbl : tables_to_delete_from) {
 		auto result = transaction.Query(StringUtil::Format(R"(
-DELETE FROM {METADATA_CATALOG}.%s
-WHERE macro_id NOT IN (SELECT macro_id FROM {METADATA_CATALOG}.ducklake_macro);)",
+DELETE FROM {METADATA_CATALOG}.%s tbl
+WHERE NOT EXISTS (
+    SELECT 1 FROM {METADATA_CATALOG}.ducklake_macro m
+    WHERE m.macro_id = tbl.macro_id
+);)",
 		                                                   delete_tbl));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4371,8 +4371,8 @@ WHERE table_id IN (%s);)",
 		}
 	}
 
-	// delete any views, schemas, etc that are no longer referenced
-	tables_to_delete_from = {"ducklake_schema", "ducklake_view", "ducklake_tag"};
+	// delete any views, schemas, macros, etc that are no longer referenced
+	tables_to_delete_from = {"ducklake_schema", "ducklake_view", "ducklake_tag", "ducklake_macro"};
 	for (auto &delete_tbl : tables_to_delete_from) {
 		auto result = transaction.Query(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s
@@ -4381,6 +4381,18 @@ WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
     FROM {METADATA_CATALOG}.ducklake_snapshot
     WHERE snapshot_id >= begin_snapshot AND snapshot_id < end_snapshot
 );)",
+		                                                   delete_tbl));
+		if (result->HasError()) {
+			result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");
+		}
+	}
+
+	// clean up macro implementation and parameters for deleted macros
+	tables_to_delete_from = {"ducklake_macro_impl", "ducklake_macro_parameters"};
+	for (auto &delete_tbl : tables_to_delete_from) {
+		auto result = transaction.Query(StringUtil::Format(R"(
+DELETE FROM {METADATA_CATALOG}.%s
+WHERE macro_id NOT IN (SELECT macro_id FROM {METADATA_CATALOG}.ducklake_macro);)",
 		                                                   delete_tbl));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");

--- a/test/sql/compaction/expire_snapshots_drop_macro.test
+++ b/test/sql/compaction/expire_snapshots_drop_macro.test
@@ -1,0 +1,71 @@
+# name: test/sql/compaction/expire_snapshots_drop_macro.test
+# description: test expire_snapshots cleans up dropped macro metadata (scalar and table macros)
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/expire_snapshots_drop_macro_files', METADATA_CATALOG 'metadata')
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE tbl(i INTEGER);
+
+# snapshot: create scalar macro
+statement ok
+CREATE MACRO add_one(x) AS (x + 1);
+
+# snapshot: create table macro
+statement ok
+CREATE MACRO get_all() AS TABLE SELECT * FROM tbl;
+
+# snapshot: drop both macros
+statement ok
+DROP MACRO add_one;
+
+statement ok
+DROP MACRO TABLE get_all;
+
+# macro metadata should still exist (referenced by historical snapshots)
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro;
+----
+2
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro_impl;
+----
+2
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro_parameters;
+----
+1
+
+# expire all old snapshots
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => NOW());
+
+# after expiration, all macro metadata should be cleaned up
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro;
+----
+0
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro_impl;
+----
+0
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_macro_parameters;
+----
+0


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/984

The root cause and fix should be straightforward: when we delete snapshots, we should consider macros related tables.