### PR TITLE
Fix set tag SQL

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3799,7 +3799,7 @@ VALUES %s
 UPDATE {METADATA_CATALOG}.ducklake_tag
 SET end_snapshot = {SNAPSHOT_ID}
 FROM overwritten_tags
-WHERE object_id=tid
+WHERE object_id=tid AND ducklake_tag.key=overwritten_tags.key AND end_snapshot IS NULL
 ;)",
 	                                        tags_list);
 
@@ -3840,7 +3840,7 @@ VALUES %s
 UPDATE {METADATA_CATALOG}.ducklake_column_tag
 SET end_snapshot = {SNAPSHOT_ID}
 FROM overwritten_tags
-WHERE table_id=tid AND column_id=cid
+WHERE table_id=tid AND column_id=cid AND ducklake_column_tag.key=overwritten_tags.key AND end_snapshot IS NULL
 ;)",
 	                                        tags_list);
 

--- a/test/sql/comments/comment_preserves_other_tags.test
+++ b/test/sql/comments/comment_preserves_other_tags.test
@@ -1,0 +1,55 @@
+# name: test/sql/comments/comment_preserves_other_tags.test
+# description: Setting a table or column comment only expires the 'comment' tag, not other tags on the same object
+# group: [comments]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/comment_unrelated_tags/')
+
+statement ok
+CREATE TABLE ducklake.tbl (i INT);
+
+# manually insert a tag with a different key ('owner') for the table
+statement ok
+INSERT INTO __ducklake_metadata_ducklake.ducklake_tag VALUES (1, 2, NULL, 'owner', 'alice');
+
+# now set a comment on the table
+statement ok
+COMMENT ON TABLE ducklake.tbl IS 'my comment';
+
+# the 'owner' tag should still be active
+query III
+SELECT key, value, end_snapshot FROM __ducklake_metadata_ducklake.ducklake_tag ORDER BY key;
+----
+comment	my comment	NULL
+owner	alice	NULL
+
+# update the comment
+statement ok
+COMMENT ON TABLE ducklake.tbl IS 'updated comment';
+
+query III
+SELECT key, value, end_snapshot IS NULL FROM __ducklake_metadata_ducklake.ducklake_tag ORDER BY key, end_snapshot IS NULL;
+----
+comment	my comment	false
+comment	updated comment	true
+owner	alice	true
+
+# verify the same for column-level tags
+statement ok
+INSERT INTO __ducklake_metadata_ducklake.ducklake_column_tag VALUES (1, 0, 4, NULL, 'pii', 'true');
+
+statement ok
+COMMENT ON COLUMN ducklake.tbl.i IS 'col comment';
+
+# the 'pii' column tag should still be active
+query III
+SELECT key, value, end_snapshot IS NULL FROM __ducklake_metadata_ducklake.ducklake_column_tag ORDER BY key;
+----
+comment	col comment	true
+pii	true	true


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/988

The bug is when we overwrite snapshot for the new tag written, the WHERE clause only checks table id and column id, instead of new key as well, thus all key-value pairs in the same table / column are overwritten.
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_metadata_manager.cpp#L3824-L3831
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_metadata_manager.cpp#L3783-L3790