### PR TITLE
[minor] Delete dead declaration

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -288,7 +288,6 @@ protected:
 private:
 	void CleanupFiles();
 	void FlushChanges();
-	void FlushSettingChanges();
 	string CommitChanges(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes,
 	                     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats);
 	void CommitCompaction(DuckLakeSnapshot &commit_snapshot, TransactionChangeInformation &transaction_changes);


### PR DESCRIPTION
The declaration is not used or defined anywhere.
```sh
hjiang@hjiangs-MacBook-Pro ducklake % git grep "FlushSettingChanges"
src/include/storage/ducklake_transaction.hpp:   void FlushSettingChanges();
```
Question: I think we should add `-Wunused-variable -Wunused-function` compilation option