### PR TITLE
Fix duplicate partition key

### DIFF
--- a/src/storage/ducklake_partition_data.cpp
+++ b/src/storage/ducklake_partition_data.cpp
@@ -11,7 +11,8 @@ string DuckLakePartitionUtils::GetPartitionKeyName(DuckLakeTransformType transfo
 	string prefix;
 	switch (transform_type) {
 	case DuckLakeTransformType::IDENTITY:
-		return field_name;
+		prefix = field_name;
+		break;
 	case DuckLakeTransformType::YEAR:
 		prefix = "year";
 		break;

--- a/test/sql/partitioning/partition_key_name_conflict.test
+++ b/test/sql/partitioning/partition_key_name_conflict.test
@@ -1,0 +1,40 @@
+# name: test/sql/partitioning/partition_key_name_conflict.test
+# description: Test that a column named "year" does not conflict with the year() partition transform
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partition_key_conflict', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t("year" INTEGER, ts TIMESTAMP, v VARCHAR);
+
+statement ok
+ALTER TABLE t SET PARTITIONED BY (year(ts), "year");
+
+statement ok
+INSERT INTO t VALUES (42, TIMESTAMP '2020-06-15', 'hello');
+
+query III
+SELECT "year", ts, v FROM t
+----
+42	2020-06-15 00:00:00	hello
+
+statement ok
+INSERT INTO t VALUES (99, TIMESTAMP '2021-12-25', 'world');
+
+query III rowsort
+SELECT "year", ts, v FROM t
+----
+42	2020-06-15 00:00:00	hello
+99	2021-12-25 00:00:00	world


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/991

I found the map which fails at https://github.com/duckdb/duckdb/blob/b24f2023b50b95e9172d7a01b96b12e8c5f66848/src/execution/operator/persistent/physical_copy_to_file.cpp#L368-L369
which means the partition keys have duplicates

Here's the code reference to get partition key name
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_partition_data.cpp#L6-L31
which we could find on partition type `DuckLakeTransformType::IDENTITY` we didn't validate whether the key has been used before.
