### PR TITLE
Fix drop schema after no dependents

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -263,6 +263,9 @@ public:
 	const set<TableIndex> &GetDroppedTables() {
 		return dropped_tables;
 	}
+	const set<TableIndex> &GetDroppedViews() {
+		return dropped_views;
+	}
 	const set<MacroIndex> &GetDroppedScalarMacros() {
 		return dropped_scalar_macros;
 	}

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -412,13 +412,14 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 	if (!cascade) {
 		// get a list of all dependents
 		vector<reference<CatalogEntry>> dependents;
+		const auto &dropped_tables = transaction.GetDroppedTables();
+		const auto &dropped_views = transaction.GetDroppedViews();
 		for (auto &entry : tables.GetEntries()) {
-			const auto &dropped_tables = transaction.GetDroppedTables();
 			bool add_dependent = false;
 			switch (entry.second->type) {
 			case CatalogType::VIEW_ENTRY: {
 				const auto &ducklake_view = entry.second->Cast<DuckLakeViewEntry>();
-				if (dropped_tables.find(ducklake_view.GetViewId()) == dropped_tables.end()) {
+				if (dropped_views.find(ducklake_view.GetViewId()) == dropped_views.end()) {
 					add_dependent = true;
 				}
 			} break;
@@ -430,7 +431,7 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 			} break;
 			default:
 				throw InternalException(
-				    "Unexpected catalog type %s for GetDroppedTables() in DuckLakeSchemaEntry::TryDropSchema()",
+				    "Unexpected catalog type %s in DuckLakeSchemaEntry::TryDropSchema()",
 				    CatalogTypeToString(entry.second->type));
 			}
 			if (add_dependent) {

--- a/test/sql/catalog/drop_schema_after_drop_dependents.test
+++ b/test/sql/catalog/drop_schema_after_drop_dependents.test
@@ -1,0 +1,56 @@
+# name: test/sql/catalog/drop_schema_after_drop_dependents.test
+# description: Regression: DROP SCHEMA (no CASCADE) after dropping the only committed dependent in the same transaction
+# group: [catalog]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_drop_schema_after_drop_dependents')
+
+statement ok
+CREATE SCHEMA ducklake.s
+
+statement ok
+CREATE VIEW ducklake.s.v AS SELECT 1 AS x
+
+statement ok
+BEGIN
+
+statement ok
+DROP VIEW ducklake.s.v
+
+statement ok
+DROP SCHEMA ducklake.s
+
+statement ok
+COMMIT
+
+# same pattern for a committed base table (only dependent is dropped in-txn, then schema)
+statement ok
+CREATE SCHEMA ducklake.s_tbl
+
+statement ok
+CREATE TABLE ducklake.s_tbl.t(i INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+DROP TABLE ducklake.s_tbl.t
+
+statement ok
+DROP SCHEMA ducklake.s_tbl
+
+statement ok
+COMMIT
+
+query I
+SELECT schema_name FROM duckdb_schemas() WHERE database_name='ducklake' ORDER BY ALL
+----
+main


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/993

The bug is, when we try to drop schema, when checking view entries we check if it's a dropped table (which should check whether it's a dropped view).
https://github.com/duckdb/ducklake/blob/336591eafea08a7297752c6e1135b04f35b31dee/src/storage/ducklake_schema_entry.cpp#L411-L416