### PR TITLE
non-native, nested and bit types serdes fixes to prevent Postgres catalog from crashing on inlined data

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -278,6 +278,13 @@ string DuckLakeUtil::ValueToSQL(DuckLakeMetadataManager &metadata_manager, Clien
 		auto str_val = val.CastAs(context, LogicalType::VARCHAR);
 		return ValueToSQL(metadata_manager, context, str_val);
 	}
+	const bool native_type = metadata_manager.TypeIsNativelySupported(val.type());
+	const bool nested_type = val.type().IsNested();
+	if (!native_type && nested_type) {
+		auto json_value = val.CastAs(context, LogicalType::JSON());
+		auto text = json_value.ToString();
+		return StringUtil::Format("%s", SQLString(text));
+	}
 	string result;
 	switch (val.type().id()) {
 	case LogicalTypeId::VARCHAR: {
@@ -286,6 +293,14 @@ string DuckLakeUtil::ValueToSQL(DuckLakeMetadataManager &metadata_manager, Clien
 			return ToByteaHexLiteral(str_val);
 		}
 		return EscapeVarcharForSQL(str_val);
+	}
+	case LogicalTypeId::BIT: {
+		auto bit_text = val.ToString();
+		if (!bit_text.empty() && (bit_text[0] == 'b' || bit_text[0] == 'B')) {
+			bit_text = bit_text.substr(1);
+		}
+		result = StringUtil::Format("%s", SQLString(bit_text));
+		break;
 	}
 	case LogicalTypeId::BLOB: {
 		if (!metadata_manager.TypeIsNativelySupported(LogicalType::BLOB)) {
@@ -297,7 +312,7 @@ string DuckLakeUtil::ValueToSQL(DuckLakeMetadataManager &metadata_manager, Clien
 	default:
 		result = ToSQLString(metadata_manager, val);
 	}
-	if (metadata_manager.TypeIsNativelySupported(val.type()) || !val.type().IsNested()) {
+	if (native_type || !val.type().IsNested()) {
 		return result;
 	}
 	return StringUtil::Format("%s", SQLString(result));

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -27,6 +27,7 @@ public:
 	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
+	string CastColumnToTarget(const string &column, const LogicalType &type) override;
 	shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
 	                                                     const vector<LogicalType> &expected_types) override;
 

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -77,6 +77,13 @@ string PostgresMetadataManager::GetColumnTypeInternal(const LogicalType &column_
 	}
 }
 
+string PostgresMetadataManager::CastColumnToTarget(const string &column, const LogicalType &type) {
+	if (type.IsNested()) {
+		return StringUtil::Format("CAST(CAST(%s AS JSON) AS %s)", column, type.ToString());
+	}
+	return DuckLakeMetadataManager::CastColumnToTarget(column, type);
+}
+
 unique_ptr<QueryResult> PostgresMetadataManager::ExecuteQuery(DuckLakeSnapshot snapshot, string &query,
                                                               string command) {
 	auto &commit_info = transaction.GetCommitInfo();

--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -1,6 +1,6 @@
 {
   "description": "Run DuckLake tests using Postgres as a catalog DBMS.",
-  "on_init": "ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg;",
+  "on_init": "SET extension_directory='{TEST_DIR}/extensions'; INSTALL postgres FROM '__BUILD_DIRECTORY__/repository'; INSTALL json FROM '__BUILD_DIRECTORY__/repository'; LOAD postgres; LOAD json; ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg;",
   "autoloading": "none",
   "statically_loaded_extensions": [
     "core_functions",

--- a/test/sql/data_inlining/postgres_inline_json_list.test
+++ b/test/sql/data_inlining/postgres_inline_json_list.test
@@ -1,0 +1,35 @@
+# name: test/sql/data_inlining/postgres_inline_json_list.test
+# description: check inline JSON[] flushing with postgres metadata
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+require json
+
+require postgres_scanner
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_postgres_inline_json_list', METADATA_SCHEMA 'inline_json_list_{UUID}', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.events (id INTEGER, artifacts JSON[]);
+
+statement ok
+INSERT INTO ducklake.events VALUES (1, [ '{"data": 1}', '{"data": 2}' ]::JSON[]);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query I
+SELECT array_length(artifacts) FROM ducklake.events;
+----
+2
+
+query I
+SELECT json_type(artifacts[1]) FROM ducklake.events;
+----
+OBJECT


### PR DESCRIPTION
The Postgres catalog needs different serialization/deserialization from/to SQL for non-native, nested or `BIT` types.

Currently it crashes when trying to read inlined data rows containing any such types.

This adds specific conversions and for non-native, nested and bit types.

This was tested end-to-end via:
1. catalog bootstrap
2. inline data writes to the Postgres catalog
3. inline data flush out to lake storage

Payloads contained a series of complex and nested types on input, flushed parquet files confirmed to contain exact schema post-flush.