### PR TITLE
Fix sort expression at flush

### DIFF
--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -1,10 +1,29 @@
 #include "storage/ducklake_sort_data.hpp"
 
-#include "duckdb/parser/column_list.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception_format_value.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
+#include "duckdb/parser/parser.hpp"
 
 namespace duckdb {
+
+namespace {
+// Recursively replace column references in an expression with the renamed column names.
+void ReplaceColumnRefs(ParsedExpression &expr, const case_insensitive_map_t<string> &rename_map) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = expr.Cast<ColumnRefExpression>();
+		auto it = rename_map.find(colref.GetColumnName());
+		if (it != rename_map.end()) {
+			colref.column_names.back() = it->second;
+		}
+		return;
+	}
+	ParsedExpressionIterator::EnumerateChildren(expr,
+	                                            [&](ParsedExpression &child) { ReplaceColumnRefs(child, rename_map); });
+}
+} // namespace
 
 string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
                                        const ColumnList &inlined_columns) {
@@ -23,14 +42,31 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 				break;
 			}
 		}
-		if (mapped_col.empty()) {
-			// Not a simple column reference or column not found
-			return string();
-		}
 		if (!result.empty()) {
 			result += ", ";
 		}
-		result += StringUtil::Format("%s", SQLIdentifier(mapped_col));
+		if (!mapped_col.empty()) {
+			result += StringUtil::Format("%s", SQLIdentifier(mapped_col));
+		} else {
+			// Expression sort key: parse it and remap any renamed column references so the ORDER BY runs correctly
+			// against the inlined metadata table's original column names.
+			auto parsed = Parser::ParseExpressionList(field.expression);
+			D_ASSERT(parsed.size() == 1);
+			idx_t mapped_count = MinValue(current_columns.PhysicalColumnCount(), inlined_columns.PhysicalColumnCount());
+			// Map current column names to inlined column names, unqualified.
+			case_insensitive_map_t<string> rename_map;
+			for (idx_t i = 0; i < mapped_count; i++) {
+				const auto &cur = current_columns.GetColumn(PhysicalIndex(i)).Name();
+				const auto &inl = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
+				if (!StringUtil::CIEquals(cur, inl)) {
+					rename_map[cur] = inl;
+				}
+			}
+			if (!rename_map.empty()) {
+				ReplaceColumnRefs(*parsed[0], rename_map);
+			}
+			result += parsed[0]->ToString();
+		}
 		result += (field.sort_direction == OrderType::ASCENDING) ? " ASC" : " DESC";
 		result += (field.null_order == OrderByNullType::NULLS_FIRST) ? " NULLS FIRST" : " NULLS LAST";
 	}

--- a/test/sql/sorted_table/data_inlining_flush_sorted_expression_rename.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_expression_rename.test
@@ -1,0 +1,59 @@
+# name: test/sql/sorted_table/data_inlining_flush_sorted_expression_rename.test
+# description: flushing inlined data with an expression sort key after a column rename should produce correct results
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_inlining_flush_sorted_expr_rename', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+CREATE TABLE ducklake.t(id INTEGER, val INTEGER);
+
+statement ok
+INSERT INTO ducklake.t VALUES (2, 0), (1, 0), (3, 0);
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+statement ok
+UPDATE ducklake.t SET val = val + 1 WHERE id = 2;
+
+# Set an expression sort key
+statement ok
+ALTER TABLE ducklake.t SET SORTED BY ((id + 0) ASC NULLS LAST);
+
+statement ok
+ALTER TABLE ducklake.t RENAME COLUMN id TO new_id;
+
+statement ok
+INSERT INTO ducklake.t VALUES (4, 0);
+
+# Before flush: verify correct live state under the new column name
+query II
+SELECT new_id, val FROM ducklake.t ORDER BY new_id
+----
+1	0
+2	3
+3	0
+4	0
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+SELECT new_id, val FROM ducklake.t ORDER BY new_id
+----
+1	0
+2	3
+3	0
+4	0


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/999

The issue is
- When inline data is flushed, flush commanded is generated here https://github.com/duckdb/ducklake/blob/96f8eb86926add08715b150888a413537b815f31/src/functions/ducklake_flush_inlined_data.cpp#L349-L352
- For non simple expression column reference, we directly return an empty string without (1) remapping and generate an expression for sort; AND (2) keep iterating to the next sorted field https://github.com/duckdb/ducklake/blob/6c69da796c95976eefd6e86856a18769afd0c5ac/src/storage/ducklake_sort_data.cpp#L26-L29

In this PR I tried to handle the sort expression and rename the column (from new column name to inline column name).