### PR TITLE
Remove stale comment for CTAS IF NOT EXISTS.

### DIFF
--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -784,7 +784,6 @@ PhysicalOperator &DuckLakeCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	auto &columns = create_info.columns;
 	auto &duck_transaction = DuckLakeTransaction::Get(context, *this);
 	auto &duck_schema = op.schema.Cast<DuckLakeSchemaEntry>();
-	// FIXME: if table already exists and we are doing CREATE IF NOT EXISTS - skip
 	reference<PhysicalOperator> root = plan;
 	optional_ptr<DuckLakeInlineData> inline_data;
 	idx_t data_inlining_row_limit = DataInliningRowLimit(context, duck_schema.GetSchemaId(), TableIndex());

--- a/test/sql/transaction/create_conflict.test
+++ b/test/sql/transaction/create_conflict.test
@@ -31,6 +31,15 @@ query II
 FROM ducklake.test
 ----
 
+# CTAS with IF NOT EXISTS - table already exists, should be ignored
+statement ok
+CREATE TABLE IF NOT EXISTS ducklake.test AS SELECT 1 i, 2 j;
+
+# original table should be unchanged (empty, INTEGER columns)
+query II
+FROM ducklake.test
+----
+
 # replace table
 statement ok
 CREATE OR REPLACE TABLE ducklake.test(i VARCHAR);


### PR DESCRIPTION
I just randomly found this comment in codebase while working on other patch. and got curious. 

It seems handled on DuckDB level already at 
https://github.com/duckdb/duckdb/blob/fc553552af581fbc84851da6f96fa315d4133729/src/catalog/catalog_entry/duck_schema_entry.cpp#L117-L122. I do offer to exchange the comment removal for unit test. Per my understanding, when table exists, DuckLake's `PlanCreateTableAs` is not reached at all.