### PR TITLE
Fix 'executed' for snapshot expiration

### DIFF
--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -106,6 +106,7 @@ void DuckLakeExpireSnapshotsExecute(ClientContext &context, TableFunctionInput &
 	if (!state.executed && !data.dry_run) {
 		auto &transaction = DuckLakeTransaction::Get(context, data.catalog);
 		transaction.DeleteSnapshots(data.snapshots);
+		state.executed = true;
 	}
 
 	idx_t count = 0;


### PR DESCRIPTION
`executed` is declared but never assigned to true, this PR fixes it.
It's hard to create a regression test since the side effect is to delete snapshots for multiple times which is not a functionality issue.