### PR TITLE
Fix NULL partition parquet file import and merge

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1236,7 +1236,7 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 		}
 		for (auto &hive_partition : file.hive_partition_values) {
 			result.partition_values.push_back({field_partition_key_map[hive_partition.field_index.index],
-			                                   hive_partition.hive_value.GetValue<string>()});
+			                                   hive_partition.hive_value});
 		}
 		result.partition_id = partition_data->partition_id;
 	}

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -75,7 +75,7 @@ vector<BoundOrderByNode> DuckLakeCompactor::BindSortOrders(Binder &binder, DuckL
 DuckLakeCompaction::DuckLakeCompaction(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
                                        DuckLakeTableEntry &table, vector<DuckLakeCompactionFileEntry> source_files_p,
                                        string encryption_key_p, optional_idx partition_id,
-                                       vector<string> partition_values_p, optional_idx row_id_start,
+                                       vector<Value> partition_values_p, optional_idx row_id_start,
                                        PhysicalOperator &child, CompactionType type)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 0), table(table),
       source_files(std::move(source_files_p)), encryption_key(std::move(encryption_key_p)), partition_id(partition_id),
@@ -198,7 +198,7 @@ struct DuckLakeCompactionCandidates {
 struct DuckLakeCompactionGroup {
 	idx_t schema_version;
 	optional_idx partition_id;
-	vector<string> partition_values;
+	vector<Value> partition_values;
 };
 
 struct DuckLakeCompactionGroupHash {
@@ -208,8 +208,14 @@ struct DuckLakeCompactionGroupHash {
 		if (group.partition_id.IsValid()) {
 			hash ^= std::hash<idx_t>()(group.partition_id.GetIndex());
 		}
-		for (auto &partition_val : group.partition_values) {
-			hash ^= std::hash<string>()(partition_val);
+		for (auto &val : group.partition_values) {
+			// NULL partitions get a fixed constant so all null-partition files
+			// hash to the same bucket regardless of type.
+			if (val.IsNull()) {
+				hash ^= 0x9E3779B97F4A7C15ULL;
+			} else {
+				hash ^= std::hash<string>()(val.ToString());
+			}
 		}
 		return hash;
 	}
@@ -217,8 +223,25 @@ struct DuckLakeCompactionGroupHash {
 
 struct DuckLakeCompactionGroupEquality {
 	bool operator()(const DuckLakeCompactionGroup &a, const DuckLakeCompactionGroup &b) const {
-		return a.schema_version == b.schema_version && a.partition_id == b.partition_id &&
-		       a.partition_values == b.partition_values;
+		if (a.schema_version != b.schema_version || a.partition_id != b.partition_id) {
+			return false;
+		}
+		if (a.partition_values.size() != b.partition_values.size()) {
+			return false;
+		}
+		for (idx_t i = 0; i < a.partition_values.size(); i++) {
+			const auto &av = a.partition_values[i];
+			const auto &bv = b.partition_values[i];
+			// NULL == NULL means "same null partition"; one NULL and one non-NULL
+			// means different partitions.
+			if (av.IsNull() != bv.IsNull()) {
+				return false;
+			}
+			if (!av.IsNull() && av.ToString() != bv.ToString()) {
+				return false;
+			}
+		}
+		return true;
 	}
 };
 

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -209,8 +209,6 @@ struct DuckLakeCompactionGroupHash {
 			hash ^= std::hash<idx_t>()(group.partition_id.GetIndex());
 		}
 		for (auto &val : group.partition_values) {
-			// NULL partitions get a fixed constant so all null-partition files
-			// hash to the same bucket regardless of type.
 			if (val.IsNull()) {
 				hash ^= 0x9E3779B97F4A7C15ULL;
 			} else {
@@ -232,8 +230,6 @@ struct DuckLakeCompactionGroupEquality {
 		for (idx_t i = 0; i < a.partition_values.size(); i++) {
 			const auto &av = a.partition_values[i];
 			const auto &bv = b.partition_values[i];
-			// NULL == NULL means "same null partition"; one NULL and one non-NULL
-			// means different partitions.
 			if (av.IsNull() != bv.IsNull()) {
 				return false;
 			}

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -33,7 +33,7 @@ class DuckLakeLogicalCompaction : public LogicalExtensionOperator {
 public:
 	DuckLakeLogicalCompaction(idx_t table_index, DuckLakeTableEntry &table,
 	                          vector<DuckLakeCompactionFileEntry> source_files_p, string encryption_key_p,
-	                          optional_idx partition_id, vector<string> partition_values_p, optional_idx row_id_start,
+	                          optional_idx partition_id, vector<Value> partition_values_p, optional_idx row_id_start,
 	                          CompactionType type)
 	    : table_index(table_index), table(table), source_files(std::move(source_files_p)),
 	      encryption_key(std::move(encryption_key_p)), partition_id(partition_id),
@@ -45,7 +45,7 @@ public:
 	vector<DuckLakeCompactionFileEntry> source_files;
 	string encryption_key;
 	optional_idx partition_id;
-	vector<string> partition_values;
+	vector<Value> partition_values;
 	optional_idx row_id_start;
 	CompactionType type;
 

--- a/src/include/storage/ducklake_compaction.hpp
+++ b/src/include/storage/ducklake_compaction.hpp
@@ -22,14 +22,14 @@ class DuckLakeCompaction : public PhysicalOperator {
 public:
 	DuckLakeCompaction(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
 	                   vector<DuckLakeCompactionFileEntry> source_files_p, string encryption_key,
-	                   optional_idx partition_id, vector<string> partition_values, optional_idx row_id_start,
+	                   optional_idx partition_id, vector<Value> partition_values, optional_idx row_id_start,
 	                   PhysicalOperator &child, CompactionType type);
 
 	DuckLakeTableEntry &table;
 	vector<DuckLakeCompactionFileEntry> source_files;
 	string encryption_key;
 	optional_idx partition_id;
-	vector<string> partition_values;
+	vector<Value> partition_values;
 	optional_idx row_id_start;
 	CompactionType type;
 

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -433,7 +433,7 @@ struct DuckLakeCompactionFileData : public DuckLakeCompactionBaseFileData {
 	optional_idx row_id_start;
 	MappingIndex mapping_id;
 	optional_idx partition_id;
-	vector<string> partition_values;
+	vector<Value> partition_values;
 };
 
 struct DuckLakeCompactionDeleteFileData : public DuckLakeCompactionBaseFileData {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1884,7 +1884,7 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 		if (!row.IsNull(col_idx)) {
 			auto list_val = row.GetValue<Value>(col_idx);
 			for (auto &entry : ListValue::GetChildren(list_val)) {
-				new_entry.file.partition_values.push_back(StringValue::Get(entry));
+				new_entry.file.partition_values.push_back(entry);
 			}
 		}
 		col_idx++;

--- a/test/sql/partitioning/merge_adjacent_null_partition.test
+++ b/test/sql/partitioning/merge_adjacent_null_partition.test
@@ -97,3 +97,144 @@ SELECT id, tag FROM ducklake.t ORDER BY id
 1	NULL
 2	NULL
 3	NULL
+
+#===----------------------------------------------------------------------===#
+# Part 3: Multiple partition columns, both NULL
+#===----------------------------------------------------------------------===#
+
+statement ok
+CREATE TABLE ducklake.multi_null (id INTEGER, a VARCHAR, b VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.multi_null SET PARTITIONED BY (a, b)
+
+statement ok
+INSERT INTO ducklake.multi_null VALUES (1, NULL, NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO ducklake.multi_null VALUES (2, NULL, NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Both files should be in the same partition group and mergeable
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake')
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file
+    WHERE table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'multi_null')
+----
+1
+
+# Both partition columns should have NULL partition values after merge
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value fpv
+    JOIN meta.ducklake_data_file df ON fpv.data_file_id = df.data_file_id
+    WHERE df.table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'multi_null')
+      AND fpv.partition_value IS NULL
+----
+2
+
+query III
+SELECT id, a, b FROM ducklake.multi_null ORDER BY id
+----
+1	NULL	NULL
+2	NULL	NULL
+
+#===----------------------------------------------------------------------===#
+# Part 4: Mixed NULL and non-NULL across partition columns
+#===----------------------------------------------------------------------===#
+
+statement ok
+CREATE TABLE ducklake.mixed_null (id INTEGER, a VARCHAR, b VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.mixed_null SET PARTITIONED BY (a, b)
+
+# Two files with a=NULL, b='x'
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (1, NULL, 'x')
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (2, NULL, 'x')
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Two files with a='y', b=NULL
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (3, 'y', NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (4, 'y', NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# One file with a=NULL, b=NULL
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (5, NULL, NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# One file with a='y', b='x'
+statement ok
+INSERT INTO ducklake.mixed_null VALUES (6, 'y', 'x')
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file
+    WHERE table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'mixed_null')
+----
+6
+
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake')
+
+# After merge: 4 files — (NULL,'x') merged, ('y',NULL) merged, (NULL,NULL) alone, ('y','x') alone
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file
+    WHERE table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'mixed_null')
+----
+4
+
+# 4 NULL partition values: (NULL,'x') has 1, ('y',NULL) has 1, (NULL,NULL) has 2
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value fpv
+    JOIN meta.ducklake_data_file df ON fpv.data_file_id = df.data_file_id
+    WHERE df.table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'mixed_null')
+      AND fpv.partition_value IS NULL
+----
+4
+
+# 4 non-NULL partition values: (NULL,'x') has 1, ('y',NULL) has 1, ('y','x') has 2
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value fpv
+    JOIN meta.ducklake_data_file df ON fpv.data_file_id = df.data_file_id
+    WHERE df.table_id = (SELECT table_id FROM meta.ducklake_table WHERE table_name = 'mixed_null')
+      AND fpv.partition_value IS NOT NULL
+----
+4
+
+query III
+SELECT id, a, b FROM ducklake.mixed_null ORDER BY id
+----
+1	NULL	x
+2	NULL	x
+3	y	NULL
+4	y	NULL
+5	NULL	NULL
+6	y	x

--- a/test/sql/partitioning/merge_adjacent_null_partition.test
+++ b/test/sql/partitioning/merge_adjacent_null_partition.test
@@ -1,0 +1,139 @@
+# name: test/sql/partitioning/merge_adjacent_null_partition.test
+# description: ducklake_merge_adjacent_files with NULL partition
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+#===----------------------------------------------------------------------===#
+# Part 1: minimal repro - crash from regular INSERT + flush alone
+#===----------------------------------------------------------------------===#
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+    DATA_PATH '{DATA_PATH}/null_partition_merge',
+    METADATA_CATALOG 'meta'
+)
+
+statement ok
+CREATE TABLE ducklake.t (id INTEGER, tag VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.t SET PARTITIONED BY (tag)
+
+# First null-partition file: INSERT + flush writes partition_value = SQL NULL
+statement ok
+INSERT INTO ducklake.t VALUES (1, NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Second null-partition file: same path, second SQL NULL stored
+statement ok
+INSERT INTO ducklake.t VALUES (2, NULL)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# Confirm two live files exist, both with partition_value = SQL NULL
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
+----
+2
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
+----
+2
+
+# Previously crashed:
+#   INTERNAL Error: Calling StringValue::Get on a NULL value
+# because GetFilesForCompaction called ARRAY_AGG(partition_value) which in DuckDB
+# includes NULLs, then passed the NULL list element to StringValue::Get.
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake')
+
+# After successful compaction: one live file, correct metadata, correct data
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
+----
+1
+
+query II
+SELECT id, tag FROM ducklake.t ORDER BY id
+----
+1	NULL
+2	NULL
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE tag IS NULL
+----
+2
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE tag IS NOT NULL
+----
+0
+
+#===----------------------------------------------------------------------===#
+# Part 2: secondary bug - add_data_files stores 'NULL' string, not SQL NULL
+#         This also interacts with compaction (different representation prevents
+#         files from the two paths being grouped together for merging).
+#===----------------------------------------------------------------------===#
+
+# Write a source parquet file with a NULL partition value via DuckDB hive partitioning
+statement ok
+COPY (SELECT 3 AS id, NULL::VARCHAR AS tag)
+TO '{DATA_PATH}/null_part_src'
+(FORMAT PARQUET, PARTITION_BY (tag))
+
+# Register it via add_data_files
+statement ok
+CALL ducklake_add_data_files('ducklake', 't',
+    '{DATA_PATH}/null_part_src/tag=__HIVE_DEFAULT_PARTITION__/*.parquet',
+    hive_partitioning => true)
+
+# Both files (one from flush, one from add_data_files) must use SQL NULL so
+# they are grouped together and compactable.
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
+----
+2
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value = 'NULL'
+----
+0
+
+# Compaction must merge the flush-registered file and the add_data_files-registered
+# file into a single output file (same null partition group).
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake')
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+query I
+SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
+----
+1
+
+# All three rows visible after the second round of compaction
+query II
+SELECT id, tag FROM ducklake.t ORDER BY id
+----
+1	NULL
+2	NULL
+3	NULL

--- a/test/sql/partitioning/merge_adjacent_null_partition.test
+++ b/test/sql/partitioning/merge_adjacent_null_partition.test
@@ -1,5 +1,5 @@
 # name: test/sql/partitioning/merge_adjacent_null_partition.test
-# description: ducklake_merge_adjacent_files with NULL partition
+# description: add data file and merge adjacent file with NULL partition
 # group: [partitioning]
 
 require ducklake
@@ -11,7 +11,7 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 test-env DATA_PATH {TEST_DIR}
 
 #===----------------------------------------------------------------------===#
-# Part 1: minimal repro - crash from regular INSERT + flush alone
+# Part 1: flush two NULL-partitioned parquet and merge
 #===----------------------------------------------------------------------===#
 
 statement ok
@@ -26,44 +26,23 @@ CREATE TABLE ducklake.t (id INTEGER, tag VARCHAR)
 statement ok
 ALTER TABLE ducklake.t SET PARTITIONED BY (tag)
 
-# First null-partition file: INSERT + flush writes partition_value = SQL NULL
+# Create two NULL partitioned parquet files
 statement ok
 INSERT INTO ducklake.t VALUES (1, NULL)
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# Second null-partition file: same path, second SQL NULL stored
 statement ok
 INSERT INTO ducklake.t VALUES (2, NULL)
 
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
-# Confirm two live files exist, both with partition_value = SQL NULL
-query I
-SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
-----
-2
-
-query I
-SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
-----
-2
-
-# Previously crashed:
-#   INTERNAL Error: Calling StringValue::Get on a NULL value
-# because GetFilesForCompaction called ARRAY_AGG(partition_value) which in DuckDB
-# includes NULLs, then passed the NULL list element to StringValue::Get.
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake')
 
-# After successful compaction: one live file, correct metadata, correct data
-query I
-SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
-----
-1
-
+# Validate partition after compaction
 query I
 SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
 ----
@@ -75,20 +54,8 @@ SELECT id, tag FROM ducklake.t ORDER BY id
 1	NULL
 2	NULL
 
-query I
-SELECT COUNT(*) FROM ducklake.t WHERE tag IS NULL
-----
-2
-
-query I
-SELECT COUNT(*) FROM ducklake.t WHERE tag IS NOT NULL
-----
-0
-
 #===----------------------------------------------------------------------===#
-# Part 2: secondary bug - add_data_files stores 'NULL' string, not SQL NULL
-#         This also interacts with compaction (different representation prevents
-#         files from the two paths being grouped together for merging).
+# Part 2: Add data file with NULL partition
 #===----------------------------------------------------------------------===#
 
 # Write a source parquet file with a NULL partition value via DuckDB hive partitioning
@@ -103,8 +70,7 @@ CALL ducklake_add_data_files('ducklake', 't',
     '{DATA_PATH}/null_part_src/tag=__HIVE_DEFAULT_PARTITION__/*.parquet',
     hive_partitioning => true)
 
-# Both files (one from flush, one from add_data_files) must use SQL NULL so
-# they are grouped together and compactable.
+# Both files (one from flush, one from add_data_files) must use SQL NULL so they are grouped together and compactable.
 query I
 SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
 ----
@@ -115,22 +81,16 @@ SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value = 
 ----
 0
 
-# Compaction must merge the flush-registered file and the add_data_files-registered
-# file into a single output file (same null partition group).
+# Merge two NULL partitioned parquet files into one, also NULL partitioned.
 statement ok
 CALL ducklake_merge_adjacent_files('ducklake')
 
-query I
-SELECT COUNT(*) FROM meta.ducklake_data_file WHERE end_snapshot IS NULL
-----
-1
-
+# Validate partition after compaction.
 query I
 SELECT COUNT(*) FROM meta.ducklake_file_partition_value WHERE partition_value IS NULL
 ----
 1
 
-# All three rows visible after the second round of compaction
 query II
 SELECT id, tag FROM ducklake.t ORDER BY id
 ----


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1014
Closes https://github.com/duckdb/ducklake/issues/1015

There're two related issues, the first one is easier to explain:
https://github.com/duckdb/ducklake/blob/eaed599213305a5e084f4331837c2cb0943bb685/src/functions/ducklake_add_data_files.cpp#L1240-L1241
When the imported parquet file is NULL partitioned, `hive_partition.hive_value.GetValue<string>()` returns a string "NULL" instead of a SQL `NULL`.
To me the easiest solution is to store `Value` directly instead of string so we don't lose the information.

The second issue is related, when use `ARRAY_AGG` to get all partition values to merge files NULL partition value is returned, `StringValue::Get()` throws on SQL NULL here
https://github.com/duckdb/ducklake/blob/eaed599213305a5e084f4331837c2cb0943bb685/src/storage/ducklake_metadata_manager.cpp#L1887
The solution is the same as the first issue -- store `Value` directly as partition value instead of converting into string