### PR TITLE
Disable hive partitioning auto-detection in ParquetFileScanner

### DIFF
--- a/src/common/parquet_file_scanner.cpp
+++ b/src/common/parquet_file_scanner.cpp
@@ -25,6 +25,9 @@ ParquetFileScanner::ParquetFileScanner(ClientContext &context, const DuckLakeFil
 	vector<LogicalType> input_types;
 	vector<string> input_names;
 
+	// ducklake-managed paths may contain incidental key=value segments
+	named_params["hive_partitioning"] = Value::BOOLEAN(false);
+
 	if (!file.encryption_key.empty()) {
 		child_list_t<Value> encryption_values;
 		encryption_values.emplace_back("footer_key_value", Value::BLOB_RAW(file.encryption_key));

--- a/test/sql/issues/issue_1027_hive_path_scan.test
+++ b/test/sql/issues/issue_1027_hive_path_scan.test
@@ -1,0 +1,30 @@
+# name: test/sql/issues/issue_1027_hive_path_scan.test
+# description: scanning a ducklake lake whose DATA_PATH contains key=value segments must not hive-auto-detect (#1027)
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+# DATA_PATH contains an incidental key=value segment: ParquetFileScanner
+# must not treat it as hive partitioning and append a synthetic column
+# to the delete-file schema.
+test-env DATA_PATH __TEST_DIR__/issue_1027/site_id=42
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}')
+
+statement ok
+CREATE TABLE ducklake.t AS SELECT i AS id FROM range(1000) t(i)
+
+statement ok
+DELETE FROM ducklake.t WHERE id % 7 = 0
+
+# FILTER forces a row-level scan that applies the delete filter.
+# Before the fix this threw "Invalid schema contained in the delete file".
+query II
+SELECT COUNT(*), COUNT(*) FILTER (WHERE id % 7 = 0) FROM ducklake.t
+----
+857	0

--- a/test/sql/issues/issue_1027_hive_path_scan.test
+++ b/test/sql/issues/issue_1027_hive_path_scan.test
@@ -8,9 +8,7 @@ require parquet
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-# DATA_PATH contains an incidental key=value segment: ParquetFileScanner
-# must not treat it as hive partitioning and append a synthetic column
-# to the delete-file schema.
+# DATA_PATH contains an incidental key=value segment
 test-env DATA_PATH __TEST_DIR__/issue_1027/site_id=42
 
 statement ok
@@ -22,9 +20,11 @@ CREATE TABLE ducklake.t AS SELECT i AS id FROM range(1000) t(i)
 statement ok
 DELETE FROM ducklake.t WHERE id % 7 = 0
 
-# FILTER forces a row-level scan that applies the delete filter.
-# Before the fix this threw "Invalid schema contained in the delete file".
+# Second DELETE adds _ducklake_internal_snapshot_id to the delete file
+statement ok
+DELETE FROM ducklake.t WHERE id % 5 = 0
+
 query II
-SELECT COUNT(*), COUNT(*) FILTER (WHERE id % 7 = 0) FROM ducklake.t
+SELECT COUNT(*), COUNT(*) FILTER (WHERE id % 7 = 0 OR id % 5 = 0) FROM ducklake.t
 ----
-857	0
+686	0


### PR DESCRIPTION
ParquetFileScanner binds parquet_scan without setting hive_partitioning, so DuckDB's default 'auto' mode synthesizes a column for every key=value segment along the file path. For ducklake-managed files those segments are incidental and the extra column breaks consumers that rely on an exact schema (DuckLakeDeleteFilter::ScanDeleteFile, ScanDataFileRowIds).

Fixes #1027.