### PR TITLE
Embed end_snapshot in flushed Parquet files

### DIFF
--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -31,21 +31,6 @@
 
 namespace duckdb {
 
-static void AttachDeleteFilesToWrittenFiles(vector<DuckLakeDeleteFile> &delete_files,
-                                            vector<DuckLakeDataFile> &written_files) {
-	unordered_map<string, reference<DuckLakeDataFile>> file_map;
-	file_map.reserve(written_files.size());
-	for (auto &written_file : written_files) {
-		file_map.emplace(written_file.file_name, written_file);
-	}
-	for (auto &delete_file : delete_files) {
-		auto it = file_map.find(delete_file.data_file_path);
-		if (it != file_map.end()) {
-			it->second.get().delete_files.push_back(std::move(delete_file));
-		}
-	}
-}
-
 //===--------------------------------------------------------------------===//
 // Flush Data Operator
 //===--------------------------------------------------------------------===//
@@ -108,85 +93,14 @@ SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chu
 //===--------------------------------------------------------------------===//
 // Finalize
 //===--------------------------------------------------------------------===//
-using DeletesPerFile = unordered_map<string, set<PositionWithSnapshot>>;
-
 SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                              OperatorSinkFinalizeInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
 	auto &transaction = DuckLakeTransaction::Get(context, global_state.table.catalog);
 	auto snapshot = transaction.GetSnapshot();
 
-	if (!global_state.written_files.empty()) {
-		DeletesPerFile deletes_per_file;
-		auto partition_sql_exprs = table.GetPartitionSQLExpressions();
-
-		// Track cumulative row offset per partition so each file knows its range
-		unordered_map<string, idx_t> partition_row_offsets;
-
-		for (auto &file : global_state.written_files) {
-			// Build partition filter (empty string for non-partitioned tables)
-			string partition_filter;
-			if (!partition_sql_exprs.empty()) {
-				vector<Value> values;
-				for (auto &pv : file.partition_values) {
-					values.push_back(pv.partition_value);
-				}
-				partition_filter = DuckLakePartitionUtils::BuildPartitionFilter(partition_sql_exprs, values);
-			}
-
-			idx_t file_offset = partition_row_offsets[partition_filter];
-			partition_row_offsets[partition_filter] += file.row_count;
-
-			// Query deleted rows within this file's row range, filtered to its partition
-			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
-			// When the table has sort metadata, the file is written in sorted order.
-			// The ORDER BY must match the actual file order so delete positions are correct.
-			string order_by = "row_id, begin_snapshot";
-			if (!sort_order_sql.empty()) {
-				order_by = sort_order_sql + ", row_id, begin_snapshot";
-			}
-			auto deleted_rows_result =
-			    transaction.Query(snapshot, StringUtil::Format(R"(
-				WITH all_rows AS (
-					SELECT end_snapshot, ROW_NUMBER() OVER (ORDER BY %s) - 1 AS output_position
-					FROM {METADATA_CATALOG}.%s
-					WHERE {SNAPSHOT_ID} >= begin_snapshot%s
-				)
-				SELECT end_snapshot, output_position
-				FROM all_rows
-				WHERE end_snapshot IS NOT NULL
-				AND output_position >= %d AND output_position < %d;)",
-			                                                   order_by, inlined_table.table_name, extra_filter,
-			                                                   file_offset, file_offset + file.row_count));
-
-			for (auto &row : *deleted_rows_result) {
-				auto end_snap = row.GetValue<int64_t>(0);
-				auto output_position = row.GetValue<int64_t>(1);
-				int64_t pos_in_file = output_position - static_cast<int64_t>(file_offset);
-				PositionWithSnapshot pos_with_snap {pos_in_file, end_snap};
-				deletes_per_file[file.file_name].insert(pos_with_snap);
-			}
-		}
-
-		if (!deletes_per_file.empty()) {
-			auto &fs = FileSystem::GetFileSystem(context);
-			vector<DuckLakeDeleteFile> delete_files;
-
-			for (auto &file_entry : deletes_per_file) {
-				// write single file, begin_snapshot is the minimum snapshot
-				WriteDeleteFileWithSnapshotsInput file_input {context,
-				                                              transaction,
-				                                              fs,
-				                                              table.DataPath(),
-				                                              encryption_key,
-				                                              file_entry.first,
-				                                              file_entry.second,
-				                                              DeleteFileSource::FLUSH};
-				delete_files.push_back(DuckLakeDeleteFileWriter::WriteDeleteFileWithSnapshots(context, file_input));
-			}
-			AttachDeleteFilesToWrittenFiles(delete_files, global_state.written_files);
-		}
-	}
+	// No delete files needed -- end_snapshot is embedded in the data file as a virtual column.
+	// The scan filters rows based on end_snapshot for visibility.
 
 	// Compute total rows flushed before moving files
 	for (auto &file : global_state.written_files) {
@@ -311,7 +225,7 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 
 	DuckLakeCopyInput copy_input(context, table);
 	copy_input.get_table_index = table_idx.index;
-	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID;
+	copy_input.virtual_columns = InsertVirtualColumns::WRITE_ALL_SNAPSHOT_COLUMNS;
 
 	auto copy_options = DuckLakeInsert::GetCopyOptions(context, copy_input);
 
@@ -325,6 +239,7 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	}
 	column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
 	column_ids.emplace_back(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID);
+	column_ids.emplace_back(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_END_SNAPSHOT_ID);
 
 	auto root = unique_ptr_cast<LogicalGet, LogicalOperator>(std::move(ducklake_scan));
 

--- a/src/functions/ducklake_murmur3.cpp
+++ b/src/functions/ducklake_murmur3.cpp
@@ -14,14 +14,13 @@ static void Murmur3ScalarFunction(DataChunk &args, ExpressionState &state, Vecto
 	input.ToUnifiedFormat(count, input_data);
 
 	auto result_data = FlatVector::GetDataMutable<int32_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 
 	auto &type = input.GetType();
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = input_data.sel->get_index(i);
 		if (!input_data.validity.RowIsValid(idx)) {
-			result_validity.SetInvalid(i);
+			FlatVector::SetNull(result, i, true);
 			continue;
 		}
 

--- a/src/include/storage/ducklake_insert.hpp
+++ b/src/include/storage/ducklake_insert.hpp
@@ -25,7 +25,14 @@ struct DuckLakePartition;
 struct DuckLakeCopyOptions;
 struct DuckLakeCopyInput;
 
-enum class InsertVirtualColumns { NONE, WRITE_ROW_ID, WRITE_SNAPSHOT_ID, WRITE_ROW_ID_AND_SNAPSHOT_ID };
+enum class InsertVirtualColumns {
+	NONE,
+	WRITE_ROW_ID,
+	WRITE_SNAPSHOT_ID,
+	WRITE_ROW_ID_AND_SNAPSHOT_ID,
+	//! Write row_id, begin_snapshot, and end_snapshot (used for flushing inlined data with deletes)
+	WRITE_ALL_SNAPSHOT_COLUMNS
+};
 
 class DuckLakeInsertGlobalState : public GlobalSinkState {
 public:

--- a/src/include/storage/ducklake_multi_file_reader.hpp
+++ b/src/include/storage/ducklake_multi_file_reader.hpp
@@ -20,6 +20,9 @@ class DuckLakeFieldData;
 struct DuckLakeMultiFileReader : public MultiFileReader {
 public:
 	static constexpr column_t COLUMN_IDENTIFIER_SNAPSHOT_ID = UINT64_C(10000000000000000000);
+	static constexpr column_t COLUMN_IDENTIFIER_END_SNAPSHOT_ID = UINT64_C(10000000000000000001);
+	//! Parquet field ID for the end_snapshot virtual column (one below LAST_UPDATED_SEQUENCE_NUMBER_ID)
+	static constexpr int32_t END_SNAPSHOT_FIELD_ID = 2147483538;
 
 public:
 	explicit DuckLakeMultiFileReader(DuckLakeFunctionInfo &read_info);
@@ -87,6 +90,7 @@ private:
 private:
 	unique_ptr<MultiFileColumnDefinition> row_id_column;
 	unique_ptr<MultiFileColumnDefinition> snapshot_id_column;
+	unique_ptr<MultiFileColumnDefinition> end_snapshot_id_column;
 	//! Inlined transaction-local data
 	shared_ptr<DuckLakeInlinedData> transaction_local_data;
 	//! For deletion scans: track which output column is snapshot_id (if any)
@@ -96,6 +100,10 @@ private:
 	//! Whether row_id was internally projected (not in user's query)
 	//! This is necessary for DCF queries over inlined deletions
 	bool internally_projected_rowid = false;
+	//! For end_snapshot filtering: which output column holds end_snapshot (if any)
+	optional_idx end_snapshot_filter_col;
+	//! Whether end_snapshot was internally projected (not in user's query)
+	bool internally_projected_end_snapshot = false;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -59,6 +59,9 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 						virtual_column = "begin_snapshot";
 					}
 					break;
+				case DuckLakeMultiFileReader::END_SNAPSHOT_FIELD_ID:
+					virtual_column = "end_snapshot";
+					break;
 				default:
 					break;
 				}

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "storage/ducklake_multi_file_reader.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
@@ -145,6 +146,10 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 						data_file.max_partial_file_snapshot = StringUtil::ToUnsigned(snapshot_stats.max);
 					}
 				}
+				continue;
+			}
+			if (column_names[0] == "_ducklake_internal_end_snapshot_id") {
+				// end_snapshot stats -- skip (no metadata extraction needed)
 				continue;
 			}
 			if (column_names[0] == "_ducklake_internal_row_id") {
@@ -305,12 +310,18 @@ static Value GetFieldIdValue(const DuckLakeFieldId &field_id) {
 
 static bool WriteRowId(InsertVirtualColumns virtual_columns) {
 	return virtual_columns == InsertVirtualColumns::WRITE_ROW_ID ||
-	       virtual_columns == InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID;
+	       virtual_columns == InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID ||
+	       virtual_columns == InsertVirtualColumns::WRITE_ALL_SNAPSHOT_COLUMNS;
 }
 
 static bool WriteSnapshotId(InsertVirtualColumns virtual_columns) {
 	return virtual_columns == InsertVirtualColumns::WRITE_SNAPSHOT_ID ||
-	       virtual_columns == InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID;
+	       virtual_columns == InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID ||
+	       virtual_columns == InsertVirtualColumns::WRITE_ALL_SNAPSHOT_COLUMNS;
+}
+
+static bool WriteEndSnapshotId(InsertVirtualColumns virtual_columns) {
+	return virtual_columns == InsertVirtualColumns::WRITE_ALL_SNAPSHOT_COLUMNS;
 }
 
 static Value WrittenFieldIds(DuckLakeFieldData &field_data, InsertVirtualColumns virtual_columns) {
@@ -325,6 +336,10 @@ static Value WrittenFieldIds(DuckLakeFieldData &field_data, InsertVirtualColumns
 	if (WriteSnapshotId(virtual_columns)) {
 		values.emplace_back("_ducklake_internal_snapshot_id",
 		                    Value::BIGINT(MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID));
+	}
+	if (WriteEndSnapshotId(virtual_columns)) {
+		values.emplace_back("_ducklake_internal_end_snapshot_id",
+		                    Value::BIGINT(DuckLakeMultiFileReader::END_SNAPSHOT_FIELD_ID));
 	}
 	return Value::STRUCT(std::move(values));
 }
@@ -434,6 +449,9 @@ static void GeneratePartitionExpressions(ClientContext &context, DuckLakeCopyInp
 	case InsertVirtualColumns::WRITE_ROW_ID_AND_SNAPSHOT_ID:
 		virtual_column_count = 2;
 		break;
+	case InsertVirtualColumns::WRITE_ALL_SNAPSHOT_COLUMNS:
+		virtual_column_count = 3;
+		break;
 	default:
 		virtual_column_count = 0;
 		break;
@@ -537,6 +555,10 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	}
 	if (WriteSnapshotId(copy_input.virtual_columns)) {
 		names_to_write.push_back("_ducklake_internal_snapshot_id");
+		types_to_write.push_back(LogicalType::BIGINT);
+	}
+	if (WriteEndSnapshotId(copy_input.virtual_columns)) {
+		names_to_write.push_back("_ducklake_internal_end_snapshot_id");
 		types_to_write.push_back(LogicalType::BIGINT);
 	}
 

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -56,6 +56,23 @@ static bool TryFindColumnByFieldId(const vector<MultiFileColumnDefinition> &loca
 	return false;
 }
 
+//! Build a selection vector keeping rows visible at the given snapshot:
+//! end_snapshot IS NULL (live) OR end_snapshot > current_snapshot (not yet deleted at this snapshot).
+static idx_t ApplyEndSnapshotFilter(Vector &end_snap_vec, idx_t count, int64_t current_snapshot,
+                                    SelectionVector &sel) {
+	UnifiedVectorFormat vdata;
+	end_snap_vec.ToUnifiedFormat(count, vdata);
+	auto end_snap_data = UnifiedVectorFormat::GetData<int64_t>(vdata);
+	idx_t result_count = 0;
+	for (idx_t i = 0; i < count; i++) {
+		auto idx = vdata.sel->get_index(i);
+		if (!vdata.validity.RowIsValid(idx) || end_snap_data[idx] > current_snapshot) {
+			sel.set_index(result_count++, i);
+		}
+	}
+	return result_count;
+}
+
 //! Add a snapshot filter to the reader's filter set
 static void AddSnapshotFilter(BaseFileReader &reader, const ColumnIndex &col_idx, const LogicalType &col_type,
                               idx_t snapshot_value, ExpressionType comparison_type) {
@@ -156,6 +173,9 @@ DuckLakeMultiFileReader::DuckLakeMultiFileReader(DuckLakeFunctionInfo &read_info
 	row_id_column->identifier = Value::INTEGER(MultiFileReader::ROW_ID_FIELD_ID);
 	snapshot_id_column = make_uniq<MultiFileColumnDefinition>("_ducklake_internal_snapshot_id", LogicalType::BIGINT);
 	snapshot_id_column->identifier = Value::INTEGER(MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID);
+	end_snapshot_id_column =
+	    make_uniq<MultiFileColumnDefinition>("_ducklake_internal_end_snapshot_id", LogicalType::BIGINT);
+	end_snapshot_id_column->identifier = Value::INTEGER(END_SNAPSHOT_FIELD_ID);
 }
 
 DuckLakeMultiFileReader::~DuckLakeMultiFileReader() {
@@ -293,6 +313,9 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			reader.deletion_filter = std::move(delete_filter);
 		}
 	}
+	end_snapshot_filter_col = optional_idx();
+	internally_projected_end_snapshot = false;
+
 	auto result = MultiFileReader::InitializeReader(reader_data, bind_data, global_columns, global_column_ids,
 	                                                table_filters, context, gstate);
 	// Handle snapshot filters for files with multiple snapshots (partial_max set)
@@ -345,6 +368,41 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			                  ExpressionType::COMPARE_GREATERTHANOREQUALTO);
 		}
 	}
+
+	// Handle end_snapshot filtering for files with embedded end_snapshot data
+	// (produced by flush of inlined data with deletes)
+	if (!file_list.IsDeleteScan() && file_entry.data_type == DuckLakeDataType::DATA_FILE) {
+		auto &reader = *reader_data.reader;
+		optional_idx end_snap_col;
+		for (idx_t col_idx = 0; col_idx < reader.columns.size(); col_idx++) {
+			auto &col = reader.columns[col_idx];
+			if (col.identifier.type() == LogicalTypeId::INTEGER &&
+			    IntegerValue::Get(col.identifier) == END_SNAPSHOT_FIELD_ID) {
+				end_snap_col = col_idx;
+				break;
+			}
+		}
+		if (end_snap_col.IsValid()) {
+			idx_t end_snap_col_id = end_snap_col.GetIndex();
+			// Check if the column is already projected
+			optional_idx end_snap_local_id;
+			for (idx_t i = 0; i < reader.column_ids.size(); i++) {
+				if (reader.column_indexes[i].GetPrimaryIndex() == end_snap_col_id) {
+					end_snap_local_id = i;
+					break;
+				}
+			}
+			if (!end_snap_local_id.IsValid()) {
+				// Internally project the end_snapshot column for filtering
+				end_snap_local_id = reader.column_indexes.size();
+				reader.column_indexes.emplace_back(end_snap_col_id);
+				reader.column_ids.emplace_back(end_snap_col_id);
+				internally_projected_end_snapshot = true;
+			}
+			end_snapshot_filter_col = end_snap_local_id.GetIndex();
+		}
+	}
+
 	return result;
 }
 
@@ -614,6 +672,14 @@ unique_ptr<Expression> DuckLakeMultiFileReader::GetVirtualColumnExpression(
 		}
 		return make_uniq<BoundConstantExpression>(entry->second);
 	}
+	if (column_id == COLUMN_IDENTIFIER_END_SNAPSHOT_ID) {
+		if (TryFindColumnByFieldId(local_columns, END_SNAPSHOT_FIELD_ID, end_snapshot_id_column.get(),
+		                           global_column_reference)) {
+			return nullptr;
+		}
+		// file does not have end_snapshot -- all rows are live
+		return make_uniq<BoundConstantExpression>(Value(LogicalType::BIGINT));
+	}
 	return MultiFileReader::GetVirtualColumnExpression(context, reader_data, local_columns, column_id, type, local_idx,
 	                                                   global_column_reference);
 }
@@ -707,6 +773,38 @@ void DuckLakeMultiFileReader::FinalizeChunk(ClientContext &context, const MultiF
 		for (idx_t i = 0; i < output_chunk.ColumnCount(); i++) {
 			output_chunk.data[i].Reference(temp_chunk.data[i]);
 		}
+	} else if (end_snapshot_filter_col.IsValid() && internally_projected_end_snapshot) {
+		// Internally projected end_snapshot: finalize into a temp chunk (user columns + end_snapshot),
+		// filter, then copy user columns back to output_chunk.
+		vector<LogicalType> temp_types;
+		for (idx_t i = 0; i < output_chunk.ColumnCount(); i++) {
+			temp_types.push_back(output_chunk.data[i].GetType());
+		}
+		temp_types.push_back(LogicalType::BIGINT);
+
+		DataChunk temp_chunk;
+		temp_chunk.Initialize(Allocator::DefaultAllocator(), temp_types);
+		MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, temp_chunk, executor,
+		                               global_state);
+
+		auto end_snap_idx = output_chunk.ColumnCount();
+		SelectionVector sel(temp_chunk.size());
+		idx_t result_count = ApplyEndSnapshotFilter(temp_chunk.data[end_snap_idx], temp_chunk.size(),
+		                                            NumericCast<int64_t>(read_info.snapshot.snapshot_id), sel);
+
+		temp_chunk.Slice(sel, result_count);
+		output_chunk.SetCardinality(result_count);
+		for (idx_t i = 0; i < output_chunk.ColumnCount(); i++) {
+			output_chunk.data[i].Reference(temp_chunk.data[i]);
+		}
+	} else if (end_snapshot_filter_col.IsValid()) {
+		MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, output_chunk, executor,
+		                               global_state);
+		SelectionVector sel(output_chunk.size());
+		idx_t result_count =
+		    ApplyEndSnapshotFilter(output_chunk.data[end_snapshot_filter_col.GetIndex()], output_chunk.size(),
+		                           NumericCast<int64_t>(read_info.snapshot.snapshot_id), sel);
+		output_chunk.Slice(sel, result_count);
 	} else {
 		MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, output_chunk, executor,
 		                               global_state);

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -335,6 +335,8 @@ virtual_column_map_t DuckLakeTableEntry::GetVirtualColumns() const {
 	result.insert(make_pair(COLUMN_IDENTIFIER_ROW_ID, TableColumn("rowid", LogicalType::BIGINT)));
 	result.insert(make_pair(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID,
 	                        TableColumn("snapshot_id", LogicalType::BIGINT)));
+	result.insert(make_pair(DuckLakeMultiFileReader::COLUMN_IDENTIFIER_END_SNAPSHOT_ID,
+	                        TableColumn("end_snapshot_id", LogicalType::BIGINT)));
 	result.insert(make_pair(COLUMN_IDENTIFIER_EMPTY, TableColumn("", LogicalType::BOOLEAN)));
 	return result;
 }


### PR DESCRIPTION
Currently, `ducklake_flush_inlined_data` writes all inlined rows to Parquet, then re-queries the same inlined table to find deleted rows, computes their positions via `ROW_NUMBER()`, and writes separate position-based delete files. The end_snapshot information was already available during the initial scan -- the re-query and delete files exist only because the write path didn't carry end_snapshot through.

This PR adds `_ducklake_internal_end_snapshot_id` as a third virtual column in flushed Parquet files. Scans apply a visibility filter (IS NULL OR > current_snapshot) in FinalizeChunk.

Result for a flush that includes deletions: one data file instead of one data file + one delete file, no per-file re-query, simpler Finalize.