### PR TITLE
Fix unbounded memory consumption on schema cache entries

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -232,11 +232,8 @@ public:
 
 	static unique_ptr<DuckLakeStats> ConstructStatsMap(vector<DuckLakeGlobalStatsInfo> &global_stats,
 	                                                   DuckLakeCatalogSet &schema);
-	//! Return the schema cache entry for the requested snapshot.
-	shared_ptr<DuckLakeSchemaCacheEntry> GetSchemaForSnapshot(DuckLakeTransaction &transaction,
-	                                                          DuckLakeSnapshot snapshot);
-	//! Pin a schema cache entry for the duration of the current query to ensure safe memory access safety.
-	void PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry);
+	//! Return the schema for the given snapshot - loading it if it is not yet loaded
+	DuckLakeCatalogSet &GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
 
 	//! Callback type for instrumenting metadata queries
 	using QueryCallback = std::function<void(const string &query, std::chrono::steady_clock::duration elapsed)>;
@@ -256,12 +253,17 @@ public:
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 	unique_ptr<DuckLakeCatalogSet> LoadSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
+	//! Look up (or load) the ObjectCache entry for a given snapshot.
+	shared_ptr<DuckLakeSchemaCacheEntry> GetSchemaCacheEntry(DuckLakeTransaction &transaction,
+	                                                         DuckLakeSnapshot snapshot);
 	shared_ptr<DuckLakeStatsCacheEntry> GetStatsForSnapshot(DuckLakeTransaction &transaction,
 	                                                        DuckLakeSnapshot snapshot);
+	//! Pin a schema cache entry for the duration of the current query to ensure safe memory access.
+	void PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry);
 	unique_ptr<DuckLakeStats> LoadStatsForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
 	                                               DuckLakeCatalogSet &schema);
 	void LoadNameMaps(DuckLakeTransaction &transaction);
-
+	//! Generate a cache key for the ObjectCache
 	string StatsCacheKey(idx_t next_file_id) const;
 	string SchemaCacheKey(idx_t schema_version) const;
 	string SchemaPinStateKey() const;
@@ -283,6 +285,8 @@ private:
 	atomic<idx_t> last_uncommitted_catalog_version;
 	//! The metadata server type
 	string metadata_type;
+	//! A per-instance identifier used to scope ObjectCache keys.
+	string instance_id;
 	//! Whether or not the catalog is initialized
 	bool initialized = false;
 	//! Cache for inlined deletion table existence checks

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -12,6 +12,7 @@
 #include "common/ducklake_options.hpp"
 #include "common/ducklake_name_map.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/main/client_context_state.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "storage/ducklake_catalog_set.hpp"
 #include "storage/ducklake_partition_data.hpp"
@@ -45,6 +46,37 @@ struct DuckLakeStatsCacheEntry : public ObjectCacheEntry {
 		return ObjectType();
 	}
 	optional_idx GetEstimatedCacheMemory() const override;
+};
+
+//! Cache entry for a DuckLake schema version
+struct DuckLakeSchemaCacheEntry : public ObjectCacheEntry {
+	static constexpr idx_t ESTIMATED_BYTES_PER_ENTRY = 4096;
+
+	explicit DuckLakeSchemaCacheEntry(unique_ptr<DuckLakeCatalogSet> catalog_set_p)
+	    : catalog_set(std::move(*catalog_set_p)) {
+	}
+
+	DuckLakeCatalogSet catalog_set;
+
+	static string ObjectType() {
+		return "ducklake_schema";
+	}
+	string GetObjectType() override {
+		return ObjectType();
+	}
+	optional_idx GetEstimatedCacheMemory() const override;
+};
+
+//! Query-scoped pin for DuckLake schema cache entries, which guarantee memory safety before transaction finishes.
+class DuckLakeSchemaPinState : public ClientContextState {
+public:
+	void QueryEnd(ClientContext &context) override;
+	void Pin(shared_ptr<DuckLakeSchemaCacheEntry> entry);
+
+private:
+	mutex lock;
+	// Maps from address of the schema cache entry to the schema cache entry.
+	unordered_map<DuckLakeSchemaCacheEntry *, shared_ptr<DuckLakeSchemaCacheEntry>> pins;
 };
 
 enum class InlinedDeletionCacheResult { EXISTS, DOES_NOT_EXIST, UNKNOWN };
@@ -200,8 +232,11 @@ public:
 
 	static unique_ptr<DuckLakeStats> ConstructStatsMap(vector<DuckLakeGlobalStatsInfo> &global_stats,
 	                                                   DuckLakeCatalogSet &schema);
-	//! Return the schema for the given snapshot - loading it if it is not yet loaded
-	DuckLakeCatalogSet &GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);
+	//! Return the schema cache entry for the requested snapshot.
+	shared_ptr<DuckLakeSchemaCacheEntry> GetSchemaForSnapshot(DuckLakeTransaction &transaction,
+	                                                          DuckLakeSnapshot snapshot);
+	//! Pin a schema cache entry for the duration of the current query to ensure safe memory access safety.
+	void PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry);
 
 	//! Callback type for instrumenting metadata queries
 	using QueryCallback = std::function<void(const string &query, std::chrono::steady_clock::duration elapsed)>;
@@ -226,14 +261,14 @@ private:
 	unique_ptr<DuckLakeStats> LoadStatsForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
 	                                               DuckLakeCatalogSet &schema);
 	void LoadNameMaps(DuckLakeTransaction &transaction);
-	//! Generate a cache key for the ObjectCache
+
 	string StatsCacheKey(idx_t next_file_id) const;
+	string SchemaCacheKey(idx_t schema_version) const;
+	string SchemaPinStateKey() const;
 	ObjectCache &GetObjectCacheInstance();
 
 private:
-	mutex schemas_lock;
-	//! Map of schema index -> schema
-	unordered_map<idx_t, unique_ptr<DuckLakeCatalogSet>> schemas;
+	mutex name_maps_lock;
 	//! Map of mapping index -> name map
 	DuckLakeNameMapSet name_maps;
 	//! The maximum name map index we have loaded so far

--- a/src/include/storage/ducklake_catalog_set.hpp
+++ b/src/include/storage/ducklake_catalog_set.hpp
@@ -44,7 +44,7 @@ public:
 		return entry->Cast<T>();
 	}
 
-	const ducklake_entries_map_t &GetEntries() {
+	const ducklake_entries_map_t &GetEntries() const {
 		return catalog_entries;
 	}
 	const map<SchemaIndex, reference<DuckLakeSchemaEntry>> &GetSchemaIdMap() {

--- a/src/include/storage/ducklake_catalog_set.hpp
+++ b/src/include/storage/ducklake_catalog_set.hpp
@@ -50,6 +50,9 @@ public:
 	const map<SchemaIndex, reference<DuckLakeSchemaEntry>> &GetSchemaIdMap() {
 		return schema_entry_map;
 	}
+	idx_t TotalEntryCount() const {
+		return catalog_entries.size() + table_entry_map.size() + macro_entry_map.size();
+	}
 
 private:
 	ducklake_entries_map_t catalog_entries;

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -43,7 +43,7 @@ optional_idx DuckLakeStatsCacheEntry::GetEstimatedCacheMemory() const {
 
 optional_idx DuckLakeSchemaCacheEntry::GetEstimatedCacheMemory() const {
 	idx_t estimate = sizeof(DuckLakeCatalogSet);
-	estimate += catalog_set.GetEntries().size() * ESTIMATED_BYTES_PER_ENTRY;
+	estimate += catalog_set.TotalEntryCount() * ESTIMATED_BYTES_PER_ENTRY;
 	return estimate;
 }
 

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -40,6 +40,24 @@ optional_idx DuckLakeStatsCacheEntry::GetEstimatedCacheMemory() const {
 	return estimate;
 }
 
+optional_idx DuckLakeSchemaCacheEntry::GetEstimatedCacheMemory() const {
+	idx_t estimate = sizeof(DuckLakeCatalogSet);
+	estimate += catalog_set.GetEntries().size() * ESTIMATED_BYTES_PER_ENTRY;
+	return estimate;
+}
+
+void DuckLakeSchemaPinState::QueryEnd(ClientContext &context) {
+	lock_guard<mutex> guard(lock);
+	pins.clear();
+}
+
+void DuckLakeSchemaPinState::Pin(shared_ptr<DuckLakeSchemaCacheEntry> entry) {
+	D_ASSERT(entry);
+	lock_guard<mutex> guard(lock);
+	auto *raw = entry.get();
+	pins.emplace(raw, std::move(entry));
+}
+
 DuckLakeCatalog::DuckLakeCatalog(AttachedDatabase &db_p, DuckLakeOptions options_p)
     : Catalog(db_p), options(std::move(options_p)), last_uncommitted_catalog_version(TRANSACTION_ID_START) {
 	// figure out the metadata server type
@@ -158,8 +176,8 @@ void DuckLakeCatalog::ScanSchemas(ClientContext &context, std::function<void(Sch
 		}
 	}
 	auto snapshot = duck_transaction.GetSnapshot();
-	auto &schemas = GetSchemaForSnapshot(duck_transaction, snapshot);
-	for (auto &schema : schemas.GetEntries()) {
+	auto schemas_entry = GetSchemaForSnapshot(duck_transaction, snapshot);
+	for (auto &schema : schemas_entry->catalog_set.GetEntries()) {
 		auto &schema_entry = schema.second->Cast<SchemaCatalogEntry>();
 		if (duck_transaction.IsDeleted(schema_entry)) {
 			continue;
@@ -174,8 +192,9 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &tr
 	if (local_entry) {
 		return local_entry;
 	}
-	auto &schema = GetSchemaForSnapshot(transaction, snapshot);
-	return schema.GetEntryById(schema_id);
+	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
+	PinSchemaForQuery(transaction, schema_entry);
+	return schema_entry->catalog_set.GetEntryById(schema_id);
 }
 
 optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
@@ -184,8 +203,9 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &tr
 	if (local_entry) {
 		return local_entry;
 	}
-	auto &schema = GetSchemaForSnapshot(transaction, snapshot);
-	return schema.GetEntryById(table_id);
+	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
+	PinSchemaForQuery(transaction, schema_entry);
+	return schema_entry->catalog_set.GetEntryById(table_id);
 }
 
 idx_t DuckLakeCatalog::GetBeginSnapshotForTable(TableIndex table_id, DuckLakeTransaction &transaction) {
@@ -199,18 +219,32 @@ idx_t DuckLakeCatalog::GetBeginSnapshotForSchemaVersion(TableIndex table_id, idx
 	return metadata_manager.GetBeginSnapshotForSchemaVersion(table_id, schema_version);
 }
 
-DuckLakeCatalogSet &DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot) {
-	lock_guard<mutex> guard(schemas_lock);
-	auto entry = schemas.find(snapshot.schema_version);
-	if (entry != schemas.end()) {
-		// this schema version is already cached
-		return *entry->second;
+shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction,
+                                                                          DuckLakeSnapshot snapshot) {
+	auto &cache = GetObjectCacheInstance();
+	auto key = SchemaCacheKey(snapshot.schema_version);
+	auto cached = cache.Get<DuckLakeSchemaCacheEntry>(key);
+	if (cached) {
+		return cached;
 	}
-	// load the schema version from the metadata manager
 	auto schema = LoadSchemaForSnapshot(transaction, snapshot);
-	auto &result = *schema;
-	schemas.insert(make_pair(snapshot.schema_version, std::move(schema)));
-	return result;
+	auto entry = make_shared_ptr<DuckLakeSchemaCacheEntry>(std::move(schema));
+	cache.Put(std::move(key), entry);
+	return entry;
+}
+
+void DuckLakeCatalog::PinSchemaForQuery(DuckLakeTransaction &transaction,
+                                        shared_ptr<DuckLakeSchemaCacheEntry> entry) {
+	if (!entry) {
+		return;
+	}
+	auto context_ref = transaction.context.lock();
+	if (!context_ref) {
+		return;
+	}
+	auto &registered = *context_ref->registered_state;
+	auto pin_state = registered.GetOrCreate<DuckLakeSchemaPinState>(SchemaPinStateKey());
+	pin_state->Pin(std::move(entry));
 }
 
 static unique_ptr<DuckLakeFieldId> TransformColumnType(DuckLakeColumnInfo &col) {
@@ -524,8 +558,8 @@ shared_ptr<DuckLakeStatsCacheEntry> DuckLakeCatalog::GetStatsForSnapshot(DuckLak
 	if (cached) {
 		return cached;
 	}
-	auto &schema = GetSchemaForSnapshot(transaction, snapshot);
-	auto table_stats = LoadStatsForSnapshot(transaction, snapshot, schema);
+	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
+	auto table_stats = LoadStatsForSnapshot(transaction, snapshot, schema_entry->catalog_set);
 	auto entry = make_shared_ptr<DuckLakeStatsCacheEntry>(std::move(table_stats));
 	cache.Put(std::move(key), entry);
 	return entry;
@@ -584,7 +618,7 @@ void DuckLakeCatalog::LoadNameMaps(DuckLakeTransaction &transaction) {
 
 optional_ptr<const DuckLakeNameMap> DuckLakeCatalog::TryGetMappingById(DuckLakeTransaction &transaction,
                                                                        MappingIndex mapping_id) {
-	lock_guard<mutex> guard(schemas_lock);
+	lock_guard<mutex> guard(name_maps_lock);
 	auto entry = name_maps.name_maps.find(mapping_id);
 	if (entry != name_maps.name_maps.end()) {
 		return entry->second.get();
@@ -601,7 +635,7 @@ optional_ptr<const DuckLakeNameMap> DuckLakeCatalog::TryGetMappingById(DuckLakeT
 
 MappingIndex DuckLakeCatalog::TryGetCompatibleNameMap(DuckLakeTransaction &transaction,
                                                       const DuckLakeNameMap &name_map) {
-	lock_guard<mutex> guard(schemas_lock);
+	lock_guard<mutex> guard(name_maps_lock);
 	LoadNameMaps(transaction);
 	return name_maps.TryGetCompatibleNameMap(name_map);
 }
@@ -704,8 +738,9 @@ optional_ptr<SchemaCatalogEntry> DuckLakeCatalog::LookupSchema(CatalogTransactio
 		}
 	}
 	auto snapshot = duck_transaction.GetSnapshot(at_clause);
-	auto &schemas = GetSchemaForSnapshot(duck_transaction, snapshot);
-	auto entry = schemas.GetEntry<SchemaCatalogEntry>(schema_name);
+	auto schemas_entry = GetSchemaForSnapshot(duck_transaction, snapshot);
+	PinSchemaForQuery(duck_transaction, schemas_entry);
+	auto entry = schemas_entry->catalog_set.GetEntry<SchemaCatalogEntry>(schema_name);
 	if (!entry) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 			throw BinderException("Schema \"%s\" not found in DuckLakeCatalog \"%s\"", schema_name, GetName());
@@ -914,6 +949,14 @@ void DuckLakeCatalog::CacheInlinedDeletionTableResult(TableIndex table_id, DuckL
 
 string DuckLakeCatalog::StatsCacheKey(idx_t next_file_id) const {
 	return StringUtil::Format("ducklake:%s:%s:stats:%llu", GetName(), MetadataPath(), next_file_id);
+}
+
+string DuckLakeCatalog::SchemaCacheKey(idx_t schema_version) const {
+	return StringUtil::Format("ducklake:%s:%s:schema:%llu", GetName(), MetadataPath(), schema_version);
+}
+
+string DuckLakeCatalog::SchemaPinStateKey() const {
+	return StringUtil::Format("ducklake_schema_pin:%s:%s", GetName(), MetadataPath());
 }
 
 ObjectCache &DuckLakeCatalog::GetObjectCacheInstance() {

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -27,6 +27,7 @@
 #include "duckdb/function/table_macro_function.hpp"
 #include "storage/ducklake_macro_entry.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "common/ducklake_util.hpp"
 
 namespace duckdb {
@@ -59,7 +60,8 @@ void DuckLakeSchemaPinState::Pin(shared_ptr<DuckLakeSchemaCacheEntry> entry) {
 }
 
 DuckLakeCatalog::DuckLakeCatalog(AttachedDatabase &db_p, DuckLakeOptions options_p)
-    : Catalog(db_p), options(std::move(options_p)), last_uncommitted_catalog_version(TRANSACTION_ID_START) {
+    : Catalog(db_p), options(std::move(options_p)), last_uncommitted_catalog_version(TRANSACTION_ID_START),
+      instance_id(UUID::ToString(UUID::GenerateRandomUUID())) {
 	// figure out the metadata server type
 	auto entry = options.metadata_parameters.find("type");
 	if (entry != options.metadata_parameters.end()) {
@@ -176,8 +178,8 @@ void DuckLakeCatalog::ScanSchemas(ClientContext &context, std::function<void(Sch
 		}
 	}
 	auto snapshot = duck_transaction.GetSnapshot();
-	auto schemas_entry = GetSchemaForSnapshot(duck_transaction, snapshot);
-	for (auto &schema : schemas_entry->catalog_set.GetEntries()) {
+	auto &schemas = GetSchemaForSnapshot(duck_transaction, snapshot);
+	for (auto &schema : schemas.GetEntries()) {
 		auto &schema_entry = schema.second->Cast<SchemaCatalogEntry>();
 		if (duck_transaction.IsDeleted(schema_entry)) {
 			continue;
@@ -192,9 +194,8 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &tr
 	if (local_entry) {
 		return local_entry;
 	}
-	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
-	PinSchemaForQuery(transaction, schema_entry);
-	return schema_entry->catalog_set.GetEntryById(schema_id);
+	auto &schema = GetSchemaForSnapshot(transaction, snapshot);
+	return schema.GetEntryById(schema_id);
 }
 
 optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
@@ -203,9 +204,8 @@ optional_ptr<CatalogEntry> DuckLakeCatalog::GetEntryById(DuckLakeTransaction &tr
 	if (local_entry) {
 		return local_entry;
 	}
-	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
-	PinSchemaForQuery(transaction, schema_entry);
-	return schema_entry->catalog_set.GetEntryById(table_id);
+	auto &schema = GetSchemaForSnapshot(transaction, snapshot);
+	return schema.GetEntryById(table_id);
 }
 
 idx_t DuckLakeCatalog::GetBeginSnapshotForTable(TableIndex table_id, DuckLakeTransaction &transaction) {
@@ -219,8 +219,8 @@ idx_t DuckLakeCatalog::GetBeginSnapshotForSchemaVersion(TableIndex table_id, idx
 	return metadata_manager.GetBeginSnapshotForSchemaVersion(table_id, schema_version);
 }
 
-shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction,
-                                                                          DuckLakeSnapshot snapshot) {
+shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaCacheEntry(DuckLakeTransaction &transaction,
+                                                                         DuckLakeSnapshot snapshot) {
 	auto &cache = GetObjectCacheInstance();
 	auto key = SchemaCacheKey(snapshot.schema_version);
 	auto cached = cache.Get<DuckLakeSchemaCacheEntry>(key);
@@ -231,6 +231,12 @@ shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaForSnapshot(DuckL
 	auto entry = make_shared_ptr<DuckLakeSchemaCacheEntry>(std::move(schema));
 	cache.Put(std::move(key), entry);
 	return entry;
+}
+
+DuckLakeCatalogSet &DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot) {
+	auto entry = GetSchemaCacheEntry(transaction, snapshot);
+	PinSchemaForQuery(transaction, entry);
+	return entry->catalog_set;
 }
 
 void DuckLakeCatalog::PinSchemaForQuery(DuckLakeTransaction &transaction,
@@ -558,7 +564,7 @@ shared_ptr<DuckLakeStatsCacheEntry> DuckLakeCatalog::GetStatsForSnapshot(DuckLak
 	if (cached) {
 		return cached;
 	}
-	auto schema_entry = GetSchemaForSnapshot(transaction, snapshot);
+	auto schema_entry = GetSchemaCacheEntry(transaction, snapshot);
 	auto table_stats = LoadStatsForSnapshot(transaction, snapshot, schema_entry->catalog_set);
 	auto entry = make_shared_ptr<DuckLakeStatsCacheEntry>(std::move(table_stats));
 	cache.Put(std::move(key), entry);
@@ -738,9 +744,8 @@ optional_ptr<SchemaCatalogEntry> DuckLakeCatalog::LookupSchema(CatalogTransactio
 		}
 	}
 	auto snapshot = duck_transaction.GetSnapshot(at_clause);
-	auto schemas_entry = GetSchemaForSnapshot(duck_transaction, snapshot);
-	PinSchemaForQuery(duck_transaction, schemas_entry);
-	auto entry = schemas_entry->catalog_set.GetEntry<SchemaCatalogEntry>(schema_name);
+	auto &schemas = GetSchemaForSnapshot(duck_transaction, snapshot);
+	auto entry = schemas.GetEntry<SchemaCatalogEntry>(schema_name);
 	if (!entry) {
 		if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
 			throw BinderException("Schema \"%s\" not found in DuckLakeCatalog \"%s\"", schema_name, GetName());
@@ -948,15 +953,15 @@ void DuckLakeCatalog::CacheInlinedDeletionTableResult(TableIndex table_id, DuckL
 }
 
 string DuckLakeCatalog::StatsCacheKey(idx_t next_file_id) const {
-	return StringUtil::Format("ducklake:%s:%s:stats:%llu", GetName(), MetadataPath(), next_file_id);
+	return StringUtil::Format("ducklake:%s:%s:%s:stats:%llu", GetName(), MetadataPath(), instance_id, next_file_id);
 }
 
 string DuckLakeCatalog::SchemaCacheKey(idx_t schema_version) const {
-	return StringUtil::Format("ducklake:%s:%s:schema:%llu", GetName(), MetadataPath(), schema_version);
+	return StringUtil::Format("ducklake:%s:%s:%s:schema:%llu", GetName(), MetadataPath(), instance_id, schema_version);
 }
 
 string DuckLakeCatalog::SchemaPinStateKey() const {
-	return StringUtil::Format("ducklake_schema_pin:%s:%s", GetName(), MetadataPath());
+	return StringUtil::Format("ducklake_schema_pin:%s:%s:%s", GetName(), MetadataPath(), instance_id);
 }
 
 ObjectCache &DuckLakeCatalog::GetObjectCacheInstance() {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2064,8 +2064,8 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 	DuckLakeNewGlobalStats new_globals;
 	unique_ptr<DuckLakeStats> dl_stats;
 	if (stats) {
-		auto &schema = ducklake_catalog.GetSchemaForSnapshot(*this, GetSnapshot());
-		dl_stats = ducklake_catalog.ConstructStatsMap(*stats, schema);
+		auto schema_entry = ducklake_catalog.GetSchemaForSnapshot(*this, GetSnapshot());
+		dl_stats = ducklake_catalog.ConstructStatsMap(*stats, schema_entry->catalog_set);
 	}
 	for (auto &entry : local_changes.Changes()) {
 		auto table_id = commit_state.GetTableId(entry.GetTableIndex());

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2064,8 +2064,8 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 	DuckLakeNewGlobalStats new_globals;
 	unique_ptr<DuckLakeStats> dl_stats;
 	if (stats) {
-		auto schema_entry = ducklake_catalog.GetSchemaForSnapshot(*this, GetSnapshot());
-		dl_stats = ducklake_catalog.ConstructStatsMap(*stats, schema_entry->catalog_set);
+		auto &schema = ducklake_catalog.GetSchemaForSnapshot(*this, GetSnapshot());
+		dl_stats = ducklake_catalog.ConstructStatsMap(*stats, schema);
 	}
 	for (auto &entry : local_changes.Changes()) {
 		auto table_id = commit_state.GetTableId(entry.GetTableIndex());

--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
+++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
@@ -34,7 +34,7 @@ statement ok
 SET temp_directory=''
 
 statement ok
-SET memory_limit='50MB'
+SET memory_limit='100MB'
 
 # Phase 1: churn schema_version via many ALTER operations.
 

--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
+++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
@@ -1,0 +1,123 @@
+# name: test/sql/alter/many_schema_versions_low_memory.test_slow
+# description: test that many DDL operations work under a low memory limit with schema cache eviction
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_many_schema_versions')
+
+# Create many tables so each schema-version cache entry is sizeable.
+loop i 0 100
+
+statement ok
+CREATE TABLE ducklake.t${i} (id INTEGER, a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
+
+endloop
+
+# A single table that we'll ALTER to churn schema_version.
+statement ok
+CREATE TABLE ducklake.target (id INTEGER)
+
+statement ok
+INSERT INTO ducklake.target VALUES (1), (2), (3)
+
+# Disable temp_directory so DuckDB cannot spill blocks for temporary tables to disk.
+# This forces the buffer pool into the EvictObjectCacheEntries path under pressure.
+statement ok
+SET temp_directory=''
+
+statement ok
+SET memory_limit='50MB'
+
+# Phase 1: churn schema_version via many ALTER operations.
+
+loop i 0 150
+
+statement ok
+ALTER TABLE ducklake.target ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+
+endloop
+
+# Sanity-check after heavy DDL.
+query I
+SELECT COUNT(*) FROM ducklake.target
+----
+3
+
+query I
+SELECT SUM(col_0) FROM ducklake.target
+----
+0
+
+query I
+SELECT SUM(col_149) FROM ducklake.target
+----
+447
+
+# Phase 2: allocate unevictable blocks via a temp table.
+# Without temp_directory these blocks cannot be spilled, so the buffer pool falls through to evict schema cache entry.
+statement ok
+CREATE TEMP TABLE mem_filler(i INTEGER, pad VARCHAR)
+
+loop j 0 2
+
+statement ok
+INSERT INTO mem_filler SELECT i + ${j} * 5000, repeat('x', 1000) FROM range(5000) t(i)
+
+endloop
+
+# Phase 3: more DDL + reads after eviction pressure.
+
+loop i 150 200
+
+statement ok
+ALTER TABLE ducklake.target ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+
+endloop
+
+# Verify correctness after both schema churn AND cache eviction.
+query I
+SELECT COUNT(*) FROM ducklake.target
+----
+3
+
+query I
+SELECT SUM(col_0) FROM ducklake.target
+----
+0
+
+query I
+SELECT SUM(col_199) FROM ducklake.target
+----
+597
+
+query I
+SELECT SUM(col_100) FROM ducklake.target
+----
+300
+
+query I
+SELECT COUNT(*) FROM ducklake.t0
+----
+0
+
+query I
+SELECT COUNT(*) FROM ducklake.t99
+----
+0
+
+# Another round of insertion and check.
+statement ok
+INSERT INTO ducklake.target (id, col_199) VALUES (4, 999)
+
+query I
+SELECT SUM(col_199) FROM ducklake.target
+----
+1596

--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
+++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
@@ -45,7 +45,7 @@ ALTER TABLE ducklake.target ADD COLUMN col_${i} INTEGER DEFAULT ${i}
 
 endloop
 
-# Sanity-check after heavy DDL.
+# Validation after DDL.
 query I
 SELECT COUNT(*) FROM ducklake.target
 ----

--- a/test/sql/insert/insert_wide_table_low_memory.test_slow
+++ b/test/sql/insert/insert_wide_table_low_memory.test_slow
@@ -1,4 +1,4 @@
-# name: test/sql/insert/insert_wide_table_low_memory.test
+# name: test/sql/insert/insert_wide_table_low_memory.test_slow
 # description: test that many small inserts into a wide table work under low memory limit
 # group: [insert]
 


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/852

Followup PR for https://github.com/duckdb/ducklake/pull/1020
The idea to limit unbounded memory consumption on schema entries is the same: use the LRU object cache.
One thing different is: a few APIs returns optional pointer, which requires `DuckLakeCatalogSet` to be valid on return.

To workaround, I stored a shared pointer for catalog set in transaction context, so it's kept valid until transaction completes.

An alternative I've thought about is: update [`LookupSchema` API](https://github.com/duckdb/duckdb/blob/e64b98f66712b9674897bb27f7f417e5e88fb4be/src/include/duckdb/catalog/catalog.hpp#L221-L223) in DuckDB core to return shared pointer
But there're two big downsides:
- It basically changes all storage extensions (i.e., ducklake, iceberg, delta, etc)
- For all other storage extensions, I don't see any benefit for changing the interface

I checked locally on the regression test (with dummy logging), LRU cache entries goes get evicted during the test run.

Followup items (which I will do in next PRs):
- Check for other unbounded cache entries
- On detach, all existing cache entries should be evicted from object cache