### PR TITLE
[fixes broken main build] Use FlatVector::SetNull for murmur3

### DIFF
--- a/src/functions/ducklake_murmur3.cpp
+++ b/src/functions/ducklake_murmur3.cpp
@@ -14,14 +14,13 @@ static void Murmur3ScalarFunction(DataChunk &args, ExpressionState &state, Vecto
 	input.ToUnifiedFormat(count, input_data);
 
 	auto result_data = FlatVector::GetDataMutable<int32_t>(result);
-	auto &result_validity = FlatVector::Validity(result);
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 
 	auto &type = input.GetType();
 	for (idx_t i = 0; i < count; i++) {
 		auto idx = input_data.sel->get_index(i);
 		if (!input_data.validity.RowIsValid(idx)) {
-			result_validity.SetInvalid(i);
+			FlatVector::SetNull(result, i, true);
 			continue;
 		}
 


### PR DESCRIPTION
The DuckDB `ValidityMask` [change here](https://github.com/duckdb/duckdb/commit/585c52efc84215a274992f672fd5d2cdcf512616) breaks the DuckLake build on recent `main` builds. This fixes it.