### PR TITLE
Populate stats for more types

### DIFF
--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -250,6 +250,8 @@ unique_ptr<BaseStatistics> DuckLakeColumnStats::CreateStringStats() const {
 
 unique_ptr<BaseStatistics> DuckLakeColumnStats::ToStats() const {
 	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+	case LogicalTypeId::TINYINT:
 	case LogicalTypeId::SMALLINT:
 	case LogicalTypeId::INTEGER:
 	case LogicalTypeId::BIGINT:
@@ -257,6 +259,7 @@ unique_ptr<BaseStatistics> DuckLakeColumnStats::ToStats() const {
 	case LogicalTypeId::USMALLINT:
 	case LogicalTypeId::UINTEGER:
 	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::DECIMAL:
 	case LogicalTypeId::DATE:
 	case LogicalTypeId::TIME:
 	case LogicalTypeId::TIMESTAMP:
@@ -264,6 +267,7 @@ unique_ptr<BaseStatistics> DuckLakeColumnStats::ToStats() const {
 	case LogicalTypeId::TIMESTAMP_SEC:
 	case LogicalTypeId::TIMESTAMP_MS:
 	case LogicalTypeId::TIMESTAMP_NS:
+	case LogicalTypeId::UUID:
 		return CreateNumericStats();
 	case LogicalTypeId::FLOAT:
 	case LogicalTypeId::DOUBLE:

--- a/test/sql/stats/global_stats.test
+++ b/test/sql/stats/global_stats.test
@@ -117,3 +117,109 @@ SELECT * FROM ducklake.test WHERE i=100
 
 statement ok
 ROLLBACK
+
+# tinyint
+statement ok
+CREATE TABLE ducklake.tinyints(d TINYINT);
+
+statement ok
+INSERT INTO ducklake.tinyints VALUES (10);
+
+statement ok
+INSERT INTO ducklake.tinyints VALUES (50);
+
+query I
+SELECT stats(d) FROM ducklake.tinyints LIMIT 1
+----
+<REGEX>:.*Min.*10.*Max.*50.*Has Null.*false.*
+
+# decimal
+statement ok
+CREATE TABLE ducklake.decimals(d DECIMAL(18, 2));
+
+statement ok
+INSERT INTO ducklake.decimals VALUES (12.50);
+
+statement ok
+INSERT INTO ducklake.decimals VALUES (99.99);
+
+query I
+SELECT stats(d) FROM ducklake.decimals LIMIT 1
+----
+<REGEX>:.*Min.*12.50.*Max.*99.99.*Has Null.*false.*
+
+# boolean
+statement ok
+CREATE TABLE ducklake.booleans(d BOOLEAN);
+
+statement ok
+INSERT INTO ducklake.booleans VALUES (true);
+
+statement ok
+INSERT INTO ducklake.booleans VALUES (false);
+
+query I
+SELECT stats(d) FROM ducklake.booleans LIMIT 1
+----
+<REGEX>:.*Min.*false.*Max.*true.*Has Null.*false.*
+
+# uuid
+statement ok
+CREATE TABLE ducklake.uuids(d UUID);
+
+statement ok
+INSERT INTO ducklake.uuids VALUES ('550e8400-e29b-41d4-a716-446655440000');
+
+statement ok
+INSERT INTO ducklake.uuids VALUES (NULL);
+
+query I
+SELECT stats(d) FROM ducklake.uuids LIMIT 1
+----
+<REGEX>:.*Min.*550e8400.*Max.*550e8400.*Has Null.*true.*
+
+# timestamp
+statement ok
+CREATE TABLE ducklake.timestamps(d TIMESTAMP);
+
+statement ok
+INSERT INTO ducklake.timestamps VALUES (TIMESTAMP '2024-01-01 00:00:00');
+
+query I
+SELECT stats(d) FROM ducklake.timestamps LIMIT 1
+----
+<REGEX>:.*Min.*2024-01-01.*Max.*2024-01-01.*Has Null.*false.*
+
+statement ok
+INSERT INTO ducklake.timestamps VALUES (TIMESTAMP '2025-06-15 12:30:00');
+
+query I
+SELECT stats(d) FROM ducklake.timestamps LIMIT 1
+----
+<REGEX>:.*Min.*2024-01-01.*Max.*2025-06-15.*Has Null.*false.*
+
+# verify optimizer uses stats to eliminate impossible filters (EMPTY_RESULT)
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.test WHERE i = -1;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.tinyints WHERE d = -1;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.decimals WHERE d = -1;
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.dates WHERE d = DATE '1900-01-01';
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*
+
+query II
+EXPLAIN ANALYZE SELECT * FROM ducklake.timestamps WHERE d = TIMESTAMP '1900-01-01';
+----
+analyzed_plan	<REGEX>:.*EMPTY_RESULT.*


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/discussions/1038

Currently we only populate stats (min/max/null) for a few types, so for uncovered types we have to go through one round trip of table scan, which involves IO, metadata query and relevant CPU work.

A few types are not included intentionally due to our parquet writer implementation:
- UHUGEINT doesn't emit stats: https://github.com/duckdb/duckdb/blob/e64b98f66712b9674897bb27f7f417e5e88fb4be/extension/parquet/include/writer/parquet_write_operators.hpp#L351-L353
- HUGEINT doesn't emit stats: https://github.com/duckdb/duckdb/blob/e64b98f66712b9674897bb27f7f417e5e88fb4be/extension/parquet/include/writer/parquet_write_operators.hpp#L335-L337
- TIME_TZ does emit stats, but with timezone information dropped: https://github.com/duckdb/duckdb/blob/e64b98f66712b9674897bb27f7f417e5e88fb4be/extension/parquet/include/writer/parquet_write_operators.hpp#L317-L322