### PR TITLE
Fix null partition prune

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1252,11 +1252,25 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 			null_checks += stat + " IS NULL OR ";
 		}
 
+		const bool needs_value_count_guard =
+		    referenced_stats.count("min_value") > 0 || referenced_stats.count("max_value") > 0;
+		if (needs_value_count_guard) {
+			referenced_stats.insert("value_count");
+		}
+
 		if (!conditions.empty()) {
 			conditions += " AND ";
 		}
-		conditions += StringUtil::Format("data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s))", cte_name,
-		                                 null_checks.c_str(), filter_condition.c_str());
+		if (needs_value_count_guard) {
+			conditions += StringUtil::Format(
+			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
+			    "(value_count IS NULL OR value_count > 0) AND (%s(%s)))",
+			    cte_name, null_checks.c_str(), filter_condition.c_str());
+		} else {
+			conditions += StringUtil::Format(
+			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s))", cte_name, null_checks.c_str(),
+			    filter_condition.c_str());
+		}
 
 		CTERequirement req(column_filter.column_field_index, referenced_stats);
 		result.required_ctes.emplace(column_filter.column_field_index, std::move(req));

--- a/test/sql/partitioning/partition_null.test
+++ b/test/sql/partitioning/partition_null.test
@@ -49,8 +49,39 @@ part_key=1
 part_key=__HIVE_DEFAULT_PARTITION__
 
 # verify files are pruned when querying the partitions
-# FIXME: we are currently also reading the file with all NULL values
 query II
 EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=1
 ----
-analyzed_plan	<REGEX>:.*Total Files Read: 2.*
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# inequality filters also prune all-NULL files
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM partitioned_tbl WHERE part_key > 0
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# verify result correctness across all filter types
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key=1
+----
+3333
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key IS NULL
+----
+3334
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key > 0
+----
+3333
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl WHERE part_key IS NOT NULL
+----
+6666
+
+query I
+SELECT COUNT(*) FROM partitioned_tbl
+----
+10000


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/discussions/1040

Copy the query here for easier viewing.
```sql
memory D ATTACH ':memory:' AS dl (TYPE ducklake, DATA_INLINING_ROW_LIMIT 0);
memory D USE dl;
dl D CREATE TABLE t(pk INTEGER, v VARCHAR);
dl D ALTER TABLE t SET PARTITIONED BY (pk);
dl D INSERT INTO t SELECT CASE WHEN i%3=0 THEN NULL ELSE i%2 END, 'val_' || i FROM range(9000) t(i);
dl D EXPLAIN ANALYZE SELECT COUNT(*) FROM t WHERE pk = 1;
[ConvertFilterPushdownToSQL] data.data_file_id IN (SELECT data_file_id FROM col_1_stats WHERE max_value IS NULL OR min_value IS NULL OR (1 BETWEEN TRY_CAST(min_value AS INTEGER) AND TRY_CAST(max_value AS INTEGER)))
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
EXPLAIN ANALYZE SELECT COUNT(*) FROM t WHERE pk = 1;
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││              Total Time: 0.289s              ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│                           │
│           0 rows          │
│           0.00s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│    UNGROUPED_AGGREGATE    │
│    ────────────────────   │
│        Aggregates:        │
│        count_star()       │
│                           │
│                           │
│                           │
│           1 row           │
│           0.00s           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│          Table: t         │
│       Filters: pk=1       │
│    Total Files Read: 2    │
│                           │
│        Filename(s):       │
│  :memory:.files/main/t/pk │
│=__HIVE_DEFAULT_PARTITION__│
│  /ducklake-019da9bf-01ec  │
│  -72b0-af4d-4dd7b5838e0c  │
│  .parquet, :memory:.files │
│   /main/t/pk=1/ducklake   │
│  -019da9bf-01f1-798e-9938 │
│   -923778025371.parquet   │
│                           │
│                           │
│                           │
│         3,000 rows        │
│           0.00s           │
└───────────────────────────┘
```

When a table is partitioned by a column that contains NULL values, files in the `__HIVE_DEFAULT_PARTITION__` directory, which contains only NULL values; for the current implementation it's never pruned during metadata-level file filtering, even for queries like `WHERE pk = 1` that can never match NULL.

The issue is when we get data files to query against we consult `ducklake_file_column_stats`, current metadata query sql looks like `WHERE min_value IS NULL OR max_value IS NULL OR (1 BETWEEN min_value AND max_value)`.
As you can tell, NULL partition data files are permissively included.
For files where all values in the filtered column are NULL, min_value and max_value are also NULL; not because stats are missing, but because there are indeed all NULL values.

This PR included mainly two changes:
- When min_value/max_value are used to decide which data files to query, we can safely prune files where value_count = 0 (all-NULL files), since a non-NULL constant can never match NULL
- We add value_count to the CTE's SELECT list so it's available for the pruning check in the generated SQL