### PR TITLE
fix: clashing ids, use race-free ids w/ postgres sequences

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -34,11 +34,19 @@ public:
 
 	unique_ptr<QueryResult> Query(DuckLakeSnapshot snapshot, string &query) override;
 
+	idx_t AllocateNextSnapshotId(idx_t current_snapshot_id) override;
+	idx_t AllocateNextCatalogId(idx_t current_next_catalog_id) override;
+	idx_t AllocateNextFileId(idx_t current_next_file_id) override;
+
+	void EnsureIdSequences();
+
 protected:
 	string GetLatestSnapshotQuery() const override;
 
 private:
 	unique_ptr<QueryResult> ExecuteQuery(DuckLakeSnapshot snapshot, string &query, string command);
+
+	idx_t FetchScalarSequenceValue(const string &seq_name);
 };
 
 } // namespace duckdb

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -37,6 +37,8 @@ public:
 	idx_t AllocateNextSnapshotId(idx_t current_snapshot_id) override;
 	idx_t AllocateNextCatalogId(idx_t current_next_catalog_id) override;
 	idx_t AllocateNextFileId(idx_t current_next_file_id) override;
+	idx_t AllocateNextSchemaVersion(idx_t current_schema_version) override;
+	void AcquireCommitLock() override;
 
 	void EnsureIdSequences();
 
@@ -47,6 +49,12 @@ private:
 	unique_ptr<QueryResult> ExecuteQuery(DuckLakeSnapshot snapshot, string &query, string command);
 
 	idx_t FetchScalarSequenceValue(const string &seq_name);
+
+	// Hex-ASCII 'DuLK'. Two-arg advisory key form; classid half is
+	// hashtext(schema) so multiple DuckLake catalogs on one pg instance
+	// do not share the key.
+	static constexpr int32_t DUCKLAKE_COMMIT_ADVISORY_SUBKEY = 0x44754C4B;
+	optional_idx commit_lock_classid;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -163,7 +163,7 @@ public:
 
 	void SetCommittedSnapshotId(idx_t value) {
 		lock_guard<mutex> guard(commit_lock);
-		// Max-update: sequence allocator lets concurrent commits arrive out of order.
+		// Max-update: sequence allocation decoupled from commit order.
 		if (!last_committed_snapshot.IsValid() || value > last_committed_snapshot.GetIndex()) {
 			last_committed_snapshot = value;
 		}

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -163,7 +163,10 @@ public:
 
 	void SetCommittedSnapshotId(idx_t value) {
 		lock_guard<mutex> guard(commit_lock);
-		last_committed_snapshot = value;
+		// Max-update: sequence allocator lets concurrent commits arrive out of order.
+		if (!last_committed_snapshot.IsValid() || value > last_committed_snapshot.GetIndex()) {
+			last_committed_snapshot = value;
+		}
 	}
 
 	Value GetLastCommittedSnapshotId() const {

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -282,6 +282,9 @@ struct DuckLakeGlobalStatsInfo {
 	idx_t record_count;
 	idx_t next_row_id;
 	idx_t table_size_bytes;
+	// CAS predicate / target. Post-verified in FlushChanges.
+	idx_t stats_version = 0;
+	idx_t new_stats_version = 0;
 	vector<DuckLakeGlobalColumnStatsInfo> column_stats;
 };
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -207,6 +207,13 @@ public:
 	virtual idx_t AllocateNextSnapshotId(idx_t current_snapshot_id);
 	virtual idx_t AllocateNextCatalogId(idx_t current_next_catalog_id);
 	virtual idx_t AllocateNextFileId(idx_t current_next_file_id);
+	virtual idx_t AllocateNextSchemaVersion(idx_t current_schema_version) {
+		return current_schema_version + 1;
+	}
+	// Backends with non-transactional id allocation MUST override: serialise
+	// allocation, INSERT, and COMMIT, or break MAX(snapshot_id)-as-horizon.
+	virtual void AcquireCommitLock() {
+	}
 
 	virtual string InsertSnapshot();
 	virtual string WriteSnapshotChanges(const SnapshotChangeInfo &change_info,

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -204,6 +204,10 @@ public:
 	virtual string WriteMergeAdjacent(const vector<DuckLakeCompactedFileInfo> &compactions);
 	virtual string WriteDeleteRewrites(const vector<DuckLakeCompactedFileInfo> &compactions);
 	virtual string WriteCompactions(const vector<DuckLakeCompactedFileInfo> &compactions, CompactionType type);
+	virtual idx_t AllocateNextSnapshotId(idx_t current_snapshot_id);
+	virtual idx_t AllocateNextCatalogId(idx_t current_next_catalog_id);
+	virtual idx_t AllocateNextFileId(idx_t current_next_file_id);
+
 	virtual string InsertSnapshot();
 	virtual string WriteSnapshotChanges(const SnapshotChangeInfo &change_info,
 	                                    const DuckLakeSnapshotCommit &commit_info);

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -316,7 +316,8 @@ private:
 	                  vector<DuckLakeOverwrittenDeleteFile> &overwritten_delete_files) const;
 	DuckLakeDeleteFileInfo GetNewDeleteFile(TableIndex table_id, const DuckLakeCommitState &commit_state,
 	                                        const DuckLakeDeleteFile &file) const;
-	string UpdateGlobalTableStats(TableIndex table_id, const DuckLakeNewGlobalStats &new_stats);
+	string UpdateGlobalTableStats(TableIndex table_id, const DuckLakeNewGlobalStats &new_stats,
+	                              idx_t expected_stats_version, idx_t new_stats_version);
 	SnapshotAndStats CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
 	                                   const TransactionChangeInformation &changes);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -157,6 +157,45 @@ idx_t PostgresMetadataManager::AllocateNextFileId(idx_t /*advisory*/) {
 	return FetchScalarSequenceValue("ducklake_file_id_seq");
 }
 
+idx_t PostgresMetadataManager::AllocateNextSchemaVersion(idx_t /*advisory*/) {
+	// Sequence-allocated: catalog cache keys on schema_version; collisions from
+	// concurrent commits cause stale-cache reuse across transactions.
+	return FetchScalarSequenceValue("ducklake_schema_version_seq");
+}
+
+void PostgresMetadataManager::AcquireCommitLock() {
+	DuckLakeSnapshot dummy {};
+	if (!commit_lock_classid.IsValid()) {
+		string probe = "SELECT hashtext({METADATA_CATALOG_NAME_LITERAL})::int4";
+		auto probe_result = Query(dummy, probe);
+		if (probe_result->HasError()) {
+			probe_result->GetErrorObject().Throw(
+			    "concurrent: failed to compute DuckLake commit lock classid: ");
+		}
+		auto chunk = probe_result->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			throw InternalException("ducklake: hashtext probe returned no row");
+		}
+		commit_lock_classid = static_cast<idx_t>(
+		    static_cast<uint32_t>(chunk->data[0].GetValue(0).GetValue<int32_t>()));
+	}
+
+	string set_timeout = "SET LOCAL lock_timeout = '30s'";
+	auto timeout_res = Execute(dummy, set_timeout);
+	if (timeout_res->HasError()) {
+		timeout_res->GetErrorObject().Throw("concurrent: failed to set lock_timeout: ");
+	}
+
+	// "concurrent:" prefix -> RetryOnError matches, transient pg error retries.
+	string query = "SELECT pg_advisory_xact_lock(" +
+	               std::to_string(static_cast<int32_t>(commit_lock_classid.GetIndex())) + ", " +
+	               std::to_string(DUCKLAKE_COMMIT_ADVISORY_SUBKEY) + ")";
+	auto result = Execute(dummy, query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("concurrent: DuckLake commit serialisation lock failed: ");
+	}
+}
+
 void PostgresMetadataManager::EnsureIdSequences() {
 	// One statement per call: postgres_execute drops all but the first of a batch.
 	DuckLakeSnapshot dummy {0, 0, 0, 0};
@@ -169,9 +208,11 @@ void PostgresMetadataManager::EnsureIdSequences() {
 	};
 
 	// file_id_seq needs MINVALUE 0: bootstrap next_file_id=0 and first allocation must return 0.
+	// CACHE > 1 breaks MAX(snapshot_id)-as-horizon (pre-backend-cached nextval).
 	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq CACHE 1");
 	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq CACHE 1");
 	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq MINVALUE 0 START WITH 0 CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq CACHE 1");
 	run(R"(SELECT setval(
   '{METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq',
   GREATEST(
@@ -196,9 +237,16 @@ void PostgresMetadataManager::EnsureIdSequences() {
   ),
   COALESCE((SELECT MAX(next_file_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0) >= 1
 ))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq),
+    GREATEST(1, COALESCE((SELECT MAX(schema_version) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(schema_version) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 1) >= 1
+))");
 
-	// Name-uniqueness constraints replace the PK-violation signal the sequence
-	// allocator eliminates, so CheckForConflicts still fires on duplicate creates.
+	// Replace the PK-violation signal the sequence allocator eliminates.
 	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_schema_name_active_uidx "
 	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_schema (schema_name) "
 	    "WHERE end_snapshot IS NULL");
@@ -207,6 +255,11 @@ void PostgresMetadataManager::EnsureIdSequences() {
 	    "WHERE end_snapshot IS NULL");
 	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_view_name_active_uidx "
 	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_view (schema_id, view_name) "
+	    "WHERE end_snapshot IS NULL");
+	// One live delete_file per data_file: without it, concurrent DELETEs
+	// double-count rows by applying both delete masks as independent variants.
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_delete_file_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_delete_file (data_file_id) "
 	    "WHERE end_snapshot IS NULL");
 }
 

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -127,6 +127,89 @@ string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 	)";
 }
 
+idx_t PostgresMetadataManager::FetchScalarSequenceValue(const string &seq_name) {
+	DuckLakeSnapshot dummy {0, 0, 0, 0};
+	string query = "SELECT nextval('{METADATA_SCHEMA_ESCAPED}." + seq_name + "')";
+	auto result = Query(dummy, query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to allocate next value from " + seq_name + ": ");
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		throw InternalException("ducklake: %s returned no value from nextval()", seq_name);
+	}
+	auto v = chunk->data[0].GetValue(0).GetValue<int64_t>();
+	if (v < 0) {
+		throw InternalException("ducklake: %s returned negative value: %lld", seq_name, (long long)v);
+	}
+	return static_cast<idx_t>(v);
+}
+
+idx_t PostgresMetadataManager::AllocateNextSnapshotId(idx_t /*advisory*/) {
+	return FetchScalarSequenceValue("ducklake_snapshot_id_seq");
+}
+
+idx_t PostgresMetadataManager::AllocateNextCatalogId(idx_t /*advisory*/) {
+	return FetchScalarSequenceValue("ducklake_catalog_id_seq");
+}
+
+idx_t PostgresMetadataManager::AllocateNextFileId(idx_t /*advisory*/) {
+	return FetchScalarSequenceValue("ducklake_file_id_seq");
+}
+
+void PostgresMetadataManager::EnsureIdSequences() {
+	// One statement per call: postgres_execute drops all but the first of a batch.
+	DuckLakeSnapshot dummy {0, 0, 0, 0};
+
+	auto run = [&](string query) {
+		auto result = Execute(dummy, query);
+		if (result->HasError()) {
+			result->GetErrorObject().Throw("Failed to ensure DuckLake id sequences: ");
+		}
+	};
+
+	// file_id_seq needs MINVALUE 0: bootstrap next_file_id=0 and first allocation must return 0.
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq MINVALUE 0 START WITH 0 CACHE 1");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq),
+    GREATEST(1, COALESCE((SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 1) >= 1
+))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq),
+    GREATEST(1, COALESCE((SELECT MAX(next_catalog_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(next_catalog_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0) >= 1
+))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq),
+    GREATEST(0, COALESCE((SELECT MAX(next_file_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(next_file_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0) >= 1
+))");
+
+	// Name-uniqueness constraints replace the PK-violation signal the sequence
+	// allocator eliminates, so CheckForConflicts still fires on duplicate creates.
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_schema_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_schema (schema_name) "
+	    "WHERE end_snapshot IS NULL");
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_table_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_table (schema_id, table_name) "
+	    "WHERE end_snapshot IS NULL");
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_view_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_view (schema_id, view_name) "
+	    "WHERE end_snapshot IS NULL");
+}
+
 // We need a specialized function here to do a reinterpret for postgres from BLOB to VARCHAR
 shared_ptr<DuckLakeInlinedData>
 PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types) {

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -192,15 +192,15 @@ idx_t DuckLakeCatalog::GetBeginSnapshotForSchemaVersion(TableIndex table_id, idx
 
 DuckLakeCatalogSet &DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot) {
 	lock_guard<mutex> guard(schemas_lock);
-	auto entry = schemas.find(snapshot.schema_version);
+	// Key on snapshot_id: two snapshots at the same schema_version can see
+	// different tables (begin_snapshot filter), so schema_version isn't unique.
+	auto entry = schemas.find(snapshot.snapshot_id);
 	if (entry != schemas.end()) {
-		// this schema version is already cached
 		return *entry->second;
 	}
-	// load the schema version from the metadata manager
 	auto schema = LoadSchemaForSnapshot(transaction, snapshot);
 	auto &result = *schema;
-	schemas.insert(make_pair(snapshot.schema_version, std::move(schema)));
+	schemas.insert(make_pair(snapshot.snapshot_id, std::move(schema)));
 	return result;
 }
 

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -36,13 +36,21 @@ string DuckLakeInitializer::GetAttachOptions() {
 			throw InternalException("Unsupported access mode in DuckLake attach");
 		}
 	}
+	bool has_isolation_level_override = false;
 	for (auto &option : options.metadata_parameters) {
 		attach_options.push_back(option.first + " " + option.second.ToSQLString());
+		if (StringUtil::Lower(option.first) == "isolation_level") {
+			has_isolation_level_override = true;
+		}
 	}
 	const string metadata_type = catalog.MetadataType();
 	if (metadata_type.empty() || metadata_type == "duckdb") {
 		// this is duckdb, we always do latest storage
 		attach_options.push_back(StringUtil::Format("STORAGE_VERSION '%s'", "latest"));
+	} else if (metadata_type == "postgres" && !has_isolation_level_override) {
+		// REPEATABLE READ pins one pg snapshot per DuckLake tx, hiding concurrent
+		// committers from CheckForConflicts. Override via meta_isolation_level.
+		attach_options.push_back("isolation_level 'read committed'");
 	}
 
 	if (attach_options.empty()) {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -159,6 +159,9 @@ void DuckLakeInitializer::InitializeNewDuckLake(DuckLakeTransaction &transaction
 	SetVersionedMetadataManager(transaction, version);
 	auto &metadata_manager = transaction.GetMetadataManager();
 	metadata_manager.InitializeDuckLake(has_explicit_schema, catalog.Encryption());
+	if (auto *pg_mgr = dynamic_cast<PostgresMetadataManager *>(&metadata_manager)) {
+		pg_mgr->EnsureIdSequences();
+	}
 	if (catalog.Encryption() == DuckLakeEncryption::AUTOMATIC) {
 		// default to unencrypted
 		catalog.SetEncryption(DuckLakeEncryption::UNENCRYPTED);
@@ -256,7 +259,11 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 	for (auto &entry : metadata.table_settings) {
 		options.table_options[entry.table_id][entry.tag.key] = entry.tag.value;
 	}
-	// set correct version metadata manager
+	if (options.access_mode != AccessMode::READ_ONLY) {
+		if (auto *pg_mgr = dynamic_cast<PostgresMetadataManager *>(&transaction.GetMetadataManager())) {
+			pg_mgr->EnsureIdSequences();
+		}
+	}
 	if (resolved_version != DuckLakeVersion::UNSET) {
 		SetVersionedMetadataManager(transaction, resolved_version);
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -161,8 +161,8 @@ CREATE TABLE {METADATA_CATALOG}.ducklake_file_column_stats(data_file_id BIGINT, 
 CREATE TABLE {METADATA_CATALOG}.ducklake_file_variant_stats(data_file_id BIGINT, table_id BIGINT, column_id BIGINT, variant_path VARCHAR, shredded_type VARCHAR, column_size_bytes BIGINT, value_count BIGINT, null_count BIGINT, min_value VARCHAR, max_value VARCHAR, contains_nan BOOLEAN, extra_stats VARCHAR);
 CREATE TABLE {METADATA_CATALOG}.ducklake_delete_file(delete_file_id BIGINT PRIMARY KEY, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, data_file_id BIGINT, path VARCHAR, path_is_relative BOOLEAN, format VARCHAR, delete_count BIGINT, file_size_bytes BIGINT, footer_size BIGINT, encryption_key VARCHAR, partial_max BIGINT);
 CREATE TABLE {METADATA_CATALOG}.ducklake_column(column_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, table_id BIGINT, column_order BIGINT, column_name VARCHAR, column_type VARCHAR, initial_default VARCHAR, default_value VARCHAR, nulls_allowed BOOLEAN, parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR);
-CREATE TABLE {METADATA_CATALOG}.ducklake_table_stats(table_id BIGINT, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT);
-CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR);
+CREATE TABLE {METADATA_CATALOG}.ducklake_table_stats(table_id BIGINT PRIMARY KEY, record_count BIGINT, next_row_id BIGINT, file_size_bytes BIGINT, stats_version BIGINT NOT NULL DEFAULT 0);
+CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, PRIMARY KEY (table_id, column_id));
 CREATE TABLE {METADATA_CATALOG}.ducklake_partition_info(partition_id BIGINT, table_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT);
 CREATE TABLE {METADATA_CATALOG}.ducklake_partition_column(partition_id BIGINT, table_id BIGINT, partition_key_index BIGINT, column_id BIGINT, transform VARCHAR);
 CREATE TABLE {METADATA_CATALOG}.ducklake_file_partition_value(data_file_id BIGINT, table_id BIGINT, partition_key_index BIGINT, partition_value VARCHAR);
@@ -303,7 +303,10 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.0' WHERE key = 'versi
 }
 
 void DuckLakeMetadataManager::MigrateV10() {
+	// Stats PKs deliberately NOT added: pg ADD PRIMARY KEY is not idempotent,
+	// concurrent init runs would race. Existing catalogs rely on CAS alone.
 	auto result = transaction.Query(R"(
+ALTER TABLE {METADATA_CATALOG}.ducklake_table_stats ADD COLUMN IF NOT EXISTS stats_version BIGINT NOT NULL DEFAULT 0;
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)");
 	if (result->HasError()) {
@@ -831,6 +834,10 @@ void TransformGlobalStatsRow(const ROW &row, vector<DuckLakeGlobalStatsInfo> &gl
 		new_entry.record_count = row.template GetValue<uint64_t>(2 + from_column);
 		new_entry.next_row_id = row.template GetValue<uint64_t>(3 + from_column);
 		new_entry.table_size_bytes = row.template GetValue<uint64_t>(4 + from_column);
+		const idx_t STATS_VERSION_COL = 10 + from_column;
+		if (!row.IsNull(STATS_VERSION_COL)) { // NULL on pre-migration rows
+			new_entry.stats_version = row.template GetValue<uint64_t>(STATS_VERSION_COL);
+		}
 		global_stats.push_back(std::move(new_entry));
 	}
 
@@ -896,7 +903,7 @@ vector<DuckLakeGlobalStatsInfo> TransformGlobalStats(QueryResult &result) {
 vector<DuckLakeGlobalStatsInfo> DuckLakeMetadataManager::GetGlobalTableStats(DuckLakeSnapshot snapshot) {
 	// query the most recent stats
 	auto result = transaction.Query(snapshot, R"(
-SELECT table_id, column_id, record_count, next_row_id, file_size_bytes, contains_null, contains_nan, min_value, max_value, extra_stats
+SELECT table_id, column_id, record_count, next_row_id, file_size_bytes, contains_null, contains_nan, min_value, max_value, extra_stats, stats_version
 FROM {METADATA_CATALOG}.ducklake_table_stats
 LEFT JOIN {METADATA_CATALOG}.ducklake_table_column_stats USING (table_id)
 WHERE record_count IS NOT NULL AND file_size_bytes IS NOT NULL
@@ -2402,7 +2409,9 @@ WHERE table_id = %d AND schema_version=(
 			// write the new inlined table
 			string inlined_tables;
 			string inlined_table_queries;
-			commit_snapshot.schema_version++;
+			// Race-free: physical name `ducklake_inlined_data_<tid>_<ver>` would
+			// collide under concurrent CREATE-inlined paths with a local ++.
+			commit_snapshot.schema_version = AllocateNextSchemaVersion(commit_snapshot.schema_version);
 			inlined_table_name =
 			    GetInlinedTableQueries(commit_snapshot, table_info, inlined_tables, inlined_table_queries);
 			batch_query += "INSERT INTO {METADATA_CATALOG}.ducklake_inlined_data_tables VALUES " + inlined_tables + ";";
@@ -3464,7 +3473,8 @@ SELECT
     NULL AS contains_nan,
     NULL AS min_value,
     NULL AS max_value,
-    NULL AS extra_stats
+    NULL AS extra_stats,
+    NULL AS stats_version
     FROM {METADATA_CATALOG}.ducklake_snapshot
     WHERE snapshot_id = (
         SELECT MAX(snapshot_id)
@@ -3485,7 +3495,8 @@ SELECT
     contains_nan,
     min_value,
     max_value,
-    extra_stats
+    extra_stats,
+    stats_version
 FROM {METADATA_CATALOG}.ducklake_table_stats
 LEFT JOIN {METADATA_CATALOG}.ducklake_table_column_stats
     USING (table_id)
@@ -3923,7 +3934,7 @@ string DuckLakeMetadataManager::UpdateGlobalTableStats(const DuckLakeGlobalStats
 
 	if (!stats.initialized) {
 		batch_query +=
-		    StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_stats VALUES (%d, %d, %d, %d);",
+		    StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_stats VALUES (%d, %d, %d, %d, 0);",
 		                       stats.table_id.index, stats.record_count, stats.next_row_id, stats.table_size_bytes);
 		string column_stats_values;
 		for (auto &col_stats : stats.column_stats) {
@@ -3938,11 +3949,13 @@ string DuckLakeMetadataManager::UpdateGlobalTableStats(const DuckLakeGlobalStats
 		batch_query += StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES %s;",
 		                                  column_stats_values);
 	} else {
-		// stats have been initialized - update them
+		// CAS: stats_version=expected, set to unique new_stats_version.
+		// FlushChanges post-verifies via SELECT to detect silent rowcount=0.
 		batch_query += StringUtil::Format(
 		    "UPDATE {METADATA_CATALOG}.ducklake_table_stats SET record_count=%d, file_size_bytes=%d, "
-		    "next_row_id=%d WHERE table_id=%d;",
-		    stats.record_count, stats.table_size_bytes, stats.next_row_id, stats.table_id.index);
+		    "next_row_id=%d, stats_version=%d WHERE table_id=%d AND stats_version=%d;",
+		    stats.record_count, stats.table_size_bytes, stats.next_row_id, stats.new_stats_version,
+		    stats.table_id.index, stats.stats_version);
 		for (auto &col_stats : stats.column_stats) {
 			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
 			batch_query +=

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3413,6 +3413,18 @@ string DuckLakeMetadataManager::InsertSnapshot() {
 	return R"(INSERT INTO {METADATA_CATALOG}.ducklake_snapshot VALUES ({SNAPSHOT_ID}, NOW(), {SCHEMA_VERSION}, {NEXT_CATALOG_ID}, {NEXT_FILE_ID});)";
 }
 
+idx_t DuckLakeMetadataManager::AllocateNextSnapshotId(idx_t current_snapshot_id) {
+	return current_snapshot_id + 1;
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextCatalogId(idx_t current_next_catalog_id) {
+	return current_next_catalog_id;
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextFileId(idx_t current_next_file_id) {
+	return current_next_file_id;
+}
+
 static string SQLStringOrNull(const string &str) {
 	if (str.empty()) {
 		return "NULL";

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -926,6 +926,10 @@ struct DuckLakeCommitState {
 	map<MappingIndex, MappingIndex> committed_mapping_indexes;
 	map<TableIndex, vector<DuckLakeDeleteFile>> local_delete_files;
 
+	// (table_id, expected new stats_version). FlushChanges post-verifies via
+	// SELECT to catch CAS UPDATEs that silently matched zero rows.
+	vector<std::pair<TableIndex, idx_t>> stats_verification;
+
 	idx_t AllocateCatalogId() const {
 		idx_t id = metadata_manager.AllocateNextCatalogId(commit_snapshot.next_catalog_id);
 		if (id + 1 > commit_snapshot.next_catalog_id) {
@@ -1934,9 +1938,13 @@ struct DuckLakeNewGlobalStats {
 };
 
 string DuckLakeTransaction::UpdateGlobalTableStats(TableIndex table_id,
-                                                   const DuckLakeNewGlobalStats &new_global_stats) {
+                                                   const DuckLakeNewGlobalStats &new_global_stats,
+                                                   idx_t expected_stats_version,
+                                                   idx_t new_stats_version) {
 	DuckLakeGlobalStatsInfo stats;
 	stats.table_id = table_id;
+	stats.stats_version = expected_stats_version;
+	stats.new_stats_version = new_stats_version;
 
 	stats.initialized = new_global_stats.initialized;
 	auto &new_stats = new_global_stats.stats;
@@ -2145,7 +2153,21 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 			}
 		}
 		// update the global stats for this table based on the newly written data
-		batch_query += UpdateGlobalTableStats(table_id, new_globals);
+		// CAS: expected = observed pre-commit version (0 if row uninitialised).
+		idx_t expected_stats_version = 0;
+		if (stats) {
+			for (auto &s : *stats) {
+				if (s.table_id == table_id) {
+					expected_stats_version = s.stats_version;
+					break;
+				}
+			}
+		}
+		idx_t new_stats_version = commit_state.commit_snapshot.snapshot_id;
+		batch_query += UpdateGlobalTableStats(table_id, new_globals, expected_stats_version, new_stats_version);
+		if (new_globals.initialized) {
+			commit_state.stats_verification.emplace_back(table_id, new_stats_version);
+		}
 	}
 	return result;
 }
@@ -2532,6 +2554,9 @@ bool RetryOnError(const string &original_message) {
 	    StringUtil::Contains(message, "connection reset")) {
 		return true;
 	}
+	if (StringUtil::Contains(message, "deadlock")) {
+		return true;
+	}
 	return false;
 }
 
@@ -2556,7 +2581,6 @@ void DuckLakeTransaction::FlushChanges() {
 	}
 
 	auto transaction_snapshot = GetSnapshot();
-	auto transaction_changes = GetTransactionChanges();
 	SnapshotAndStats commit_stats_snapshot;
 	auto &commit_snapshot = commit_stats_snapshot.snapshot;
 	optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats;
@@ -2564,15 +2588,19 @@ void DuckLakeTransaction::FlushChanges() {
 		bool can_retry;
 		try {
 			can_retry = false;
-			// Must run every attempt: sequence allocator has no PK-violation
-			// retry, so logical conflicts only surface via this explicit check.
+			// Re-capture every attempt: tx-local state may have changed and
+			// stale tx_changes make CheckForConflicts miss real conflicts.
+			auto transaction_changes = GetTransactionChanges();
 			commit_stats_snapshot = CheckForConflicts(transaction_snapshot, transaction_changes);
 			stats = &commit_stats_snapshot.stats;
-			// Set before the allocator call so a pg connection fault retries.
 			can_retry = true;
+			// Must share the pg tx with AllocateNextSnapshotId below; release
+			// tied to COMMIT/ROLLBACK. Split breaks MAX(snapshot_id)-as-horizon.
+			metadata_manager->AcquireCommitLock();
 			commit_snapshot.snapshot_id = metadata_manager->AllocateNextSnapshotId(commit_snapshot.snapshot_id);
 			if (SchemaChangesMade()) {
-				commit_snapshot.schema_version++;
+				commit_snapshot.schema_version =
+				    metadata_manager->AllocateNextSchemaVersion(commit_snapshot.schema_version);
 			}
 			DuckLakeCommitState commit_state(commit_snapshot, *metadata_manager);
 			// write the new snapshot
@@ -2583,6 +2611,30 @@ void DuckLakeTransaction::FlushChanges() {
 			auto res = metadata_manager->Execute(commit_snapshot, batch_queries);
 			if (res->HasError()) {
 				res->GetErrorObject().Throw("Failed to flush changes into DuckLake: ");
+			}
+			// Own-writes visible pre-COMMIT. Row with a different stats_version
+			// means a concurrent committer's UPDATE won; our CAS matched zero.
+			for (auto &entry : commit_state.stats_verification) {
+				string check_sql = StringUtil::Format(
+				    "SELECT stats_version FROM {METADATA_CATALOG}.ducklake_table_stats WHERE table_id = %d",
+				    entry.first.index);
+				auto check_res = metadata_manager->Query(commit_snapshot, check_sql);
+				if (check_res->HasError()) {
+					check_res->GetErrorObject().Throw("Failed to verify stats_version post-commit: ");
+				}
+				auto chunk = check_res->Fetch();
+				if (!chunk || chunk->size() == 0) {
+					throw TransactionException(
+					    "concurrent update to ducklake_table_stats: row missing for table_id=%d, retrying",
+					    entry.first.index);
+				}
+				idx_t actual = chunk->data[0].GetValue(0).GetValue<uint64_t>();
+				if (actual != entry.second) {
+					throw TransactionException(
+					    "concurrent update to ducklake_table_stats detected (stats_version=%llu, "
+					    "expected=%llu for table_id=%d), retrying",
+					    (unsigned long long)actual, (unsigned long long)entry.second, entry.first.index);
+				}
 			}
 			connection->Commit();
 			catalog_version = commit_snapshot.schema_version;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -914,15 +914,32 @@ TransactionChangeInformation DuckLakeTransaction::GetTransactionChanges() const 
 }
 
 struct DuckLakeCommitState {
-	explicit DuckLakeCommitState(DuckLakeSnapshot &snapshot) : commit_snapshot(snapshot) {
+	DuckLakeCommitState(DuckLakeSnapshot &snapshot, DuckLakeMetadataManager &metadata_manager)
+	    : commit_snapshot(snapshot), metadata_manager(metadata_manager) {
 	}
 
 	DuckLakeSnapshot &commit_snapshot;
+	DuckLakeMetadataManager &metadata_manager;
 	map<SchemaIndex, SchemaIndex> committed_schemas;
 	map<TableIndex, TableIndex> committed_tables;
 	map<idx_t, idx_t> committed_partition_ids;
 	map<MappingIndex, MappingIndex> committed_mapping_indexes;
 	map<TableIndex, vector<DuckLakeDeleteFile>> local_delete_files;
+
+	idx_t AllocateCatalogId() const {
+		idx_t id = metadata_manager.AllocateNextCatalogId(commit_snapshot.next_catalog_id);
+		if (id + 1 > commit_snapshot.next_catalog_id) {
+			commit_snapshot.next_catalog_id = id + 1;
+		}
+		return id;
+	}
+	idx_t AllocateFileId() const {
+		idx_t id = metadata_manager.AllocateNextFileId(commit_snapshot.next_file_id);
+		if (id + 1 > commit_snapshot.next_file_id) {
+			commit_snapshot.next_file_id = id + 1;
+		}
+		return id;
+	}
 
 	void RemapIdentifier(SchemaIndex &schema_id) const {
 		auto entry = committed_schemas.find(schema_id);
@@ -1353,7 +1370,7 @@ vector<DuckLakeSchemaInfo> DuckLakeTransaction::GetNewSchemas(DuckLakeCommitStat
 		auto &schema_entry = entry.second->Cast<DuckLakeSchemaEntry>();
 		auto old_id = schema_entry.GetSchemaId();
 		DuckLakeSchemaInfo schema_info;
-		schema_info.id = SchemaIndex(commit_state.commit_snapshot.next_catalog_id++);
+		schema_info.id = SchemaIndex(commit_state.AllocateCatalogId());
 		schema_info.uuid = schema_entry.GetSchemaUUID();
 		schema_info.name = schema_entry.name;
 		schema_info.path = schema_entry.DataPath();
@@ -1381,7 +1398,7 @@ DuckLakePartitionInfo DuckLakeTransaction::GetNewPartitionKey(DuckLakeCommitStat
 		return partition_key;
 	}
 	auto local_partition_id = partition_data->partition_id;
-	auto partition_id = commit_state.commit_snapshot.next_catalog_id++;
+	auto partition_id = commit_state.AllocateCatalogId();
 	partition_key.id = partition_id;
 	partition_data->partition_id = partition_id;
 	for (auto &field : partition_data->fields) {
@@ -1430,7 +1447,7 @@ DuckLakeSortInfo DuckLakeTransaction::GetNewSortKey(DuckLakeCommitState &commit_
 		return sort_key;
 	}
 
-	auto sort_id = commit_state.commit_snapshot.next_catalog_id++;
+	auto sort_id = commit_state.AllocateCatalogId();
 	sort_key.id = sort_id;
 	sort_data->sort_id = sort_id;
 	for (auto &field : sort_data->fields) {
@@ -1477,7 +1494,7 @@ DuckLakeTableInfo DuckLakeTransaction::GetNewTable(DuckLakeCommitState &commit_s
 	auto original_id = table_entry.id;
 	bool is_new_table;
 	if (IsTransactionLocal(original_id.index)) {
-		table_entry.id = TableIndex(commit_state.commit_snapshot.next_catalog_id++);
+		table_entry.id = TableIndex(commit_state.AllocateCatalogId());
 		is_new_table = true;
 	} else {
 		// this table already has an id - keep it
@@ -1743,7 +1760,7 @@ DuckLakeViewInfo DuckLakeTransaction::GetNewView(DuckLakeCommitState &commit_sta
 	DuckLakeViewInfo view_entry;
 	auto original_id = view.GetViewId();
 	if (IsTransactionLocal(original_id.index)) {
-		view_entry.id = TableIndex(commit_state.commit_snapshot.next_catalog_id++);
+		view_entry.id = TableIndex(commit_state.AllocateCatalogId());
 	} else {
 		// this view already has an id - keep it
 		// this happens if e.g. this view is renamed
@@ -1764,7 +1781,7 @@ void DuckLakeTransaction::GetNewMacroInfo(DuckLakeCommitState &commit_state, ref
 	auto &macro_entry = entry.get().Cast<MacroCatalogEntry>();
 	auto &ducklake_schema = macro_entry.schema.Cast<DuckLakeSchemaEntry>();
 
-	new_macro_info.macro_id = MacroIndex(commit_state.commit_snapshot.next_catalog_id++);
+	new_macro_info.macro_id = MacroIndex(commit_state.AllocateCatalogId());
 	new_macro_info.macro_name = macro_entry.name;
 	new_macro_info.schema_id = commit_state.GetSchemaId(ducklake_schema);
 	// Let's do the implementations
@@ -1995,7 +2012,8 @@ DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(const DuckLakeDataFile &fil
                                                      TableIndex table_id, optional_idx row_id_start) {
 	auto &commit_snapshot = commit_state.commit_snapshot;
 	DuckLakeFileInfo data_file;
-	data_file.id = DataFileIndex(commit_snapshot.next_file_id++);
+	data_file.id = DataFileIndex(commit_state.AllocateFileId());
+	(void)commit_snapshot;
 	data_file.table_id = table_id;
 	data_file.file_name = file.file_name;
 	data_file.row_count = file.row_count;
@@ -2123,7 +2141,7 @@ NewDataInfo DuckLakeTransaction::GetNewDataFiles(string &batch_query, DuckLakeCo
 
 			if (table_changes.new_data_files.empty()) {
 				// force an increment of file_id to signal a data change if we have only inlined data changes
-				commit_state.commit_snapshot.next_file_id++;
+				(void)commit_state.AllocateFileId();
 			}
 		}
 		// update the global stats for this table based on the newly written data
@@ -2136,7 +2154,7 @@ DuckLakeDeleteFileInfo DuckLakeTransaction::GetNewDeleteFile(TableIndex table_id
                                                              const DuckLakeCommitState &commit_state,
                                                              const DuckLakeDeleteFile &file) const {
 	DuckLakeDeleteFileInfo delete_file;
-	delete_file.id = DataFileIndex(commit_state.commit_snapshot.next_file_id++);
+	delete_file.id = DataFileIndex(commit_state.AllocateFileId());
 	delete_file.table_id = table_id;
 	delete_file.data_file_id = file.data_file_id;
 	delete_file.path = file.file_name;
@@ -2214,7 +2232,7 @@ NewNameMapInfo DuckLakeTransaction::GetNewNameMaps(DuckLakeCommitState &commit_s
 		// generate a new mapping id
 		auto local_map_id = entry.first;
 		auto &mapping = *entry.second;
-		MappingIndex new_map_id(commit_state.commit_snapshot.next_file_id++);
+		MappingIndex new_map_id(commit_state.AllocateFileId());
 
 		DuckLakeColumnMappingInfo map_info;
 		map_info.table_id = commit_state.GetTableId(mapping.table_id);
@@ -2509,6 +2527,11 @@ bool RetryOnError(const string &original_message) {
 	if (StringUtil::Contains(message, "concurrent")) {
 		return true;
 	}
+	if (StringUtil::Contains(message, "server closed the connection") ||
+	    StringUtil::Contains(message, "connection to server") ||
+	    StringUtil::Contains(message, "connection reset")) {
+		return true;
+	}
 	return false;
 }
 
@@ -2541,21 +2564,17 @@ void DuckLakeTransaction::FlushChanges() {
 		bool can_retry;
 		try {
 			can_retry = false;
-			if (i > 0) {
-				// we failed our first commit due to another transaction committing
-				// retry - but first check for conflicts
-				commit_stats_snapshot = CheckForConflicts(transaction_snapshot, transaction_changes);
-				stats = &commit_stats_snapshot.stats;
-			} else {
-				commit_stats_snapshot.snapshot = GetSnapshot();
-			}
-			commit_snapshot.snapshot_id++;
+			// Must run every attempt: sequence allocator has no PK-violation
+			// retry, so logical conflicts only surface via this explicit check.
+			commit_stats_snapshot = CheckForConflicts(transaction_snapshot, transaction_changes);
+			stats = &commit_stats_snapshot.stats;
+			// Set before the allocator call so a pg connection fault retries.
+			can_retry = true;
+			commit_snapshot.snapshot_id = metadata_manager->AllocateNextSnapshotId(commit_snapshot.snapshot_id);
 			if (SchemaChangesMade()) {
-				// we changed the schema - need to get a new schema version
 				commit_snapshot.schema_version++;
 			}
-			can_retry = true;
-			DuckLakeCommitState commit_state(commit_snapshot);
+			DuckLakeCommitState commit_state(commit_snapshot, *metadata_manager);
 			// write the new snapshot
 			string batch_queries = metadata_manager->InsertSnapshot();
 			batch_queries += CommitChanges(commit_state, transaction_changes, stats);

--- a/test/sql/concurrent/concurrent_insert_pg_sequences.test
+++ b/test/sql/concurrent/concurrent_insert_pg_sequences.test
@@ -1,0 +1,79 @@
+# name: test/sql/concurrent/concurrent_insert_pg_sequences.test
+# description: verify Postgres sequence-backed ID allocators are adopted and advance
+#              under concurrent load (fixes ducklake_snapshot_pkey race).
+# group: [concurrent]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+test-env DUCKLAKE_CONNECTION none
+
+test-env PG_METADATA_CONN none
+
+test-env DATA_PATH {TEST_DIR}
+
+# Print the effective conn strings so a test-runner issue is immediately visible.
+query I
+SELECT '{PG_METADATA_CONN}' AS pg_conn;
+----
+dbname=ducklakedb host=localhost port=5433 user=postgres
+
+query I
+SELECT '{DUCKLAKE_CONNECTION}' AS ducklake_conn;
+----
+postgres:dbname=ducklakedb host=localhost port=5433 user=postgres
+
+statement ok
+ATTACH '{PG_METADATA_CONN}' AS _clean_pg (TYPE postgres);
+
+statement ok
+CALL postgres_execute('_clean_pg',
+    'DROP SCHEMA IF EXISTS metadata_pg_seq_test CASCADE');
+
+query I
+SELECT COUNT(*)::BIGINT FROM postgres_query('_clean_pg',
+    'SELECT 1 FROM pg_namespace WHERE nspname = ''metadata_pg_seq_test''');
+----
+0
+
+statement ok
+DETACH _clean_pg;
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl_pg_seq (DATA_PATH '{DATA_PATH}/ducklake_pg_seq_files', METADATA_SCHEMA 'metadata_pg_seq_test');
+
+statement ok
+ATTACH '{PG_METADATA_CONN}' AS pg_meta (TYPE postgres);
+
+statement ok
+CREATE TABLE dl_pg_seq.tbl(key INTEGER);
+
+concurrentloop i 0 4
+
+query I
+INSERT INTO dl_pg_seq.tbl VALUES ({i})
+----
+1
+
+endloop
+
+# All three sequences should be marked as is_called=true — proves the override
+# was wired and called nextval() during commits.
+query III
+SELECT is_called_snap, is_called_cat, is_called_fil
+FROM postgres_query('pg_meta',
+    'SELECT (SELECT is_called FROM metadata_pg_seq_test.ducklake_snapshot_id_seq) AS is_called_snap,
+            (SELECT is_called FROM metadata_pg_seq_test.ducklake_catalog_id_seq)  AS is_called_cat,
+            (SELECT is_called FROM metadata_pg_seq_test.ducklake_file_id_seq)     AS is_called_fil');
+----
+true	true	true
+
+query II
+SELECT COUNT(*), SUM(key) FROM dl_pg_seq.tbl;
+----
+4	6

--- a/test/sql/concurrent/concurrent_insert_pg_sequences.test
+++ b/test/sql/concurrent/concurrent_insert_pg_sequences.test
@@ -11,22 +11,11 @@ require parquet
 
 require postgres_scanner
 
-test-env DUCKLAKE_CONNECTION none
+test-env DUCKLAKE_CONNECTION postgres:dbname=ducklakedb
 
-test-env PG_METADATA_CONN none
+test-env PG_METADATA_CONN dbname=ducklakedb
 
-test-env DATA_PATH {TEST_DIR}
-
-# Print the effective conn strings so a test-runner issue is immediately visible.
-query I
-SELECT '{PG_METADATA_CONN}' AS pg_conn;
-----
-dbname=ducklakedb host=localhost port=5433 user=postgres
-
-query I
-SELECT '{DUCKLAKE_CONNECTION}' AS ducklake_conn;
-----
-postgres:dbname=ducklakedb host=localhost port=5433 user=postgres
+test-env DATA_PATH __TEST_DIR__
 
 statement ok
 ATTACH '{PG_METADATA_CONN}' AS _clean_pg (TYPE postgres);

--- a/test/sql/migration/pg_sequences_bootstrap.test
+++ b/test/sql/migration/pg_sequences_bootstrap.test
@@ -1,0 +1,97 @@
+# name: test/sql/migration/pg_sequences_bootstrap.test
+# description: verify EnsureIdSequences bootstraps from a pre-sequence catalog state
+# group: [migration]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+test-env DUCKLAKE_CONNECTION none
+
+test-env PG_METADATA_CONN none
+
+test-env DATA_PATH {TEST_DIR}
+
+# First attach creates the catalog with sequences.
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_pg_seq_bootstrap', METADATA_SCHEMA 'metadata_s1')
+
+statement ok
+CREATE TABLE ducklake.tbl(key INTEGER);
+
+statement ok
+INSERT INTO ducklake.tbl VALUES (1), (2), (3);
+
+statement ok
+DETACH ducklake
+
+# Simulate a pre-sequence catalog by dropping the three sequences while
+# leaving the tables intact. EnsureIdSequences should re-create them on
+# the next attach and setval them to the current catalog state.
+statement ok
+ATTACH '{PG_METADATA_CONN}' AS pg_raw (TYPE postgres);
+
+statement ok
+CALL postgres_execute('pg_raw',
+    'DROP SEQUENCE IF EXISTS metadata_s1.ducklake_snapshot_id_seq;
+     DROP SEQUENCE IF EXISTS metadata_s1.ducklake_catalog_id_seq;
+     DROP SEQUENCE IF EXISTS metadata_s1.ducklake_file_id_seq;');
+
+# Verify sequences are gone
+query I
+SELECT COUNT(*)
+FROM pg_raw.pg_catalog.pg_class c
+JOIN pg_raw.pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'S'
+  AND n.nspname = 'metadata_s1'
+  AND c.relname IN ('ducklake_snapshot_id_seq', 'ducklake_catalog_id_seq', 'ducklake_file_id_seq');
+----
+0
+
+statement ok
+DETACH pg_raw
+
+# Re-attach — EnsureIdSequences hook must restore them
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_pg_seq_bootstrap', METADATA_SCHEMA 'metadata_s1')
+
+statement ok
+ATTACH '{PG_METADATA_CONN}' AS pg_meta (TYPE postgres);
+
+# All three sequences exist again
+query I
+SELECT COUNT(*)
+FROM pg_meta.pg_catalog.pg_class c
+JOIN pg_meta.pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'S'
+  AND n.nspname = 'metadata_s1'
+  AND c.relname IN ('ducklake_snapshot_id_seq', 'ducklake_catalog_id_seq', 'ducklake_file_id_seq');
+----
+3
+
+# setval is correct: last_value >= MAX for all three counters (read via postgres_query
+# because postgres_scanner does not expose sequences as duckdb tables).
+query III
+SELECT snap_ok, cat_ok, fil_ok FROM postgres_query('pg_meta',
+    'SELECT
+       (SELECT last_value FROM metadata_s1.ducklake_snapshot_id_seq) >=
+         COALESCE((SELECT MAX(snapshot_id) FROM metadata_s1.ducklake_snapshot), 0) AS snap_ok,
+       (SELECT last_value FROM metadata_s1.ducklake_catalog_id_seq)  >=
+         COALESCE((SELECT MAX(next_catalog_id) - 1 FROM metadata_s1.ducklake_snapshot), 0) AS cat_ok,
+       (SELECT last_value FROM metadata_s1.ducklake_file_id_seq)     >=
+         COALESCE((SELECT MAX(next_file_id) - 1 FROM metadata_s1.ducklake_snapshot), 0) AS fil_ok');
+----
+true	true	true
+
+# Next commit must not PK-collide with existing rows
+statement ok
+INSERT INTO ducklake.tbl VALUES (4);
+
+query II
+SELECT COUNT(*), SUM(key) FROM ducklake.tbl;
+----
+4	10

--- a/test/sql/migration/pg_sequences_bootstrap.test
+++ b/test/sql/migration/pg_sequences_bootstrap.test
@@ -10,11 +10,11 @@ require parquet
 
 require postgres_scanner
 
-test-env DUCKLAKE_CONNECTION none
+test-env DUCKLAKE_CONNECTION postgres:dbname=ducklakedb
 
-test-env PG_METADATA_CONN none
+test-env PG_METADATA_CONN dbname=ducklakedb
 
-test-env DATA_PATH {TEST_DIR}
+test-env DATA_PATH __TEST_DIR__
 
 # First attach creates the catalog with sequences.
 statement ok

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,6 @@
 {
   "dependencies": [
-    "roaring"
+    "roaring",
+    "openssl"
   ]
 }


### PR DESCRIPTION
## Problem

Currently the snapshot, catalog, and file ids are created by reading the max id and adding 1 in C++ across two Postgres round trips. Concurrent writers often read the same max id, leading to both picking same plus-1 id, raising a uniqueness error. The retry loop eventually gets the data inserted, but the errors spam the logs, We're seeing 1MB+/hr. 

## Solution

Use Postgres `sequence`s and `nextval()`. It's atomic and race-free.

---

> [!NOTE]
> ***UPDATE***: Welp, I learned a lot really fast! I soon found out that the primary key violations are actually what helped keep files ordered and identifiers properly allocated. #243 and #512  were really helpful in understanding exactly what was going on. 

With postgres as the ducklake catalog, there are some unique conditions that the other catalogs do not experience as single writers, namely races. `snapshot_id`, `catalog_id`, `file_id`, and `schema_version` need unique values. Currently we find these with `max(id) ++` which gets complicated by multiple ducklake writers. These collisions/dupes can silently overwrite each other's stats or lead to stale caches that never self-correct.

To fix these uniquely postgres issues we use [sequences](https://www.postgresql.org/docs/17/sql-createsequence.html). We're guaranteed uniqueness even under heavy concurrent writes. This does lead to some edge cases to handle though.

Worker A can get assigned 23 in the sequence and worker B 24 shortly after, but worker B can finish and get committed first. That breaks a cache that assumes all previous ids in the sequence have been handled. To get around it, we add a short lock that's picked up by each writer immediately before id assignment and let go of upon commit. a 30 second timeout is provided to prevent any possibility of becoming stuck.

We also change up the cache key to be the `snapshot_id` (now always unique at any moment) rather than the `schema_version` since two different `snapshot_id`s can share a `schema_version`. The problem being they could still see two different tables despite the same `schema_version`. 

Before coordinated queueing, it was possible for one worker to overwrite the stats of another. A version number was added to the stats that'll be checked, triggering fresh numbers if not matched ensuring stats always converge towards accurate.

