### PR TITLE
feat: Merge adjacent files across schema versions when only columns were added

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -196,7 +196,9 @@ struct DuckLakeCompactionCandidates {
 };
 
 struct DuckLakeCompactionGroup {
-	idx_t schema_version;
+	//! Unset when cross-schema merging is allowed, so files from different
+	//! schema_versions fall into the same bucket.
+	optional_idx schema_version;
 	optional_idx partition_id;
 	vector<string> partition_values;
 };
@@ -204,7 +206,9 @@ struct DuckLakeCompactionGroup {
 struct DuckLakeCompactionGroupHash {
 	uint64_t operator()(const DuckLakeCompactionGroup &group) const {
 		uint64_t hash = 0;
-		hash ^= std::hash<idx_t>()(group.schema_version);
+		if (group.schema_version.IsValid()) {
+			hash ^= std::hash<idx_t>()(group.schema_version.GetIndex());
+		}
 		if (group.partition_id.IsValid()) {
 			hash ^= std::hash<idx_t>()(group.partition_id.GetIndex());
 		}
@@ -261,7 +265,14 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 		}
 		// construct the compaction group for this file - i.e. the set of candidate files we can compact it with
 		DuckLakeCompactionGroup group;
-		group.schema_version = candidate.schema_version;
+		if (!options.allow_cross_schema || type != CompactionType::MERGE_ADJACENT_TABLES) {
+			// by default, files written under different schema_versions must stay in
+			// separate groups. With allow_cross_schema we let them merge - the reader
+			// will project each file into the latest schema via its mapping_id.
+			// Cross-schema merging is only supported for MERGE_ADJACENT_TABLES; the
+			// REWRITE_DELETES path assumes the source and target schemas match.
+			group.schema_version = candidate.schema_version;
+		}
 		group.partition_id = candidate.file.partition_id;
 		group.partition_values = candidate.file.partition_values;
 
@@ -387,9 +398,20 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 
 unique_ptr<LogicalOperator>
 DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files) {
-	// get the table entry at the specified snapshot
-	auto snapshot_id = source_files[0].file.begin_snapshot;
-	DuckLakeSnapshot snapshot(snapshot_id, source_files[0].schema_version, 0, 0);
+	// Determine which snapshot to bind the scan + output schema against.
+	// Normally this is the schema_version that the source files were written
+	// under (they all share one, enforced by DuckLakeCompactionGroup). When
+	// allow_cross_schema is set for MERGE_ADJACENT_TABLES, the group may contain
+	// files from multiple schema_versions; in that case we bind against the
+	// latest snapshot so the merged output is written under the current schema,
+	// and let DuckLakeMultiFileReader project each source file via its
+	// per-file mapping_id.
+	const bool use_latest_snapshot =
+	    options.allow_cross_schema && type == CompactionType::MERGE_ADJACENT_TABLES;
+	DuckLakeSnapshot snapshot = use_latest_snapshot
+	                                ? transaction.GetSnapshot()
+	                                : DuckLakeSnapshot(source_files[0].file.begin_snapshot,
+	                                                   source_files[0].schema_version, 0, 0);
 
 	auto entry = catalog.GetEntryById(transaction, snapshot, table_id);
 	if (!entry) {
@@ -639,13 +661,14 @@ static void GenerateCompaction(ClientContext &context, DuckLakeTransaction &tran
                                DuckLakeCatalog &ducklake_catalog, TableFunctionBindInput &input,
                                DuckLakeTableEntry &cur_table, CompactionType type, double delete_threshold,
                                uint64_t max_files, optional_idx min_file_size, optional_idx max_file_size,
-                               vector<unique_ptr<LogicalOperator>> &compactions) {
+                               bool allow_cross_schema, vector<unique_ptr<LogicalOperator>> &compactions) {
 	switch (type) {
 	case CompactionType::MERGE_ADJACENT_TABLES: {
 		DuckLakeMergeAdjacentOptions options;
 		options.max_files = max_files;
 		options.min_file_size = min_file_size;
 		options.max_file_size = max_file_size;
+		options.allow_cross_schema = allow_cross_schema;
 		DuckLakeCompactor compactor(context, ducklake_catalog, transaction, *input.binder, cur_table.GetTableId(),
 		                            options);
 		compactor.GenerateCompactions(cur_table, compactions);
@@ -727,6 +750,15 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 		throw BinderException("The min_file_size must be less than max_file_size.");
 	}
 
+	bool allow_cross_schema = false;
+	auto allow_cross_schema_entry = input.named_parameters.find("allow_cross_schema");
+	if (allow_cross_schema_entry != input.named_parameters.end()) {
+		if (allow_cross_schema_entry->second.IsNull()) {
+			throw BinderException("The allow_cross_schema option must be a non-null boolean.");
+		}
+		allow_cross_schema = BooleanValue::Get(allow_cross_schema_entry->second);
+	}
+
 	if (input.inputs.size() == 1) {
 		// No default schema/table, we will perform rewrites on deletes in the whole database
 		auto schemas = ducklake_catalog.GetSchemas(context);
@@ -739,7 +771,8 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 					                                             cur_table.GetTableId(), "true") == "true") {
 						auto delete_threshold = GetDeleteThreshold(&dl_cur_schema, cur_table, ducklake_catalog, input);
 						GenerateCompaction(context, transaction, ducklake_catalog, input, cur_table, type,
-						                   delete_threshold, max_files, min_file_size, max_file_size, compactions);
+						                   delete_threshold, max_files, min_file_size, max_file_size,
+						                   allow_cross_schema, compactions);
 					}
 				}
 			});
@@ -773,7 +806,7 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 	if (auto_compact) {
 		auto delete_threshold = GetDeleteThreshold(dl_schema, ducklake_table, ducklake_catalog, input);
 		GenerateCompaction(context, transaction, ducklake_catalog, input, ducklake_table, type, delete_threshold,
-		                   max_files, min_file_size, max_file_size, compactions);
+		                   max_files, min_file_size, max_file_size, allow_cross_schema, compactions);
 	}
 
 	return GenerateCompactionOperator(input, bind_index, compactions);
@@ -797,6 +830,7 @@ TableFunctionSet DuckLakeMergeAdjacentFilesFunction::GetFunctions() {
 		function.named_parameters["min_file_size"] = LogicalType::UBIGINT;
 		function.named_parameters["max_file_size"] = LogicalType::UBIGINT;
 		function.named_parameters["max_compacted_files"] = LogicalType::UBIGINT;
+		function.named_parameters["allow_cross_schema"] = LogicalType::BOOLEAN;
 		if (type.size() == 2) {
 			function.named_parameters["schema"] = LogicalType::VARCHAR;
 		}

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -207,7 +207,9 @@ struct DuckLakeCompactionCandidates {
 };
 
 struct DuckLakeCompactionGroup {
-	idx_t schema_version;
+	//! Unset when the file can be rewritten under the latest schema (compatible files then share one bucket);
+	//! otherwise the file's own schema_version, keeping incompatible files isolated.
+	optional_idx schema_version;
 	optional_idx partition_id;
 	vector<Value> partition_values;
 };
@@ -215,7 +217,9 @@ struct DuckLakeCompactionGroup {
 struct DuckLakeCompactionGroupHash {
 	uint64_t operator()(const DuckLakeCompactionGroup &group) const {
 		uint64_t hash = 0;
-		hash ^= std::hash<idx_t>()(group.schema_version);
+		if (group.schema_version.IsValid()) {
+			hash ^= std::hash<idx_t>()(group.schema_version.GetIndex());
+		}
 		if (group.partition_id.IsValid()) {
 			hash ^= std::hash<idx_t>()(group.partition_id.GetIndex());
 		}
@@ -256,6 +260,28 @@ template <typename T>
 using compaction_map_t =
     unordered_map<DuckLakeCompactionGroup, T, DuckLakeCompactionGroupHash, DuckLakeCompactionGroupEquality>;
 
+//! Returns true if every field in `older_fields` still exists in `latest` with an identical field id, name and type.
+//! New fields in `latest` (ADD COLUMN) are allowed; a dropped, renamed, retyped or nested-changed field is not.
+static bool FieldsPreservedInLatest(const vector<unique_ptr<DuckLakeFieldId>> &older_fields,
+                                    const DuckLakeFieldData &latest) {
+	for (auto &older_field : older_fields) {
+		auto latest_field = latest.GetByFieldIndex(older_field->GetFieldIndex());
+		if (!latest_field) {
+			return false;
+		}
+		if (older_field->Name() != latest_field->Name()) {
+			return false;
+		}
+		if (older_field->Type() != latest_field->Type()) {
+			return false;
+		}
+		if (!FieldsPreservedInLatest(older_field->Children(), latest)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
                                             vector<unique_ptr<LogicalOperator>> &compactions) {
 	auto &metadata_manager = transaction.GetMetadataManager();
@@ -270,6 +296,36 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 	// FIXME: pass in the sort_data so that list of files is approximately sorted in the same way
 	// (sorted by the min/max metadata)
 	auto files = metadata_manager.GetFilesForCompaction(table, type, delete_threshold, snapshot, filter_options);
+
+	// Resolve, per schema_version (cached), whether a file written under it can be rewritten under the latest schema.
+	auto latest_entry = catalog.GetEntryById(transaction, snapshot, table_id);
+	auto &latest_table = latest_entry ? latest_entry->Cast<DuckLakeTableEntry>() : table;
+	auto &latest_field_data = latest_table.GetFieldData();
+	const idx_t latest_schema_version = snapshot.schema_version;
+	unordered_map<idx_t, bool> merges_into_latest_schema;
+	auto can_merge_into_latest = [&](idx_t schema_version) -> bool {
+		if (type != CompactionType::MERGE_ADJACENT_TABLES) {
+			// REWRITE_DELETES assumes the source and target schemas match - never merge across schemas
+			return false;
+		}
+		if (schema_version == latest_schema_version) {
+			return true;
+		}
+		auto cached = merges_into_latest_schema.find(schema_version);
+		if (cached != merges_into_latest_schema.end()) {
+			return cached->second;
+		}
+		auto begin_snapshot = catalog.GetBeginSnapshotForSchemaVersion(table_id, schema_version, transaction);
+		DuckLakeSnapshot version_snapshot(begin_snapshot, schema_version, 0, 0);
+		auto version_entry = catalog.GetEntryById(transaction, version_snapshot, table_id);
+		bool result = false;
+		if (version_entry) {
+			auto &version_table = version_entry->Cast<DuckLakeTableEntry>();
+			result = FieldsPreservedInLatest(version_table.GetFieldData().GetFieldIds(), latest_field_data);
+		}
+		merges_into_latest_schema[schema_version] = result;
+		return result;
+	};
 
 	// iterate over the files and split into separate compaction groups
 	compaction_map_t<DuckLakeCompactionCandidates> candidates;
@@ -288,7 +344,10 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 		}
 		// construct the compaction group for this file - i.e. the set of candidate files we can compact it with
 		DuckLakeCompactionGroup group;
-		group.schema_version = candidate.schema_version;
+		if (!can_merge_into_latest(candidate.schema_version)) {
+			// incompatible with the latest schema - keep this file isolated in its own schema_version group
+			group.schema_version = candidate.schema_version;
+		}
 		group.partition_id = candidate.file.partition_id;
 		group.partition_values = candidate.file.partition_values;
 
@@ -321,6 +380,8 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 			// we need at least 2 files to consider a merge
 			continue;
 		}
+		// groups with an unset schema_version contain files that must be rewritten under the latest schema
+		const bool bind_to_latest = !entry.first.schema_version.IsValid();
 		for (idx_t start_idx = 0; start_idx < candidate_list.size(); start_idx++) {
 			// check if we can merge this file with subsequent files
 			idx_t current_file_size = 0;
@@ -355,7 +416,7 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 				for (idx_t i = start_idx; i < compaction_idx; i++) {
 					compaction_files.push_back(std::move(files[candidate_list[i]]));
 				}
-				compactions.push_back(GenerateCompactionCommand(std::move(compaction_files)));
+				compactions.push_back(GenerateCompactionCommand(std::move(compaction_files), bind_to_latest));
 				start_idx += compaction_file_count - 1;
 			}
 			compacted_files++;
@@ -452,10 +513,14 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 }
 
 unique_ptr<LogicalOperator>
-DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files) {
-	// get the table entry at the specified snapshot
-	auto snapshot_id = source_files[0].file.begin_snapshot;
-	DuckLakeSnapshot snapshot(snapshot_id, source_files[0].schema_version, 0, 0);
+DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files,
+                                             bool bind_to_latest_schema) {
+	// Cross-schema groups bind to the latest snapshot so the merged file is written under the current schema (the
+	// reader projects each source via its own mapping_id); same-schema groups bind to the source schema_version.
+	DuckLakeSnapshot snapshot = bind_to_latest_schema
+	                                ? transaction.GetSnapshot()
+	                                : DuckLakeSnapshot(source_files[0].file.begin_snapshot,
+	                                                   source_files[0].schema_version, 0, 0);
 
 	auto entry = catalog.GetEntryById(transaction, snapshot, table_id);
 	if (!entry) {

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -87,7 +87,8 @@ public:
 	DuckLakeCompactor(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
 	                  Binder &binder, TableIndex table_id, double delete_threshold);
 	void GenerateCompactions(DuckLakeTableEntry &table, vector<unique_ptr<LogicalOperator>> &compactions);
-	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files);
+	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files,
+	                                                      bool bind_to_latest_schema = false);
 	static unique_ptr<LogicalOperator> InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
 	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data,
 	                                              bool add_tiebreakers = false);

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -482,6 +482,10 @@ struct DuckLakeMergeAdjacentOptions {
 	uint64_t max_files;
 	optional_idx min_file_size;
 	optional_idx max_file_size;
+	//! When true, files written under different schema_versions may be merged
+	//! together into the current schema. Relies on the per-file mapping_id +
+	//! DuckLakeMultiFileReader to project each source into the latest schema.
+	bool allow_cross_schema = false;
 };
 
 struct DuckLakeFileSizeOptions {

--- a/test/sql/compaction/compaction_alter_table.test
+++ b/test/sql/compaction/compaction_alter_table.test
@@ -124,28 +124,29 @@ SET VARIABLE s4 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVE
 statement ok
 SET VARIABLE s6 = (SELECT snapshot_id FROM (SELECT snapshot_id, row_number() OVER (ORDER BY snapshot_id) AS rn FROM ducklake_snapshots('ducklake') WHERE changes::VARCHAR LIKE '%insert%=[1]%') WHERE rn = 6);
 
+# Schema timeline: (id, i) -> ADD j -> DROP i -> ADD i VARCHAR. Files still carrying the dropped "i" stay isolated
+# (2 -> 1 each); the (id, j) files only carry surviving columns and merge with the latest schema (2 + 2 -> 1).
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
 ----
 test	2	1
 test	2	1
-test	2	1
-test	2	1
+test	4	1
 
-# we cannot merge across alter statements - so this results in 4 separate merges
+# three merges: two isolated (across the dropped column) and one that spans the trailing ADD COLUMN boundary
 query I
 SELECT COUNT(*) FROM GLOB('{DATA_PATH}/ducklake_compaction_alter_files/**/*')
 ----
-12
+11
 
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
 
-# four files remain
+# three files remain
 query I
 SELECT COUNT(*) FROM GLOB('{DATA_PATH}/ducklake_compaction_alter_files/**/*')
 ----
-4
+3
 
 # verify correct behavior when operating on the compacted file
 # time travel

--- a/test/sql/compaction/compaction_schema_version_per_table.test
+++ b/test/sql/compaction/compaction_schema_version_per_table.test
@@ -129,17 +129,17 @@ SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'another_table')
 ----
 4
 
+# another_table only added a column (schema_version 3 -> 4), so all four files merge into the latest schema
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'another_table') ORDER BY ALL
 ----
-another_table	2	1
-another_table	2	1
+another_table	4	1
 
-# after cleanup we should have 2 file for another_table
+# after cleanup we should have 1 file for another_table
 query I
 SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'another_table')
 ----
-2
+1
 
 query II
 FROM another_table ORDER BY ALL;

--- a/test/sql/compaction/merge_adjacent_cross_schema.test
+++ b/test/sql/compaction/merge_adjacent_cross_schema.test
@@ -1,0 +1,186 @@
+# name: test/sql/compaction/merge_adjacent_cross_schema.test
+# description: test allow_cross_schema flag on ducklake_merge_adjacent_files
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_cross_schema/')
+
+statement ok
+USE ducklake;
+
+#
+# Core scenario: ADD COLUMN between inserts. With allow_cross_schema => true,
+# files written under both schemas merge into a single file under the latest
+# schema. Old rows take NULL for the new column.
+#
+
+statement ok
+CREATE TABLE t AS SELECT range AS id FROM range(5);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t ADD COLUMN label VARCHAR;
+
+statement ok
+INSERT INTO t VALUES (7, 'seven'), (8, 'eight');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# three files exist, spanning two schema_versions
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't')
+----
+3
+
+# merge everything across the schema_version boundary
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't', allow_cross_schema => true)
+----
+t	3	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't')
+----
+1
+
+# data integrity: old rows fill NULL on the new column, new rows keep their values
+query IT
+SELECT id, label FROM t ORDER BY id;
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	seven
+8	eight
+
+#
+# Backward compat: without the flag, old + new schema files stay in separate
+# groups and only same-schema groups merge. This is the current behavior.
+#
+
+statement ok
+CREATE TABLE t_compat AS SELECT range AS id FROM range(3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_compat VALUES (3), (4);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_compat ADD COLUMN label VARCHAR;
+
+statement ok
+INSERT INTO t_compat VALUES (5, 'a'), (6, 'b');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_compat VALUES (7, 'c'), (8, 'd');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# 4 files: 2 pre-ALTER + 2 post-ALTER
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_compat')
+----
+4
+
+# default call: one merge per schema_version group (2 + 2 -> 1 + 1)
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_compat') ORDER BY ALL
+----
+t_compat	2	1
+t_compat	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+# two files remain - one per schema_version
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_compat')
+----
+2
+
+#
+# Partition isolation: even with allow_cross_schema => true, files written
+# under different partition specs must not be merged together. The grouping
+# key still includes partition_id, and SET PARTITIONED BY mints a new one.
+#
+
+statement ok
+CREATE TABLE t_part (id INTEGER, part INTEGER);
+
+statement ok
+ALTER TABLE t_part SET PARTITIONED BY (part);
+
+statement ok
+INSERT INTO t_part VALUES (1, 0), (2, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_part VALUES (3, 0), (4, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# repartition - bumps partition_id (and schema_version)
+statement ok
+ALTER TABLE t_part SET PARTITIONED BY (id);
+
+statement ok
+INSERT INTO t_part VALUES (5, 0), (6, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_part VALUES (7, 0), (8, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# with allow_cross_schema => true, the two partition specs still isolate:
+# old spec has part=0 bucket with 2 files; new spec has 4 per-id buckets
+# with 1 file each. Only the old-spec (part=0) bucket has >=2 files and merges.
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_part', allow_cross_schema => true) ORDER BY ALL
+----
+t_part	2	1
+
+# row count preserved
+query I
+SELECT COUNT(*) FROM t_part
+----
+8

--- a/test/sql/compaction/merge_adjacent_cross_schema.test
+++ b/test/sql/compaction/merge_adjacent_cross_schema.test
@@ -1,0 +1,233 @@
+# name: test/sql/compaction/merge_adjacent_cross_schema.test
+# description: ducklake_merge_adjacent_files merges files across a schema_version boundary when the schema only had columns added (the incompatible/isolation cases live in merge_adjacent_cross_schema_isolation.test)
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_cross_schema/')
+
+statement ok
+USE ducklake;
+
+#
+# Core scenario: ADD COLUMN between inserts. Files written under both schemas merge into a single file under the
+# latest schema by default - no option required. Old rows read NULL for the new column.
+#
+
+statement ok
+CREATE TABLE t AS SELECT range AS id FROM range(5);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# Capture snapshot ids for time travel below - hardcoding version numbers is unsafe because the
+# snapshot count depends on the data inlining config (flushes are no-ops under no_inline.json).
+statement ok
+SET VARIABLE v_after_create = (SELECT max(snapshot_id) FROM ducklake.snapshots());
+
+statement ok
+INSERT INTO t VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# snapshot before the ALTER (rows 0-6, only the id column exists)
+statement ok
+SET VARIABLE v_before_alter = (SELECT max(snapshot_id) FROM ducklake.snapshots());
+
+statement ok
+ALTER TABLE t ADD COLUMN label VARCHAR;
+
+statement ok
+INSERT INTO t VALUES (7, 'seven'), (8, 'eight');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# three files exist, spanning two schema_versions
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't')
+----
+3
+
+# merge everything across the schema_version boundary into the latest schema
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't')
+----
+t	3	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't')
+----
+1
+
+# data integrity: old rows read NULL for the new column, new rows keep their values
+query IT
+SELECT id, label FROM t ORDER BY id;
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	seven
+8	eight
+
+# time travel keeps working over the merged file even after the original files have been cleaned up.
+# v_before_alter is the last snapshot before ADD COLUMN (rows 0-6, only the id column exists).
+query I
+SELECT id FROM t AT (VERSION => getvariable('v_before_alter')) ORDER BY id;
+----
+0
+1
+2
+3
+4
+5
+6
+
+# v_after_create is right after the table was created and flushed (rows 0-4).
+query I
+SELECT id FROM t AT (VERSION => getvariable('v_after_create')) ORDER BY id;
+----
+0
+1
+2
+3
+4
+
+# the new column cannot be referenced at a snapshot where it did not exist yet
+statement error
+SELECT label FROM t AT (VERSION => getvariable('v_before_alter'))
+----
+<REGEX>:.*abel.*
+
+#
+# Added column with a DEFAULT: old rows read the column default after the merge, not NULL.
+#
+
+statement ok
+CREATE TABLE t_default AS SELECT range AS id FROM range(3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_default VALUES (3), (4);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_default ADD COLUMN status VARCHAR DEFAULT 'unknown';
+
+statement ok
+INSERT INTO t_default VALUES (5, 'ok'), (6, 'ok');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_default')
+----
+t_default	3	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query IT
+SELECT id, status FROM t_default ORDER BY id;
+----
+0	unknown
+1	unknown
+2	unknown
+3	unknown
+4	unknown
+5	ok
+6	ok
+
+#
+# Re-compaction safety: a merged cross-schema file inherits the oldest source's (older) begin_snapshot but is written
+# under the latest schema. Merging it again must keep rewriting it under the latest schema so the added column survives.
+#
+
+statement ok
+CREATE TABLE t_again AS SELECT range AS id FROM range(5);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_again VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_again ADD COLUMN label VARCHAR;
+
+statement ok
+INSERT INTO t_again VALUES (7, 'seven'), (8, 'eight');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_again')
+----
+t_again	3	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+statement ok
+INSERT INTO t_again VALUES (9, 'nine');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_again VALUES (10, 'ten');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_again')
+----
+t_again	3	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_again')
+----
+1
+
+query IT
+SELECT id, label FROM t_again ORDER BY id;
+----
+0	NULL
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+5	NULL
+6	NULL
+7	seven
+8	eight
+9	nine
+10	ten

--- a/test/sql/compaction/merge_adjacent_cross_schema_isolation.test
+++ b/test/sql/compaction/merge_adjacent_cross_schema_isolation.test
@@ -1,0 +1,207 @@
+# name: test/sql/compaction/merge_adjacent_cross_schema_isolation.test
+# description: ducklake_merge_adjacent_files keeps files isolated across a schema_version boundary when the schema change is not column-add-only (the merge cases live in merge_adjacent_cross_schema.test)
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_cross_schema_isolation/')
+
+statement ok
+USE ducklake;
+
+#
+# RENAME COLUMN bumps the schema_version incompatibly: pre- and post-rename files must not merge - only the two
+# same-schema (pre-rename) files merge, the post-rename file is left untouched.
+#
+
+statement ok
+CREATE TABLE t_rename AS SELECT range AS id FROM range(3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_rename VALUES (3), (4);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_rename RENAME COLUMN id TO ident;
+
+statement ok
+INSERT INTO t_rename VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_rename') ORDER BY ALL
+----
+t_rename	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+# the same-schema pair merged (2 -> 1), the post-rename file is separate => 2 files remain
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_rename')
+----
+2
+
+query I
+SELECT ident FROM t_rename ORDER BY ident;
+----
+0
+1
+2
+3
+4
+5
+6
+
+#
+# DROP COLUMN. Files written before the drop still carry the dropped column and must not be merged into the latest
+# (smaller) schema.
+#
+
+statement ok
+CREATE TABLE t_drop AS SELECT range AS id, range AS extra FROM range(3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_drop VALUES (3, 3), (4, 4);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_drop DROP COLUMN extra;
+
+statement ok
+INSERT INTO t_drop VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_drop') ORDER BY ALL
+----
+t_drop	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_drop')
+----
+2
+
+query I
+SELECT id FROM t_drop ORDER BY id;
+----
+0
+1
+2
+3
+4
+5
+6
+
+#
+# ALTER COLUMN TYPE. The column type differs across the boundary so files must stay isolated.
+#
+
+statement ok
+CREATE TABLE t_type AS SELECT range::INTEGER AS id FROM range(3);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_type VALUES (3), (4);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+ALTER TABLE t_type ALTER id TYPE BIGINT;
+
+statement ok
+INSERT INTO t_type VALUES (5), (6);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_type') ORDER BY ALL
+----
+t_type	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 't_type')
+----
+2
+
+#
+# Partition isolation: even when the column schema is unchanged across the boundary, files written under different
+# partition specs must not be merged together. The grouping key still includes partition_id / partition_values.
+#
+
+statement ok
+CREATE TABLE t_part (id INTEGER, part INTEGER);
+
+statement ok
+ALTER TABLE t_part SET PARTITIONED BY (part);
+
+statement ok
+INSERT INTO t_part VALUES (1, 0), (2, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_part VALUES (3, 0), (4, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# repartition - bumps partition_id (and schema_version) without changing the columns
+statement ok
+ALTER TABLE t_part SET PARTITIONED BY (id);
+
+statement ok
+INSERT INTO t_part VALUES (5, 0), (6, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+INSERT INTO t_part VALUES (7, 0), (8, 0);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# the two partition specs still isolate: only the old-spec part=0 bucket has >= 2 files and merges
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 't_part') ORDER BY ALL
+----
+t_part	2	1
+
+# row count preserved
+query I
+SELECT COUNT(*) FROM t_part
+----
+8


### PR DESCRIPTION
This solves #1048.
Fixes #536.

## Summary

`ducklake_merge_adjacent_files` now merges files across a `schema_version` boundary automatically when it is safe - no option required. A file written under an older schema is rewritten under the latest schema only when every field it carries still exists unchanged (same field id, name and type), i.e. the schema was unchanged or only had columns added (`ADD COLUMN`).

Fixes the limitation where `ADD COLUMN` left small files stranded on each side of a schema seam forever.

## Safety consideration

- Only column-add-only changes merge; `RENAME` / `DROP` / `ALTER TYPE` keep their files isolated, as before.
- Each file is checked against the latest schema (not pairwise), so this is robust across many schema versions.
- Time travel is preserved: old rows read `NULL`/default for added columns, and columns still can't be referenced before they existed.

## Tests

- `merge_adjacent_cross_schema.test` - ADD COLUMN merges, column defaults, time travel after cleanup, re-compaction safety.
- `merge_adjacent_cross_schema_isolation.test` - `RENAME` / `DROP` / `ALTER TYPE` and differing partition specs stay isolated.
