### PR TITLE
fix: update dynamic filter api

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -330,7 +330,7 @@ DynamicFilter *DuckLakeUtil::GetOptionalDynamicFilter(const TableFilter &filter)
 		return nullptr;
 	}
 	auto &dynamic = optional.child_filter->Cast<DynamicFilter>();
-	if (!dynamic.filter_data || !dynamic.filter_data->filter) {
+	if (!dynamic.filter_data) {
 		return nullptr;
 	}
 	return &dynamic;

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -33,6 +33,7 @@ class BoundAtClause;
 class QueryResult;
 class FileSystem;
 class ConstantFilter;
+class Expression;
 
 struct SnapshotAndStats;
 struct FlushedInlinedTableInfo;
@@ -315,6 +316,7 @@ private:
 	                                                  TableIndex table_id);
 	virtual string GenerateFilterFromTableFilter(const TableFilter &filter, const LogicalType &type,
 	                                             unordered_set<string> &referenced_stats);
+	static unique_ptr<TableFilter> ExtractTableFilterFromExpression(const Expression &expr);
 	virtual bool ValueIsFinite(const Value &val);
 	virtual string CastValueToTarget(const Value &val, const LogicalType &type);
 	virtual string CastStatsToTarget(const string &stats, const LogicalType &type);

--- a/src/storage/ducklake_delete_filter.cpp
+++ b/src/storage/ducklake_delete_filter.cpp
@@ -1,7 +1,11 @@
 #include "storage/ducklake_delete_filter.hpp"
 #include "storage/ducklake_deletion_vector.hpp"
 #include "common/parquet_file_scanner.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
@@ -178,16 +182,20 @@ DeleteFileScanResult DuckLakeDeleteFilter::ScanDeleteFile(ClientContext &context
 		auto filters = make_uniq<TableFilterSet>();
 		ProjectionIndex snapshot_col_idx(2); // snapshot_id is column 2
 
+		auto make_expr_filter = [](ExpressionType cmp_type, Value constant) {
+			auto lhs = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0ULL);
+			auto rhs = make_uniq<BoundConstantExpression>(std::move(constant));
+			auto cmp = make_uniq<BoundComparisonExpression>(cmp_type, std::move(lhs), std::move(rhs));
+			return make_uniq<ExpressionFilter>(std::move(cmp));
+		};
 		if (snapshot_filter_min.IsValid()) {
 			auto min_constant = Value::BIGINT(NumericCast<int64_t>(snapshot_filter_min.GetIndex()));
-			auto min_filter =
-			    make_uniq<ConstantFilter>(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(min_constant));
+			auto min_filter = make_expr_filter(ExpressionType::COMPARE_GREATERTHANOREQUALTO, std::move(min_constant));
 			filters->PushFilter(snapshot_col_idx, std::move(min_filter));
 		}
 		if (snapshot_filter_max.IsValid()) {
 			auto max_constant = Value::BIGINT(NumericCast<int64_t>(snapshot_filter_max.GetIndex()));
-			auto max_filter =
-			    make_uniq<ConstantFilter>(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_constant));
+			auto max_filter = make_expr_filter(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(max_constant));
 			filters->PushFilter(snapshot_col_idx, std::move(max_filter));
 		}
 		scanner.SetFilters(std::move(filters));

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1466,9 +1466,6 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 				ExpressionType comparison_type;
 				{
 					lock_guard<mutex> l(dynamic->filter_data->lock);
-					if (!dynamic->filter_data->initialized) {
-						continue;
-					}
 					comparison_type = dynamic->filter_data->comparison_type;
 				}
 				dynamic_filter_columns.push_back(

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -15,12 +15,19 @@
 #include "metadata_manager/sqlite_metadata_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/filter/null_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
-#include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
@@ -978,6 +985,88 @@ static void SetSnapshotFilter(const DuckLakeSnapshot &snapshot, idx_t max_partia
 	file_entry.snapshot_filter_max = snapshot.snapshot_id;
 }
 
+unique_ptr<TableFilter> DuckLakeMetadataManager::ExtractTableFilterFromExpression(const Expression &expr) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COMPARISON: {
+		auto &cmp = expr.Cast<BoundComparisonExpression>();
+		const Expression *const_expr = nullptr;
+		ExpressionType cmp_type = cmp.GetExpressionType();
+		if (cmp.left->GetExpressionClass() == ExpressionClass::BOUND_REF &&
+		    cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			const_expr = cmp.right.get();
+		} else if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_REF &&
+		           cmp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			const_expr = cmp.left.get();
+			cmp_type = FlipComparisonExpression(cmp_type);
+		} else {
+			return nullptr;
+		}
+		auto &constant = const_expr->Cast<BoundConstantExpression>().value;
+		if (constant.IsNull()) {
+			return nullptr;
+		}
+		return make_uniq<ConstantFilter>(cmp_type, constant);
+	}
+	case ExpressionClass::BOUND_OPERATOR: {
+		auto &op = expr.Cast<BoundOperatorExpression>();
+		auto op_type = op.GetExpressionType();
+		if (op_type == ExpressionType::OPERATOR_IS_NULL) {
+			return make_uniq<IsNullFilter>();
+		}
+		if (op_type == ExpressionType::OPERATOR_IS_NOT_NULL) {
+			return make_uniq<IsNotNullFilter>();
+		}
+		if (op_type == ExpressionType::COMPARE_IN && !op.children.empty() &&
+		    op.children[0]->GetExpressionClass() == ExpressionClass::BOUND_REF) {
+			vector<Value> values;
+			for (idx_t i = 1; i < op.children.size(); i++) {
+				if (op.children[i]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+					return nullptr;
+				}
+				auto &value = op.children[i]->Cast<BoundConstantExpression>().value;
+				if (value.IsNull()) {
+					return nullptr;
+				}
+				values.push_back(value);
+			}
+			return make_uniq<InFilter>(std::move(values));
+		}
+		return nullptr;
+	}
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conj = expr.Cast<BoundConjunctionExpression>();
+		auto conj_type = conj.GetExpressionType();
+		if (conj_type == ExpressionType::CONJUNCTION_AND) {
+			auto result = make_uniq<ConjunctionAndFilter>();
+			for (auto &child : conj.children) {
+				auto extracted = ExtractTableFilterFromExpression(*child);
+				if (extracted) {
+					result->child_filters.push_back(std::move(extracted));
+				}
+			}
+			if (result->child_filters.empty()) {
+				return nullptr;
+			}
+			return std::move(result);
+		}
+		if (conj_type == ExpressionType::CONJUNCTION_OR) {
+			auto result = make_uniq<ConjunctionOrFilter>();
+			for (auto &child : conj.children) {
+				auto extracted = ExtractTableFilterFromExpression(*child);
+				if (!extracted) {
+					return nullptr;
+				}
+				result->child_filters.push_back(std::move(extracted));
+			}
+			return std::move(result);
+		}
+		return nullptr;
+	}
+	default:
+		return nullptr;
+	}
+}
+
 string DuckLakeMetadataManager::GenerateFilterFromTableFilter(const TableFilter &filter, const LogicalType &type,
                                                               unordered_set<string> &referenced_stats) {
 	switch (filter.filter_type) {
@@ -1048,6 +1137,14 @@ string DuckLakeMetadataManager::GenerateFilterFromTableFilter(const TableFilter 
 			result += "(" + next_filter + ")";
 		}
 		return result;
+	}
+	case TableFilterType::EXPRESSION_FILTER: {
+		auto &expr_filter = filter.Cast<ExpressionFilter>();
+		auto extracted = ExtractTableFilterFromExpression(*expr_filter.expr);
+		if (!extracted) {
+			return string();
+		}
+		return GenerateFilterFromTableFilter(*extracted, type, referenced_stats);
 	}
 	default:
 		return string();
@@ -1248,6 +1345,14 @@ string DuckLakeMetadataManager::GenerateFilterPushdown(const TableFilter &filter
 		}
 		return result;
 	}
+	case TableFilterType::EXPRESSION_FILTER: {
+		auto &expr_filter = filter.Cast<ExpressionFilter>();
+		auto extracted = ExtractTableFilterFromExpression(*expr_filter.expr);
+		if (!extracted) {
+			return string();
+		}
+		return GenerateFilterPushdown(*extracted, referenced_stats);
+	}
 	default:
 		// unsupported filter
 		return string();
@@ -1361,6 +1466,9 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 				ExpressionType comparison_type;
 				{
 					lock_guard<mutex> l(dynamic->filter_data->lock);
+					if (!dynamic->filter_data->initialized) {
+						continue;
+					}
 					comparison_type = dynamic->filter_data->comparison_type;
 				}
 				dynamic_filter_columns.push_back(

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1011,9 +1011,15 @@ unique_ptr<TableFilter> DuckLakeMetadataManager::ExtractTableFilterFromExpressio
 		auto &op = expr.Cast<BoundOperatorExpression>();
 		auto op_type = op.GetExpressionType();
 		if (op_type == ExpressionType::OPERATOR_IS_NULL) {
+			if (op.children.empty() || op.children[0]->GetExpressionClass() != ExpressionClass::BOUND_REF) {
+				return nullptr;
+			}
 			return make_uniq<IsNullFilter>();
 		}
 		if (op_type == ExpressionType::OPERATOR_IS_NOT_NULL) {
+			if (op.children.empty() || op.children[0]->GetExpressionClass() != ExpressionClass::BOUND_REF) {
+				return nullptr;
+			}
 			return make_uniq<IsNotNullFilter>();
 		}
 		if (op_type == ExpressionType::COMPARE_IN && !op.children.empty() &&

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1361,7 +1361,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 				ExpressionType comparison_type;
 				{
 					lock_guard<mutex> l(dynamic->filter_data->lock);
-					comparison_type = dynamic->filter_data->filter->comparison_type;
+					comparison_type = dynamic->filter_data->comparison_type;
 				}
 				dynamic_filter_columns.push_back(
 				    {col_filter.column_field_index, comparison_type, col_filter.column_type});

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -25,8 +25,10 @@
 #include "storage/ducklake_delete.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "storage/ducklake_inlined_data_reader.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 
 namespace duckdb {
@@ -60,7 +62,10 @@ static bool TryFindColumnByFieldId(const vector<MultiFileColumnDefinition> &loca
 static void AddSnapshotFilter(BaseFileReader &reader, const ColumnIndex &col_idx, const LogicalType &col_type,
                               idx_t snapshot_value, ExpressionType comparison_type) {
 	auto constant = Value::UBIGINT(snapshot_value).DefaultCastAs(col_type);
-	auto filter = make_uniq<ConstantFilter>(comparison_type, std::move(constant));
+	auto lhs = make_uniq<BoundReferenceExpression>(col_type, 0ULL);
+	auto rhs = make_uniq<BoundConstantExpression>(std::move(constant));
+	auto cmp = make_uniq<BoundComparisonExpression>(comparison_type, std::move(lhs), std::move(rhs));
+	auto filter = make_uniq<ExpressionFilter>(std::move(cmp));
 	reader.filters->PushFilter(ProjectionIndex(col_idx.GetPrimaryIndex()), std::move(filter));
 }
 

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -96,8 +96,8 @@ static bool CanSkipFileByTopNDynamicFilter(const DuckLakeFileListEntry &file_ent
 			if (!filter->filter_data->initialized) {
 				return false;
 			}
-			comparison_type = filter->filter_data->filter->comparison_type;
-			constant = filter->filter_data->filter->constant;
+			comparison_type = filter->filter_data->comparison_type;
+			constant = filter->filter_data->constant;
 		}
 
 		auto mm_it = file_entry.column_min_max.find(col_filter.column_field_index);


### PR DESCRIPTION
## Problem

DuckDB changed the api for `DynamicFilterData` busting up ci for ducklake 

## Solution 

Align with the new api to unblock ci 

### Upstream duckdb regression

The remaining test failures are due to this

https://github.com/duckdb/duckdb/issues/22226