### PR TITLE
Throw exception for invalid snapshot expiration request

### DIFF
--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -14,7 +14,6 @@ struct ExpireSnapshotsBindData : public TableFunctionData {
 	Catalog &catalog;
 	vector<DuckLakeSnapshotInfo> snapshots;
 	bool dry_run = false;
-	bool valid = true;
 };
 
 static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &context, TableFunctionBindInput &input,
@@ -48,10 +47,15 @@ static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &conte
 			throw InternalException("Unsupported named parameter for ducklake_expire_snapshots");
 		}
 	}
-	if ((has_versions == has_timestamp && has_versions == true) ||
-	    (has_versions == has_timestamp && has_versions == false && older_than_default.empty())) {
-		result->valid = false;
-		return std::move(result);
+	if (has_versions && has_timestamp) {
+		throw InvalidInputException(
+		    "ducklake_expire_snapshots: cannot specify both 'versions' and 'older_than' parameters at the "
+		    "same time. Please use only one criterion.");
+	}
+	if (!has_versions && !has_timestamp && older_than_default.empty()) {
+		throw InvalidInputException(
+		    "ducklake_expire_snapshots: must specify either 'versions' or 'older_than' parameter, or set "
+		    "the 'expire_older_than' global option via set_option.");
 	}
 
 	string filter;
@@ -96,9 +100,6 @@ unique_ptr<GlobalTableFunctionState> DuckLakeExpireSnapshotsInit(ClientContext &
 
 void DuckLakeExpireSnapshotsExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.bind_data->Cast<ExpireSnapshotsBindData>();
-	if (!data.valid) {
-		return;
-	}
 	auto &state = data_p.global_state->Cast<DuckLakeExpireSnapshotsData>();
 	if (state.offset >= data.snapshots.size()) {
 		return;

--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -14,6 +14,7 @@ struct ExpireSnapshotsBindData : public TableFunctionData {
 	Catalog &catalog;
 	vector<DuckLakeSnapshotInfo> snapshots;
 	bool dry_run = false;
+	bool valid = true;
 };
 
 static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &context, TableFunctionBindInput &input,
@@ -52,10 +53,10 @@ static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &conte
 		    "ducklake_expire_snapshots: cannot specify both 'versions' and 'older_than' parameters at the "
 		    "same time. Please use only one criterion.");
 	}
+	// No criteria given and no global default: silently no-op.
 	if (!has_versions && !has_timestamp && older_than_default.empty()) {
-		throw InvalidInputException(
-		    "ducklake_expire_snapshots: must specify either 'versions' or 'older_than' parameter, or set "
-		    "the 'expire_older_than' global option via set_option.");
+		result->valid = false;
+		return std::move(result);
 	}
 
 	string filter;
@@ -100,6 +101,9 @@ unique_ptr<GlobalTableFunctionState> DuckLakeExpireSnapshotsInit(ClientContext &
 
 void DuckLakeExpireSnapshotsExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.bind_data->Cast<ExpireSnapshotsBindData>();
+	if (!data.valid) {
+		return;
+	}
 	auto &state = data_p.global_state->Cast<DuckLakeExpireSnapshotsData>();
 	if (state.offset >= data.snapshots.size()) {
 		return;

--- a/test/sql/compaction/expire_snapshots_invalid_params.test
+++ b/test/sql/compaction/expire_snapshots_invalid_params.test
@@ -31,53 +31,8 @@ SELECT COUNT(*) FROM ducklake_snapshots('ducklake')
 ----
 5
 
-# Test 1: Valid case - only versions parameter
-query I
-SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1])
-----
-1
-
-# Test 2: Valid case - only older_than parameter
-query I
-SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, older_than => NOW())
-----
-4
-
-# Test 3: Invalid case - both versions AND older_than together
+# Test invalid case, both versions AND older_than are specified
 statement error
 SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1, 2], older_than => NOW())
-----
-cannot specify both 'versions' and 'older_than'
-
-# Test 4: Neither versions nor older_than, and no global option set
-query I
-SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true)
-----
-0
-
-# Verify all snapshots are still present
-query I
-SELECT COUNT(*) FROM ducklake_snapshots('ducklake')
-----
-5
-
-# Verify table data is intact
-query I
-SELECT COUNT(*) FROM ducklake.test
-----
-3
-
-# Test 5: Set global option, then call with no params
-statement ok
-CALL ducklake.set_option('expire_older_than', '1 millisecond')
-
-query I
-SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true)
-----
-4
-
-# Invalid case with both versions AND older_than explicitly specified
-statement error
-SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1], older_than => NOW())
 ----
 cannot specify both 'versions' and 'older_than'

--- a/test/sql/compaction/expire_snapshots_invalid_params.test
+++ b/test/sql/compaction/expire_snapshots_invalid_params.test
@@ -49,11 +49,11 @@ SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, vers
 ----
 cannot specify both 'versions' and 'older_than'
 
-# Test 4: Invalid case - neither versions nor older_than, and no global option set
-statement error
+# Test 4: Neither versions nor older_than, and no global option set
+query I
 SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true)
 ----
-must specify either 'versions' or 'older_than'
+0
 
 # Verify all snapshots are still present
 query I

--- a/test/sql/compaction/expire_snapshots_invalid_params.test
+++ b/test/sql/compaction/expire_snapshots_invalid_params.test
@@ -1,0 +1,83 @@
+# name: test/sql/compaction/expire_snapshots_invalid_params.test
+# description: test ducklake_expire_snapshots with invalid parameter combinations
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/expire_snapshots_invalid_params', METADATA_CATALOG 'metadata')
+
+# Create table and make multiple snapshots
+statement ok
+CREATE TABLE ducklake.test(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.test VALUES (1)
+
+statement ok
+INSERT INTO ducklake.test VALUES (2)
+
+statement ok
+INSERT INTO ducklake.test VALUES (3)
+
+query I
+SELECT COUNT(*) FROM ducklake_snapshots('ducklake')
+----
+5
+
+# Test 1: Valid case - only versions parameter
+query I
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1])
+----
+1
+
+# Test 2: Valid case - only older_than parameter
+query I
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, older_than => NOW())
+----
+4
+
+# Test 3: Invalid case - both versions AND older_than together
+statement error
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1, 2], older_than => NOW())
+----
+cannot specify both 'versions' and 'older_than'
+
+# Test 4: Invalid case - neither versions nor older_than, and no global option set
+statement error
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true)
+----
+must specify either 'versions' or 'older_than'
+
+# Verify all snapshots are still present
+query I
+SELECT COUNT(*) FROM ducklake_snapshots('ducklake')
+----
+5
+
+# Verify table data is intact
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+3
+
+# Test 5: Set global option, then call with no params
+statement ok
+CALL ducklake.set_option('expire_older_than', '1 millisecond')
+
+query I
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true)
+----
+4
+
+# Invalid case with both versions AND older_than explicitly specified
+statement error
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1], older_than => NOW())
+----
+cannot specify both 'versions' and 'older_than'


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/discussions/1062

Hi team, I feel confused that no error message or exception thrown when I expire snapshot with invalid params, it just silently passes.
In this PR, I directly throw InvalidInputException when invalid requests detected. Let me know if you think it makes sense!