### PR TITLE
Fix view rename but comment dropped

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -164,7 +164,7 @@ public:
 	virtual void RemoveFilesScheduledForCleanup(const vector<DuckLakeFileForCleanup> &cleaned_up_files);
 	virtual string DropSchemas(const set<SchemaIndex> &ids);
 	virtual string DropTables(const set<TableIndex> &ids, bool renamed);
-	virtual string DropViews(const set<TableIndex> &ids);
+	virtual string DropViews(const set<TableIndex> &ids, bool renamed = false);
 	virtual string DropMacros(const set<MacroIndex> &ids);
 
 	virtual string WriteNewSchemas(const vector<DuckLakeSchemaInfo> &new_schemas);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -164,7 +164,7 @@ public:
 	virtual void RemoveFilesScheduledForCleanup(const vector<DuckLakeFileForCleanup> &cleaned_up_files);
 	virtual string DropSchemas(const set<SchemaIndex> &ids);
 	virtual string DropTables(const set<TableIndex> &ids, bool renamed);
-	virtual string DropViews(const set<TableIndex> &ids, bool renamed = false);
+	virtual string DropViews(const set<TableIndex> &ids, bool renamed);
 	virtual string DropMacros(const set<MacroIndex> &ids);
 
 	virtual string WriteNewSchemas(const vector<DuckLakeSchemaInfo> &new_schemas);

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -275,6 +275,9 @@ public:
 	const set<TableIndex> &GetRenamedTables() {
 		return renamed_tables;
 	}
+	const set<TableIndex> &GetRenamedViews() {
+		return renamed_views;
+	}
 	const case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> &GetNewTables() {
 		return new_tables;
 	}
@@ -357,6 +360,7 @@ private:
 	set<MacroIndex> dropped_table_macros;
 
 	set<TableIndex> renamed_tables;
+	set<TableIndex> renamed_views;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
 	set<TableIndex> tables_deleted_from;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -275,9 +275,6 @@ public:
 	const set<TableIndex> &GetRenamedTables() {
 		return renamed_tables;
 	}
-	const set<TableIndex> &GetRenamedViews() {
-		return renamed_views;
-	}
 	const case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> &GetNewTables() {
 		return new_tables;
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2037,9 +2037,11 @@ string DuckLakeMetadataManager::DropTables(const set<TableIndex> &ids, bool rena
 	return batch_query;
 }
 
-string DuckLakeMetadataManager::DropViews(const set<TableIndex> &ids) {
+string DuckLakeMetadataManager::DropViews(const set<TableIndex> &ids, bool renamed) {
 	string batch_query = FlushDrop("ducklake_view", "view_id", ids);
-	batch_query += FlushDrop("ducklake_tag", "object_id", ids);
+	if (!renamed) {
+		batch_query += FlushDrop("ducklake_tag", "object_id", ids);
+	}
 	return batch_query;
 }
 

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -727,8 +727,8 @@ Connection &DuckLakeTransaction::GetConnection() {
 
 bool DuckLakeTransaction::SchemaChangesMade() const {
 	return !new_tables.empty() || !dropped_tables.empty() || new_schemas || !dropped_schemas.empty() ||
-	       !dropped_views.empty() || !new_macros.empty() || !dropped_scalar_macros.empty() ||
-	       !dropped_table_macros.empty();
+	       !dropped_views.empty() || !renamed_views.empty() || !new_macros.empty() ||
+	       !dropped_scalar_macros.empty() || !dropped_table_macros.empty();
 }
 
 bool DuckLakeTransaction::ChangesMade() const {
@@ -2318,7 +2318,11 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 	}
 
 	if (!dropped_views.empty()) {
-		batch_queries += metadata_manager->DropViews(dropped_views);
+		batch_queries += metadata_manager->DropViews(dropped_views, false);
+	}
+
+	if (!renamed_views.empty()) {
+		batch_queries += metadata_manager->DropViews(renamed_views, true);
 	}
 
 	if (!dropped_scalar_macros.empty()) {
@@ -3059,7 +3063,10 @@ bool DuckLakeTransaction::IsRenamed(CatalogEntry &entry) {
 		auto &table_entry = entry.Cast<DuckLakeTableEntry>();
 		return renamed_tables.find(table_entry.GetTableId()) != renamed_tables.end();
 	}
-	case CatalogType::VIEW_ENTRY:
+	case CatalogType::VIEW_ENTRY: {
+		auto &view_entry = entry.Cast<DuckLakeViewEntry>();
+		return renamed_views.find(view_entry.GetViewId()) != renamed_views.end();
+	}
 	case CatalogType::MACRO_ENTRY:
 	case CatalogType::SCHEMA_ENTRY:
 	case CatalogType::TABLE_MACRO_ENTRY: {
@@ -3127,14 +3134,14 @@ void DuckLakeTransaction::AlterEntryInternal(DuckLakeViewEntry &view, unique_ptr
 	entries.CreateEntry(std::move(new_entry));
 	switch (new_view.GetLocalChange().type) {
 	case LocalChangeType::RENAMED: {
-		// rename - take care of the old table
+		// rename - take care of the old view
 		if (view.IsTransactionLocal()) {
-			// view is transaction local - delete the old table from there
+			// view is transaction local - delete the old view from there
 			entries.DropEntry(view.name);
 		} else {
-			// view is not transaction local - add to drop list
-			auto table_id = view.GetViewId();
-			dropped_views.insert(table_id);
+			// view is not transaction local - add to rename list (preserves tags such as comments)
+			auto view_id = view.GetViewId();
+			renamed_views.insert(view_id);
 		}
 		break;
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -3139,7 +3139,7 @@ void DuckLakeTransaction::AlterEntryInternal(DuckLakeViewEntry &view, unique_ptr
 			// view is transaction local - delete the old view from there
 			entries.DropEntry(view.name);
 		} else {
-			// view is not transaction local - add to rename list (preserves tags such as comments)
+			// view is not transaction local - add to rename list
 			auto view_id = view.GetViewId();
 			renamed_views.insert(view_id);
 		}

--- a/test/sql/comments/rename_view_preserves_comment.test
+++ b/test/sql/comments/rename_view_preserves_comment.test
@@ -1,0 +1,37 @@
+# name: test/sql/comments/rename_view_preserves_comment.test
+# description: Verify ALTER VIEW ... RENAME preserves COMMENT ON VIEW
+# group: [comments]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '__TEST_DIR__/rename_view_preserves_comment/')
+
+statement ok
+USE dl
+
+statement ok
+CREATE TABLE t(i INT)
+
+statement ok
+CREATE VIEW v AS SELECT * FROM t
+
+statement ok
+COMMENT ON VIEW v IS 'view comment'
+
+query II
+SELECT view_name, comment FROM duckdb_views() WHERE view_name = 'v'
+----
+v	view comment
+
+statement ok
+ALTER VIEW v RENAME TO v2
+
+query II
+SELECT view_name, comment FROM duckdb_views() WHERE view_name = 'v2'
+----
+v2	view comment


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1068

The issue is
- When we commit a transaction for a renamed view, it's added to `dropped_views` directly
https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/storage/ducklake_transaction.cpp#L3097-L3099
- As a comparison (which works fine for table), it's added to `renamed_tables` https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/storage/ducklake_transaction.cpp#L3063-L3065

The fix here is simple: just mimic what we do for tables to add a `renamed_views` field. 