### PR TITLE
Fix drop table/view after change in txn

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2935,13 +2935,12 @@ void DuckLakeTransaction::DropSchema(DuckLakeSchemaEntry &schema) {
 
 void DuckLakeTransaction::DropTable(DuckLakeTableEntry &table) {
 	catalog_version = ducklake_catalog.GetNewUncommittedCatalogVersion();
+	auto table_id = table.GetTableId();
 	if (table.IsTransactionLocal()) {
-		// table is transaction-local - drop it from the transaction local changes
 		auto schema_entry = new_tables.find(table.ParentSchema().name);
 		if (schema_entry == new_tables.end()) {
-			throw InternalException("Dropping a transaction local table that does not exist?");
+			throw InternalException("Dropping a transaction local table %s that does not exist", table.name);
 		}
-		auto table_id = table.GetTableId();
 		schema_entry->second->DropEntry(table.name);
 		// if we have written any files for this table - clean them up
 		auto context_ref = context.lock();
@@ -2949,15 +2948,18 @@ void DuckLakeTransaction::DropTable(DuckLakeTableEntry &table) {
 		if (schema_entry->second->GetEntries().empty()) {
 			new_tables.erase(schema_entry);
 		}
-	} else {
-		auto table_id = table.GetTableId();
+	}
+
+	// The table exists before the transaction, drop the table anyway.
+	if (!table_id.IsTransactionLocal()) {
+		renamed_tables.erase(table_id);
 		dropped_tables.insert(table_id);
 	}
 }
 
 void DuckLakeTransaction::DropView(DuckLakeViewEntry &view) {
+	auto view_id = view.GetViewId();
 	if (view.IsTransactionLocal()) {
-		// table is transaction-local - drop it from the transaction local changes
 		auto schema_entry = new_tables.find(view.ParentSchema().name);
 		if (schema_entry == new_tables.end()) {
 			throw InternalException("Dropping a transaction local view that does not exist?");
@@ -2966,8 +2968,11 @@ void DuckLakeTransaction::DropView(DuckLakeViewEntry &view) {
 		if (schema_entry->second->GetEntries().empty()) {
 			new_tables.erase(schema_entry);
 		}
-	} else {
-		auto view_id = view.GetViewId();
+	}
+
+	// The view exists before the transaction, drop the view anyway.
+	if (!view_id.IsTransactionLocal()) {
+		// TODO(hjiang): sync with https://github.com/duckdb/ducklake/pull/1069 to remove renamed views.
 		dropped_views.insert(view_id);
 	}
 }

--- a/test/sql/alter/comment_then_drop_same_transaction.test
+++ b/test/sql/alter/comment_then_drop_same_transaction.test
@@ -1,5 +1,5 @@
 # name: test/sql/alter/comment_then_drop_same_transaction.test
-# description: COMMENT followed by DROP in the same transaction must commit the DROP
+# description: ALTER followed by DROP in the same transaction must commit the DROP
 # group: [alter]
 
 require ducklake
@@ -68,5 +68,39 @@ COMMIT;
 
 statement error
 SELECT count(*) FROM v;
+----
+does not exist
+
+# ============================================
+# TABLE: RENAME TABLE + DROP TABLE in same transaction
+# ============================================
+
+statement ok
+CREATE TABLE t_rename (i INT);
+
+statement ok
+INSERT INTO t_rename VALUES (1), (2);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE t_rename RENAME TO t_rename2;
+
+statement ok
+DROP TABLE t_rename2;
+
+statement ok
+COMMIT;
+
+# the renamed-away name must not exist
+statement error
+SELECT count(*) FROM t_rename2;
+----
+does not exist
+
+# the original name must not exist either, the DROP must take effect
+statement error
+SELECT count(*) FROM t_rename;
 ----
 does not exist

--- a/test/sql/alter/comment_then_drop_same_transaction.test
+++ b/test/sql/alter/comment_then_drop_same_transaction.test
@@ -1,0 +1,72 @@
+# name: test/sql/alter/comment_then_drop_same_transaction.test
+# description: COMMENT followed by DROP in the same transaction must commit the DROP
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '__TEST_DIR__/comment_then_drop/')
+
+statement ok
+USE dl
+
+# ============================================
+# TABLE: COMMENT ON TABLE + DROP TABLE in same transaction
+# ============================================
+
+statement ok
+CREATE TABLE t (i INT);
+
+statement ok
+INSERT INTO t VALUES (1), (2);
+
+statement ok
+BEGIN;
+
+statement ok
+COMMENT ON TABLE t IS 'foo';
+
+statement ok
+DROP TABLE t;
+
+statement ok
+COMMIT;
+
+statement error
+SELECT count(*) FROM t;
+----
+does not exist
+
+# ============================================
+# VIEW: COMMENT ON VIEW + DROP VIEW in same transaction
+# ============================================
+
+statement ok
+CREATE TABLE t (i INT);
+
+statement ok
+INSERT INTO t VALUES (1), (2);
+
+statement ok
+CREATE VIEW v AS SELECT * FROM t;
+
+statement ok
+BEGIN;
+
+statement ok
+COMMENT ON VIEW v IS 'foo';
+
+statement ok
+DROP VIEW v;
+
+statement ok
+COMMIT;
+
+statement error
+SELECT count(*) FROM v;
+----
+does not exist


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1070

The issue is
- For [`DuckLakeTableEntry::IsTransactionLocal`](https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/include/storage/ducklake_table_entry.hpp#L49-L51), it's returning "whether the table was changed inside the transaction", instead of "whether the table is created brand-new in the transaction"
- The confusing part is, [`SchemaIndex`](https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/include/common/index.hpp#L52-L55) has a function with the same name, but indicates whether it's created inside of the transaction
- Now looking back to our current implementation, if a table was changed inside of a transaction, it won't be added to `dropped_tables` https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/storage/ducklake_transaction.cpp#L2900-L2913

The fix for this PR is simple:
- Correct handle both semantics
- Apply the same change to view as well

Followup items:
- We need better naming / semantics for `IsTransactionLocal`, but I would prefer and willing to to followup with another PR; this PR should be self-contained enough
