### PR TITLE
Fix deletion filter initialization with snapshot cleared

### DIFF
--- a/src/storage/ducklake_delete_filter.cpp
+++ b/src/storage/ducklake_delete_filter.cpp
@@ -245,13 +245,44 @@ void DuckLakeDeleteFilter::Initialize(ClientContext &context, const DuckLakeFile
 
 void DuckLakeDeleteFilter::Initialize(const DuckLakeInlinedDataDeletes &inlined_deletes) {
 	D_ASSERT(std::is_sorted(delete_data->deleted_rows.begin(), delete_data->deleted_rows.end()));
-	auto mid_idx = delete_data->deleted_rows.size();
-	for (auto &idx : inlined_deletes.rows) {
-		delete_data->deleted_rows.push_back(idx);
+
+	// Fast path: existing delete data has no per-row snapshot tracking.
+	if (delete_data->snapshot_ids.empty()) {
+		int mid_idx = delete_data->deleted_rows.size();
+		for (auto &idx : inlined_deletes.rows) {
+			delete_data->deleted_rows.push_back(idx);
+		}
+		std::inplace_merge(delete_data->deleted_rows.begin(), delete_data->deleted_rows.begin() + mid_idx,
+		                   delete_data->deleted_rows.end());
+		return;
 	}
-	delete_data->snapshot_ids.clear();
-	std::inplace_merge(delete_data->deleted_rows.begin(), delete_data->deleted_rows.begin() + mid_idx,
-	                   delete_data->deleted_rows.end());
+
+	// Merge existing deletes with inlined deletes.
+	const idx_t merged_size = delete_data->deleted_rows.size() + inlined_deletes.rows.size();
+	vector<idx_t> merged_rows;
+	vector<idx_t> merged_snapshot_ids;
+	merged_rows.reserve(merged_size);
+	merged_snapshot_ids.reserve(merged_size);
+
+	auto lhs_row_it = delete_data->deleted_rows.begin();
+	auto lhs_snapshot_it = delete_data->snapshot_ids.begin();
+	auto rhs_row_it = inlined_deletes.rows.begin();
+	while (lhs_row_it != delete_data->deleted_rows.end() || rhs_row_it != inlined_deletes.rows.end()) {
+		if (rhs_row_it == inlined_deletes.rows.end() ||
+		    (lhs_row_it != delete_data->deleted_rows.end() && *lhs_row_it < *rhs_row_it)) {
+			merged_rows.push_back(*lhs_row_it);
+			merged_snapshot_ids.push_back(*lhs_snapshot_it);
+			lhs_row_it++;
+			lhs_snapshot_it++;
+		} else {
+			merged_rows.push_back(*rhs_row_it);
+			merged_snapshot_ids.push_back(0);
+			rhs_row_it++;
+		}
+	}
+
+	delete_data->deleted_rows = std::move(merged_rows);
+	delete_data->snapshot_ids = std::move(merged_snapshot_ids);
 }
 
 unordered_map<idx_t, idx_t> DuckLakeDeleteFilter::ScanDataFileRowIds(ClientContext &context,

--- a/test/configs/deletion_vectors.json
+++ b/test/configs/deletion_vectors.json
@@ -24,7 +24,8 @@
         "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
         "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",
         "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
-        "test/sql/rewrite_data_files/test_rewrite_db.test"
+        "test/sql/rewrite_data_files/test_rewrite_db.test",
+        "test/sql/issues/issue_1074.test"
       ]
     }
   ]

--- a/test/sql/issues/issue_1073.test
+++ b/test/sql/issues/issue_1073.test
@@ -1,0 +1,51 @@
+# name: test/sql/issues/issue_1073.test
+# description: regression test for issue #1073
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '${DATA_PATH}', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE dl.t AS SELECT i AS id FROM range(100) t(i)
+
+statement ok
+DELETE FROM dl.t WHERE id = 0
+
+statement ok
+DELETE FROM dl.t WHERE id = 1
+
+statement ok
+BEGIN
+
+statement ok
+CALL dl.set_option('data_inlining_row_limit', 100);
+
+statement ok
+DELETE FROM dl.t WHERE id = 2
+
+# FIXME: the snapshot of version 1 should return 100.
+query I
+SELECT count(*) FROM dl.t AT (VERSION => 1);
+----
+99
+
+query I
+SELECT count(*) FROM dl.t AT (VERSION => 2);
+----
+98
+
+query I
+SELECT count(*) FROM dl.t AT (VERSION => 3);
+----
+97
+
+statement ok
+ROLLBACK

--- a/test/sql/issues/issue_1074.test
+++ b/test/sql/issues/issue_1074.test
@@ -1,5 +1,5 @@
-# name: test/sql/issues/issue_1073.test
-# description: regression test for issue #1073
+# name: test/sql/issues/issue_1074.test
+# description: regression test for issue #1074
 # group: [issues]
 
 require ducklake
@@ -14,38 +14,39 @@ statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '${DATA_PATH}', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
+CALL dl.set_option('data_inlining_row_limit', 100);
+
+statement ok
 CREATE TABLE dl.t AS SELECT i AS id FROM range(100) t(i)
 
 statement ok
 DELETE FROM dl.t WHERE id = 0
 
 statement ok
+CALL dl.set_option('data_inlining_row_limit', 0);
+
+statement ok
 DELETE FROM dl.t WHERE id = 1
-
-statement ok
-BEGIN
-
-statement ok
-CALL dl.set_option('data_inlining_row_limit', 100);
 
 statement ok
 DELETE FROM dl.t WHERE id = 2
 
-# FIXME: the snapshot of version 1 should return 100.
 query I
 SELECT count(*) FROM dl.t AT (VERSION => 1);
 ----
-99
+100
 
 query I
 SELECT count(*) FROM dl.t AT (VERSION => 2);
 ----
-98
+99
 
 query I
 SELECT count(*) FROM dl.t AT (VERSION => 3);
 ----
-97
+98
 
-statement ok
-ROLLBACK
+query I
+SELECT count(*) FROM dl.t AT (VERSION => 4);
+----
+97

--- a/test/sql/issues/issue_1074.test
+++ b/test/sql/issues/issue_1074.test
@@ -14,10 +14,10 @@ statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '${DATA_PATH}', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
-CALL dl.set_option('data_inlining_row_limit', 100);
+CREATE TABLE dl.t AS SELECT i AS id FROM range(100) t(i)
 
 statement ok
-CREATE TABLE dl.t AS SELECT i AS id FROM range(100) t(i)
+CALL dl.set_option('data_inlining_row_limit', 100);
 
 statement ok
 DELETE FROM dl.t WHERE id = 0


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1074

Debugging process:
- First, I confirm data file, deletion file, and inline deletion looks ok
- So the incorrect query result must come from how to filter deleted rows, namely `DuckLakeDeleteFilter`
- I add logging to `deleted_rows` and `snapshot_ids` and find the culprit: when we combine deletion files and inline deletions, [snapshot ids are cleared](https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/storage/ducklake_delete_filter.cpp#L252), which means certain rows are always considered as deleted