### PR TITLE
Fix sort SQL with quoted columns

### DIFF
--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -1,6 +1,8 @@
 #include "storage/ducklake_sort_data.hpp"
 
 #include "duckdb/parser/column_list.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception_format_value.hpp"
 
@@ -13,10 +15,18 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 		if (field.dialect != "duckdb") {
 			continue;
 		}
-		// Check if expression matches a column name in the current table, then map to inlined table's name by index
+		// Parse the expression to extract the unquoted column name
+		auto parsed = Parser::ParseExpressionList(field.expression);
+		if (parsed.empty() || parsed[0]->type != ExpressionType::COLUMN_REF) {
+			return string();
+		}
+		auto &colref = parsed[0]->Cast<ColumnRefExpression>();
+		auto &col_name = colref.GetColumnName();
+
+		// Check if column name matches a column in the current table, then map to inlined table's name by index
 		string mapped_col;
 		for (idx_t i = 0; i < current_columns.PhysicalColumnCount(); i++) {
-			if (current_columns.GetColumn(PhysicalIndex(i)).Name() == field.expression) {
+			if (StringUtil::CIEquals(current_columns.GetColumn(PhysicalIndex(i)).Name(), col_name)) {
 				if (i < inlined_columns.PhysicalColumnCount()) {
 					mapped_col = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
 				}

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -16,8 +16,9 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 		// Check if expression matches a column name in the current table, then map to inlined table's name by index
 		string mapped_col;
 		for (idx_t i = 0; i < current_columns.PhysicalColumnCount(); i++) {
-			if (KeywordHelper::WriteOptionallyQuoted(current_columns.GetColumn(PhysicalIndex(i)).Name()) ==
-			    field.expression) {
+			if (StringUtil::CIEquals(
+			        KeywordHelper::WriteOptionallyQuoted(current_columns.GetColumn(PhysicalIndex(i)).Name()),
+			        field.expression)) {
 				if (i < inlined_columns.PhysicalColumnCount()) {
 					mapped_col = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
 				}

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -1,8 +1,6 @@
 #include "storage/ducklake_sort_data.hpp"
 
 #include "duckdb/parser/column_list.hpp"
-#include "duckdb/parser/parser.hpp"
-#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception_format_value.hpp"
 
@@ -15,18 +13,11 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 		if (field.dialect != "duckdb") {
 			continue;
 		}
-		// Parse the expression to extract the unquoted column name
-		auto parsed = Parser::ParseExpressionList(field.expression);
-		if (parsed.empty() || parsed[0]->type != ExpressionType::COLUMN_REF) {
-			return string();
-		}
-		auto &colref = parsed[0]->Cast<ColumnRefExpression>();
-		auto &col_name = colref.GetColumnName();
-
-		// Check if column name matches a column in the current table, then map to inlined table's name by index
+		// Check if expression matches a column name in the current table, then map to inlined table's name by index
 		string mapped_col;
 		for (idx_t i = 0; i < current_columns.PhysicalColumnCount(); i++) {
-			if (StringUtil::CIEquals(current_columns.GetColumn(PhysicalIndex(i)).Name(), col_name)) {
+			if (KeywordHelper::WriteOptionallyQuoted(current_columns.GetColumn(PhysicalIndex(i)).Name()) ==
+			    field.expression) {
 				if (i < inlined_columns.PhysicalColumnCount()) {
 					mapped_col = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
 				}

--- a/test/sql/sorted_table/flush_sorted_rename_quoted.test
+++ b/test/sql/sorted_table/flush_sorted_rename_quoted.test
@@ -1,0 +1,35 @@
+# name: test/sql/sorted_table/flush_sorted_rename_quoted.test
+# description: flush sorted inlined data with deletes when column name requires SQL quoting
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '${DATA_PATH}/rename_with_quote', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+CREATE TABLE dl.t("My Col" INTEGER)
+
+statement ok
+INSERT INTO dl.t VALUES (3), (1), (2)
+
+statement ok
+DELETE FROM dl.t WHERE "My Col" = 1
+
+statement ok
+ALTER TABLE dl.t SET SORTED BY ("My Col" DESC)
+
+statement ok
+CALL ducklake_flush_inlined_data('dl', table_name => 't')
+
+query I
+SELECT "My Col" FROM dl.t ORDER BY "My Col" DESC
+----
+3
+2

--- a/test/sql/sorted_table/flush_sorted_rename_quoted.test
+++ b/test/sql/sorted_table/flush_sorted_rename_quoted.test
@@ -23,7 +23,7 @@ statement ok
 DELETE FROM dl.t WHERE "My Col" = 1
 
 statement ok
-ALTER TABLE dl.t SET SORTED BY ("My Col" DESC)
+ALTER TABLE dl.t SET SORTED BY ("my col" DESC)
 
 statement ok
 CALL ducklake_flush_inlined_data('dl', table_name => 't')


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1080

I add debugging message on building sort SQL, and found the issue is [current implementation](https://github.com/duckdb/ducklake/blob/202c966dd0f6dc2241bbe657f6ee5cad25207c75/src/storage/ducklake_sort_data.cpp#L19) doesn't consider quoted columns.
- `current_columns.GetColumn(PhysicalIndex(i)).Name()` -> `My Col` (no quotes around)
- `field.expression` -> `"My Col"` (with quotes around)
- so column name comparison fails