### PR TITLE
fix: retryable sqlite busy lock

### DIFF
--- a/src/include/metadata_manager/sqlite_metadata_manager.hpp
+++ b/src/include/metadata_manager/sqlite_metadata_manager.hpp
@@ -27,6 +27,9 @@ public:
 	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
+
+protected:
+	bool RetryOnMessage(const string &lower_message) const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/common.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/optional_idx.hpp"
@@ -117,6 +118,8 @@ public:
 	virtual idx_t MaxIdentifierLength() const {
 		return NumericLimits<idx_t>::Maximum();
 	}
+	//! Return true if a failed commit should be retried
+	virtual bool Retry(const ErrorData &error) const;
 	//! Check if columns (stored as DuckLakeColumnInfo) support inlining, recursing into children
 	bool SupportsInliningColumns(const vector<DuckLakeColumnInfo> &columns);
 
@@ -268,6 +271,8 @@ public:
 protected:
 	virtual string GetLatestSnapshotQuery() const;
 
+	//! Catalog-specific retry rules (message already lower-cased)
+	virtual bool RetryOnMessage(const string &lower_message) const;
 	//! Wrap field selections with list aggregation of struct objects (DBMS-specific)
 	//! For DuckDB: LIST({'key1': val1, 'key2': val2, ...})
 	//! For Postgres: jsonb_agg(jsonb_build_object('key1', val1, 'key2', val2, ...))

--- a/src/metadata_manager/sqlite_metadata_manager.cpp
+++ b/src/metadata_manager/sqlite_metadata_manager.cpp
@@ -1,5 +1,6 @@
 #include "metadata_manager/sqlite_metadata_manager.hpp"
 #include "common/ducklake_util.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/main/database.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_transaction.hpp"
@@ -46,4 +47,12 @@ string SQLiteMetadataManager::GetColumnTypeInternal(const LogicalType &column_ty
 		return column_type.ToString();
 	}
 }
+
+bool SQLiteMetadataManager::RetryOnMessage(const string &lower_message) const {
+	if (DuckLakeMetadataManager::RetryOnMessage(lower_message)) {
+		return true;
+	}
+	return StringUtil::Contains(lower_message, "database is locked");
+}
+
 } // namespace duckdb

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -86,6 +86,24 @@ bool DuckLakeMetadataManager::SupportsInlining(const LogicalType &type) {
 	return true;
 }
 
+bool DuckLakeMetadataManager::Retry(const ErrorData &error) const {
+	const string lower_message = StringUtil::Lower(error.Message());
+	return RetryOnMessage(lower_message);
+}
+
+bool DuckLakeMetadataManager::RetryOnMessage(const string &lower_message) const {
+	if (StringUtil::Contains(lower_message, "primary key") || StringUtil::Contains(lower_message, "unique")) {
+		return true;
+	}
+	if (StringUtil::Contains(lower_message, "conflict")) {
+		return true;
+	}
+	if (StringUtil::Contains(lower_message, "concurrent")) {
+		return true;
+	}
+	return false;
+}
+
 bool DuckLakeMetadataManager::SupportsInliningColumns(const vector<DuckLakeColumnInfo> &columns) {
 	for (auto &col : columns) {
 		auto col_type = DuckLakeTypes::FromString(col.type);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2542,23 +2542,6 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 	return result;
 }
 
-bool RetryOnError(const string &original_message) {
-	auto message = StringUtil::Lower(original_message);
-	// retry on primary key errors
-	if (StringUtil::Contains(message, "primary key") || StringUtil::Contains(message, "unique")) {
-		return true;
-	}
-	// retry on conflicts
-	if (StringUtil::Contains(message, "conflict")) {
-		return true;
-	}
-	// retry on concurrent access
-	if (StringUtil::Contains(message, "concurrent")) {
-		return true;
-	}
-	return false;
-}
-
 void DuckLakeTransaction::FlushChanges() {
 	if (!ChangesMade()) {
 		// read-only transactions don't need to do anything
@@ -2624,7 +2607,7 @@ void DuckLakeTransaction::FlushChanges() {
 			if (has_active_transaction) {
 				connection->Rollback();
 			}
-			bool retry_on_error = RetryOnError(error.Message());
+			bool retry_on_error = metadata_manager->Retry(error);
 			bool finished_retrying = i + 1 >= max_retry_count;
 			if (!can_retry || !retry_on_error || finished_retrying) {
 				// we abort after the max retry count

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -8,14 +8,11 @@
     "sqlite_scanner",
     "icu",
     "httpfs"
-  ],"skip_error_messages": [
-    "database is locked"
   ],
   "test_env": [{
       "env_name":  "DUCKLAKE_CONNECTION",
       "env_value": "sqlite:{TEST_DIR}/{BASE_TEST_NAME}.db"
    }],
-  "skip_error_messages": ["database is locked"],
   "skip_tests": [
     {
       "reason": "Test is slow",
@@ -33,27 +30,6 @@
       "reason": "SQLite databases do not support creating new schemas",
       "paths": [
         "test/sql/catalog/quoted_identifiers.test"
-      ]
-    },
-    {
-      "reason": "Failed to execute query COMMIT: database is locked",
-      "paths": [
-        "test/sql/compaction/compaction_delete_conflict.test",
-        "test/sql/concurrent/concurrent_insert_conflict.test",
-        "test/sql/concurrent/concurrent_insert_data_inlining.test",
-        "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
-        "test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test",
-        "test/sql/settings/max_retry_count.test",
-        "test/sql/snapshot_info/ducklake_current_commit.test",
-        "test/sql/snapshot_info/ducklake_last_commit.test",
-        "test/sql/stats/global_stats_transactions.test",
-        "test/sql/transaction/concurrent_table_creation.test",
-        "test/sql/transaction/transaction_conflict_cleanup.test",
-        "test/sql/transaction/transaction_conflicts.test",
-        "test/sql/transaction/transaction_conflicts_delete.test",
-        "test/sql/transaction/transaction_conflicts_view.test",
-        "test/sql/concurrent/file_level_conflict.test",
-        "test/sql/transaction/transaction_conflict_inlining.test"
       ]
     },
     {


### PR DESCRIPTION
The SQLite busy lock is considered retryable as far as I can tell.

But the test suite fails intermittently because the current code does not treat it as such. Making it retryable causes the tests to reliably reach a consistent state via retry on busy locks