### PR TITLE
Fix merge_adjacent_files with empty source files

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -145,8 +145,18 @@ SinkFinalizeType DuckLakeCompaction::Finalize(Pipeline &pipeline, Event &event, 
 	if (global_state.written_files.size() > 1) {
 		throw InternalException("DuckLakeCompaction - expected at most a single output file");
 	}
-	if (global_state.written_files.empty() && type != CompactionType::REWRITE_DELETES) {
-		throw InternalException("DuckLakeCompaction - expected a single output file");
+	if (global_state.written_files.empty()) {
+		idx_t rows_to_write = 0;
+		for (auto &source : source_files) {
+			rows_to_write += source.file.row_count;
+			if (!source.delete_files.empty()) {
+				rows_to_write -= source.delete_files.back().row_count;
+			}
+			rows_to_write -= source.inlined_file_deletions.size();
+		}
+		if (rows_to_write != 0) {
+			throw InternalException("DuckLakeCompaction - expected a single output file for %llu rows", rows_to_write);
+		}
 	}
 	// set the partition values correctly
 	for (auto &file : global_state.written_files) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2458,11 +2458,7 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 			bool has_new_file = !compaction.written_file.file_name.empty();
 			DuckLakeFileInfo new_file;
 
-			if (!has_new_file) {
-				if (type != CompactionType::REWRITE_DELETES) {
-					throw InternalException("Compaction error - expected output file for non-rewrite compaction");
-				}
-			} else {
+			if (has_new_file) {
 				new_file = GetNewDataFile(compaction.written_file, commit_state, table_id, compaction.row_id_start);
 				switch (type) {
 				case CompactionType::REWRITE_DELETES:
@@ -2523,7 +2519,8 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 			}
 			if (!has_new_file && row_id_limit != 0) {
 				throw InternalException(
-				    "Compaction error - rewrite compaction without output file must fully delete source files");
+				    "Compaction error - compaction without output file must have zero live source rows (got %llu)",
+				    row_id_limit);
 			}
 			if (has_new_file) {
 				result.new_files.push_back(std::move(new_file));

--- a/test/sql/compaction/repro_merge_adjacent_zero_output.test
+++ b/test/sql/compaction/repro_merge_adjacent_zero_output.test
@@ -1,0 +1,63 @@
+# name: test/sql/compaction/repro_merge_adjacent_zero_output.test
+# description: reproduce DuckLakeCompaction "expected a single output file" assertion
+#              when merge_adjacent_files merges several empty parquet files.
+#              See https://github.com/duckdb/ducklake/issues/525
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+SET threads=4;
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '{DATA_PATH}/repro_merge_zero')
+
+statement ok
+USE lake;
+
+statement ok
+CALL lake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+CALL lake.set_option('per_thread_output', 'true');
+
+statement ok
+CREATE TABLE t (id INT, payload VARCHAR);
+
+foreach N 1 2 3 4
+
+statement ok
+INSERT INTO t SELECT range, 'x' FROM range(100) WHERE range < 0;
+
+endloop
+
+query II
+SELECT count(*), COALESCE(sum(record_count), 0)
+FROM __ducklake_metadata_lake.ducklake_data_file
+WHERE end_snapshot IS NULL;
+----
+4	0
+
+# merge_adjacent_files should consume empty files without creating a replacement file.
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('lake');
+----
+main	t	4	0
+
+query II
+SELECT count(*), COALESCE(sum(record_count), 0)
+FROM __ducklake_metadata_lake.ducklake_data_file
+WHERE end_snapshot IS NULL;
+----
+0	0
+
+query I
+SELECT count(*) FROM t;
+----
+0


### PR DESCRIPTION
Allow compaction to finish without an output file when the source files have zero live rows. This lets merge_adjacent_files compact zero-row parquet files without tripping the single-output-file assertion while still rejecting missing output for non-empty input.

Fixes https://github.com/duckdb/ducklake/issues/525