### PR TITLE
Fix quote processing for macros

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2285,26 +2285,28 @@ string DuckLakeMetadataManager::WriteNewMacros(const vector<DuckLakeMacroInfo> &
 	for (auto &macro : new_macros) {
 		// Insert in the macro table
 		batch_query += StringUtil::Format(R"(
-INSERT INTO {METADATA_CATALOG}.ducklake_macro values(%llu,%llu,'%s',{SNAPSHOT_ID}, NULL);
+INSERT INTO {METADATA_CATALOG}.ducklake_macro values(%llu,%llu,%s,{SNAPSHOT_ID}, NULL);
 )",
-		                                  macro.schema_id.index, macro.macro_id.index, macro.macro_name);
+		                                  macro.schema_id.index, macro.macro_id.index, SQLString(macro.macro_name));
 		// Insert in the implementation table
 		for (idx_t impl_id = 0; impl_id < macro.implementations.size(); ++impl_id) {
 			auto &impl = macro.implementations[impl_id];
 			batch_query += StringUtil::Format(R"(
-INSERT INTO {METADATA_CATALOG}.ducklake_macro_impl values(%llu,%llu,'%s','%s','%s');
+INSERT INTO {METADATA_CATALOG}.ducklake_macro_impl values(%llu,%llu,%s,%s,%s);
 )",
-			                                  macro.macro_id.index, impl_id, impl.dialect, impl.sql, impl.type);
+			                                  macro.macro_id.index, impl_id, SQLString(impl.dialect),
+			                                  SQLString(impl.sql), SQLString(impl.type));
 
 			for (idx_t param_id = 0; param_id < impl.parameters.size(); ++param_id) {
 				// Insert in the parameter table
 				auto &param = impl.parameters[param_id];
 				batch_query +=
 				    StringUtil::Format(R"(
-INSERT INTO {METADATA_CATALOG}.ducklake_macro_parameters values(%llu,%llu,%llu,'%s','%s','%s', '%s');
+INSERT INTO {METADATA_CATALOG}.ducklake_macro_parameters values(%llu,%llu,%llu,%s,%s,%s,%s);
 )",
-				                       macro.macro_id.index, impl_id, param_id, param.parameter_name,
-				                       param.parameter_type, param.default_value.ToString(), param.default_value_type);
+				                       macro.macro_id.index, impl_id, param_id, SQLString(param.parameter_name),
+				                       SQLString(param.parameter_type), SQLString(param.default_value.ToString()),
+				                       SQLString(param.default_value_type));
 			}
 		}
 	}
@@ -2792,10 +2794,10 @@ SELECT TRUE
 FROM {METADATA_CATALOG}.ducklake_table t
 INNER JOIN {METADATA_CATALOG}.ducklake_column c
   ON c.table_id = t.table_id
- WHERE c.column_name = '%s' AND
- t.table_name = '%s' AND c.begin_snapshot = t.begin_snapshot AND c.end_snapshot IS NULL;
+ WHERE c.column_name = %s AND
+ t.table_name = %s AND c.begin_snapshot = t.begin_snapshot AND c.end_snapshot IS NULL;
 )",
-	                                                   column_name, table_name));
+	                                                   SQLString(column_name), SQLString(table_name)));
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get schema information from DuckLake: ");
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1821,23 +1821,16 @@ void DuckLakeTransaction::GetNewMacroInfo(DuckLakeCommitState &commit_state, ref
 		default:
 			throw NotImplementedException("Unsupported macro type");
 		}
-		macro_impl.sql = StringUtil::Replace(macro_impl.sql, "'", "''");
 		// Let's do the parameters
 		for (idx_t i = 0; i < impl->parameters.size(); i++) {
 			DuckLakeMacroParameters parameter;
 			parameter.parameter_name = impl->parameters[i]->GetName();
 			parameter.parameter_type = DuckLakeTypes::ToString(impl->types[i]);
-			if (impl->default_parameters.find(parameter.parameter_name) != impl->default_parameters.end()) {
-				auto value = impl->default_parameters[parameter.parameter_name]->ToString();
-				if (StringUtil::StartsWith(value, "'")) {
-					value = value.substr(1, value.size() - 2);
-				}
-				value = StringUtil::Replace(value, "'", "''");
-
-				parameter.default_value = value;
-
-				parameter.default_value_type = DuckLakeTypes::ToString(
-				    impl->default_parameters[parameter.parameter_name]->Cast<ConstantExpression>().value.type());
+			auto default_it = impl->default_parameters.find(parameter.parameter_name);
+			if (default_it != impl->default_parameters.end()) {
+				auto &const_expr = default_it->second->Cast<ConstantExpression>();
+				parameter.default_value = const_expr.value.ToString();
+				parameter.default_value_type = DuckLakeTypes::ToString(const_expr.value.type());
 			} else {
 				parameter.default_value_type = "unknown";
 			}

--- a/test/sql/catalog/macro_special_characters.test
+++ b/test/sql/catalog/macro_special_characters.test
@@ -1,0 +1,47 @@
+# name: test/sql/catalog/macro_special_characters.test
+# description: Test creating macros with special characters
+# group: [catalog]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '__TEST_DIR__/macro_special_chars/')
+
+statement ok
+USE ducklake;
+
+# macro name with single quote
+statement ok
+CREATE MACRO "it's_a_macro"() AS 42;
+
+query I
+SELECT "it's_a_macro"();
+----
+42
+
+# macro body that produces a string with a single quote
+statement ok
+CREATE MACRO greet(name) AS 'hello ' || name || '''s world';
+
+query I
+SELECT greet('bob');
+----
+hello bob's world
+
+# macro with a default parameter containing a single quote
+statement ok
+CREATE MACRO greeting(who := 'it''s me') AS 'hi ' || who;
+
+query I
+SELECT greeting();
+----
+hi it's me
+
+query I
+SELECT greeting('y''all');
+----
+hi y'all


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1098

The issue with current implementation is, take macro creation as an example, it takes the macro name and simply prepending and appending a single quote.
In detail, `it's_a_macro` becomes `'it''s_a_macro'` which is unparsable.

The fix is easy -- DuckDB already has util function `SQLString` to handle all cases.
I used opus 4.7 to scan the codebase and replace all self-implemented quote-handling to the util function.