### PR TITLE
Drop view id from renamed

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2975,7 +2975,7 @@ void DuckLakeTransaction::DropView(DuckLakeViewEntry &view) {
 
 	// The view exists before the transaction, drop the view anyway.
 	if (!view_id.IsTransactionLocal()) {
-		// TODO(hjiang): sync with https://github.com/duckdb/ducklake/pull/1069 to remove renamed views.
+		renamed_views.erase(view_id);
 		dropped_views.insert(view_id);
 	}
 }

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2313,22 +2313,6 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 		    "message to false with \"CALL ducklake.set_option('require_commit_message', False)\" '\"");
 	}
 
-	// Invariant: a given table/view id can be either renamed OR dropped in a transaction, never both.
-#ifdef DEBUG
-	{
-		set<TableIndex> overlap;
-		std::set_intersection(dropped_tables.begin(), dropped_tables.end(), renamed_tables.begin(),
-		                      renamed_tables.end(), std::inserter(overlap, overlap.begin()));
-		D_ASSERT(overlap.empty());
-	}
-	{
-		set<TableIndex> overlap;
-		std::set_intersection(dropped_views.begin(), dropped_views.end(), renamed_views.begin(),
-		                      renamed_views.end(), std::inserter(overlap, overlap.begin()));
-		D_ASSERT(overlap.empty());
-	}
-#endif
-
 	string batch_queries;
 	// drop entries
 	if (!dropped_tables.empty()) {
@@ -3131,6 +3115,8 @@ void DuckLakeTransaction::AlterEntryInternal(DuckLakeTableEntry &table, unique_p
 		} else {
 			// table is not transaction local - add to drop list
 			auto table_id = table.GetTableId();
+			// Invariant: a table id cannot be both renamed and dropped in the same transaction.
+			D_ASSERT(dropped_tables.find(table_id) == dropped_tables.end());
 			renamed_tables.insert(table_id);
 		}
 		break;
@@ -3165,6 +3151,8 @@ void DuckLakeTransaction::AlterEntryInternal(DuckLakeViewEntry &view, unique_ptr
 		} else {
 			// view is not transaction local - add to rename list
 			auto view_id = view.GetViewId();
+			// Invariant: a view id cannot be both renamed and dropped in the same transaction.
+			D_ASSERT(dropped_views.find(view_id) == dropped_views.end());
 			renamed_views.insert(view_id);
 		}
 		break;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1,8 +1,5 @@
 #include "storage/ducklake_transaction.hpp"
 
-#include <algorithm>
-#include <iterator>
-
 #include "common/ducklake_types.hpp"
 #include "common/ducklake_util.hpp"
 #include "duckdb/common/thread.hpp"

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1,5 +1,8 @@
 #include "storage/ducklake_transaction.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 #include "common/ducklake_types.hpp"
 #include "common/ducklake_util.hpp"
 #include "duckdb/common/thread.hpp"
@@ -2309,6 +2312,23 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 		    "with \"CALL ducklake.set_commit_message('author_name', 'commit_message'); \n * Set the required commit "
 		    "message to false with \"CALL ducklake.set_option('require_commit_message', False)\" '\"");
 	}
+
+	// Invariant: a given table/view id can be either renamed OR dropped in a transaction, never both.
+#ifdef DEBUG
+	{
+		set<TableIndex> overlap;
+		std::set_intersection(dropped_tables.begin(), dropped_tables.end(), renamed_tables.begin(),
+		                      renamed_tables.end(), std::inserter(overlap, overlap.begin()));
+		D_ASSERT(overlap.empty());
+	}
+	{
+		set<TableIndex> overlap;
+		std::set_intersection(dropped_views.begin(), dropped_views.end(), renamed_views.begin(),
+		                      renamed_views.end(), std::inserter(overlap, overlap.begin()));
+		D_ASSERT(overlap.empty());
+	}
+#endif
+
 	string batch_queries;
 	// drop entries
 	if (!dropped_tables.empty()) {

--- a/test/sql/alter/comment_then_drop_same_transaction.test
+++ b/test/sql/alter/comment_then_drop_same_transaction.test
@@ -104,3 +104,40 @@ statement error
 SELECT count(*) FROM t_rename;
 ----
 does not exist
+
+# ============================================
+# VIEW: RENAME VIEW + DROP VIEW in same transaction
+# ============================================
+
+statement ok
+CREATE TABLE base_for_view (i INT);
+
+statement ok
+INSERT INTO base_for_view VALUES (1), (2);
+
+statement ok
+CREATE VIEW v_rename AS SELECT * FROM base_for_view;
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER VIEW v_rename RENAME TO v_rename2;
+
+statement ok
+DROP VIEW v_rename2;
+
+statement ok
+COMMIT;
+
+# the renamed-away name must not exist
+statement error
+SELECT count(*) FROM v_rename2;
+----
+does not exist
+
+# the original name must not exist either, the DROP must take effect
+statement error
+SELECT count(*) FROM v_rename;
+----
+does not exist


### PR DESCRIPTION
Followup PR for https://github.com/duckdb/ducklake/pull/1071 and https://github.com/duckdb/ducklake/pull/1069

Mimic what we do for tables
- When a view (which exists before transaction) gets dropped, we remove it from both dropped items and renamed items 
https://github.com/duckdb/ducklake/blob/90da74d5df014008d4ada27146c128a1c36beec6/src/storage/ducklake_transaction.cpp#L2956

I don't find it easy to reproduce with SQL tests, so as a regression test I added debug assertion.