### PR TITLE
Fix bucket out of range

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -489,6 +489,9 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 			if (bucket_count <= 0) {
 				throw InvalidInputException("Bucket count must be positive");
 			}
+			if (bucket_count > NumericLimits<int32_t>::Maximum()) {
+				throw InvalidInputException("Bucket count cannot exceed %d", NumericLimits<int32_t>::Maximum());
+			}
 
 			field.transform.bucket_count = bucket_count;
 			column_name = GetPartitionColumnName(function.children[1]->Cast<ColumnRefExpression>());

--- a/test/sql/partitioning/bucket_partitioning.test
+++ b/test/sql/partitioning/bucket_partitioning.test
@@ -136,6 +136,12 @@ ALTER TABLE bucketed_tbl SET PARTITIONED BY (bucket(-1, user_id));
 ----
 Bucket count must be positive
 
+# Bucket count exceeding INT32 maximum leads to error.
+statement error
+ALTER TABLE bucketed_tbl SET PARTITIONED BY (bucket(2147483648, user_id));
+----
+Bucket count cannot exceed
+
 # Non-existent column
 statement error
 ALTER TABLE bucketed_tbl SET PARTITIONED BY (bucket(4, nonexistent_col));


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1109

The root cause is, on row ingestion we apply partition transformation, here we convert partition count to uint32, which leads to INTERNAL exception if our partition bucket exceeds that range: https://github.com/duckdb/ducklake/blob/654147764169a948a99b92d53b1823135ce07ff5/src/storage/ducklake_partition_data.cpp#L123