### PR TITLE
Disallow dropping sorted columns

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/parser/parsed_data/comment_on_column_info.hpp"
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "functions/ducklake_compaction_functions.hpp"
 #include "storage/ducklake_multi_file_reader.hpp"
 
 namespace duckdb {
@@ -727,6 +728,21 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 				                       "change the partitioning on this table in order to drop this column",
 				                       col.Name());
 			}
+		}
+	}
+	// check if we are sorting on this column
+	if (sort_data) {
+		auto orders = DuckLakeCompactor::ParseSortOrders(*sort_data);
+		for (auto &order : orders) {
+			ParsedExpressionIterator::VisitExpression<ColumnRefExpression>(
+			    *order.expression, [&](const ColumnRefExpression &colref) {
+				    if (StringUtil::CIEquals(colref.GetColumnName(), col.Name())) {
+					    throw CatalogException(
+					        "Cannot drop column \"%s\" - the table is sorted by this column. Reset or "
+					        "change the sort order on this table in order to drop this column",
+					        col.Name());
+				    }
+			    });
 		}
 	}
 	if (transaction.HasTransactionInlinedData(GetTableId())) {

--- a/test/sql/sorted_table/drop_sorted_column.test
+++ b/test/sql/sorted_table/drop_sorted_column.test
@@ -1,0 +1,33 @@
+# name: test/sql/sorted_table/drop_sorted_column.test
+# description: Dropping a column referenced by SET SORTED BY should be rejected
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_drop_sorted_column')
+
+statement ok
+CREATE TABLE ducklake.t(a INTEGER, b INTEGER)
+
+statement ok
+ALTER TABLE ducklake.t SET SORTED BY (b ASC)
+
+# cannot drop a column that is the sort key
+statement error
+ALTER TABLE ducklake.t DROP COLUMN b
+----
+the table is sorted by this column
+
+# reset sorted by, then drop works
+statement ok
+ALTER TABLE ducklake.t RESET SORTED BY
+
+statement ok
+ALTER TABLE ducklake.t DROP COLUMN b

--- a/test/sql/sorted_table/insert_sorted_transaction.test
+++ b/test/sql/sorted_table/insert_sorted_transaction.test
@@ -168,7 +168,7 @@ SELECT * FROM ducklake.test_add_sort_insert
 30	2
 10	3
 
-# test: BEGIN -> SET SORTED BY -> DROP that column -> INSERT should error -> ROLLBACK
+# test: BEGIN -> SET SORTED BY -> DROP that column should error -> ROLLBACK
 statement ok
 CREATE TABLE ducklake.test_sort_drop_insert(a INTEGER, b INTEGER)
 
@@ -178,18 +178,15 @@ BEGIN
 statement ok
 ALTER TABLE ducklake.test_sort_drop_insert SET SORTED BY (b ASC)
 
-statement ok
-ALTER TABLE ducklake.test_sort_drop_insert DROP COLUMN b
-
 statement error
-INSERT INTO ducklake.test_sort_drop_insert VALUES (1)
+ALTER TABLE ducklake.test_sort_drop_insert DROP COLUMN b
 ----
-Columns in the SET SORTED BY statement were not found
+the table is sorted by this column
 
 statement ok
 ROLLBACK
 
-# test: BEGIN -> SET SORTED BY -> DROP column -> ADD column back -> INSERT -> COMMIT
+# test: BEGIN -> SET SORTED BY -> RESET SORTED BY -> DROP column -> ADD column back -> SET SORTED BY -> INSERT -> COMMIT
 statement ok
 CREATE TABLE ducklake.test_sort_drop_readd(a INTEGER, b INTEGER)
 
@@ -200,10 +197,16 @@ statement ok
 ALTER TABLE ducklake.test_sort_drop_readd SET SORTED BY (b DESC)
 
 statement ok
+ALTER TABLE ducklake.test_sort_drop_readd RESET SORTED BY
+
+statement ok
 ALTER TABLE ducklake.test_sort_drop_readd DROP COLUMN b
 
 statement ok
 ALTER TABLE ducklake.test_sort_drop_readd ADD COLUMN b INTEGER
+
+statement ok
+ALTER TABLE ducklake.test_sort_drop_readd SET SORTED BY (b DESC)
 
 statement ok
 INSERT INTO ducklake.test_sort_drop_readd VALUES (10, 3), (20, 1), (30, 2)


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1111

I think the current behavior for dropping a sorted column is confusing:
- Dropping a sorted column is acceptable with no issue
- But inserting a new row afterwards fails

In this PR, I try to mimic the behavior for dropping a partitioned column to keep behavior consistent and reasonable: users can only drop a column when it's not partitioned or sorted, and print out prompt to drop / reset sort before dropping.