### PR TITLE
Avoid opening metadata transactions for read-only metadata queries

### DIFF
--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -574,7 +574,7 @@ LEFT JOIN (
 
 	// Delete the flushed inlined deletions
 	auto delete_result =
-	    transaction.Query(snapshot, StringUtil::Format("DELETE FROM {METADATA_CATALOG}.%s", inlined_table_name));
+	    transaction.Execute(snapshot, StringUtil::Format("DELETE FROM {METADATA_CATALOG}.%s", inlined_table_name));
 	if (delete_result->HasError()) {
 		delete_result->GetErrorObject().Throw("Failed to delete inlined file deletions after flush: ");
 	}

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -171,7 +171,10 @@ public:
 	}
 	unique_ptr<QueryResult> Query(DuckLakeSnapshot snapshot, string query);
 	unique_ptr<QueryResult> Query(string query);
+	unique_ptr<QueryResult> Execute(DuckLakeSnapshot snapshot, string query);
+	unique_ptr<QueryResult> Execute(string query);
 	Connection &GetConnection();
+	void EnsureMetadataTransaction();
 
 	DuckLakeSnapshot GetSnapshot();
 	DuckLakeSnapshot GetSnapshot(optional_ptr<BoundAtClause> at_clause,
@@ -337,6 +340,9 @@ private:
 	void AlterEntryInternal(DuckLakeViewEntry &old_entry, unique_ptr<CatalogEntry> new_entry);
 	void AddTableChanges(TableIndex table_id, const LocalTableDataChanges &table_changes,
 	                     TransactionChangeInformation &changes) const;
+	unique_ptr<QueryResult> QueryInternal(string query, bool ensure_metadata_transaction);
+	void CommitMetadataTransactionIfActive();
+	void RollbackMetadataTransactionIfActive();
 
 private:
 	DuckLakeCatalog &ducklake_catalog;

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -110,6 +110,7 @@ unique_ptr<QueryResult> PostgresMetadataManager::ExecuteQuery(DuckLakeSnapshot s
 	return connection.Query(StringUtil::Format("CALL %s(%s, %s)", command, catalog_literal, SQLString(query)));
 }
 unique_ptr<QueryResult> PostgresMetadataManager::Execute(DuckLakeSnapshot snapshot, string &query) {
+	transaction.EnsureMetadataTransaction();
 	return ExecuteQuery(snapshot, query, "postgres_execute");
 }
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -164,7 +164,7 @@ INSERT INTO {METADATA_CATALOG}.ducklake_schema VALUES (0, '%s'::UUID, 0, NULL, '
 	)",
 	                                       GetVersionString(), DuckDB::SourceID(), SQLString(data_path), encryption_str,
 	                                       initial_schema_uuid);
-	auto result = transaction.Query(initialize_query);
+	auto result = transaction.Execute(initialize_query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to initialize DuckLake: ");
 	}
@@ -222,7 +222,7 @@ CREATE TABLE {METADATA_CATALOG}.ducklake_name_mapping(mapping_id BIGINT, column_
 UPDATE {METADATA_CATALOG}.ducklake_partition_column SET column_id = (SELECT LIST(column_id ORDER BY column_order) FROM {METADATA_CATALOG}.ducklake_column WHERE table_id = ducklake_partition_column.table_id AND parent_column IS NULL AND end_snapshot IS NULL)[ducklake_partition_column.column_id + 1];
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.2' WHERE key = 'version';
 	)";
-	auto result = transaction.Query(migrate_query);
+	auto result = transaction.Execute(migrate_query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to migrate DuckLake from v0.1 to v0.2: ");
 	}
@@ -242,7 +242,7 @@ void DuckLakeMetadataManager::ExecuteMigration(string migrate_query, bool allow_
 		migrate_query = StringUtil::Replace(migrate_query, "{IF_EXISTS}", "");
 		migrate_query = StringUtil::Replace(migrate_query, "{WHERE_EMPTY}", "");
 	}
-	auto result = transaction.Query(migrate_query);
+	auto result = transaction.Execute(migrate_query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to migrate DuckLake from v" + from_version + " to v" + to_version + ":");
 	}
@@ -292,7 +292,7 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '0.4' WHERE key = 'versi
 	)";
 	ExecuteMigration(migrate_query, allow_failures, "0.3", "0.4");
 
-	auto migrate_schema_versions = transaction.Query(R"(
+	auto migrate_schema_versions = transaction.Execute(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_schema_versions (table_id, begin_snapshot, schema_version)
 SELECT t.table_id, sv.begin_snapshot, sv.schema_version
 FROM {METADATA_CATALOG}.ducklake_schema_versions sv
@@ -307,7 +307,7 @@ WHERE sv.table_id IS NULL;
 			    "Failed to migrate schema_versions to per-table tracking: ");
 		}
 	}
-	auto delete_global_entries = transaction.Query(R"(
+	auto delete_global_entries = transaction.Execute(R"(
 DELETE FROM {METADATA_CATALOG}.ducklake_schema_versions WHERE table_id IS NULL;
 )");
 	if (delete_global_entries->HasError()) {
@@ -318,7 +318,7 @@ DELETE FROM {METADATA_CATALOG}.ducklake_schema_versions WHERE table_id IS NULL;
 }
 
 void DuckLakeMetadataManager::MigrateV04() {
-	auto result = transaction.Query(R"(
+	auto result = transaction.Execute(R"(
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.0' WHERE key = 'version';
 	)");
 	if (result->HasError()) {
@@ -327,7 +327,7 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.0' WHERE key = 'versi
 }
 
 void DuckLakeMetadataManager::MigrateV10() {
-	auto result = transaction.Query(R"(
+	auto result = transaction.Execute(R"(
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)");
 	if (result->HasError()) {
@@ -2129,7 +2129,7 @@ string DuckLakeMetadataManager::DropViews(const set<TableIndex> &ids) {
 }
 
 unique_ptr<QueryResult> DuckLakeMetadataManager::Execute(DuckLakeSnapshot snapshot, string &query) {
-	return transaction.Query(snapshot, query);
+	return transaction.Execute(snapshot, query);
 }
 
 unique_ptr<QueryResult> DuckLakeMetadataManager::Query(DuckLakeSnapshot snapshot, string &query) {
@@ -2734,7 +2734,7 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 		auto create_query = StringUtil::Format(
 		    "CREATE TABLE IF NOT EXISTS {METADATA_CATALOG}.%s(file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT);",
 		    table_name);
-		auto create_result = transaction.Query(snapshot, create_query);
+		auto create_result = transaction.Execute(snapshot, create_query);
 		if (create_result->HasError()) {
 			create_result->GetErrorObject().Throw("Failed to create inlined deletion table: ");
 		}
@@ -3069,6 +3069,7 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
                                                               const vector<DuckLakeTableInfo> &new_tables,
                                                               vector<DuckLakeSchemaInfo> &new_schemas_result) {
 	auto &catalog = transaction.GetCatalog();
+	transaction.EnsureMetadataTransaction();
 	auto &connection = transaction.GetConnection();
 	const auto &db_name = catalog.MetadataDatabaseName();
 	auto schema_name = catalog.MetadataSchemaName();
@@ -4196,11 +4197,11 @@ void DuckLakeMetadataManager::RemoveFilesScheduledForCleanup(const vector<DuckLa
 		}
 		deleted_file_ids += to_string(file.id.index);
 	}
-	auto result = transaction.Query(StringUtil::Format(R"(
+	auto result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 WHERE data_file_id IN (%s);
 )",
-	                                                   deleted_file_ids));
+	                                                     deleted_file_ids));
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to delete scheduled cleanup files in DuckLake: ");
 	}
@@ -4321,6 +4322,7 @@ string DuckLakeMetadataManager::WriteCompactions(const vector<DuckLakeCompactedF
 }
 
 void DuckLakeMetadataManager::DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots) {
+	transaction.EnsureMetadataTransaction();
 	unique_ptr<QueryResult> result;
 	// first delete the actual snapshots
 	string snapshot_ids;
@@ -4332,11 +4334,11 @@ void DuckLakeMetadataManager::DeleteSnapshots(const vector<DuckLakeSnapshotInfo>
 	}
 	vector<string> tables_to_delete_from {"ducklake_snapshot", "ducklake_snapshot_changes"};
 	for (auto &delete_tbl : tables_to_delete_from) {
-		result = transaction.Query(StringUtil::Format(R"(
+		result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s
 WHERE snapshot_id IN (%s);
 )",
-		                                              delete_tbl, snapshot_ids));
+		                                                delete_tbl, snapshot_ids));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete snapshots in DuckLake: ");
 		}
@@ -4419,21 +4421,21 @@ WHERE %s (end_snapshot IS NOT NULL AND NOT EXISTS(
 		tables_to_delete_from = {"ducklake_data_file", "ducklake_file_column_stats", "ducklake_file_variant_stats",
 		                         "ducklake_file_partition_value"};
 		for (auto &delete_tbl : tables_to_delete_from) {
-			result = transaction.Query(StringUtil::Format(R"(
+			result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s
 WHERE data_file_id IN (%s);
 )",
-			                                              delete_tbl, deleted_file_ids));
+			                                                delete_tbl, deleted_file_ids));
 			if (result->HasError()) {
 				result->GetErrorObject().Throw("Failed to delete old data file information in DuckLake: ");
 			}
 		}
 		// insert the to-be-cleaned-up files
-		result = transaction.Query(StringUtil::Format(R"(
+		result = transaction.Execute(StringUtil::Format(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 VALUES %s;
 )",
-		                                              files_scheduled_for_cleanup));
+		                                                files_scheduled_for_cleanup));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to schedule files for clean-up in DuckLake: ");
 		}
@@ -4484,20 +4486,20 @@ WHERE %s %s (end_snapshot IS NOT NULL AND NOT EXISTS(
 			    "(%d, %s, %s, NOW())", file.id.index, SQLString(path.path), path.path_is_relative ? "true" : "false");
 		}
 		// delete the delete files
-		result = transaction.Query(StringUtil::Format(R"(
+		result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.ducklake_delete_file
 WHERE delete_file_id IN (%s);
 )",
-		                                              deleted_delete_ids));
+		                                                deleted_delete_ids));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete old delete file information in DuckLake: ");
 		}
 		// insert the to-be-cleaned-up files
-		result = transaction.Query(StringUtil::Format(R"(
+		result = transaction.Execute(StringUtil::Format(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 VALUES %s;
 )",
-		                                              files_scheduled_for_cleanup));
+		                                                files_scheduled_for_cleanup));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to schedule files for clean-up in DuckLake: ");
 		}
@@ -4511,10 +4513,10 @@ VALUES %s;
 		    "ducklake_column_tag",      "ducklake_sort_info",           "ducklake_sort_expression",
 		    "ducklake_schema_versions", "ducklake_inlined_data_tables", "ducklake_column_mapping"};
 		for (auto &delete_tbl : tables_to_delete_from) {
-			auto result = transaction.Query(StringUtil::Format(R"(
+			auto result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s
 WHERE table_id IN (%s);)",
-			                                                   delete_tbl, deleted_table_ids));
+			                                                     delete_tbl, deleted_table_ids));
 			if (result->HasError()) {
 				result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");
 			}
@@ -4524,14 +4526,14 @@ WHERE table_id IN (%s);)",
 	// delete any views, schemas, macros, etc that are no longer referenced
 	tables_to_delete_from = {"ducklake_schema", "ducklake_view", "ducklake_tag", "ducklake_macro"};
 	for (auto &delete_tbl : tables_to_delete_from) {
-		auto result = transaction.Query(StringUtil::Format(R"(
+		auto result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s
 WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
     SELECT snapshot_id
     FROM {METADATA_CATALOG}.ducklake_snapshot
     WHERE snapshot_id >= begin_snapshot AND snapshot_id < end_snapshot
 );)",
-		                                                   delete_tbl));
+		                                                     delete_tbl));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");
 		}
@@ -4540,13 +4542,13 @@ WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
 	// clean up macro implementation and parameters for deleted macros
 	tables_to_delete_from = {"ducklake_macro_impl", "ducklake_macro_parameters"};
 	for (auto &delete_tbl : tables_to_delete_from) {
-		auto result = transaction.Query(StringUtil::Format(R"(
+		auto result = transaction.Execute(StringUtil::Format(R"(
 DELETE FROM {METADATA_CATALOG}.%s tbl
 WHERE NOT EXISTS (
     SELECT 1 FROM {METADATA_CATALOG}.ducklake_macro m
     WHERE m.macro_id = tbl.macro_id
 );)",
-		                                                   delete_tbl));
+		                                                     delete_tbl));
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");
 		}
@@ -4554,7 +4556,7 @@ WHERE NOT EXISTS (
 
 	// clean up name mappings for deleted column mappings
 	{
-		auto result = transaction.Query(R"(
+		auto result = transaction.Execute(R"(
 DELETE FROM {METADATA_CATALOG}.ducklake_name_mapping tbl
 WHERE NOT EXISTS (
     SELECT 1 FROM {METADATA_CATALOG}.ducklake_column_mapping m
@@ -4567,10 +4569,10 @@ WHERE NOT EXISTS (
 }
 
 void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table) {
-	auto result = transaction.Query(StringUtil::Format(R"(
+	auto result = transaction.Execute(StringUtil::Format(R"(
 		DELETE FROM {METADATA_CATALOG}.%s
 )",
-	                                                   SQLIdentifier(inlined_table.table_name)));
+	                                                     SQLIdentifier(inlined_table.table_name)));
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to delete inlined data in DuckLake from table " +
 		                               inlined_table.table_name + ": ");
@@ -4579,10 +4581,10 @@ void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &
 
 void DuckLakeMetadataManager::DeleteFlushedInlinedData(const DuckLakeInlinedTableInfo &inlined_table,
                                                        idx_t flush_snapshot_id) {
-	auto result = transaction.Query(StringUtil::Format(R"(
+	auto result = transaction.Execute(StringUtil::Format(R"(
 		DELETE FROM {METADATA_CATALOG}.%s WHERE begin_snapshot <= %d
 )",
-	                                                   SQLIdentifier(inlined_table.table_name), flush_snapshot_id));
+	                                                     SQLIdentifier(inlined_table.table_name), flush_snapshot_id));
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to delete flushed inlined data in DuckLake from table " +
 		                               inlined_table.table_name + ": ");
@@ -4655,6 +4657,7 @@ WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_s
 }
 
 void DuckLakeMetadataManager::SetConfigOption(const DuckLakeConfigOption &option) {
+	transaction.EnsureMetadataTransaction();
 	// check if the option already exists
 	auto &option_key = option.option.key;
 	auto &option_value = option.option.value;
@@ -4684,16 +4687,17 @@ WHERE key = %s AND %s
 	auto count = result->Fetch()->GetValue(0, 0).GetValue<idx_t>();
 	if (count == 0) {
 		// option does not yet exist - insert the value
-		result = transaction.Query(StringUtil::Format(R"(
+		result =
+		    transaction.Execute(StringUtil::Format(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_metadata VALUES (%s, %s, %s, %s)
 )",
-		                                              SQLString(option_key), SQLString(option_value), scope, scope_id));
+		                                           SQLString(option_key), SQLString(option_value), scope, scope_id));
 	} else {
 		// option already exists - update it
-		result = transaction.Query(StringUtil::Format(R"(
+		result = transaction.Execute(StringUtil::Format(R"(
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value=%s WHERE key=%s AND %s
 )",
-		                                              SQLString(option_value), SQLString(option_key), scope_filter));
+		                                                SQLString(option_value), SQLString(option_key), scope_filter));
 	}
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to insert config option in DuckLake: ");

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -686,19 +686,16 @@ void DuckLakeTransaction::Start() {
 void DuckLakeTransaction::Commit() {
 	if (ChangesMade()) {
 		FlushChanges();
-	} else if (connection) {
-		connection->Commit();
+	} else {
+		CommitMetadataTransactionIfActive();
 	}
 	connection.reset();
 	local_changes.Clear();
 }
 
 void DuckLakeTransaction::Rollback() {
-	if (connection) {
-		// rollback any changes made to the metadata catalog
-		connection->Rollback();
-		connection.reset();
-	}
+	RollbackMetadataTransactionIfActive();
+	connection.reset();
 	CleanupFiles();
 	local_changes.Clear();
 }
@@ -726,9 +723,36 @@ Connection &DuckLakeTransaction::GetConnection() {
 		if (metadata_type == "postgres" || metadata_type == "postgres_scanner") {
 			connection->Query("SET pg_experimental_filter_pushdown=false");
 		}
-		connection->BeginTransaction();
 	}
 	return *connection;
+}
+
+void DuckLakeTransaction::EnsureMetadataTransaction() {
+	auto &connection = GetConnection();
+	auto has_active_transaction = connection.context->transaction.HasActiveTransaction();
+	if (!has_active_transaction) {
+		connection.BeginTransaction();
+	}
+}
+
+void DuckLakeTransaction::CommitMetadataTransactionIfActive() {
+	if (!connection) {
+		return;
+	}
+	auto has_active_transaction = connection->context->transaction.HasActiveTransaction();
+	if (has_active_transaction) {
+		connection->Commit();
+	}
+}
+
+void DuckLakeTransaction::RollbackMetadataTransactionIfActive() {
+	if (!connection) {
+		return;
+	}
+	auto has_active_transaction = connection->context->transaction.HasActiveTransaction();
+	if (has_active_transaction) {
+		connection->Rollback();
+	}
 }
 
 bool DuckLakeTransaction::SchemaChangesMade() const {
@@ -2617,10 +2641,7 @@ void DuckLakeTransaction::FlushChanges() {
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
 			// rollback if there is an active transaction
-			auto has_active_transaction = connection->context->transaction.HasActiveTransaction();
-			if (has_active_transaction) {
-				connection->Rollback();
-			}
+			RollbackMetadataTransactionIfActive();
 			bool retry_on_error = RetryOnError(error.Message());
 			bool finished_retrying = i + 1 >= max_retry_count;
 			if (!can_retry || !retry_on_error || finished_retrying) {
@@ -2650,7 +2671,7 @@ void DuckLakeTransaction::FlushChanges() {
 			// retry the transaction (with a new snapshot id)
 			// clear the inlined table caches - the rollback undid any table creation from the previous attempt
 			metadata_manager->ClearInlinedTableCaches();
-			connection->BeginTransaction();
+			EnsureMetadataTransaction();
 			snapshot.reset();
 		}
 	}
@@ -2689,7 +2710,7 @@ void DuckLakeTransaction::MarkInlinedDataForDeletion(DuckLakeInlinedTableInfo in
 	flushed_inlined_tables.push_back({std::move(inlined_table), flush_snapshot_id});
 }
 
-unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
+unique_ptr<QueryResult> DuckLakeTransaction::QueryInternal(string query, bool ensure_metadata_transaction) {
 	auto &connection = GetConnection();
 	auto catalog_identifier = DuckLakeUtil::SQLIdentifierToString(ducklake_catalog.MetadataDatabaseName());
 	auto catalog_literal = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataDatabaseName());
@@ -2706,6 +2727,9 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	query = StringUtil::Replace(query, "{METADATA_SCHEMA_ESCAPED}", schema_identifier_escaped);
 	query = StringUtil::Replace(query, "{METADATA_PATH}", metadata_path);
 	query = StringUtil::Replace(query, "{DATA_PATH}", data_path);
+	if (ensure_metadata_transaction) {
+		EnsureMetadataTransaction();
+	}
 	auto start = std::chrono::steady_clock::now();
 	auto result = connection.Query(query);
 	auto end = std::chrono::steady_clock::now();
@@ -2720,7 +2744,16 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
 	return result;
 }
 
-unique_ptr<QueryResult> DuckLakeTransaction::Query(DuckLakeSnapshot snapshot, string query) {
+unique_ptr<QueryResult> DuckLakeTransaction::Query(string query) {
+	return QueryInternal(std::move(query), false);
+}
+
+unique_ptr<QueryResult> DuckLakeTransaction::Execute(string query) {
+	return QueryInternal(std::move(query), true);
+}
+
+static string ReplaceSnapshotPlaceholders(DuckLakeSnapshot snapshot, string query,
+                                          const DuckLakeSnapshotCommit &commit_info) {
 	query = StringUtil::Replace(query, "{SNAPSHOT_ID}", to_string(snapshot.snapshot_id));
 	query = StringUtil::Replace(query, "{SCHEMA_VERSION}", to_string(snapshot.schema_version));
 	query = StringUtil::Replace(query, "{NEXT_CATALOG_ID}", to_string(snapshot.next_catalog_id));
@@ -2728,15 +2761,40 @@ unique_ptr<QueryResult> DuckLakeTransaction::Query(DuckLakeSnapshot snapshot, st
 	query = StringUtil::Replace(query, "{AUTHOR}", commit_info.author.ToSQLString());
 	query = StringUtil::Replace(query, "{COMMIT_MESSAGE}", commit_info.commit_message.ToSQLString());
 	query = StringUtil::Replace(query, "{COMMIT_EXTRA_INFO}", commit_info.commit_extra_info.ToSQLString());
+	return query;
+}
 
+unique_ptr<QueryResult> DuckLakeTransaction::Query(DuckLakeSnapshot snapshot, string query) {
+	query = ReplaceSnapshotPlaceholders(snapshot, std::move(query), commit_info);
 	return Query(std::move(query));
 }
 
+unique_ptr<QueryResult> DuckLakeTransaction::Execute(DuckLakeSnapshot snapshot, string query) {
+	query = ReplaceSnapshotPlaceholders(snapshot, std::move(query), commit_info);
+	return Execute(std::move(query));
+}
+
 string DuckLakeTransaction::GetDefaultSchemaName() {
-	auto &metadata_context = *connection->context;
-	auto &db_manager = DatabaseManager::Get(metadata_context);
-	auto metadb = db_manager.GetDatabase(metadata_context, ducklake_catalog.MetadataDatabaseName());
-	return metadb->GetCatalog().GetDefaultSchema();
+	auto &connection = GetConnection();
+	auto has_active_transaction = connection.context->transaction.HasActiveTransaction();
+	if (!has_active_transaction) {
+		connection.BeginTransaction();
+	}
+	try {
+		auto &metadata_context = *connection.context;
+		auto &db_manager = DatabaseManager::Get(metadata_context);
+		auto metadb = db_manager.GetDatabase(metadata_context, ducklake_catalog.MetadataDatabaseName());
+		auto result = metadb->GetCatalog().GetDefaultSchema();
+		if (!has_active_transaction) {
+			connection.Commit();
+		}
+		return result;
+	} catch (...) {
+		if (!has_active_transaction) {
+			connection.Rollback();
+		}
+		throw;
+	}
 }
 
 DuckLakeSnapshot DuckLakeTransaction::GetSnapshot() {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -94,7 +94,8 @@
     },{
       "reason": "Test only for Postgres as catalog",
       "paths": [
-        "test/sql/metadata/ducklake_settings_postgres.test"
+        "test/sql/metadata/ducklake_settings_postgres.test",
+        "test/sql/transaction/postgres_metadata_read_transactions.test"
       ]
     },
     {

--- a/test/sql/transaction/metadata_write_transaction_rollback.test
+++ b/test/sql/transaction/metadata_write_transaction_rollback.test
@@ -1,0 +1,45 @@
+# name: test/sql/transaction/metadata_write_transaction_rollback.test
+# description: Direct metadata writes remain transaction-local after lazy metadata transaction changes
+# group: [transaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/metadata_write_transaction_rollback')
+
+statement ok
+USE ducklake
+
+statement ok
+BEGIN
+
+statement ok
+CALL ducklake.set_option('parquet_compression', 'uncompressed')
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_metadata WHERE key = 'parquet_compression'
+----
+0
+
+statement ok
+BEGIN
+
+statement ok
+CALL ducklake.set_option('parquet_compression', 'uncompressed')
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_metadata WHERE key = 'parquet_compression'
+----
+1

--- a/test/sql/transaction/postgres_metadata_read_transactions.test
+++ b/test/sql/transaction/postgres_metadata_read_transactions.test
@@ -1,0 +1,98 @@
+# name: test/sql/transaction/postgres_metadata_read_transactions.test
+# description: Metadata reads should not leave Postgres metadata transactions open
+# group: [transaction]
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres)
+
+statement ok
+CALL postgres_execute('pg', 'DROP SCHEMA IF EXISTS postgres_metadata_read_transactions CASCADE', use_transaction=false)
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION} application_name=ducklake_metadata_read_transactions' AS ducklake (DATA_PATH '{DATA_PATH}/postgres_metadata_read_transactions', METADATA_SCHEMA 'postgres_metadata_read_transactions')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t(i INTEGER)
+
+statement ok
+INSERT INTO t VALUES (1), (2)
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+BEGIN
+
+query I
+SELECT count(*) FROM postgres_query('pg', 'SELECT pid FROM pg_stat_activity WHERE application_name = ''ducklake_metadata_read_transactions'' AND state = ''idle in transaction''')
+----
+0
+
+query I
+SELECT sum(i) FROM t
+----
+3
+
+query I
+/* leading comment read */ SELECT sum(i) FROM t
+----
+3
+
+statement ok
+EXPLAIN SELECT sum(i) FROM t
+
+query I
+SELECT count(*) FROM postgres_query('pg', 'SELECT pid FROM pg_stat_activity WHERE application_name = ''ducklake_metadata_read_transactions'' AND state = ''idle in transaction''')
+----
+0
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN
+
+statement ok
+CALL ducklake.set_option('parquet_compression', 'uncompressed')
+
+query I
+SELECT count(*) FROM postgres_query('pg', 'SELECT pid FROM pg_stat_activity WHERE application_name = ''ducklake_metadata_read_transactions'' AND state = ''idle in transaction''')
+----
+1
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.postgres_metadata_read_transactions.ducklake_metadata WHERE key = 'parquet_compression'
+----
+0
+
+statement ok
+BEGIN
+
+query I
+SELECT sum(i) FROM t
+----
+3
+
+query I
+SELECT count(*) FROM postgres_query('pg', 'SELECT pid FROM pg_stat_activity WHERE application_name = ''ducklake_metadata_read_transactions'' AND state = ''idle in transaction''')
+----
+0
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
## What changed

- Split DuckLake metadata access into read-only `Query(...)` and write-oriented `Execute(...)` paths.
- Made metadata transactions lazy: reads no longer implicitly begin a metadata transaction, while writes explicitly ensure one is active.
- Updated metadata mutation paths, migrations, cleanup, config writes, Postgres metadata execution, and inlined data flush cleanup to use the write path.
- Added active metadata transaction commit/rollback helpers.
- Added regression coverage for Postgres metadata reads and transaction-local metadata writes.

## Why

Read-only metadata operations against Postgres could leave metadata connections open in a transaction, including during user transactions that only read DuckLake data. This keeps Postgres sessions from sitting `idle in transaction` unless DuckLake actually performs metadata writes.

## Validation

- `cmake --build build/release --target duckdb`
- `git diff --check`
- `duckdb/scripts/format.py ... --check` for the touched C++ and `.test` files
- `./build/release/test/unittest test/sql/transaction/metadata_write_transaction_rollback.test`
- `./build/release/test/unittest test/sql/transaction/basic_transaction.test`
- `./build/release/test/unittest test/sql/transaction/transaction_conflicts.test`
- `./build/release/test/unittest test/sql/data_inlining/data_inlining_option_transaction_local.test`
- `./build/release/test/unittest --test-config test/configs/postgres.json --test-dir ./ test/sql/transaction/postgres_metadata_read_transactions.test`
