### PR TITLE
fix: use ANSI CAST instead of PostgreSQL ::boolean cast in stats update

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3971,7 +3971,7 @@ WITH new_values(tid, cid, new_contains_null, new_contains_nan, new_min, new_max,
 VALUES %s
 )
 UPDATE {METADATA_CATALOG}.ducklake_table_column_stats
-SET contains_null=new_contains_null::boolean, contains_nan=new_contains_nan::boolean, min_value=new_min, max_value=new_max, extra_stats=new_extra_stats
+SET contains_null=CAST(new_contains_null AS boolean), contains_nan=CAST(new_contains_nan AS boolean), min_value=new_min, max_value=new_max, extra_stats=new_extra_stats
 FROM new_values
 WHERE table_id=tid AND column_id=cid;
 )",


### PR DESCRIPTION
## Summary
- Replaces PostgreSQL-style `::boolean` casts with ANSI `CAST(... AS boolean)` in the column-stats `UPDATE` query in `ducklake_metadata_manager.cpp`.
- Improves portability of the metadata SQL across catalog backends that don't support the `::` cast syntax.

## Test plan
- [ ] Existing test suite passes against DuckDB/SQLite metadata catalogs
- [ ] Verify column stats updates still produce identical results