### PR TITLE
Add VgiMetadataManager for VGI / Durable Object backend

### DIFF
--- a/src/include/metadata_manager/vgi_metadata_manager.hpp
+++ b/src/include/metadata_manager/vgi_metadata_manager.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// metadata_manager/vgi_metadata_manager.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "storage/ducklake_metadata_manager.hpp"
+
+namespace duckdb {
+
+class VgiMetadataManager : public DuckLakeMetadataManager {
+public:
+	explicit VgiMetadataManager(DuckLakeTransaction &transaction);
+
+	static unique_ptr<DuckLakeMetadataManager> Create(DuckLakeTransaction &transaction) {
+		return make_uniq<VgiMetadataManager>(transaction);
+	}
+
+	bool TypeIsNativelySupported(const LogicalType &type) override;
+	bool SupportsInlining(const LogicalType &type) override;
+	bool SupportsAppender() const override {
+		return false;
+	}
+
+	string GetColumnTypeInternal(const LogicalType &type) override;
+
+	void InitializeDuckLake(bool has_explicit_schema, DuckLakeEncryption encryption) override;
+	unique_ptr<QueryResult> Execute(DuckLakeSnapshot snapshot, string &query) override;
+};
+
+} // namespace duckdb

--- a/src/metadata_manager/CMakeLists.txt
+++ b/src/metadata_manager/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ducklake_metadata_manager OBJECT postgres_metadata_manager.cpp
-                                             sqlite_metadata_manager.cpp)
+                                             sqlite_metadata_manager.cpp
+                                             vgi_metadata_manager.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_metadata_manager>
     PARENT_SCOPE)

--- a/src/metadata_manager/vgi_metadata_manager.cpp
+++ b/src/metadata_manager/vgi_metadata_manager.cpp
@@ -1,0 +1,93 @@
+#include "metadata_manager/vgi_metadata_manager.hpp"
+#include "common/ducklake_util.hpp"
+#include "duckdb/main/database.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_transaction.hpp"
+
+namespace duckdb {
+
+VgiMetadataManager::VgiMetadataManager(DuckLakeTransaction &transaction) : DuckLakeMetadataManager(transaction) {
+}
+
+bool VgiMetadataManager::TypeIsNativelySupported(const LogicalType &type) {
+	// SQLite-backed DO storage. Mirror SQLiteMetadataManager.
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::LIST:
+	// SQLite converts IEEE 754 NaN to NULL when storing double values,
+	// so FLOAT/DOUBLE must be stored as VARCHAR to preserve NaN through the round-trip
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::VARIANT:
+		return false;
+	default:
+		return true;
+	}
+}
+
+bool VgiMetadataManager::SupportsInlining(const LogicalType &type) {
+	if (type.id() == LogicalTypeId::VARIANT) {
+		return false;
+	}
+	return DuckLakeMetadataManager::SupportsInlining(type);
+}
+
+string VgiMetadataManager::GetColumnTypeInternal(const LogicalType &column_type) {
+	switch (column_type.id()) {
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::VARIANT:
+		return "VARCHAR";
+	default:
+		return column_type.ToString();
+	}
+}
+
+void VgiMetadataManager::InitializeDuckLake(bool, DuckLakeEncryption) {
+	// The VGI worker owns bootstrap. Re-attach the VGI catalog with the
+	// `data_path` option to auto-bootstrap, or call
+	// `<catalog>.main.catalog_create('<path>')` before attaching DuckLake.
+	throw InvalidInputException(
+	    "DuckLake metadata tables are not present in the VGI-backed catalog. "
+	    "Bootstrap is owned by the VGI ATTACH — re-ATTACH the VGI catalog with "
+	    "the `data_path` option set, or call `<catalog>.main.catalog_create('<path>')` "
+	    "manually before attaching DuckLake.");
+}
+
+unique_ptr<QueryResult> VgiMetadataManager::Execute(DuckLakeSnapshot snapshot, string &query) {
+	auto &commit_info = transaction.GetCommitInfo();
+
+	// Snapshot / commit-info substitutions (same set as the base path).
+	query = StringUtil::Replace(query, "{SNAPSHOT_ID}", to_string(snapshot.snapshot_id));
+	query = StringUtil::Replace(query, "{SCHEMA_VERSION}", to_string(snapshot.schema_version));
+	query = StringUtil::Replace(query, "{NEXT_CATALOG_ID}", to_string(snapshot.next_catalog_id));
+	query = StringUtil::Replace(query, "{NEXT_FILE_ID}", to_string(snapshot.next_file_id));
+	query = StringUtil::Replace(query, "{AUTHOR}", commit_info.author.ToSQLString());
+	query = StringUtil::Replace(query, "{COMMIT_MESSAGE}", commit_info.commit_message.ToSQLString());
+	query = StringUtil::Replace(query, "{COMMIT_EXTRA_INFO}", commit_info.commit_extra_info.ToSQLString());
+
+	auto &connection = transaction.GetConnection();
+	auto &ducklake_catalog = transaction.GetCatalog();
+	auto vgi_catalog_identifier = DuckLakeUtil::SQLIdentifierToString(ducklake_catalog.MetadataDatabaseName());
+	auto data_path = DuckLakeUtil::SQLLiteralToString(ducklake_catalog.DataPath());
+
+	// The DO's SQLite has only the `main` schema, so all metadata-catalog
+	// references resolve to plain `main.<table>`. Substitute every variant of
+	// `{METADATA_*}` with the DO-side schema; do not introduce DuckDB-side
+	// catalog/database qualifiers because the SQL is shipped as a literal to
+	// the DO and resolved by SQLite there.
+	query = StringUtil::Replace(query, "{METADATA_CATALOG_NAME_LITERAL}", "'main'");
+	query = StringUtil::Replace(query, "{METADATA_CATALOG_NAME_IDENTIFIER}", "main");
+	query = StringUtil::Replace(query, "{METADATA_SCHEMA_NAME_LITERAL}", "'main'");
+	query = StringUtil::Replace(query, "{METADATA_CATALOG}", "main");
+	query = StringUtil::Replace(query, "{METADATA_SCHEMA_ESCAPED}", "main");
+	query = StringUtil::Replace(query, "{DATA_PATH}", data_path);
+
+	// Forward the entire batch as a single HTTP POST to the DO via the worker.
+	return connection.Query(StringUtil::Format("CALL %s.main.ducklake_do_execute(%s)", vgi_catalog_identifier,
+	                                            SQLString(query)));
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/appender.hpp"
 #include "metadata_manager/postgres_metadata_manager.hpp"
 #include "metadata_manager/sqlite_metadata_manager.hpp"
+#include "metadata_manager/vgi_metadata_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
@@ -38,7 +39,8 @@ unordered_map<string /* name */, DuckLakeMetadataManager::create_t> DuckLakeMeta
     {"postgres", PostgresMetadataManager::Create},
     {"postgres_scanner", PostgresMetadataManager::Create},
     {"sqlite", SQLiteMetadataManager::Create},
-    {"sqlite_scanner", SQLiteMetadataManager::Create}};
+    {"sqlite_scanner", SQLiteMetadataManager::Create},
+    {"vgi", VgiMetadataManager::Create}};
 
 mutex DuckLakeMetadataManager::metadata_managers_lock;
 


### PR DESCRIPTION
@pdet, how do you want to start to handle pluggable metadata managers?  Right now this is the start of one but it doesn't seem like you've gotten many others. I'll probably have a few more changes soon, as this is just Durable Objects but really this could be any API.

Routes DuckLake metadata commits through the VGI worker's ducklake_do_execute(sql) function so the entire commit batch ships as one HTTP POST to the DO. Reads flow through the existing VGI catalog readers. Bootstrap is owned by the VGI ATTACH (data_path option) — InitializeDuckLake() throws if tables are missing.