### PR TITLE
Fix type promotion for UINTEGER

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -850,7 +850,7 @@ bool TypePromotionIsAllowed(const LogicalType &source, const LogicalType &target
 	case LogicalTypeId::USMALLINT:
 		return TypePromotionIsAllowedUSmallint(target);
 	case LogicalTypeId::UINTEGER:
-		return target.id() == LogicalTypeId::UBIGINT;
+		return target.id() == LogicalTypeId::UBIGINT || target.id() == LogicalTypeId::BIGINT;
 	case LogicalTypeId::UBIGINT:
 		return false;
 	case LogicalTypeId::FLOAT:

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -788,78 +788,15 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	return std::move(new_entry);
 }
 
-static bool TypePromotionIsAllowedTinyint(const LogicalType &to) {
-	switch (to.id()) {
-	case LogicalTypeId::SMALLINT:
-	case LogicalTypeId::INTEGER:
-	case LogicalTypeId::BIGINT:
-		return true;
-	default:
-		return false;
-	}
-}
-
-static bool TypePromotionIsAllowedSmallint(const LogicalType &to) {
-	switch (to.id()) {
-	case LogicalTypeId::INTEGER:
-	case LogicalTypeId::BIGINT:
-		return true;
-	default:
-		return false;
-	}
-}
-
-static bool TypePromotionIsAllowedUTinyint(const LogicalType &to) {
-	switch (to.id()) {
-	case LogicalTypeId::SMALLINT:
-	case LogicalTypeId::INTEGER:
-	case LogicalTypeId::BIGINT:
-	case LogicalTypeId::USMALLINT:
-	case LogicalTypeId::UINTEGER:
-	case LogicalTypeId::UBIGINT:
-		return true;
-	default:
-		return false;
-	}
-}
-
-static bool TypePromotionIsAllowedUSmallint(const LogicalType &to) {
-	switch (to.id()) {
-	case LogicalTypeId::INTEGER:
-	case LogicalTypeId::BIGINT:
-	case LogicalTypeId::UINTEGER:
-	case LogicalTypeId::UBIGINT:
-		return true;
-	default:
-		return false;
-	}
-}
 bool TypePromotionIsAllowed(const LogicalType &source, const LogicalType &target) {
-	// FIXME: Rework to use DUCKDB_API static LogicalType MaxLogicalType
-	switch (source.id()) {
-	case LogicalTypeId::TINYINT:
-		return TypePromotionIsAllowedTinyint(target);
-	case LogicalTypeId::SMALLINT:
-		return TypePromotionIsAllowedSmallint(target);
-	case LogicalTypeId::INTEGER:
-		return target.id() == LogicalTypeId::BIGINT;
-	case LogicalTypeId::BIGINT:
-		return false;
-	case LogicalTypeId::UTINYINT:
-		return TypePromotionIsAllowedUTinyint(target);
-	case LogicalTypeId::USMALLINT:
-		return TypePromotionIsAllowedUSmallint(target);
-	case LogicalTypeId::UINTEGER:
-		return target.id() == LogicalTypeId::UBIGINT || target.id() == LogicalTypeId::BIGINT;
-	case LogicalTypeId::UBIGINT:
-		return false;
-	case LogicalTypeId::FLOAT:
-		return target.id() == LogicalTypeId::DOUBLE;
-	case LogicalTypeId::TIMESTAMP:
-		return target.id() == LogicalTypeId::TIMESTAMP_TZ;
-	default:
+	if (source == target) {
 		return false;
 	}
+	LogicalType result;
+	if (!LogicalType::TryGetMaxLogicalTypeUnchecked(source, target, result)) {
+		return false;
+	}
+	return result == target;
 }
 
 bool IsSimpleCast(const ParsedExpression &expr) {

--- a/test/sql/alter/promote_type.test
+++ b/test/sql/alter/promote_type.test
@@ -37,6 +37,12 @@ FROM ducklake.test
 25
 1000
 
+statement ok
+ALTER TABLE ducklake.test ADD COLUMN col2 UINTEGER;
+
+statement ok
+ALTER TABLE ducklake.test ALTER COLUMN col2 TYPE BIGINT;
+
 # cannot widen type
 statement error
 ALTER TABLE ducklake.test ALTER COLUMN col1 SET DATA TYPE SMALLINT;

--- a/test/sql/alter/promote_type.test
+++ b/test/sql/alter/promote_type.test
@@ -37,12 +37,6 @@ FROM ducklake.test
 25
 1000
 
-statement ok
-ALTER TABLE ducklake.test ADD COLUMN col2 UINTEGER;
-
-statement ok
-ALTER TABLE ducklake.test ALTER COLUMN col2 TYPE BIGINT;
-
 # cannot widen type
 statement error
 ALTER TABLE ducklake.test ALTER COLUMN col1 SET DATA TYPE SMALLINT;

--- a/test/sql/alter/promote_type_all.test
+++ b/test/sql/alter/promote_type_all.test
@@ -1,0 +1,151 @@
+# name: test/sql/alter/promote_type_all.test
+# description: test ducklake type promotion rules (widening casts)
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_promote_type_all', METADATA_CATALOG 'xx')
+
+# -------------------------------------------------------
+# Signed integer widening chain
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.ti(c TINYINT);
+
+# allowed: TINYINT -> SMALLINT -> INTEGER -> BIGINT -> HUGEINT
+statement ok
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE SMALLINT;
+
+statement ok
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE INTEGER;
+
+statement ok
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE BIGINT;
+
+statement ok
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE HUGEINT;
+
+# rejected: narrowing back down
+statement error
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE BIGINT;
+----
+only widening
+
+statement error
+ALTER TABLE ducklake.ti ALTER COLUMN c SET DATA TYPE INTEGER;
+----
+only widening
+
+# -------------------------------------------------------
+# TINYINT -> FLOAT -> DOUBLE
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.ti_f(c TINYINT);
+
+statement ok
+ALTER TABLE ducklake.ti_f ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+ALTER TABLE ducklake.ti_f ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+# rejected: DOUBLE -> FLOAT (narrowing)
+statement error
+ALTER TABLE ducklake.ti_f ALTER COLUMN c SET DATA TYPE FLOAT;
+----
+only widening
+
+# -------------------------------------------------------
+# Unsigned integer widening chain
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.uti(c UTINYINT);
+
+# allowed: UTINYINT -> USMALLINT -> UINTEGER -> UBIGINT
+statement ok
+ALTER TABLE ducklake.uti ALTER COLUMN c SET DATA TYPE USMALLINT;
+
+statement ok
+ALTER TABLE ducklake.uti ALTER COLUMN c SET DATA TYPE UINTEGER;
+
+statement ok
+ALTER TABLE ducklake.uti ALTER COLUMN c SET DATA TYPE UBIGINT;
+
+# rejected: UBIGINT -> UINTEGER (narrowing)
+statement error
+ALTER TABLE ducklake.uti ALTER COLUMN c SET DATA TYPE UINTEGER;
+----
+only widening
+
+# -------------------------------------------------------
+# Unsigned -> Signed cross-family
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.uti2(c UTINYINT);
+
+# allowed: UTINYINT -> SMALLINT
+statement ok
+ALTER TABLE ducklake.uti2 ALTER COLUMN c SET DATA TYPE SMALLINT;
+
+# -------------------------------------------------------
+# FLOAT -> DOUBLE
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.fl(c FLOAT);
+
+statement ok
+ALTER TABLE ducklake.fl ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+# rejected: DOUBLE -> FLOAT (narrowing)
+statement error
+ALTER TABLE ducklake.fl ALTER COLUMN c SET DATA TYPE FLOAT;
+----
+only widening
+
+# -------------------------------------------------------
+# TIMESTAMP -> TIMESTAMP WITH TIME ZONE
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.ts(c TIMESTAMP);
+
+statement ok
+ALTER TABLE ducklake.ts ALTER COLUMN c SET DATA TYPE TIMESTAMPTZ;
+
+# rejected: TIMESTAMPTZ -> TIMESTAMP (narrowing)
+statement error
+ALTER TABLE ducklake.ts ALTER COLUMN c SET DATA TYPE TIMESTAMP;
+----
+only widening
+
+# -------------------------------------------------------
+# Rejected: incompatible type changes
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.rej(c INTEGER);
+
+# rejected: INTEGER -> VARCHAR
+statement error
+ALTER TABLE ducklake.rej ALTER COLUMN c SET DATA TYPE VARCHAR;
+----
+only widening
+
+# rejected: INTEGER -> BOOLEAN
+statement error
+ALTER TABLE ducklake.rej ALTER COLUMN c SET DATA TYPE BOOLEAN;
+----
+only widening
+
+# -------------------------------------------------------
+# Same type is a no-op, not a promotion error
+# -------------------------------------------------------
+statement ok
+CREATE TABLE ducklake.same(c INTEGER);
+
+statement ok
+ALTER TABLE ducklake.same ALTER COLUMN c SET DATA TYPE INTEGER;


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1127

According to the physical/logical type mapping
- `UINTEGER` type is of `uint32_t` physical type: https://github.com/duckdb/duckdb/blob/b3ed0d5191465b8e10fc1dc74fe1880e26e4ca45/src/include/duckdb/common/types/value.hpp#L401-L403
- `BIGINT` type of of `int64_t` physical type: https://github.com/duckdb/duckdb/blob/b3ed0d5191465b8e10fc1dc74fe1880e26e4ca45/src/include/duckdb/common/types/value.hpp#L385-L387
- So we `UINTEGER` columns should be able to cast to `BIGINT`

Update: use DuckDB type promotion check function to unlock all possible type conversions.