### PR TITLE
Fix table/scalar macro with same name creation in same txn

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -335,6 +335,7 @@ private:
 	void AlterEntryInternal(DuckLakeViewEntry &old_entry, unique_ptr<CatalogEntry> new_entry);
 	void AddTableChanges(TableIndex table_id, const LocalTableDataChanges &table_changes,
 	                     TransactionChangeInformation &changes) const;
+	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> &GetNewMacroMap(CatalogType type);
 
 private:
 	DuckLakeCatalog &ducklake_catalog;
@@ -351,8 +352,9 @@ private:
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_tables;
 	set<TableIndex> dropped_tables;
 
-	//! New macros added by this transaction
-	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_macros;
+	//! New macros added by this transaction.
+	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_scalar_macros;
+	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> new_table_macros;
 	set<MacroIndex> dropped_scalar_macros;
 	set<MacroIndex> dropped_table_macros;
 

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -408,7 +408,8 @@ void DuckLakeSchemaEntry::AddEntry(CatalogType type, unique_ptr<CatalogEntry> en
 
 void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool cascade) {
 	auto local_tables = transaction.GetTransactionLocalEntries(CatalogType::TABLE_ENTRY, name);
-	auto local_macros = transaction.GetTransactionLocalEntries(CatalogType::MACRO_ENTRY, name);
+	auto local_scalar_macros = transaction.GetTransactionLocalEntries(CatalogType::MACRO_ENTRY, name);
+	auto local_table_macros = transaction.GetTransactionLocalEntries(CatalogType::TABLE_MACRO_ENTRY, name);
 	if (!cascade) {
 		// get a list of all dependents
 		vector<reference<CatalogEntry>> dependents;
@@ -482,9 +483,15 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 				dependents.push_back(*entry.second);
 			}
 		}
-		if (local_macros) {
-			dependents.reserve(dependents.size() + local_macros->GetEntries().size());
-			for (auto &entry : local_macros->GetEntries()) {
+		if (local_scalar_macros) {
+			dependents.reserve(dependents.size() + local_scalar_macros->GetEntries().size());
+			for (auto &entry : local_scalar_macros->GetEntries()) {
+				dependents.push_back(*entry.second);
+			}
+		}
+		if (local_table_macros) {
+			dependents.reserve(dependents.size() + local_table_macros->GetEntries().size());
+			for (auto &entry : local_table_macros->GetEntries()) {
 				dependents.push_back(*entry.second);
 			}
 		}
@@ -509,9 +516,15 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 			local_entries_to_drop.push_back(*entry.second);
 		}
 	}
-	if (local_macros) {
-		local_entries_to_drop.reserve(local_entries_to_drop.size() + local_macros->GetEntries().size());
-		for (auto &entry : local_macros->GetEntries()) {
+	if (local_scalar_macros) {
+		local_entries_to_drop.reserve(local_entries_to_drop.size() + local_scalar_macros->GetEntries().size());
+		for (auto &entry : local_scalar_macros->GetEntries()) {
+			local_entries_to_drop.push_back(*entry.second);
+		}
+	}
+	if (local_table_macros) {
+		local_entries_to_drop.reserve(local_entries_to_drop.size() + local_table_macros->GetEntries().size());
+		for (auto &entry : local_table_macros->GetEntries()) {
 			local_entries_to_drop.push_back(*entry.second);
 		}
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -734,10 +734,23 @@ Connection &DuckLakeTransaction::GetConnection() {
 	return *connection;
 }
 
+case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> &DuckLakeTransaction::GetNewMacroMap(CatalogType type) {
+	switch (type) {
+	case CatalogType::MACRO_ENTRY:
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		return new_scalar_macros;
+	case CatalogType::TABLE_MACRO_ENTRY:
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+		return new_table_macros;
+	default:
+		throw InternalException("Unsupported catalog type for GetNewMacroMap");
+	}
+}
+
 bool DuckLakeTransaction::SchemaChangesMade() const {
 	return !new_tables.empty() || !dropped_tables.empty() || new_schemas || !dropped_schemas.empty() ||
-	       !dropped_views.empty() || !renamed_views.empty() || !new_macros.empty() ||
-	       !dropped_scalar_macros.empty() || !dropped_table_macros.empty();
+	       !dropped_views.empty() || !renamed_views.empty() || !new_scalar_macros.empty() ||
+	       !new_table_macros.empty() || !dropped_scalar_macros.empty() || !dropped_table_macros.empty();
 }
 
 bool DuckLakeTransaction::ChangesMade() const {
@@ -875,24 +888,18 @@ TransactionChangeInformation DuckLakeTransaction::GetTransactionChanges() const 
 			changes.created_schemas.insert(schema_entry.name);
 		}
 	}
-	for (auto &schema_entry : new_macros) {
+	for (auto &schema_entry : new_scalar_macros) {
 		for (auto &entry : schema_entry.second->GetEntries()) {
-			switch (entry.second->type) {
-			case CatalogType::MACRO_ENTRY: {
-				auto &macro = *entry.second;
-				auto &schema = macro.ParentSchema().Cast<DuckLakeSchemaEntry>();
-				changes.created_scalar_macros[schema.name].insert(macro);
-				break;
-			}
-			case CatalogType::TABLE_MACRO_ENTRY: {
-				auto &macro = *entry.second;
-				auto &schema = macro.ParentSchema().Cast<DuckLakeSchemaEntry>();
-				changes.created_table_macros[schema.name].insert(macro);
-				break;
-			}
-			default:
-				throw InternalException("Unsupported type found in new_macros");
-			}
+			auto &macro = *entry.second;
+			auto &schema = macro.ParentSchema().Cast<DuckLakeSchemaEntry>();
+			changes.created_scalar_macros[schema.name].insert(macro);
+		}
+	}
+	for (auto &schema_entry : new_table_macros) {
+		for (auto &entry : schema_entry.second->GetEntries()) {
+			auto &macro = *entry.second;
+			auto &schema = macro.ParentSchema().Cast<DuckLakeSchemaEntry>();
+			changes.created_table_macros[schema.name].insert(macro);
 		}
 	}
 	for (auto &schema_entry : new_tables) {
@@ -1932,16 +1939,14 @@ NewTableInfo DuckLakeTransaction::GetNewTables(DuckLakeCommitState &commit_state
 NewMacroInfo DuckLakeTransaction::GetNewMacros(DuckLakeCommitState &commit_state,
                                                TransactionChangeInformation &transaction_changes) {
 	NewMacroInfo result;
-	for (auto &schema_entry : new_macros) {
+	for (auto &schema_entry : new_scalar_macros) {
 		for (auto &entry : schema_entry.second->GetEntries()) {
-			switch (entry.second->type) {
-			case CatalogType::MACRO_ENTRY:
-			case CatalogType::TABLE_MACRO_ENTRY:
-				GetNewMacroInfo(commit_state, *entry.second, result);
-				break;
-			default:
-				throw InternalException("Unknown type in GetNewMacros");
-			}
+			GetNewMacroInfo(commit_state, *entry.second, result);
+		}
+	}
+	for (auto &schema_entry : new_table_macros) {
+		for (auto &entry : schema_entry.second->GetEntries()) {
+			GetNewMacroInfo(commit_state, *entry.second, result);
 		}
 	}
 	return result;
@@ -2367,7 +2372,7 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 		new_inlined_data_tables_result = result.new_inlined_data_tables;
 	}
 
-	if (!new_macros.empty()) {
+	if (!new_scalar_macros.empty() || !new_table_macros.empty()) {
 		auto result = GetNewMacros(commit_state, transaction_changes);
 		batch_queries += metadata_manager->WriteNewMacros(result.new_macros);
 	}
@@ -3015,11 +3020,15 @@ void DuckLakeTransaction::DropEntry(CatalogEntry &entry) {
 	case CatalogType::TABLE_MACRO_ENTRY: {
 		auto local_entry = GetTransactionLocalEntry(entry.type, entry.ParentSchema().name, entry.name);
 		if (local_entry) {
-			auto schema_entry = new_macros.find(entry.ParentSchema().name);
-			if (schema_entry == new_macros.end()) {
-				throw InternalException("Dropping a transaction local macro that does not exist.");
+			auto &macro_map = GetNewMacroMap(entry.type);
+			auto schema_entry = macro_map.find(entry.ParentSchema().name);
+			if (schema_entry == macro_map.end()) {
+				throw InternalException("Dropping a transaction local macro %s that does not exist.", entry.name);
 			}
 			schema_entry->second->DropEntry(entry.name);
+			if (schema_entry->second->GetEntries().empty()) {
+				macro_map.erase(schema_entry);
+			}
 		} else if (entry.type == CatalogType::MACRO_ENTRY) {
 			DropScalarMacro(entry.Cast<DuckLakeScalarMacroEntry>());
 		} else {
@@ -3184,9 +3193,10 @@ DuckLakeCatalogSet &DuckLakeTransaction::GetOrCreateTransactionLocalEntries(Cata
 	}
 	case CatalogType::MACRO_ENTRY:
 	case CatalogType::TABLE_MACRO_ENTRY: {
+		auto &macro_map = GetNewMacroMap(catalog_type);
 		auto new_macro_list = make_uniq<DuckLakeCatalogSet>();
 		auto &result = *new_macro_list;
-		new_macros.insert(make_pair(schema_name, std::move(new_macro_list)));
+		macro_map.insert(make_pair(schema_name, std::move(new_macro_list)));
 		return result;
 	}
 	default:
@@ -3223,8 +3233,9 @@ optional_ptr<DuckLakeCatalogSet> DuckLakeTransaction::GetTransactionLocalEntries
 	case CatalogType::TABLE_MACRO_ENTRY:
 	case CatalogType::SCALAR_FUNCTION_ENTRY:
 	case CatalogType::TABLE_FUNCTION_ENTRY: {
-		auto entry = new_macros.find(schema_name);
-		if (entry == new_macros.end()) {
+		auto &macro_map = GetNewMacroMap(catalog_type);
+		auto entry = macro_map.find(schema_name);
+		if (entry == macro_map.end()) {
 			return nullptr;
 		}
 		return entry->second;

--- a/test/sql/macros/test_multi_macro_transaction.test
+++ b/test/sql/macros/test_multi_macro_transaction.test
@@ -1,0 +1,49 @@
+# name: test/sql/macros/test_multi_macro_transaction.test
+# description: test creating scalar + table macro with same name in one transaction
+# group: [macros]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/test_multi_macro_txn');
+
+statement ok
+USE ducklake;
+
+statement ok
+BEGIN
+
+statement ok
+CREATE MACRO bar(x) AS x + 1;
+
+statement ok
+CREATE MACRO bar(x, y) AS TABLE SELECT x AS a, y AS b;
+
+query I
+SELECT bar(41);
+----
+42
+
+query II
+FROM bar(10, 20);
+----
+10	20
+
+statement ok
+COMMIT
+
+query I
+SELECT bar(99);
+----
+100
+
+query II
+FROM bar(1, 2);
+----
+1	2


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1131

The root cause of the issue is
- For committed entries, scalar and table macros are stored as separate data members: https://github.com/duckdb/ducklake/blob/de16277a2eefd90077de2ccba3da7edd2aa565ec/src/include/storage/ducklake_schema_entry.hpp#L77-L78
- While inside of a transaction, these two macros are stored in the same field: https://github.com/duckdb/ducklake/blob/de16277a2eefd90077de2ccba3da7edd2aa565ec/src/include/storage/ducklake_transaction.hpp#L354-L355

So the fix in this PR is fairly straightforward, just to split the new macro map into two parts and update all usages.