### PR TITLE
Fix column rename with case insensitive case

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -640,7 +640,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	ColumnList new_columns;
 	for (auto &col : columns.Logical()) {
 		auto copy = col.Copy();
-		if (copy.Name() == info.old_name) {
+		if (StringUtil::CIEquals(copy.Name(), info.old_name)) {
 			copy.SetName(info.new_name);
 		}
 		new_columns.AddColumn(std::move(copy));

--- a/test/sql/alter/rename_column_with_case_insensitive_name.test
+++ b/test/sql/alter/rename_column_with_case_insensitive_name.test
@@ -1,0 +1,20 @@
+# name: test/sql/alter/rename_column_with_case_insensitive_name.test
+# description: test ducklake column rename with case insensitive name
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_promote_type_files', METADATA_CATALOG 'xx')
+
+statement ok
+CREATE TABLE ducklake.test("MyCol" INT);
+
+statement ok
+ALTER TABLE ducklake.test RENAME COLUMN mycol to newname;


### PR DESCRIPTION
Close https://github.com/duckdb/ducklake/issues/1137

The issue is:
- DuckDB treats column name as case insensitive: https://github.com/duckdb/duckdb/blob/0929f580c838801485ac58864a232a58c63981a6/src/include/duckdb/parser/column_list.hpp#L65-L66
- when we rename, we seem to throw away the case insensitive logic, which leaves table column list unchanged: https://github.com/duckdb/ducklake/blob/c80b9155c8ff260778b6a5bc726e50d65edc84dc/src/storage/ducklake_table_entry.cpp#L661