### PR TITLE
Use ANSI CAST(...) instead of `::` cast operator throughout

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -143,10 +143,14 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 	case LogicalTypeId::TIMESTAMP_NS:
 	case LogicalTypeId::BLOB:
 	case LogicalTypeId::GEOMETRY:
-		return "'" + value.ToString() + "'::" + value_type;
+		// ANSI CAST(value AS type) instead of the PostgreSQL-flavored
+		// `'value'::type` operator: SQLite's parser rejects `::` outright,
+		// which breaks SQLite-backed metadata backends that ship these
+		// inlined-INSERT batches directly to SQLite.
+		return StringUtil::Format("CAST('%s' AS %s)", value.ToString(), value_type);
 	case LogicalTypeId::INTERVAL: {
 		auto interval = IntervalValue::Get(value);
-		return StringUtil::Format("'%d months %d days %lld microseconds'::%s", interval.months, interval.days,
+		return StringUtil::Format("CAST('%d months %d days %lld microseconds' AS %s)", interval.months, interval.days,
 		                          interval.micros, value_type);
 	}
 	case LogicalTypeId::VARCHAR:
@@ -190,14 +194,14 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 	case LogicalTypeId::FLOAT: {
 		float fval = FloatValue::Get(value);
 		if (!Value::FloatIsFinite(fval) || (fval == 0.0f && std::signbit(fval))) {
-			return "'" + value.ToString() + "'::" + value_type;
+			return StringUtil::Format("CAST('%s' AS %s)", value.ToString(), value_type);
 		}
 		return value.ToString();
 	}
 	case LogicalTypeId::DOUBLE: {
 		double val = DoubleValue::Get(value);
 		if (!Value::DoubleIsFinite(val) || (val == 0.0 && std::signbit(val))) {
-			return "'" + value.ToString() + "'::" + value_type;
+			return StringUtil::Format("CAST('%s' AS %s)", value.ToString(), value_type);
 		}
 		return value.ToString();
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1077,7 +1077,8 @@ string DuckLakeMetadataManager::CastStatsToTarget(const string &stats, const Log
 }
 
 string DuckLakeMetadataManager::CastColumnToTarget(const string &column, const LogicalType &type) {
-	return column + "::" + type.ToString();
+	// ANSI CAST(...) — same reason as elsewhere: SQLite rejects `::` casts.
+	return "CAST(" + column + " AS " + type.ToString() + ")";
 }
 
 string DuckLakeMetadataManager::GenerateConstantFilter(const ConstantFilter &constant_filter, const LogicalType &type,
@@ -3966,12 +3967,17 @@ string DuckLakeMetadataManager::UpdateGlobalTableStats(const DuckLakeGlobalStats
 		    "UPDATE {METADATA_CATALOG}.ducklake_table_stats SET record_count=%d, file_size_bytes=%d, "
 		    "next_row_id=%d WHERE table_id=%d;",
 		    stats.record_count, stats.table_size_bytes, stats.next_row_id, stats.table_id.index);
+		// Use ANSI CAST(... AS BOOLEAN) instead of the PostgreSQL-flavored
+		// `::boolean` operator. Both DuckDB and Postgres accept ANSI CAST,
+		// and SQLite's parser rejects `::` outright (SQLITE_ERROR:
+		// unrecognized token ":"), which breaks SQLite-backed metadata
+		// backends that ship this batch directly to SQLite.
 		batch_query += StringUtil::Format(R"(
 WITH new_values(tid, cid, new_contains_null, new_contains_nan, new_min, new_max, new_extra_stats) AS (
 VALUES %s
 )
 UPDATE {METADATA_CATALOG}.ducklake_table_column_stats
-SET contains_null=CAST(new_contains_null AS boolean), contains_nan=CAST(new_contains_nan AS boolean), min_value=new_min, max_value=new_max, extra_stats=new_extra_stats
+SET contains_null=CAST(new_contains_null AS BOOLEAN), contains_nan=CAST(new_contains_nan AS BOOLEAN), min_value=new_min, max_value=new_max, extra_stats=new_extra_stats
 FROM new_values
 WHERE table_id=tid AND column_id=cid;
 )",


### PR DESCRIPTION
The `'value'::TYPE` cast syntax is PostgreSQL/DuckDB-flavored and is rejected by SQLite's parser with `SQLITE_ERROR: unrecognized token ":"`. When these inlined-INSERT and filter-pushdown SQL batches are shipped verbatim to a SQLite-backed metadata backend, the `::` operator breaks writes for TIMESTAMP / DATE / UUID / BLOB / GEOMETRY / INTERVAL / non-finite FLOAT/DOUBLE columns: rows are silently dropped and the user-visible SELECT returns zero rows.

Switch to ANSI `CAST(value AS TYPE)`, which DuckDB, Postgres, and SQLite all accept. Covers:

  * `ToSQLString` (date/time, UUID, BLOB, GEOMETRY)
  * `ToSQLString` interval encoding
  * `ToSQLString` non-finite FLOAT/DOUBLE special-case branches
  * `DuckLakeMetadataManager::CastColumnToTarget`
  * `UpdateGlobalTableStats` boolean cast (already in place)