### PR TITLE
Add ducklake_target_file_size session setting

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -34,6 +34,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("ducklake_default_data_inlining_row_limit",
 	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
 	                          Value::UBIGINT(10), nullptr, SetScope::GLOBAL);
+	config.AddExtensionOption("ducklake_target_file_size", "Target file size for insertion and compaction",
+	                          LogicalType::VARCHAR, Value(), nullptr, SetScope::GLOBAL);
 	config.AddExtensionOption(
 	    "ducklake_write_deletion_vectors",
 	    "[EXPERIMENTAL] Write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)",

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -34,8 +34,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("ducklake_default_data_inlining_row_limit",
 	                          "Default row limit for data inlining (0 disables inlining)", LogicalType::UBIGINT,
 	                          Value::UBIGINT(10), nullptr, SetScope::GLOBAL);
+	auto set_target_file_size = [](ClientContext &, SetScope, Value &parameter) {
+		if (!parameter.IsNull() && !parameter.ToString().empty()) {
+			DBConfig::ParseMemoryLimit(parameter.ToString());
+		}
+	};
 	config.AddExtensionOption("ducklake_target_file_size", "Target file size for insertion and compaction",
-	                          LogicalType::VARCHAR, Value(), nullptr, SetScope::GLOBAL);
+	                          LogicalType::VARCHAR, Value(), set_target_file_size, SetScope::GLOBAL);
 	config.AddExtensionOption(
 	    "ducklake_write_deletion_vectors",
 	    "[EXPERIMENTAL] Write Iceberg V3 deletion vectors (puffin) instead of positional delete files (parquet)",

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -259,11 +259,7 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 	auto &metadata_manager = transaction.GetMetadataManager();
 	auto snapshot = transaction.GetSnapshot();
 
-	idx_t target_file_size = DuckLakeCatalog::DEFAULT_TARGET_FILE_SIZE;
-	string target_file_size_str;
-	if (catalog.TryGetConfigOption("target_file_size", target_file_size_str, table)) {
-		target_file_size = Value(target_file_size_str).DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
-	}
+	idx_t target_file_size = catalog.GetTargetFileSize(context, table);
 
 	DuckLakeFileSizeOptions filter_options;
 	filter_options.min_file_size = options.min_file_size;

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -116,6 +116,8 @@ public:
 	idx_t DataInliningRowLimit(ClientContext &context, SchemaIndex schema_index, TableIndex table_index) const;
 	//! Returns the inlining limit (0 if the table is not eligible)
 	idx_t GetInliningLimit(ClientContext &context, DuckLakeTableEntry &table);
+	idx_t GetTargetFileSize(ClientContext &context, SchemaIndex schema_id, TableIndex table_id) const;
+	idx_t GetTargetFileSize(ClientContext &context, DuckLakeTableEntry &table) const;
 	string &Separator() {
 		return separator;
 	}

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
@@ -899,6 +900,20 @@ idx_t DuckLakeCatalog::DataInliningRowLimit(ClientContext &context, SchemaIndex 
 		return setting_val.GetValue<idx_t>();
 	}
 	return 10;
+}
+
+idx_t DuckLakeCatalog::GetTargetFileSize(ClientContext &context, SchemaIndex schema_id, TableIndex table_id) const {
+	Value setting_val;
+	if (context.TryGetCurrentSetting("ducklake_target_file_size", setting_val) && !setting_val.IsNull() &&
+	    !setting_val.ToString().empty()) {
+		return DBConfig::ParseMemoryLimit(setting_val.ToString());
+	}
+	return GetConfigOption<idx_t>("target_file_size", schema_id, table_id, DEFAULT_TARGET_FILE_SIZE);
+}
+
+idx_t DuckLakeCatalog::GetTargetFileSize(ClientContext &context, DuckLakeTableEntry &table) const {
+	auto &schema = table.ParentSchema().Cast<DuckLakeSchemaEntry>();
+	return GetTargetFileSize(context, schema.GetSchemaId(), table.GetTableId());
 }
 
 idx_t DuckLakeCatalog::GetInliningLimit(ClientContext &context, DuckLakeTableEntry &table) {

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -514,8 +514,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	if (catalog.TryGetConfigOption("per_thread_output", per_thread_output_str, schema_id, table_id)) {
 		per_thread_output = per_thread_output_str == "true";
 	}
-	idx_t target_file_size = catalog.GetConfigOption<idx_t>("target_file_size", schema_id, table_id,
-	                                                        DuckLakeCatalog::DEFAULT_TARGET_FILE_SIZE);
+	idx_t target_file_size = catalog.GetTargetFileSize(context, schema_id, table_id);
 
 	// Always use native parquet geometry for writing
 	info->options["geoparquet_version"].emplace_back("NONE");

--- a/test/sql/compaction/compaction_session_target_file_size.test
+++ b/test/sql/compaction/compaction_session_target_file_size.test
@@ -1,0 +1,81 @@
+# name: test/sql/compaction/compaction_session_target_file_size.test
+# description: test that ducklake_target_file_size session setting governs compaction output target size
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/compaction_session_target_file_size', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake;
+
+# Set a tiny metadata target_file_size at all scopes so compaction would produce many output files
+statement ok
+CALL ducklake_set_option('ducklake', 'target_file_size', '1B');
+
+statement ok
+CREATE TABLE example (id INTEGER, s VARCHAR);
+
+statement ok
+CALL ducklake_set_option('ducklake', 'target_file_size', '1B', schema => 'main');
+
+statement ok
+CALL ducklake_set_option('ducklake', 'target_file_size', '1B', table_name => 'example');
+
+statement ok
+INSERT INTO example SELECT i, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 10000, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 20000, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 30000, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+----
+4
+
+# Session setting overrides metadata target - compaction merges all 4 files into 1
+statement ok
+SET ducklake_target_file_size = '512MB'
+
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example')
+----
+main	example	4	1
+
+query I
+SELECT COUNT(*) FROM example
+----
+40000
+
+# Reset the session - metadata target (1B) governs again
+statement ok
+RESET ducklake_target_file_size
+
+statement ok
+INSERT INTO example SELECT i, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 10000, concat('thisisalongstring', i) FROM range(10000) t(i);
+
+# With metadata target_file_size = 1B, files above target are not merged - compaction skips them
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example')
+----
+
+query I
+SELECT COUNT(*) FROM example
+----
+60000

--- a/test/sql/insert/insert_session_target_file_size.test
+++ b/test/sql/insert/insert_session_target_file_size.test
@@ -31,6 +31,11 @@ statement error
 SET ducklake_target_file_size = 'not-a-size'
 ----
 
+# 0 should fail at SET time
+statement error
+SET ducklake_target_file_size = '0'
+----
+
 # Session setting overrides all metadata scopes - should produce multiple files
 statement ok
 SET ducklake_target_file_size = '10KB'

--- a/test/sql/insert/insert_session_target_file_size.test
+++ b/test/sql/insert/insert_session_target_file_size.test
@@ -1,0 +1,54 @@
+# name: test/sql/insert/insert_session_target_file_size.test
+# description: test that ducklake_target_file_size session setting overrides metadata target_file_size
+# group: [insert]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_session_target_file_size')
+
+statement ok
+CREATE TABLE ducklake.test(id INTEGER, s VARCHAR);
+
+# Set a large target_file_size in metadata so everything fits in one file
+statement ok
+CALL ducklake.set_option('target_file_size', '512MB')
+
+# Override with a tiny session setting - should produce multiple files
+statement ok
+SET ducklake_target_file_size = '10KB'
+
+query I
+INSERT INTO ducklake.test SELECT i, concat('thisisalongstring', i) FROM range(500000) t(i)
+----
+500000
+
+# Session setting should have taken precedence: multiple files expected
+query I
+SELECT COUNT(*) > 1 FROM glob('{DATA_PATH}/ducklake_session_target_file_size/main/test/*.parquet')
+----
+true
+
+# Reset the session setting - metadata value (512MB) should now govern: everything in one file
+statement ok
+RESET ducklake_target_file_size
+
+statement ok
+CREATE TABLE ducklake.test2(id INTEGER, s VARCHAR);
+
+query I
+INSERT INTO ducklake.test2 SELECT i, concat('thisisalongstring', i) FROM range(500000) t(i)
+----
+500000
+
+query I
+SELECT COUNT(*) = 1 FROM glob('{DATA_PATH}/ducklake_session_target_file_size/main/test2/*.parquet')
+----
+true

--- a/test/sql/insert/insert_session_target_file_size.test
+++ b/test/sql/insert/insert_session_target_file_size.test
@@ -6,22 +6,32 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
-test-env DATA_PATH {TEST_DIR}
-
+test-env DATA_PATH __TEST_DIR__
 
 statement ok
-ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_session_target_file_size')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_session_target_file_size')
 
 statement ok
 CREATE TABLE ducklake.test(id INTEGER, s VARCHAR);
 
-# Set a large target_file_size in metadata so everything fits in one file
+# Set a large target_file_size in metadata at global, schema and table scope
 statement ok
 CALL ducklake.set_option('target_file_size', '512MB')
 
-# Override with a tiny session setting - should produce multiple files
+statement ok
+CALL ducklake.set_option('target_file_size', '512MB', schema => 'main')
+
+statement ok
+CALL ducklake.set_option('target_file_size', '512MB', table_name => 'test')
+
+# A borked string should fail at SET time
+statement error
+SET ducklake_target_file_size = 'not-a-size'
+----
+
+# Session setting overrides all metadata scopes - should produce multiple files
 statement ok
 SET ducklake_target_file_size = '10KB'
 
@@ -30,9 +40,9 @@ INSERT INTO ducklake.test SELECT i, concat('thisisalongstring', i) FROM range(50
 ----
 500000
 
-# Session setting should have taken precedence: multiple files expected
+# Session setting should have taken precedence over all metadata scopes: multiple files expected
 query I
-SELECT COUNT(*) > 1 FROM glob('{DATA_PATH}/ducklake_session_target_file_size/main/test/*.parquet')
+SELECT COUNT(*) > 1 FROM glob('${DATA_PATH}/ducklake_session_target_file_size/main/test/*.parquet')
 ----
 true
 
@@ -49,6 +59,6 @@ INSERT INTO ducklake.test2 SELECT i, concat('thisisalongstring', i) FROM range(5
 500000
 
 query I
-SELECT COUNT(*) = 1 FROM glob('{DATA_PATH}/ducklake_session_target_file_size/main/test2/*.parquet')
+SELECT COUNT(*) = 1 FROM glob('${DATA_PATH}/ducklake_session_target_file_size/main/test2/*.parquet')
 ----
 true


### PR DESCRIPTION
This PR adds a `ducklake_target_file_size` session-level setting that overrides the `target_file_size` metadata option for both inserts and compaction. This is useful when concurrent sessions need different file size targets; for example, a background compaction session targeting large files while foreground inserts use a smaller size, without either modifying the shared catalog metadata.