### PR TITLE
Remove orphaned inlined tables

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -250,6 +250,9 @@ public:
 	//! Cache the result of an inlined deletion table existence check
 	void CacheInlinedDeletionTableResult(TableIndex table_id, DuckLakeSnapshot snapshot, bool exists);
 
+	//! Invalidate the cached schema entry for a given schema_version.
+	void InvalidateSchemaCache(idx_t schema_version);
+
 private:
 	void DropSchema(ClientContext &context, DropInfo &info) override;
 	unique_ptr<DuckLakeCatalogSet> LoadSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -243,6 +243,11 @@ public:
 
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());
 	virtual void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
+	//! After a flush has emptied inlined-data rows, drop any (tid, sv) physical
+	//! table that is superseded by a newer schema_version on the same table_id
+	//! and is now empty. No more writes can land in such an entry, so the drop
+	//! is safe; invalidates the schema ObjectCache so in-session reads reload.
+	virtual void DropEmptySupersededInlinedTables();
 	virtual vector<DuckLakeTableSizeInfo> GetTableSizes(DuckLakeSnapshot snapshot);
 	virtual void SetConfigOption(const DuckLakeConfigOption &option);
 	virtual string GetPathForSchema(SchemaIndex schema_id, vector<DuckLakeSchemaInfo> &new_schemas_result);

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -953,6 +953,10 @@ string DuckLakeCatalog::SchemaCacheKey(idx_t schema_version) const {
 	return StringUtil::Format("ducklake:%s:%s:%s:schema:%llu", GetName(), MetadataPath(), instance_id, schema_version);
 }
 
+void DuckLakeCatalog::InvalidateSchemaCache(idx_t schema_version) {
+	GetObjectCacheInstance().Delete(SchemaCacheKey(schema_version));
+}
+
 string DuckLakeCatalog::SchemaPinStateKey() const {
 	return StringUtil::Format("ducklake_schema_pin:%s:%s:%s", GetName(), MetadataPath(), instance_id);
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4516,6 +4516,53 @@ WHERE NOT EXISTS (
 	}
 }
 
+void DuckLakeMetadataManager::DropEmptySupersededInlinedTables() {
+	// Gather the tables that are empty and have a later schema version, as it will be safe to delete their
+	// inlined tables.
+	auto targets = transaction.Query(R"(
+SELECT idt.table_id, idt.schema_version, idt.table_name
+FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt
+JOIN duckdb_tables() dt
+    ON dt.database_name = {METADATA_CATALOG_NAME_LITERAL}
+   AND dt.table_name = idt.table_name
+WHERE idt.schema_version < (
+    SELECT MAX(idt2.schema_version)
+    FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt2
+    WHERE idt2.table_id = idt.table_id
+)
+AND dt.estimated_size = 0;)");
+	if (targets->HasError()) {
+		targets->GetErrorObject().Throw("Failed to identify empty superseded inlined-data tables in DuckLake: ");
+	}
+	string drops;
+	for (auto &row : *targets) {
+		auto table_id = row.GetValue<idx_t>(0);
+		auto schema_version = row.GetValue<idx_t>(1);
+		auto table_name = row.GetValue<string>(2);
+		drops += StringUtil::Format(
+		    "DELETE FROM {METADATA_CATALOG}.ducklake_inlined_data_tables WHERE table_id=%d AND schema_version=%d;"
+		    "DROP TABLE IF EXISTS {METADATA_CATALOG}.%s;",
+		    table_id, schema_version, SQLIdentifier(table_name));
+	}
+	if (drops.empty()) {
+		return;
+	}
+	auto res = transaction.Query(drops);
+	if (res->HasError()) {
+		res->GetErrorObject().Throw("Failed to drop superseded inlined-data tables in DuckLake: ");
+	}
+	// We also need to invalidate the existing schema versions in our catalog
+	auto &catalog = transaction.GetCatalog();
+	auto snapshot_versions =
+	    transaction.Query("SELECT DISTINCT schema_version FROM {METADATA_CATALOG}.ducklake_snapshot;");
+	if (snapshot_versions->HasError()) {
+		snapshot_versions->GetErrorObject().Throw("Failed to list schema versions for cache invalidation: ");
+	}
+	for (auto &row : *snapshot_versions) {
+		catalog.InvalidateSchemaCache(row.GetValue<idx_t>(0));
+	}
+}
+
 void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table) {
 	auto result = transaction.Query(StringUtil::Format(R"(
 		DELETE FROM {METADATA_CATALOG}.%s

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4430,6 +4430,22 @@ VALUES %s;
 
 	// delete based on table id -> ducklake_table_stats, ducklake_table_column_stats, ducklake_partition_info
 	if (!deleted_table_ids.empty()) {
+		// Collect orphaned_inlined tables
+		vector<string> inlined_tables_to_drop;
+		{
+			auto result = transaction.Query(StringUtil::Format(R"(
+SELECT table_name
+FROM {METADATA_CATALOG}.ducklake_inlined_data_tables
+WHERE table_id IN (%s);)",
+			                                                   deleted_table_ids));
+			if (result->HasError()) {
+				result->GetErrorObject().Throw("Failed to read ducklake_inlined_data_tables for cleanup in DuckLake: ");
+			}
+			for (auto &row : *result) {
+				inlined_tables_to_drop.push_back(row.GetValue<string>(0));
+			}
+		}
+
 		tables_to_delete_from = {
 		    "ducklake_table",           "ducklake_table_stats",         "ducklake_table_column_stats",
 		    "ducklake_partition_info",  "ducklake_partition_column",    "ducklake_column",
@@ -4442,6 +4458,15 @@ WHERE table_id IN (%s);)",
 			                                                   delete_tbl, deleted_table_ids));
 			if (result->HasError()) {
 				result->GetErrorObject().Throw("Failed to delete from " + delete_tbl + " in DuckLake: ");
+			}
+		}
+
+		// Drop orphaned inlined tables
+		for (auto &inlined_table_name : inlined_tables_to_drop) {
+			auto result = transaction.Query(
+			    StringUtil::Format("DROP TABLE IF EXISTS {METADATA_CATALOG}.%s;", SQLIdentifier(inlined_table_name)));
+			if (result->HasError()) {
+				result->GetErrorObject().Throw("Failed to drop inlined-data table in DuckLake: ");
 			}
 		}
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2612,7 +2612,11 @@ void DuckLakeTransaction::FlushChanges() {
 			if (res->HasError()) {
 				res->GetErrorObject().Throw("Failed to flush changes into DuckLake: ");
 			}
+			bool flushed_inlined = !flushed_inlined_tables.empty();
 			connection->Commit();
+			if (flushed_inlined) {
+				metadata_manager->DropEmptySupersededInlinedTables();
+			}
 			catalog_version = commit_snapshot.schema_version;
 
 			// finished writing

--- a/test/sql/alter/add_column_default_stats.test
+++ b/test/sql/alter/add_column_default_stats.test
@@ -1,6 +1,6 @@
 # name: test/sql/alter/add_column_default_stats.test
 # description: verify min/max/null stats are correct after ADD COLUMN with DEFAULT on inlined data
-# group: [default]
+# group: [alter]
 
 require ducklake
 

--- a/test/sql/compaction/repro_merge_adjacent_zero_output.test
+++ b/test/sql/compaction/repro_merge_adjacent_zero_output.test
@@ -1,8 +1,9 @@
 # name: test/sql/compaction/repro_merge_adjacent_zero_output.test
 # description: reproduce DuckLakeCompaction "expected a single output file" assertion
+# group: [compaction]
+
 #              when merge_adjacent_files merges several empty parquet files.
 #              See https://github.com/duckdb/ducklake/issues/525
-# group: [compaction]
 
 require ducklake
 

--- a/test/sql/data_inlining/inlined_data_flush_cleanup.test
+++ b/test/sql/data_inlining/inlined_data_flush_cleanup.test
@@ -1,0 +1,60 @@
+# name: test/sql/data_inlining/inlined_data_flush_cleanup.test
+# description: validate inlined data of a superseeded schema gets deleted at flush
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/inlined_data_flush_cache.db' AS ducklake (DATA_PATH '__TEST_DIR__/inlined_data_flush_cache_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.t(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.t VALUES (1), (2), (3)
+
+statement ok
+ALTER TABLE ducklake.t ADD COLUMN j INTEGER
+
+statement ok
+INSERT INTO ducklake.t VALUES (4, 40)
+
+query I
+SELECT snapshot_id FROM ducklake_snapshots('ducklake') WHERE schema_version = 1 ORDER BY snapshot_id LIMIT 1
+----
+1
+
+query I
+SELECT COUNT(*) FROM ducklake.t AT (VERSION => 2)
+----
+3
+
+query I
+SELECT COUNT(*) FROM ducklake.t
+----
+4
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name = 'ducklake_inlined_data_1_1'
+----
+0
+
+query II
+SELECT COUNT(*), SUM(i) FROM ducklake.t
+----
+4	10
+
+query I
+SELECT COUNT(*) FROM ducklake.t AT (VERSION => 2)
+----
+3
+
+query II
+SELECT COUNT(*), SUM(i) FROM ducklake.t AT (VERSION => 4)
+----
+4	10

--- a/test/sql/data_inlining/inlined_data_table_leak.test
+++ b/test/sql/data_inlining/inlined_data_table_leak.test
@@ -1,0 +1,57 @@
+# name: test/sql/data_inlining/inlined_data_table_leak.test
+# description: verify that orphaned inlined tables ar edropped
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/inlined_data_table_leak_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.t1(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (1), (2), (3)
+
+statement ok
+ALTER TABLE ducklake.t1 ADD COLUMN j INTEGER
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (4, 40)
+
+statement ok
+ALTER TABLE ducklake.t1 ADD COLUMN k INTEGER
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (5, 50, 500)
+
+statement ok
+ALTER TABLE ducklake.t1 ADD COLUMN l INTEGER
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (6, 60, 600, 6000)
+
+statement ok
+DROP TABLE ducklake.t1
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
+
+query I
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_1_%'
+----
+0
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables WHERE table_id = 1
+----
+0


### PR DESCRIPTION
We remove inlined tables for two different reasons:
1. The OG table has been fully deleted and expired, hence it is no longer accessible.
2.  During flush, the inlined table is from a schema that has been superseded. As that inlined table will never have an insertion again (We might have to change this if we decide to do git branching in the future.)

Fix: https://github.com/duckdb/ducklake/issues/1088
Fix: https://github.com/duckdb/ducklake/issues/1065