### PR TITLE
fix: don't annotate non-native type values with ::TYPE inside STRUCT while Inlining

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -147,9 +147,19 @@ string ToSQLString(DuckLakeMetadataManager &metadata_manager, const Value &value
 		// `'value'::type` operator: SQLite's parser rejects `::` outright,
 		// which breaks SQLite-backed metadata backends that ship these
 		// inlined-INSERT batches directly to SQLite.
+		if (!use_native_type) {
+			// When the backend stores this type as VARCHAR, emit a plain quoted
+			// string with no type annotation. The CAST(... AS VARCHAR) suffix
+			// survives verbatim inside STRUCT string literals and breaks the
+			// struct-from-string parser on read-back.
+			return EscapeVarcharForSQL(value.ToString());
+		}
 		return StringUtil::Format("CAST('%s' AS %s)", value.ToString(), value_type);
 	case LogicalTypeId::INTERVAL: {
 		auto interval = IntervalValue::Get(value);
+		if (!use_native_type) {
+			return EscapeVarcharForSQL(value.ToString());
+		}
 		return StringUtil::Format("CAST('%d months %d days %lld microseconds' AS %s)", interval.months, interval.days,
 		                          interval.micros, value_type);
 	}

--- a/test/sql/data_inlining/data_inlining_struct_non_native_types.test
+++ b/test/sql/data_inlining/data_inlining_struct_non_native_types.test
@@ -7,7 +7,6 @@ require ducklake
 
 require parquet
 
-#FIXME: ADD THIS TO PG CI WHEN IT GETS BACK
 require-env DUCKLAKE_CI
 
 test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db

--- a/test/sql/data_inlining/data_inlining_struct_non_native_types.test
+++ b/test/sql/data_inlining/data_inlining_struct_non_native_types.test
@@ -1,0 +1,40 @@
+# name: test/sql/data_inlining/data_inlining_struct_non_native_types.test
+# description: STRUCT columns with non-natively-supported field types (e.g. TIMESTAMPTZ on Postgres)
+#              must round-trip correctly through inlining
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+#FIXME: ADD THIS TO PG CI WHEN IT GETS BACK
+require-env DUCKLAKE_CI
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/struct_non_native_files', DATA_INLINING_ROW_LIMIT 10)
+
+# STRUCT with TIMESTAMPTZ — non-native on Postgres, triggers CAST(... AS VARCHAR) in ToSQLString
+statement ok
+CREATE TABLE ducklake.t (id VARCHAR, attrs STRUCT(name VARCHAR, ts TIMESTAMPTZ));
+
+statement ok
+INSERT INTO ducklake.t VALUES ('row1', {'name': 'foo', 'ts': TIMESTAMPTZ '2026-05-13 04:56:37+00'});
+
+# Verify the row was inlined (no parquet file written)
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/struct_non_native_files/main/t/**/*.parquet')
+----
+0
+
+# Must round-trip without error
+statement ok
+SET timezone='UTC';
+
+query II
+SELECT id, attrs.ts FROM ducklake.t;
+----
+row1	2026-05-13 04:56:37+00


### PR DESCRIPTION
When a STRUCT column is inlined on Postgres/SQLite, field values of non-natively supported types (TIMESTAMPTZ, DATE, etc.) were serialized as CAST('value' AS VARCHAR). This annotation survives verbatim in the stored struct string and breaks the struct-from-string parser on read-back, causing an internal crash in TransformInlinedData.

Fix: emit a plain quoted string when !use_native_type since the storage column is already VARCHAR — the annotation is redundant and harmful in this context.


Related to https://github.com/duckdb/ducklake/issues/1155