### PR TITLE
Fix incorrect data when flushing inlined deletes with sorting

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -373,7 +373,7 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 
 unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
                                                           DuckLakeTableEntry &table,
-                                                          optional_ptr<DuckLakeSort> sort_data) {
+                                                          optional_ptr<DuckLakeSort> sort_data, bool add_tiebreakers) {
 	auto bindings = plan->GetColumnBindings();
 
 	// Parse the sort expressions from the sort_data
@@ -394,6 +394,44 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 
 	// Bind the ORDER BY expressions
 	auto orders = DuckLakeCompactor::BindSortOrders(binder, table, table_index, pre_bound_orders);
+
+	// Append (row_id, snapshot_id) as deterministic tiebreakers when requested so the file order
+	// exactly matches the deletes-position query's ORDER BY, including ties in the user sort key.
+	// We resolve binding positions by scanning the LogicalGet's column_ids for the virtual-column
+	// identifiers -- counting from latest_table.GetColumns().PhysicalColumnCount() would be wrong
+	// when the inlined-table physical layout differs from the latest table (e.g. after ALTER TABLE
+	// ADD COLUMN in the same transaction as the flush; covered by data_inlining_flush_sorted_alter_table.test).
+	if (add_tiebreakers) {
+		LogicalOperator *get_op = plan.get();
+		while (get_op->type != LogicalOperatorType::LOGICAL_GET) {
+			if (get_op->children.size() != 1) {
+				throw InternalException("DuckLakeCompactor::InsertSort: expected single-child operator chain to "
+				                        "LogicalGet when add_tiebreakers=true");
+			}
+			get_op = get_op->children[0].get();
+		}
+		auto &logical_get = get_op->Cast<LogicalGet>();
+		auto &column_ids = logical_get.GetColumnIds();
+		idx_t row_id_pos = DConstants::INVALID_INDEX;
+		idx_t snapshot_id_pos = DConstants::INVALID_INDEX;
+		for (idx_t i = 0; i < column_ids.size(); i++) {
+			auto primary = column_ids[i].GetPrimaryIndex();
+			if (primary == COLUMN_IDENTIFIER_ROW_ID) {
+				row_id_pos = i;
+			} else if (primary == DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID) {
+				snapshot_id_pos = i;
+			}
+		}
+		if (row_id_pos == DConstants::INVALID_INDEX || snapshot_id_pos == DConstants::INVALID_INDEX ||
+		    row_id_pos >= bindings.size() || snapshot_id_pos >= bindings.size()) {
+			throw InternalException("DuckLakeCompactor::InsertSort: row_id and snapshot_id virtual columns must be "
+			                        "present in the LogicalGet's column_ids when add_tiebreakers=true");
+		}
+		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, bindings[row_id_pos]));
+		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                    make_uniq<BoundColumnRefExpression>(LogicalType::BIGINT, bindings[snapshot_id_pos]));
+	}
 
 	// Create the LogicalOrder operator
 	auto order = make_uniq<LogicalOrder>(std::move(orders));

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -397,10 +397,7 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 
 	// Append (row_id, snapshot_id) as deterministic tiebreakers when requested so the file order
 	// exactly matches the deletes-position query's ORDER BY, including ties in the user sort key.
-	// We resolve binding positions by scanning the LogicalGet's column_ids for the virtual-column
-	// identifiers -- counting from latest_table.GetColumns().PhysicalColumnCount() would be wrong
-	// when the inlined-table physical layout differs from the latest table (e.g. after ALTER TABLE
-	// ADD COLUMN in the same transaction as the flush; covered by data_inlining_flush_sorted_alter_table.test).
+	// Handles ALTER TABLE ADD COLUMN in the same transaction as the flush
 	if (add_tiebreakers) {
 		LogicalOperator *get_op = plan.get();
 		while (get_op->type != LogicalOperatorType::LOGICAL_GET) {

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -141,9 +141,9 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
 			// When the table has sort metadata, the file is written in sorted order.
 			// The ORDER BY must match the actual file order so delete positions are correct.
-			string order_by = "row_id, begin_snapshot";
+			string order_by = "row_id ASC NULLS LAST, begin_snapshot ASC NULLS LAST";
 			if (!sort_order_sql.empty()) {
-				order_by = sort_order_sql + ", row_id, begin_snapshot";
+				order_by = sort_order_sql + ", row_id ASC NULLS LAST, begin_snapshot ASC NULLS LAST";
 			}
 			auto deleted_rows_result =
 			    transaction.Query(snapshot, StringUtil::Format(R"(
@@ -359,7 +359,7 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	string sort_order_sql;
 	auto sort_data = latest_table.GetSortData();
 	if (sort_data) {
-		root = DuckLakeCompactor::InsertSort(binder, root, latest_table, sort_data);
+		root = DuckLakeCompactor::InsertSort(binder, root, latest_table, sort_data, /*add_tiebreakers=*/true);
 		sort_order_sql = DuckLakeSort::BuildSortOrderSQL(*sort_data, latest_table.GetColumns(), table.GetColumns());
 	}
 

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -89,7 +89,8 @@ public:
 	void GenerateCompactions(DuckLakeTableEntry &table, vector<unique_ptr<LogicalOperator>> &compactions);
 	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files);
 	static unique_ptr<LogicalOperator> InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
-	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data);
+	                                              DuckLakeTableEntry &table, optional_ptr<DuckLakeSort> sort_data,
+	                                              bool add_tiebreakers = false);
 	static vector<OrderByNode> ParseSortOrders(const DuckLakeSort &sort_data);
 	static vector<BoundOrderByNode> BindSortOrders(Binder &binder, DuckLakeTableEntry &table, idx_t table_index,
 	                                               vector<OrderByNode> &pre_bound_orders);

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -3,36 +3,57 @@
 #include "duckdb/parser/column_list.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception_format_value.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
+#include "duckdb/common/case_insensitive_map.hpp"
 
 namespace duckdb {
 
+// Round-trip user sort expressions through the parser so non-bare-column expressions (e.g.
+// `(id + 0)`) survive into the deletes-position query. Parser::ParseExpressionList rejects
+// malformed input; ParsedExpression::ToString is the canonical re-serializer; the rename
+// rewrite touches only ColumnRefExpression::column_names. Macros and other user-catalog
+// references emit verbatim and will fail at bind time on the metadata connection -- this is
+// a clean error (vs v1.5's silent wrong delete positions when there are inlined deletes).
 string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
                                        const ColumnList &inlined_columns) {
+	// Build rename map: current physical name -> inlined physical name (only entries that differ).
+	case_insensitive_map_t<string> rename_map;
+	auto column_count = MinValue(current_columns.PhysicalColumnCount(), inlined_columns.PhysicalColumnCount());
+	for (idx_t i = 0; i < column_count; i++) {
+		auto &current_name = current_columns.GetColumn(PhysicalIndex(i)).Name();
+		auto &inlined_name = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
+		if (current_name != inlined_name) {
+			rename_map[current_name] = inlined_name;
+		}
+	}
+
 	string result;
 	for (auto &field : sort_data.fields) {
 		if (field.dialect != "duckdb") {
 			continue;
 		}
-		// Check if expression matches a column name in the current table, then map to inlined table's name by index
-		string mapped_col;
-		for (idx_t i = 0; i < current_columns.PhysicalColumnCount(); i++) {
-			if (StringUtil::CIEquals(
-			        KeywordHelper::WriteOptionallyQuoted(current_columns.GetColumn(PhysicalIndex(i)).Name()),
-			        field.expression)) {
-				if (i < inlined_columns.PhysicalColumnCount()) {
-					mapped_col = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
-				}
-				break;
-			}
-		}
-		if (mapped_col.empty()) {
-			// Not a simple column reference or column not found
-			return string();
-		}
 		if (!result.empty()) {
 			result += ", ";
 		}
-		result += StringUtil::Format("%s", SQLIdentifier(mapped_col));
+		// field.expression was produced by ParsedExpression::ToString() at ALTER time, so it is already
+		// canonical SQL. Only re-parse + rewrite when columns were renamed between the inlined-table
+		// write and the flush.
+		if (rename_map.empty()) {
+			result += field.expression;
+		} else {
+			auto parsed = Parser::ParseExpressionList(field.expression);
+			D_ASSERT(parsed.size() == 1);
+			ParsedExpressionIterator::VisitExpressionMutable<ColumnRefExpression>(
+			    *parsed[0], [&](ColumnRefExpression &colref) {
+				    auto entry = rename_map.find(colref.GetColumnName());
+				    if (entry != rename_map.end()) {
+					    colref.column_names.back() = entry->second;
+				    }
+			    });
+			result += parsed[0]->ToString();
+		}
 		result += (field.sort_direction == OrderType::ASCENDING) ? " ASC" : " DESC";
 		result += (field.null_order == OrderByNullType::NULLS_FIRST) ? " NULLS FIRST" : " NULLS LAST";
 	}

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -11,11 +11,9 @@
 namespace duckdb {
 
 // Round-trip user sort expressions through the parser so non-bare-column expressions (e.g.
-// `(id + 0)`) survive into the deletes-position query. Parser::ParseExpressionList rejects
-// malformed input; ParsedExpression::ToString is the canonical re-serializer; the rename
-// rewrite touches only ColumnRefExpression::column_names. Macros and other user-catalog
-// references emit verbatim and will fail at bind time on the metadata connection -- this is
-// a clean error (vs v1.5's silent wrong delete positions when there are inlined deletes).
+// `(id + 0)`) survive into the deletes-position query. 
+
+// FIXME: TODO: Macros and other user-catalog references will fail at bind time on the metadata connection 
 string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
                                        const ColumnList &inlined_columns) {
 	// Build rename map: current physical name -> inlined physical name (only entries that differ).
@@ -37,8 +35,7 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 		if (!result.empty()) {
 			result += ", ";
 		}
-		// field.expression was produced by ParsedExpression::ToString() at ALTER time, so it is already
-		// canonical SQL. Only re-parse + rewrite when columns were renamed between the inlined-table
+		// Only re-parse + rewrite when columns were renamed between the inlined-table
 		// write and the flush.
 		if (rename_map.empty()) {
 			result += field.expression;

--- a/test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999.test
@@ -1,0 +1,43 @@
+# name: test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999.test
+# description: issue #999 reproducer - flush_inlined_data with non-bare-column SORT BY and inlined deletes
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '__TEST_DIR__/issue_999/', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+USE dl
+
+statement ok
+CREATE TABLE t(id INTEGER, val INTEGER)
+
+statement ok
+INSERT INTO t VALUES (2, 0), (1, 0), (3, 0)
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+ALTER TABLE t SET SORTED BY ((id + 0) ASC NULLS LAST)
+
+statement ok
+CALL ducklake_flush_inlined_data('dl', table_name => 't')
+
+query II
+SELECT id, val FROM t ORDER BY id
+----
+1	0
+2	3
+3	0

--- a/test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999_transaction.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999_transaction.test
@@ -1,0 +1,56 @@
+# name: test/sql/sorted_table/data_inlining_flush_sorted_expression_deletes_999_transaction.test
+# description: issue #999 in-transaction variant - non-bare-column SORT BY and inlined deletes inside BEGIN..COMMIT (non-macro)
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '__TEST_DIR__/issue_999_txn/', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+USE dl
+
+statement ok
+CREATE TABLE t(id INTEGER, val INTEGER)
+
+statement ok
+INSERT INTO t VALUES (2, 0), (1, 0), (3, 0)
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+UPDATE t SET val = val + 1 WHERE id = 2
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE t SET SORTED BY ((id + 0) ASC NULLS LAST)
+
+statement ok
+CALL ducklake_flush_inlined_data('dl', table_name => 't')
+
+query II
+SELECT id, val FROM t ORDER BY id
+----
+1	0
+2	3
+3	0
+
+statement ok
+COMMIT
+
+query II
+SELECT id, val FROM t ORDER BY id
+----
+1	0
+2	3
+3	0

--- a/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
@@ -72,6 +72,7 @@ ABC	XYZ	AXBYCZ
 321	000	302010
 123	000	102030
 
+# FIXME TODO: This should get fixed to that it succeeds. See commented out tests below.
 statement error
 CALL ducklake_flush_inlined_data('ducklake', table_name => 'macro_sort_test');
 ----
@@ -83,3 +84,36 @@ ROLLBACK
 statement ok
 DROP MACRO IF EXISTS zip_varchar
 
+# FIXME - these tests should be re-enabled.
+# statement ok
+# CALL ducklake_flush_inlined_data('ducklake', table_name => 'macro_sort_test');
+
+# # Verify data is now sorted by the macro
+# query III
+# SELECT i, j, zip_varchar(i, j, num_chars := 3)
+# FROM macro_sort_test
+# ----
+# 123	000	102030
+# 321	000	302010
+# ABC	XYZ	AXBYCZ
+# ZYX	CBA	ZCYBXA
+
+# # We can even clear the sorting before committing
+# statement ok 
+# ALTER TABLE ducklake.macro_sort_test RESET SORTED BY
+
+# statement ok
+# COMMIT
+
+# # Verify data is still sorted by the macro
+# query III
+# SELECT i, j, zip_varchar(i, j, num_chars := 3)
+# FROM macro_sort_test
+# ----
+# 123	000	102030
+# 321	000	302010
+# ABC	XYZ	AXBYCZ
+# ZYX	CBA	ZCYBXA
+
+# statement ok
+# DROP MACRO zip_varchar

--- a/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
@@ -72,36 +72,14 @@ ABC	XYZ	AXBYCZ
 321	000	302010
 123	000	102030
 
-statement ok
+statement error
 CALL ducklake_flush_inlined_data('ducklake', table_name => 'macro_sort_test');
-
-# Verify data is now sorted by the macro
-query III
-SELECT i, j, zip_varchar(i, j, num_chars := 3)
-FROM macro_sort_test
 ----
-123	000	102030
-321	000	302010
-ABC	XYZ	AXBYCZ
-ZYX	CBA	ZCYBXA
-
-# We can even clear the sorting before committing
-statement ok 
-ALTER TABLE ducklake.macro_sort_test RESET SORTED BY
+Catalog Error: Scalar Function with name zip_varchar does not exist!
 
 statement ok
-COMMIT
-
-# Verify data is still sorted by the macro
-query III
-SELECT i, j, zip_varchar(i, j, num_chars := 3)
-FROM macro_sort_test
-----
-123	000	102030
-321	000	302010
-ABC	XYZ	AXBYCZ
-ZYX	CBA	ZCYBXA
+ROLLBACK
 
 statement ok
-DROP MACRO zip_varchar
+DROP MACRO IF EXISTS zip_varchar
 

--- a/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_macro_expression_transaction.test
@@ -76,7 +76,7 @@ ABC	XYZ	AXBYCZ
 statement error
 CALL ducklake_flush_inlined_data('ducklake', table_name => 'macro_sort_test');
 ----
-Catalog Error: Scalar Function with name zip_varchar does not exist!
+Scalar Function with name zip_varchar does not exist!
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
This PR fixes https://github.com/duckdb/ducklake/issues/999 . 

However, there is a previously silently failing condition that this now causes to error, so it is a FIXME for a follow up PR. It will fail if a single transaction contains:
1. A `CREATE MACRO` for a DuckLake macro 
2. A`SET SORTED BY` that uses that macro
3. An inline flush will fail with an error message that the function is missing. 

This is because the connection to the metadata DB does not have the user's DuckLake transaction context where that macro exists. 

I wanted to split it apart since the PR was growing in scope and I think I need some help on how to cleanly handle within-transaction DuckLake macros in this case. This PR at least removes the silent corruption issue and throws an error in the very specific case above instead of a silent failure.