### PR TITLE
Cache per-table stats

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -30,17 +30,17 @@ struct DuckLakeConfigOption;
 struct DeleteFileMap;
 class LogicalGet;
 
-//! Cache entry for DuckLake table statistics
-struct DuckLakeStatsCacheEntry : public ObjectCacheEntry {
+//! Per-table stats cache entry, keyed by <next_file_id, table_id>.
+struct DuckLakeTableStatsCacheEntry : public ObjectCacheEntry {
 	static constexpr idx_t ESTIMATED_BYTES_PER_COLUMN_STATS = 256;
 
-	explicit DuckLakeStatsCacheEntry(unique_ptr<DuckLakeStats> stats_p) : stats(std::move(*stats_p)) {
+	explicit DuckLakeTableStatsCacheEntry(DuckLakeTableStats stats_p) : stats(std::move(stats_p)) {
 	}
 
-	DuckLakeStats stats;
+	DuckLakeTableStats stats;
 
 	static string ObjectType() {
-		return "ducklake_stats";
+		return "ducklake_table_stats";
 	}
 	string GetObjectType() override {
 		return ObjectType();
@@ -259,15 +259,10 @@ private:
 	//! Look up (or load) the ObjectCache entry for a given snapshot.
 	shared_ptr<DuckLakeSchemaCacheEntry> GetSchemaCacheEntry(DuckLakeTransaction &transaction,
 	                                                         DuckLakeSnapshot snapshot);
-	shared_ptr<DuckLakeStatsCacheEntry> GetStatsForSnapshot(DuckLakeTransaction &transaction,
-	                                                        DuckLakeSnapshot snapshot);
 	//! Pin a schema cache entry for the duration of the current query to ensure safe memory access.
 	void PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry);
-	unique_ptr<DuckLakeStats> LoadStatsForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot,
-	                                               DuckLakeCatalogSet &schema);
 	void LoadNameMaps(DuckLakeTransaction &transaction);
-	//! Generate a cache key for the ObjectCache
-	string StatsCacheKey(idx_t next_file_id) const;
+	string StatsCacheKey(idx_t next_file_id, TableIndex table_id) const;
 	string SchemaCacheKey(idx_t schema_version) const;
 	string SchemaPinStateKey() const;
 	ObjectCache &GetObjectCacheInstance();

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -163,7 +163,7 @@ protected:
 public:
 	//! Get the catalog information for a specific snapshot
 	virtual DuckLakeCatalogInfo GetCatalogForSnapshot(DuckLakeSnapshot snapshot);
-	virtual vector<DuckLakeGlobalStatsInfo> GetGlobalTableStats(DuckLakeSnapshot snapshot);
+	virtual vector<DuckLakeGlobalStatsInfo> GetGlobalTableStats(DuckLakeSnapshot snapshot, TableIndex table_id);
 	virtual vector<DuckLakeFileListEntry> GetFilesForTable(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot,
 	                                                       const FilterPushdownInfo *filter_info = nullptr);
 	virtual vector<DuckLakeFileListEntry> GetTableInsertions(DuckLakeTableEntry &table, DuckLakeSnapshot start_snapshot,

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -32,12 +32,9 @@
 
 namespace duckdb {
 
-optional_idx DuckLakeStatsCacheEntry::GetEstimatedCacheMemory() const {
-	idx_t estimate = sizeof(DuckLakeStats);
-	for (auto &table_entry : stats.table_stats) {
-		estimate += sizeof(DuckLakeTableStats);
-		estimate += table_entry.second->column_stats.size() * ESTIMATED_BYTES_PER_COLUMN_STATS;
-	}
+optional_idx DuckLakeTableStatsCacheEntry::GetEstimatedCacheMemory() const {
+	idx_t estimate = sizeof(DuckLakeTableStats);
+	estimate += stats.column_stats.size() * ESTIMATED_BYTES_PER_COLUMN_STATS;
 	return estimate;
 }
 
@@ -555,21 +552,6 @@ unique_ptr<DuckLakeCatalogSet> DuckLakeCatalog::LoadSchemaForSnapshot(DuckLakeTr
 	return schema_set;
 }
 
-shared_ptr<DuckLakeStatsCacheEntry> DuckLakeCatalog::GetStatsForSnapshot(DuckLakeTransaction &transaction,
-                                                                         DuckLakeSnapshot snapshot) {
-	auto &cache = GetObjectCacheInstance();
-	auto key = StatsCacheKey(snapshot.next_file_id);
-	auto cached = cache.Get<DuckLakeStatsCacheEntry>(key);
-	if (cached) {
-		return cached;
-	}
-	auto schema_entry = GetSchemaCacheEntry(transaction, snapshot);
-	auto table_stats = LoadStatsForSnapshot(transaction, snapshot, schema_entry->catalog_set);
-	auto entry = make_shared_ptr<DuckLakeStatsCacheEntry>(std::move(table_stats));
-	cache.Put(std::move(key), entry);
-	return entry;
-}
-
 static unique_ptr<DuckLakeNameMap> ConvertNameMap(DuckLakeColumnMappingInfo column_mapping) {
 	if (column_mapping.map_type != "map_by_name") {
 		throw InvalidInputException("Unsupported column mapping type \"%s\"", column_mapping.map_type);
@@ -696,26 +678,40 @@ unique_ptr<DuckLakeStats> DuckLakeCatalog::ConstructStatsMap(vector<DuckLakeGlob
 	return lake_stats;
 }
 
-unique_ptr<DuckLakeStats> DuckLakeCatalog::LoadStatsForSnapshot(DuckLakeTransaction &transaction,
-                                                                DuckLakeSnapshot snapshot, DuckLakeCatalogSet &schema) {
-	auto &metadata_manager = transaction.GetMetadataManager();
-	auto global_stats = metadata_manager.GetGlobalTableStats(snapshot);
-	// construct the stats map
-	return ConstructStatsMap(global_stats, schema);
-}
-
 shared_ptr<DuckLakeTableStats> DuckLakeCatalog::GetTableStats(DuckLakeTransaction &transaction, TableIndex table_id) {
 	return GetTableStats(transaction, transaction.GetSnapshot(), table_id);
 }
 
 shared_ptr<DuckLakeTableStats> DuckLakeCatalog::GetTableStats(DuckLakeTransaction &transaction,
                                                               DuckLakeSnapshot snapshot, TableIndex table_id) {
-	auto stats_entry = GetStatsForSnapshot(transaction, snapshot);
-	auto it = stats_entry->stats.table_stats.find(table_id);
-	if (it == stats_entry->stats.table_stats.end()) {
+	auto &cache = GetObjectCacheInstance();
+	auto key = StatsCacheKey(snapshot.next_file_id, table_id);
+	auto cached = cache.Get<DuckLakeTableStatsCacheEntry>(key);
+	if (cached) {
+		auto* raw = cached.get();
+		return shared_ptr<DuckLakeTableStats>(std::move(cached), &raw->stats);
+	}
+
+	// Load from the metadata manager
+	auto schema_entry = GetSchemaCacheEntry(transaction, snapshot);
+	auto global_stats = transaction.GetMetadataManager().GetGlobalTableStats(snapshot, table_id);
+	auto lake_stats = ConstructStatsMap(global_stats, schema_entry->catalog_set);
+
+	unique_ptr<DuckLakeTableStats> table_stats;
+	auto it = lake_stats->table_stats.find(table_id);
+	if (it != lake_stats->table_stats.end()) {
+		table_stats = std::move(it->second);
+	}
+
+	if (!table_stats) {
+		// Table had no stats row for this snapshot (or did not exist at the snapshot)
 		return nullptr;
 	}
-	return shared_ptr<DuckLakeTableStats>(std::move(stats_entry), it->second.get());
+
+	auto entry = make_shared_ptr<DuckLakeTableStatsCacheEntry>(std::move(*table_stats));
+	cache.Put(std::move(key), entry);
+	auto* raw = entry.get();
+	return shared_ptr<DuckLakeTableStats>(std::move(entry), &raw->stats);
 }
 
 optional_ptr<SchemaCatalogEntry> DuckLakeCatalog::LookupSchema(CatalogTransaction transaction,
@@ -945,8 +941,9 @@ void DuckLakeCatalog::CacheInlinedDeletionTableResult(TableIndex table_id, DuckL
 	}
 }
 
-string DuckLakeCatalog::StatsCacheKey(idx_t next_file_id) const {
-	return StringUtil::Format("ducklake:%s:%s:%s:stats:%llu", GetName(), MetadataPath(), instance_id, next_file_id);
+string DuckLakeCatalog::StatsCacheKey(idx_t next_file_id, TableIndex table_id) const {
+	return StringUtil::Format("ducklake:%s:%s:%s:stats:%llu:table:%llu",
+	                          GetName(), MetadataPath(), instance_id, next_file_id, table_id.index);
 }
 
 string DuckLakeCatalog::SchemaCacheKey(idx_t schema_version) const {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -914,15 +914,19 @@ vector<DuckLakeGlobalStatsInfo> TransformGlobalStats(QueryResult &result) {
 	return global_stats;
 }
 
-vector<DuckLakeGlobalStatsInfo> DuckLakeMetadataManager::GetGlobalTableStats(DuckLakeSnapshot snapshot) {
-	// query the most recent stats
-	auto result = transaction.Query(snapshot, R"(
+vector<DuckLakeGlobalStatsInfo> DuckLakeMetadataManager::GetGlobalTableStats(DuckLakeSnapshot snapshot, TableIndex table_id) {
+	// query the most recent stats for a single table
+	string query = StringUtil::Format(R"(
 SELECT table_id, column_id, record_count, next_row_id, file_size_bytes, contains_null, contains_nan, min_value, max_value, extra_stats
 FROM {METADATA_CATALOG}.ducklake_table_stats
 LEFT JOIN {METADATA_CATALOG}.ducklake_table_column_stats USING (table_id)
-WHERE record_count IS NOT NULL AND file_size_bytes IS NOT NULL
+WHERE table_id = %llu
+  AND record_count IS NOT NULL 
+  AND file_size_bytes IS NOT NULL
 ORDER BY table_id;
-)");
+)", table_id.index);
+
+	auto result = transaction.Query(snapshot, query);
 	return TransformGlobalStats(*result);
 }
 


### PR DESCRIPTION
Hi team, recently I see more and more issue report on memleak / excessive memory consumption so I'd love to take a look, analysis see: https://github.com/duckdb/ducklake/issues/1136#issuecomment-4414008087

In the current implementation, we use [`DuckLakeStats`](https://github.com/duckdb/ducklake/blob/d897bc5a35f887c9087403bc20efd92d99272e69/src/include/storage/ducklake_stats.hpp#L66-L78) as the cache entry, which contains all the tables and all their columns, thus not scalable.

In this PR, I update the cache granularity to use table as the cache entry, which mimics DuckDB core [`ParquetMetadataCache`](https://github.com/duckdb/duckdb/blob/c7a9c8fe3bcd10a923037b8e03ab7936515e47c4/extension/parquet/include/parquet_file_metadata_cache.hpp).

Two considerations:
- I thought about using table column as the cache unit, but we have a few functions to get table stats, thought it'd be an overkill
- This PR targets at v1.5 branch, because I found all recent PRs (whether bug or feature) all land against v1.5 instead of main (maybe we should merge v1.5 commits to main branch?)