### PR TITLE
Fix mis-pruned data files

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1306,16 +1306,23 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 		if (!conditions.empty()) {
 			conditions += " AND ";
 		}
+		// Files that have no stats entry for this column (i.e., written before the column was added) must
+		// NOT be pruned, we cannot determine filter satisfaction without stats.
 		if (needs_value_count_guard) {
-			conditions += StringUtil::Format("data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
-			                                 "(value_count IS NULL OR value_count > 0) AND (%s(%s)))",
-			                                 cte_name, null_checks.c_str(), filter_condition.c_str());
+			conditions += StringUtil::Format(
+			    "(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
+			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
+			    "(value_count IS NULL OR value_count > 0) AND (%s(%s))))",
+			    cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
 		} else {
-			conditions += StringUtil::Format("data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s))",
-			                                 cte_name, null_checks.c_str(), filter_condition.c_str());
+			conditions += StringUtil::Format(
+			    "(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
+			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s)))",
+			    cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
 		}
 
 		CTERequirement req(column_filter.column_field_index, referenced_stats);
+		req.reference_count = 2;
 		result.required_ctes.emplace(column_filter.column_field_index, std::move(req));
 	}
 

--- a/test/sql/issues/issue_1135.test
+++ b/test/sql/issues/issue_1135.test
@@ -1,0 +1,31 @@
+# name: test/sql/issues/issue_1135.test
+# description: Test that filter pushdown works correctly with columns added via ALTER TABLE ADD COLUMN with DEFAULT
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS duck (DATA_PATH '${DATA_PATH}/issue_1135')
+
+statement ok
+CREATE TABLE duck.tbl (a INT);
+
+statement ok
+INSERT INTO duck.tbl SELECT i FROM range(10) t(i);
+
+statement ok
+CALL ducklake_flush_inlined_data('duck')
+
+statement ok
+ALTER TABLE duck.tbl ADD COLUMN b INT DEFAULT 42;
+
+query I
+SELECT count(*) FROM duck.tbl WHERE b = 42;
+----
+10


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1135

The bug is: when we get data files, current implementation only select those with columns which matches the predicate (i.e., col_b <= 42), but miss all data files without the requested column.

Data file query before this fix:
```sql
data.data_file_id IN (
	SELECT data_file_id FROM col_2_stats
	WHERE (value_count IS NULL OR value_count > 0)
	  AND (min_value IS NULL OR max_value IS NULL OR (min_value <= '42' AND max_value >= '42'))
  )
```
After the fix
```sql
(
	data.data_file_id NOT IN (SELECT data_file_id FROM col_2_stats)
	OR
	data.data_file_id IN (
	  SELECT data_file_id FROM col_2_stats
	  WHERE (value_count IS NULL OR value_count > 0)
		AND (min_value IS NULL OR max_value IS NULL OR (min_value <= '42' AND max_value >= '42'))
	)
  )
```