### PR TITLE
Optimize partition-only deletes

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -148,6 +148,7 @@ public:
 	                             optional_ptr<PhysicalOperator> plan) override;
 	PhysicalOperator &PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner, LogicalCreateTable &op,
 	                                    PhysicalOperator &plan) override;
+	PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op) override;
 	PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
 	                             PhysicalOperator &plan) override;
 	PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,

--- a/src/include/storage/ducklake_delete.hpp
+++ b/src/include/storage/ducklake_delete.hpp
@@ -160,7 +160,8 @@ public:
 	static PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner,
 	                                    DuckLakeTableEntry &table, PhysicalOperator &child_plan,
 	                                    vector<idx_t> row_id_indexes, string encryption_key,
-	                                    bool allow_duplicates = true);
+	                                    bool allow_duplicates = true,
+	                                    unordered_map<idx_t, vector<Value>> metadata_delete_partition_values = {});
 
 public:
 	// Sink interface

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -421,6 +421,7 @@ struct DuckLakeFileListExtendedEntry {
 	idx_t delete_count = 0;
 	MappingIndex mapping_id;
 	DuckLakeDataType data_type = DuckLakeDataType::DATA_FILE;
+	vector<DuckLakeFilePartitionInfo> partition_values;
 };
 
 struct DuckLakeCompactionBaseFileData {

--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -44,6 +44,9 @@ public:
 	idx_t GetTotalFileCount() const override;
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const override;
 	DuckLakeTableEntry &GetTable();
+	optional_ptr<const FilterPushdownInfo> GetFilterPushdownInfo() const {
+		return filter_info.get();
+	}
 	unique_ptr<MultiFileList> Copy() const override;
 	bool HasTransactionLocalData() const {
 		return !transaction_local_files.empty() || transaction_local_data;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -48,6 +48,11 @@ struct FlushedInlinedTableInfo {
 	idx_t flush_snapshot_id;
 };
 
+struct DroppedDataFileStats {
+	idx_t row_count = 0;
+	idx_t file_size_bytes = 0;
+};
+
 struct LocalTableDataChanges {
 	vector<DuckLakeDataFile> new_data_files;
 	unique_ptr<DuckLakeInlinedData> new_inlined_data;
@@ -246,7 +251,8 @@ public:
 	void DropView(DuckLakeViewEntry &view);
 	void DropScalarMacro(DuckLakeScalarMacroEntry &macro);
 	void DropTableMacro(DuckLakeTableMacroEntry &macro);
-	void DropFile(TableIndex table_id, DataFileIndex data_file_id, string path);
+	void DropFile(TableIndex table_id, DataFileIndex data_file_id, string path, idx_t row_count = 0,
+	              idx_t file_size_bytes = 0);
 
 	void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
 	void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -99,6 +99,9 @@ struct DuckLakeCommitContext {
 	std::function<void(idx_t)> set_catalog_version;
 	//! Records the committed snapshot id on the catalog.
 	std::function<void(idx_t)> set_committed_snapshot_id;
+	//! Invalidates the cached stats entry for a table after a stats-affecting metadata-only commit.
+	std::function<void(idx_t, TableIndex)> invalidate_table_stats_cache = [](idx_t, TableIndex) {
+	};
 	//! Author / message / extra info for the snapshot row.
 	DuckLakeSnapshotCommit commit_info;
 	//! When true, Commit() skips the post-commit DropEmptySupersededInlinedTables cleanup.
@@ -131,7 +134,8 @@ public:
 	                            const DuckLakeSnapshotCommit &commit_info) const;
 
 	string CommitChanges(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes,
-	                     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context);
+	                     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context,
+	                     map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 
 	vector<DuckLakeSchemaInfo> GetNewSchemas(DuckLakeCommitState &commit_state);
 	NewTableInfo GetNewTables(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
@@ -144,7 +148,15 @@ public:
 	NewMacroInfo GetNewMacros(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
 	NewDataInfo GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
 	                            optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-	                            const DuckLakeCommitContext &context);
+	                            const DuckLakeCommitContext &context,
+	                            map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	//! Subtract the dropped-file counts for `table_id` (if any) from `new_stats` and consume the entry.
+	static void ApplyDroppedFileStats(TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
+	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	//! Emit stats decrements for tables whose files were dropped without any new data being written.
+	string UpdateStatsForDroppedFiles(optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
+	                                  const DuckLakeCommitContext &context,
+	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 	CompactionInformation GetCompactionChanges(DuckLakeCommitState &commit_state, CompactionType type);
 	//! After a REWRITE_DELETES compaction, recompute EXACT global stats for `table_id` from the post-rewrite file set
 	//! (+ committed inlined data) and append the UpdateGlobalTableStats SQL to `batch_query`. No-op (leaving the
@@ -199,6 +211,7 @@ public:
 	set<TableIndex> renamed_views;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
+	map<TableIndex, DroppedDataFileStats> dropped_file_stats;
 	set<TableIndex> tables_deleted_from;
 	unique_ptr<DuckLakeCatalogSet> new_schemas;
 	map<SchemaIndex, reference<DuckLakeSchemaEntry>> dropped_schemas;

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -255,7 +255,8 @@ public:
 			}
 			count += file.row_count;
 			if (file.file_id.IsValid()) {
-				transaction.DropFile(table.GetTableId(), file.file_id, file.file.path);
+				transaction.DropFile(table.GetTableId(), file.file_id, file.file.path, file.row_count,
+				                     file.file.file_size_bytes);
 			} else {
 				transaction.DropTransactionLocalFile(table.GetTableId(), file.file.path);
 			}
@@ -443,7 +444,8 @@ bool DuckLakeDelete::TryDropFullyDeletedFile(DuckLakeTransaction &transaction, c
 	}
 	// ALL rows in this file are deleted - drop the file
 	if (delete_file.data_file_id.IsValid()) {
-		transaction.DropFile(table.GetTableId(), delete_file.data_file_id, data_file_info.file.path);
+		transaction.DropFile(table.GetTableId(), delete_file.data_file_id, data_file_info.file.path,
+		                     data_file_info.row_count, data_file_info.file.file_size_bytes);
 	} else {
 		transaction.DropTransactionLocalFile(table.GetTableId(), data_file_info.file.path);
 	}

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -14,7 +14,24 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_set_operation.hpp"
 #include "duckdb/planner/operator/logical_empty_result.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
+#include "duckdb/planner/expression/legacy_bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
+#include "duckdb/planner/filter/optional_filter.hpp"
+#include "duckdb/planner/filter/table_filter_functions.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "duckdb/execution/operator/filter/physical_filter.hpp"
+#include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "storage/ducklake_delete.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_schema_entry.hpp"
@@ -195,6 +212,72 @@ DuckLakeDelete::DuckLakeDelete(PhysicalPlan &physical_plan, DuckLakeTableEntry &
       encryption_key(std::move(encryption_key_p)), allow_duplicates(allow_duplicates) {
 	children.push_back(child);
 }
+
+class DuckLakeMetadataDeleteGlobalState : public GlobalSourceState {
+public:
+	mutex lock;
+	bool finished = false;
+};
+
+class DuckLakeMetadataDelete : public PhysicalOperator {
+public:
+	DuckLakeMetadataDelete(PhysicalPlan &physical_plan, DuckLakeTableEntry &table,
+	                       vector<DuckLakeFileListExtendedEntry> files)
+	    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, {LogicalType::BIGINT}, 1), table(table),
+	      files(std::move(files)) {
+	}
+
+	DuckLakeTableEntry &table;
+	vector<DuckLakeFileListExtendedEntry> files;
+
+public:
+	bool IsSource() const override {
+		return true;
+	}
+
+	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override {
+		return make_uniq<DuckLakeMetadataDeleteGlobalState>();
+	}
+
+	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
+	                                 OperatorSourceInput &input) const override {
+		auto &state = input.global_state.Cast<DuckLakeMetadataDeleteGlobalState>();
+		lock_guard<mutex> guard(state.lock);
+		if (state.finished) {
+			return SourceResultType::FINISHED;
+		}
+
+		auto &transaction = DuckLakeTransaction::Get(context.client, table.catalog);
+		idx_t count = 0;
+		for (auto &file : files) {
+			if (file.data_type != DuckLakeDataType::DATA_FILE) {
+				throw InternalException("DuckLakeMetadataDelete can only drop data files");
+			}
+			count += file.row_count;
+			if (file.file_id.IsValid()) {
+				transaction.DropFile(table.GetTableId(), file.file_id, file.file.path);
+			} else {
+				transaction.DropTransactionLocalFile(table.GetTableId(), file.file.path);
+			}
+		}
+
+		chunk.SetCardinality(1);
+		chunk.data[0].SetValue(0, Value::BIGINT(NumericCast<int64_t>(count)));
+		state.finished = true;
+		return SourceResultType::HAVE_MORE_OUTPUT;
+	}
+
+	string GetName() const override {
+		return "DUCKLAKE_METADATA_DELETE";
+	}
+
+	InsertionOrderPreservingMap<string> ParamsToString() const override {
+		InsertionOrderPreservingMap<string> result;
+		result["Table Name"] = table.name;
+		result["Files"] = std::to_string(files.size());
+		return result;
+	}
+};
 
 //===--------------------------------------------------------------------===//
 // States
@@ -657,10 +740,827 @@ optional_ptr<PhysicalTableScan> FindDeleteSource(PhysicalOperator &plan) {
 	return nullptr;
 }
 
+bool IsIdentityPartitionField(DuckLakeTableEntry &table, idx_t field_index);
+
+bool PhysicalFilterReferencesOnlyIdentityPartitionFields(DuckLakeTableEntry &table, const Expression &expr,
+                                                         PhysicalTableScan &scan) {
+	bool result = true;
+	ExpressionIterator::VisitExpression<BoundReferenceExpression>(expr, [&](const BoundReferenceExpression &col_ref) {
+		auto column_index = col_ref.Index();
+		if (column_index >= scan.column_ids.size()) {
+			result = false;
+			return;
+		}
+		auto &column_id = scan.column_ids[column_index];
+		if (column_id.IsVirtualColumn()) {
+			result = false;
+			return;
+		}
+		auto &field_id = table.GetFieldId(PhysicalIndex(column_id.GetPrimaryIndex()));
+		if (!IsIdentityPartitionField(table, field_id.GetFieldIndex().index)) {
+			result = false;
+		}
+	});
+	return result;
+}
+
+optional_ptr<PhysicalTableScan> FindMetadataDeleteSource(DuckLakeTableEntry &table, PhysicalOperator &plan) {
+	if (plan.type == PhysicalOperatorType::TABLE_SCAN) {
+		return plan.Cast<PhysicalTableScan>();
+	}
+	// Residual filters are transparent only when they still reference identity partition columns. File-level safety is
+	// enforced below by checking recorded partition values for every candidate file.
+	if (plan.type == PhysicalOperatorType::PROJECTION && plan.children.size() == 1) {
+		return FindMetadataDeleteSource(table, plan.children[0].get());
+	}
+	if (plan.type == PhysicalOperatorType::FILTER && plan.children.size() == 1) {
+		auto scan = FindMetadataDeleteSource(table, plan.children[0].get());
+		if (!scan) {
+			return nullptr;
+		}
+		auto &filter = plan.Cast<PhysicalFilter>();
+		if (!filter.expression || !PhysicalFilterReferencesOnlyIdentityPartitionFields(table, *filter.expression, *scan)) {
+			return nullptr;
+		}
+		return scan;
+	}
+	return nullptr;
+}
+
+bool IsIdentityPartitionField(DuckLakeTableEntry &table, idx_t field_index) {
+	auto partition_data = table.GetPartitionData();
+	if (!partition_data) {
+		return false;
+	}
+	for (auto &field : partition_data->fields) {
+		if (field.field_id.index == field_index && field.transform.type == DuckLakeTransformType::IDENTITY) {
+			return true;
+		}
+	}
+	return false;
+}
+
+struct MetadataDeleteLogicalContext {
+	optional_idx table_index;
+	vector<optional_idx> output_partition_keys;
+};
+
+bool ExpressionReferencesOnlyIdentityPartitionFields(DuckLakeTableEntry &table, const Expression &expr,
+                                                     const MetadataDeleteLogicalContext &logical_context) {
+	bool result = true;
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &col_ref) {
+		auto &binding = col_ref.Binding();
+		if (!logical_context.table_index.IsValid() ||
+		    binding.table_index != TableIndex(logical_context.table_index.GetIndex())) {
+			result = false;
+			return;
+		}
+		auto &column = table.GetColumn(LogicalIndex(binding.column_index));
+		auto &field_id = table.GetFieldId(column.Physical());
+		if (!IsIdentityPartitionField(table, field_id.GetFieldIndex().index)) {
+			result = false;
+		}
+	});
+	ExpressionIterator::VisitExpression<BoundReferenceExpression>(expr, [&](const BoundReferenceExpression &col_ref) {
+		auto column_index = col_ref.Index();
+		if (column_index >= logical_context.output_partition_keys.size() ||
+		    !logical_context.output_partition_keys[column_index].IsValid()) {
+			result = false;
+		}
+	});
+	return result;
+}
+
+bool GetIdentityPartitionKeyIndex(DuckLakeTableEntry &table, idx_t field_index, optional_idx &partition_key_index) {
+	auto partition_data = table.GetPartitionData();
+	if (!partition_data) {
+		return false;
+	}
+	for (auto &field : partition_data->fields) {
+		if (field.field_id.index == field_index && field.transform.type == DuckLakeTransformType::IDENTITY) {
+			partition_key_index = field.partition_key_index;
+			return true;
+		}
+	}
+	return false;
+}
+
+bool AddPartitionValue(vector<Value> &values, const Value &value) {
+	if (value.IsNull()) {
+		return false;
+	}
+	for (auto &existing_value : values) {
+		if (Value::NotDistinctFrom(existing_value, value)) {
+			return true;
+		}
+	}
+	values.push_back(value);
+	return true;
+}
+
+bool IntersectPartitionValues(vector<Value> &left, const vector<Value> &right) {
+	vector<Value> result;
+	for (auto &left_value : left) {
+		for (auto &right_value : right) {
+			if (Value::NotDistinctFrom(left_value, right_value)) {
+				if (!AddPartitionValue(result, left_value)) {
+					return false;
+				}
+				break;
+			}
+		}
+	}
+	if (result.empty()) {
+		return false;
+	}
+	left = std::move(result);
+	return true;
+}
+
+bool MergePartitionValuesConjunction(unordered_map<idx_t, vector<Value>> &target,
+                                     const unordered_map<idx_t, vector<Value>> &source) {
+	for (auto &entry : source) {
+		if (entry.second.empty()) {
+			return false;
+		}
+		auto result = target.find(entry.first);
+		if (result == target.end()) {
+			target.emplace(entry.first, entry.second);
+		} else if (!IntersectPartitionValues(result->second, entry.second)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool MergePartitionValuesDisjunction(unordered_map<idx_t, vector<Value>> &target,
+                                     const unordered_map<idx_t, vector<Value>> &source) {
+	if (source.size() != 1) {
+		return false;
+	}
+	if (target.empty()) {
+		target = source;
+		return true;
+	}
+	if (target.size() != 1 || target.begin()->first != source.begin()->first) {
+		return false;
+	}
+	for (auto &value : source.begin()->second) {
+		if (!AddPartitionValue(target.begin()->second, value)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool ExtractTableFilterValuesFromExpression(const Expression &expr, vector<Value> &values);
+
+bool ExtractTableFilterValuesFromComparison(const BoundFunctionExpression &expr, vector<Value> &values) {
+	if (!BoundComparisonExpression::IsComparison(expr) || expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return false;
+	}
+	auto &left = BoundComparisonExpression::Left(expr);
+	auto &right = BoundComparisonExpression::Right(expr);
+	if (right.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		return AddPartitionValue(values, right.Cast<BoundConstantExpression>().GetValue());
+	}
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		return AddPartitionValue(values, left.Cast<BoundConstantExpression>().GetValue());
+	}
+	return false;
+}
+
+bool ExtractTableFilterValuesFromComparison(const LegacyBoundComparisonExpression &expr, vector<Value> &values) {
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return false;
+	}
+	if (!expr.left.get() || !expr.right.get()) {
+		return false;
+	}
+	if (expr.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		return AddPartitionValue(values, expr.right->Cast<BoundConstantExpression>().GetValue());
+	}
+	if (expr.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		return AddPartitionValue(values, expr.left->Cast<BoundConstantExpression>().GetValue());
+	}
+	return false;
+}
+
+bool ExtractTableFilterValuesFromOperator(const BoundOperatorExpression &expr, vector<Value> &values) {
+	auto &children = expr.GetChildren();
+	switch (expr.GetExpressionType()) {
+	case ExpressionType::COMPARE_EQUAL:
+		if (children.size() != 2) {
+			return false;
+		}
+		if (!children[0].get() || !children[1].get()) {
+			return false;
+		}
+		if (children[1]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			return AddPartitionValue(values, children[1]->Cast<BoundConstantExpression>().GetValue());
+		}
+		if (children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			return AddPartitionValue(values, children[0]->Cast<BoundConstantExpression>().GetValue());
+		}
+		return false;
+	case ExpressionType::COMPARE_IN:
+		if (children.size() < 2) {
+			return false;
+		}
+		if (!children[0].get()) {
+			return false;
+		}
+		for (idx_t child_idx = 1; child_idx < children.size(); child_idx++) {
+			if (!children[child_idx].get() ||
+			    children[child_idx]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+			    !AddPartitionValue(values, children[child_idx]->Cast<BoundConstantExpression>().GetValue())) {
+				return false;
+			}
+		}
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool ExtractTableFilterValuesFromExpression(const Expression &expr, vector<Value> &values) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::LEGACY_BOUND_COMPARISON:
+		return ExtractTableFilterValuesFromComparison(expr.Cast<LegacyBoundComparisonExpression>(), values);
+	case ExpressionClass::BOUND_FUNCTION: {
+		auto &func = expr.Cast<BoundFunctionExpression>();
+		if (BoundComparisonExpression::IsComparison(func)) {
+			return ExtractTableFilterValuesFromComparison(func, values);
+		}
+		if (func.Function().GetName() == OptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<OptionalFilterFunctionData>();
+			return data.child_filter_expr ? ExtractTableFilterValuesFromExpression(*data.child_filter_expr, values) : false;
+		}
+		if (func.Function().GetName() == SelectivityOptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<SelectivityOptionalFilterFunctionData>();
+			return data.child_filter_expr ? ExtractTableFilterValuesFromExpression(*data.child_filter_expr, values) : false;
+		}
+		return false;
+	}
+	case ExpressionClass::BOUND_OPERATOR:
+		return ExtractTableFilterValuesFromOperator(expr.Cast<BoundOperatorExpression>(), values);
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
+		auto &children = conjunction.GetChildren();
+		if (children.empty()) {
+			return false;
+		}
+		bool initialized = false;
+		for (auto &child : children) {
+			if (!child.get()) {
+				return false;
+			}
+			vector<Value> child_values;
+			if (!ExtractTableFilterValuesFromExpression(*child, child_values)) {
+				return false;
+			}
+			if (!initialized) {
+				values = std::move(child_values);
+				initialized = true;
+				continue;
+			}
+			switch (conjunction.GetExpressionType()) {
+			case ExpressionType::CONJUNCTION_AND:
+				if (!IntersectPartitionValues(values, child_values)) {
+					return false;
+				}
+				break;
+			case ExpressionType::CONJUNCTION_OR:
+				for (auto &value : child_values) {
+					if (!AddPartitionValue(values, value)) {
+						return false;
+					}
+				}
+				break;
+			default:
+				return false;
+			}
+		}
+		return initialized;
+	}
+	default:
+		return false;
+	}
+}
+
+bool ExtractTableFilterValues(const TableFilter &filter, vector<Value> &values) {
+	switch (filter.filter_type) {
+	case TableFilterType::LEGACY_CONSTANT_COMPARISON: {
+		auto &constant_filter = filter.Cast<LegacyConstantFilter>();
+		if (constant_filter.comparison_type != ExpressionType::COMPARE_EQUAL) {
+			return false;
+		}
+		return AddPartitionValue(values, constant_filter.constant);
+	}
+	case TableFilterType::LEGACY_IN_FILTER: {
+		auto &in_filter = filter.Cast<LegacyInFilter>();
+		if (in_filter.values.empty()) {
+			return false;
+		}
+		for (auto &value : in_filter.values) {
+			if (!AddPartitionValue(values, value)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	case TableFilterType::LEGACY_OPTIONAL_FILTER: {
+		auto &optional_filter = filter.Cast<LegacyOptionalFilter>();
+		return optional_filter.child_filter.get() ? ExtractTableFilterValues(*optional_filter.child_filter, values) : false;
+	}
+	case TableFilterType::LEGACY_CONJUNCTION_OR: {
+		auto &conjunction = filter.Cast<LegacyConjunctionOrFilter>();
+		if (conjunction.child_filters.empty()) {
+			return false;
+		}
+		for (auto &child_filter : conjunction.child_filters) {
+			if (!child_filter.get()) {
+				return false;
+			}
+			if (!ExtractTableFilterValues(*child_filter, values)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	case TableFilterType::EXPRESSION_FILTER: {
+		auto &expression_filter = filter.Cast<ExpressionFilter>();
+		return expression_filter.expr.get() ? ExtractTableFilterValuesFromExpression(*expression_filter.expr, values) : false;
+	}
+	default:
+		return false;
+	}
+}
+
+bool ExtractPartitionValuesFromLogicalGet(DuckLakeTableEntry &table, LogicalGet &get,
+                                          unordered_map<idx_t, vector<Value>> &partition_values) {
+	if (!get.table_filters.HasFilters()) {
+		return true;
+	}
+	for (auto &entry : get.table_filters) {
+		auto column_idx = entry.GetIndex();
+		auto &column_id = get.GetColumnIndex(column_idx);
+		if (column_id.IsVirtualColumn()) {
+			return false;
+		}
+		auto &field_id = table.GetFieldId(PhysicalIndex(column_id.GetPrimaryIndex()));
+		optional_idx partition_key_index;
+		if (!GetIdentityPartitionKeyIndex(table, field_id.GetFieldIndex().index, partition_key_index)) {
+			return false;
+		}
+		unordered_map<idx_t, vector<Value>> filter_partition_values;
+		if (!ExtractTableFilterValues(entry.Filter(), filter_partition_values[partition_key_index.GetIndex()]) ||
+		    !MergePartitionValuesConjunction(partition_values, filter_partition_values)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool GetExpressionIdentityPartitionKeyIndex(DuckLakeTableEntry &table, const Expression &expr,
+                                            const MetadataDeleteLogicalContext &logical_context,
+                                            optional_idx &partition_key_index) {
+	bool result = true;
+	bool found_column = false;
+	auto set_partition_key_index = [&](optional_idx next_partition_key_index) {
+		if (!next_partition_key_index.IsValid()) {
+			result = false;
+			return;
+		}
+		if (found_column && partition_key_index != next_partition_key_index) {
+			result = false;
+			return;
+		}
+		found_column = true;
+		partition_key_index = next_partition_key_index;
+	};
+	ExpressionIterator::VisitExpression<BoundColumnRefExpression>(expr, [&](const BoundColumnRefExpression &col_ref) {
+		auto &binding = col_ref.Binding();
+		if (!logical_context.table_index.IsValid() ||
+		    binding.table_index != TableIndex(logical_context.table_index.GetIndex())) {
+			result = false;
+			return;
+		}
+		auto &column = table.GetColumn(LogicalIndex(binding.column_index));
+		auto &field_id = table.GetFieldId(column.Physical());
+		optional_idx next_partition_key_index;
+		if (!GetIdentityPartitionKeyIndex(table, field_id.GetFieldIndex().index, next_partition_key_index)) {
+			result = false;
+			return;
+		}
+		set_partition_key_index(next_partition_key_index);
+	});
+	ExpressionIterator::VisitExpression<BoundReferenceExpression>(expr, [&](const BoundReferenceExpression &col_ref) {
+		auto column_index = col_ref.Index();
+		if (column_index >= logical_context.output_partition_keys.size()) {
+			result = false;
+			return;
+		}
+		set_partition_key_index(logical_context.output_partition_keys[column_index]);
+	});
+	return result && found_column && partition_key_index.IsValid();
+}
+
+bool ExtractComparisonPartitionValues(DuckLakeTableEntry &table, const BoundFunctionExpression &expr,
+                                      const MetadataDeleteLogicalContext &logical_context,
+                                      unordered_map<idx_t, vector<Value>> &partition_values) {
+	if (!BoundComparisonExpression::IsComparison(expr) || expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return false;
+	}
+	auto &left = BoundComparisonExpression::Left(expr);
+	auto &right = BoundComparisonExpression::Right(expr);
+	reference<const Expression> column_expr(left);
+	reference<const Expression> constant_expr(right);
+	if (left.GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		column_expr = right;
+		constant_expr = left;
+	}
+	if (constant_expr.get().GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+	    !ExpressionReferencesOnlyIdentityPartitionFields(table, column_expr.get(), logical_context)) {
+		return false;
+	}
+	optional_idx partition_key_index;
+	if (!GetExpressionIdentityPartitionKeyIndex(table, column_expr.get(), logical_context, partition_key_index)) {
+		return false;
+	}
+	return AddPartitionValue(partition_values[partition_key_index.GetIndex()],
+	                         constant_expr.get().Cast<BoundConstantExpression>().GetValue());
+}
+
+bool ExtractComparisonPartitionValues(DuckLakeTableEntry &table, const LegacyBoundComparisonExpression &expr,
+                                      const MetadataDeleteLogicalContext &logical_context,
+                                      unordered_map<idx_t, vector<Value>> &partition_values) {
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+		return false;
+	}
+	if (!expr.left.get() || !expr.right.get()) {
+		return false;
+	}
+	reference<const Expression> column_expr(*expr.left);
+	reference<const Expression> constant_expr(*expr.right);
+	if (expr.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		column_expr = *expr.right;
+		constant_expr = *expr.left;
+	}
+	if (constant_expr.get().GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+	    !ExpressionReferencesOnlyIdentityPartitionFields(table, column_expr.get(), logical_context)) {
+		return false;
+	}
+	optional_idx partition_key_index;
+	if (!GetExpressionIdentityPartitionKeyIndex(table, column_expr.get(), logical_context, partition_key_index)) {
+		return false;
+	}
+	return AddPartitionValue(partition_values[partition_key_index.GetIndex()],
+	                         constant_expr.get().Cast<BoundConstantExpression>().GetValue());
+}
+
+bool ExtractInPartitionValues(DuckLakeTableEntry &table, const BoundOperatorExpression &expr,
+                              const MetadataDeleteLogicalContext &logical_context,
+                              unordered_map<idx_t, vector<Value>> &partition_values) {
+	auto &children = expr.GetChildren();
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_IN || children.size() < 2 || !children[0].get() ||
+	    !ExpressionReferencesOnlyIdentityPartitionFields(table, *children[0], logical_context)) {
+		return false;
+	}
+	optional_idx partition_key_index;
+	if (!GetExpressionIdentityPartitionKeyIndex(table, *children[0], logical_context, partition_key_index)) {
+		return false;
+	}
+	auto &values = partition_values[partition_key_index.GetIndex()];
+	for (idx_t child_idx = 1; child_idx < children.size(); child_idx++) {
+		if (!children[child_idx].get() ||
+		    children[child_idx]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+		    !AddPartitionValue(values, children[child_idx]->Cast<BoundConstantExpression>().GetValue())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool ExtractOperatorPartitionValues(DuckLakeTableEntry &table, const BoundOperatorExpression &expr,
+                                    const MetadataDeleteLogicalContext &logical_context,
+                                    unordered_map<idx_t, vector<Value>> &partition_values) {
+	if (expr.GetExpressionType() == ExpressionType::COMPARE_IN) {
+		return ExtractInPartitionValues(table, expr, logical_context, partition_values);
+	}
+	auto &children = expr.GetChildren();
+	if (expr.GetExpressionType() != ExpressionType::COMPARE_EQUAL || children.size() != 2) {
+		return false;
+	}
+	if (!children[0].get() || !children[1].get()) {
+		return false;
+	}
+	reference<const Expression> column_expr(*children[0]);
+	reference<const Expression> constant_expr(*children[1]);
+	if (children[0]->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		column_expr = *children[1];
+		constant_expr = *children[0];
+	}
+	if (constant_expr.get().GetExpressionClass() != ExpressionClass::BOUND_CONSTANT ||
+	    !ExpressionReferencesOnlyIdentityPartitionFields(table, column_expr.get(), logical_context)) {
+		return false;
+	}
+	optional_idx partition_key_index;
+	if (!GetExpressionIdentityPartitionKeyIndex(table, column_expr.get(), logical_context, partition_key_index)) {
+		return false;
+	}
+	return AddPartitionValue(partition_values[partition_key_index.GetIndex()],
+	                         constant_expr.get().Cast<BoundConstantExpression>().GetValue());
+}
+
+bool ExtractPartitionValuesFromLogicalExpression(DuckLakeTableEntry &table, const Expression &expr,
+                                                 const MetadataDeleteLogicalContext &logical_context,
+                                                 unordered_map<idx_t, vector<Value>> &partition_values) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::LEGACY_BOUND_COMPARISON:
+		return ExtractComparisonPartitionValues(table, expr.Cast<LegacyBoundComparisonExpression>(), logical_context,
+		                                        partition_values);
+	case ExpressionClass::BOUND_FUNCTION:
+		return ExtractComparisonPartitionValues(table, expr.Cast<BoundFunctionExpression>(), logical_context,
+		                                        partition_values);
+	case ExpressionClass::BOUND_OPERATOR:
+		return ExtractOperatorPartitionValues(table, expr.Cast<BoundOperatorExpression>(), logical_context,
+		                                      partition_values);
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
+		auto &children = conjunction.GetChildren();
+		if (children.empty()) {
+			return false;
+		}
+		unordered_map<idx_t, vector<Value>> conjunction_values;
+		bool initialized = false;
+		for (auto &child : children) {
+			if (!child.get()) {
+				return false;
+			}
+			unordered_map<idx_t, vector<Value>> child_values;
+			if (!ExtractPartitionValuesFromLogicalExpression(table, *child, logical_context, child_values)) {
+				return false;
+			}
+			if (!initialized) {
+				conjunction_values = std::move(child_values);
+				initialized = true;
+				continue;
+			}
+			switch (conjunction.GetExpressionType()) {
+			case ExpressionType::CONJUNCTION_AND:
+				if (!MergePartitionValuesConjunction(conjunction_values, child_values)) {
+					return false;
+				}
+				break;
+			case ExpressionType::CONJUNCTION_OR:
+				if (!MergePartitionValuesDisjunction(conjunction_values, child_values)) {
+					return false;
+				}
+				break;
+			default:
+				return false;
+			}
+		}
+		return initialized && MergePartitionValuesConjunction(partition_values, conjunction_values);
+	}
+	default:
+		return false;
+	}
+}
+
+bool LogicalPlanGetMetadataDeletePartitionValues(DuckLakeTableEntry &table, LogicalOperator &op,
+                                                 MetadataDeleteLogicalContext &logical_context,
+                                                 unordered_map<idx_t, vector<Value>> &partition_values) {
+	switch (op.type) {
+	case LogicalOperatorType::LOGICAL_GET: {
+		auto &get = op.Cast<LogicalGet>();
+		logical_context.table_index = get.table_index.index;
+		logical_context.output_partition_keys.clear();
+		for (auto &column_id : get.GetColumnIds()) {
+			optional_idx partition_key_index;
+			if (!column_id.IsVirtualColumn()) {
+				auto &field_id = table.GetFieldId(PhysicalIndex(column_id.GetPrimaryIndex()));
+				GetIdentityPartitionKeyIndex(table, field_id.GetFieldIndex().index, partition_key_index);
+			}
+			logical_context.output_partition_keys.push_back(partition_key_index);
+		}
+		return ExtractPartitionValuesFromLogicalGet(table, get, partition_values);
+	}
+	case LogicalOperatorType::LOGICAL_PROJECTION: {
+		if (op.children.size() != 1) {
+			return false;
+		}
+		if (!LogicalPlanGetMetadataDeletePartitionValues(table, *op.children[0], logical_context, partition_values)) {
+			return false;
+		}
+		auto &projection = op.Cast<LogicalProjection>();
+		vector<optional_idx> projection_partition_keys;
+		for (auto &expr : projection.expressions) {
+			optional_idx partition_key_index;
+			if (expr->GetExpressionClass() == ExpressionClass::BOUND_REF) {
+				auto &bound_ref = expr->Cast<BoundReferenceExpression>();
+				auto column_index = bound_ref.Index();
+				if (column_index < logical_context.output_partition_keys.size()) {
+					partition_key_index = logical_context.output_partition_keys[column_index];
+				}
+			}
+			projection_partition_keys.push_back(partition_key_index);
+		}
+		logical_context.output_partition_keys = std::move(projection_partition_keys);
+		return true;
+	}
+	case LogicalOperatorType::LOGICAL_FILTER: {
+		auto &filter = op.Cast<LogicalFilter>();
+		if (filter.children.size() != 1 ||
+		    !LogicalPlanGetMetadataDeletePartitionValues(table, *filter.children[0], logical_context, partition_values) ||
+		    !logical_context.table_index.IsValid()) {
+			return false;
+		}
+		for (auto &expr : filter.expressions) {
+			if (!ExpressionReferencesOnlyIdentityPartitionFields(table, *expr, logical_context)) {
+				return false;
+			}
+			unordered_map<idx_t, vector<Value>> expression_partition_values;
+			if (!ExtractPartitionValuesFromLogicalExpression(table, *expr, logical_context,
+			                                                 expression_partition_values) ||
+			    !MergePartitionValuesConjunction(partition_values, expression_partition_values)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	default:
+		return false;
+	}
+}
+
+bool ScanHasOnlyPartitionFilters(DuckLakeTableEntry &table, PhysicalTableScan &scan, DuckLakeMultiFileList &file_list) {
+	if (scan.dynamic_filters && scan.dynamic_filters->HasFilters()) {
+		return false;
+	}
+	if (!scan.table_filters || !scan.table_filters->HasFilters()) {
+		return true;
+	}
+	auto filter_info = file_list.GetFilterPushdownInfo();
+	if (!filter_info || filter_info->column_filters.size() != scan.table_filters->FilterCount()) {
+		return false;
+	}
+	for (auto &entry : filter_info->column_filters) {
+		if (!IsIdentityPartitionField(table, entry.first)) {
+			return false;
+		}
+	}
+	for (auto &entry : *scan.table_filters) {
+		auto column_idx = entry.GetIndex().GetIndex();
+		if (column_idx >= scan.column_ids.size()) {
+			return false;
+		}
+		auto &column_id = scan.column_ids[column_idx];
+		if (column_id.IsVirtualColumn()) {
+			return false;
+		}
+		auto &field_id = table.GetFieldId(PhysicalIndex(column_id.GetPrimaryIndex()));
+		if (!IsIdentityPartitionField(table, field_id.GetFieldIndex().index)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool PartitionValueMatches(const Value &partition_value, const vector<Value> &accepted_values) {
+	if (partition_value.IsNull()) {
+		return false;
+	}
+	for (auto &accepted_value : accepted_values) {
+		Value cast_value;
+		if (!accepted_value.DefaultTryCastAs(partition_value.type(), cast_value, nullptr, true)) {
+			continue;
+		}
+		if (Value::NotDistinctFrom(partition_value, cast_value)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool FileMatchesMetadataDeletePartitionValues(const DuckLakeFileListExtendedEntry &file,
+                                              const unordered_map<idx_t, vector<Value>> &partition_values) {
+	for (auto &entry : partition_values) {
+		bool found = false;
+		for (auto &file_partition : file.partition_values) {
+			if (file_partition.partition_column_idx != entry.first) {
+				continue;
+			}
+			if (found || !PartitionValueMatches(file_partition.partition_value, entry.second)) {
+				return false;
+			}
+			found = true;
+		}
+		if (!found) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool HasActiveDeleteFilesForDataFiles(DuckLakeTransaction &transaction, TableIndex table_id,
+                                      const vector<DuckLakeFileListExtendedEntry> &files) {
+	string file_ids;
+	for (auto &file : files) {
+		if (!file.file_id.IsValid()) {
+			continue;
+		}
+		if (!file_ids.empty()) {
+			file_ids += ",";
+		}
+		file_ids += to_string(file.file_id.index);
+	}
+	if (file_ids.empty()) {
+		return false;
+	}
+	auto result = transaction.Query(transaction.GetSnapshot(), StringUtil::Format(R"(
+SELECT COUNT(*)
+FROM {METADATA_CATALOG}.ducklake_delete_file
+WHERE table_id=%d AND data_file_id IN (%s)
+  AND {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
+)",
+	                                                                              table_id.index, file_ids));
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to check active DuckLake delete files: ");
+	}
+	for (auto &row : *result) {
+		return row.GetValue<idx_t>(0) > 0;
+	}
+	return false;
+}
+
+bool CanUseMetadataDelete(ClientContext &context, DuckLakeTableEntry &table, PhysicalOperator &child_plan,
+                          const unordered_map<idx_t, vector<Value>> &partition_values,
+                          vector<DuckLakeFileListExtendedEntry> &files) {
+	auto scan = FindMetadataDeleteSource(table, child_plan);
+	if (!scan || !table.GetPartitionData()) {
+		return false;
+	}
+
+	auto &bind_data = scan->bind_data->Cast<MultiFileBindData>();
+	auto &file_list = bind_data.file_list->Cast<DuckLakeMultiFileList>();
+	if (!ScanHasOnlyPartitionFilters(table, *scan, file_list)) {
+		return false;
+	}
+	if (partition_values.empty() && table.GetPartitionData() &&
+	    (!scan->table_filters || !scan->table_filters->HasFilters())) {
+		// Full-table delete on a partitioned table: every file selected by the scan is fully deleted.
+	} else if (partition_values.empty()) {
+		return false;
+	}
+	auto &transaction = DuckLakeTransaction::Get(context, table.catalog);
+	if (!transaction.GetMetadataManager()
+	         .GetInlinedDeletionTableName(table.GetTableId(), transaction.GetSnapshot())
+	         .empty()) {
+		return false;
+	}
+	auto extended_files = file_list.GetFilesExtended();
+	vector<DuckLakeFileListExtendedEntry> data_files;
+	optional_idx inlined_row_count;
+	for (auto &file : extended_files) {
+		if (file.data_type != DuckLakeDataType::DATA_FILE) {
+			if (file.data_type == DuckLakeDataType::INLINED_DATA) {
+				if (!inlined_row_count.IsValid()) {
+					inlined_row_count = table.GetNetInlinedRowCount(transaction);
+				}
+				if (inlined_row_count.GetIndex() == 0) {
+					continue;
+				}
+			}
+			return false;
+		}
+		// Existing row-level deletes make the raw file row count different from the visible DELETE count.
+		if (file.delete_file_id.IsValid() || !file.delete_file.path.empty()) {
+			return false;
+		}
+		if (!FileMatchesMetadataDeletePartitionValues(file, partition_values)) {
+			return false;
+		}
+		data_files.push_back(std::move(file));
+	}
+	if (HasActiveDeleteFilesForDataFiles(transaction, table.GetTableId(), data_files)) {
+		return false;
+	}
+	files = std::move(data_files);
+	return true;
+}
+
 PhysicalOperator &DuckLakeDelete::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner,
                                              DuckLakeTableEntry &table, PhysicalOperator &child_plan,
-                                             vector<idx_t> row_id_indexes, string encryption_key,
-                                             bool allow_duplicates) {
+                                             vector<idx_t> row_id_indexes, string encryption_key, bool allow_duplicates,
+                                             unordered_map<idx_t, vector<Value>> metadata_delete_partition_values) {
+	vector<DuckLakeFileListExtendedEntry> metadata_delete_files;
+	if (allow_duplicates &&
+	    CanUseMetadataDelete(context, table, child_plan, metadata_delete_partition_values, metadata_delete_files)) {
+		return planner.Make<DuckLakeMetadataDelete>(table, std::move(metadata_delete_files));
+	}
+
 	auto delete_source = FindDeleteSource(child_plan);
 	auto delete_map = make_shared_ptr<DuckLakeDeleteMap>();
 	if (delete_source) {
@@ -677,19 +1577,38 @@ PhysicalOperator &DuckLakeDelete::PlanDelete(ClientContext &context, PhysicalPla
 	                                    std::move(encryption_key), allow_duplicates);
 }
 
-PhysicalOperator &DuckLakeCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
-                                              PhysicalOperator &child_plan) {
+static PhysicalOperator &PlanDuckLakeDelete(DuckLakeCatalog &catalog, ClientContext &context,
+                                            PhysicalPlanGenerator &planner, LogicalDelete &op, PhysicalOperator &child_plan,
+                                            unordered_map<idx_t, vector<Value>> metadata_delete_partition_values) {
 	if (op.return_chunk) {
 		throw BinderException("RETURNING clause not yet supported for deletion of a DuckLake table");
 	}
-	auto encryption_key = GenerateEncryptionKey(context);
+	auto encryption_key = catalog.GenerateEncryptionKey(context);
 	vector<idx_t> row_id_indexes;
 	for (idx_t i = 0; i < 3; i++) {
 		auto &bound_ref = op.expressions[i + 1]->Cast<BoundReferenceExpression>();
 		row_id_indexes.push_back(bound_ref.Index());
 	}
 	return DuckLakeDelete::PlanDelete(context, planner, op.table.Cast<DuckLakeTableEntry>(), child_plan,
-	                                  std::move(row_id_indexes), std::move(encryption_key));
+	                                  std::move(row_id_indexes), std::move(encryption_key), true,
+	                                  std::move(metadata_delete_partition_values));
+}
+
+PhysicalOperator &DuckLakeCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op) {
+	D_ASSERT(op.children.size() == 1);
+	MetadataDeleteLogicalContext logical_context;
+	unordered_map<idx_t, vector<Value>> metadata_delete_partition_values;
+	if (!LogicalPlanGetMetadataDeletePartitionValues(op.table.Cast<DuckLakeTableEntry>(), *op.children[0],
+	                                                logical_context, metadata_delete_partition_values)) {
+		metadata_delete_partition_values.clear();
+	}
+	auto &child_plan = planner.CreatePlan(*op.children[0]);
+	return PlanDuckLakeDelete(*this, context, planner, op, child_plan, std::move(metadata_delete_partition_values));
+}
+
+PhysicalOperator &DuckLakeCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+                                              PhysicalOperator &child_plan) {
+	return PlanDuckLakeDelete(*this, context, planner, op, child_plan, {});
 }
 
 } // namespace duckdb

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -8,9 +8,7 @@
 #include "storage/ducklake_table_entry.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
 #include "duckdb/planner/operator/logical_dummy_scan.hpp"
-#include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
@@ -479,16 +477,13 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		break;
 	}
 	case MergeActionType::MERGE_DELETE: {
-		LogicalDelete delete_op(op.table, TableIndex(0));
-		delete_op.expressions.push_back(nullptr);
-
-		vector<LogicalType> row_id_types {LogicalType::VARCHAR, LogicalType::UBIGINT, LogicalType::BIGINT};
+		vector<idx_t> row_id_indexes;
 		for (idx_t i = 0; i < 3; i++) {
-			auto ref = make_uniq<BoundReferenceExpression>(row_id_types[i], op.row_id_start + i + 1);
-			delete_op.expressions.push_back(std::move(ref));
+			row_id_indexes.push_back(op.row_id_start + i + 1);
 		}
-		delete_op.bound_constraints = std::move(bound_constraints);
-		result->op = catalog.PlanDelete(context, planner, delete_op, child_plan);
+		auto encryption_key = catalog.GenerateEncryptionKey(context);
+		result->op = DuckLakeDelete::PlanDelete(context, planner, op.table.Cast<DuckLakeTableEntry>(), child_plan,
+		                                        std::move(row_id_indexes), std::move(encryption_key));
 		break;
 	}
 	case MergeActionType::MERGE_INSERT: {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2098,7 +2098,8 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 
 	// Add base query
 	query += StringUtil::Format(R"(
-SELECT data.data_file_id, del.delete_file_id, data.record_count, %s
+SELECT data.data_file_id, del.delete_file_id, data.record_count,
+       partition_values.partition_key_indexes, partition_values.partition_value_list, %s
 FROM {METADATA_CATALOG}.ducklake_data_file data
 LEFT JOIN (
 	SELECT *
@@ -2106,9 +2107,17 @@ LEFT JOIN (
     WHERE table_id=%d  AND {SNAPSHOT_ID} >= begin_snapshot
           AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
     ) del USING (data_file_id)
+LEFT JOIN (
+   SELECT data_file_id,
+          ARRAY_AGG(partition_key_index ORDER BY partition_key_index) partition_key_indexes,
+          ARRAY_AGG(partition_value ORDER BY partition_key_index) partition_value_list
+   FROM {METADATA_CATALOG}.ducklake_file_partition_value
+   WHERE table_id=%d
+   GROUP BY data_file_id
+) partition_values USING (data_file_id)
 WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
 		)",
-	                            select_list, table_id.index, table_id.index);
+	                            select_list, table_id.index, table_id.index, table_id.index);
 
 	// Add WHERE clause from filters if it was generated
 	if (!where_clause.empty()) {
@@ -2127,7 +2136,20 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 			file_entry.delete_file_id = DataFileIndex(row.GetValue<idx_t>(1));
 		}
 		file_entry.row_count = row.GetValue<idx_t>(2);
-		idx_t col_idx = 3;
+		if (!row.IsNull(3) && !row.IsNull(4)) {
+			auto partition_key_indexes = row.GetValue<Value>(3);
+			auto partition_values = row.GetValue<Value>(4);
+			auto &partition_key_children = ListValue::GetChildren(partition_key_indexes);
+			auto &partition_value_children = ListValue::GetChildren(partition_values);
+			D_ASSERT(partition_key_children.size() == partition_value_children.size());
+			for (idx_t partition_idx = 0; partition_idx < partition_key_children.size(); partition_idx++) {
+				DuckLakeFilePartitionInfo partition_value;
+				partition_value.partition_column_idx = partition_key_children[partition_idx].GetValue<idx_t>();
+				partition_value.partition_value = partition_value_children[partition_idx];
+				file_entry.partition_values.push_back(std::move(partition_value));
+			}
+		}
+		idx_t col_idx = 5;
 		file_entry.file = ReadDataFile(table, row, col_idx, IsEncrypted());
 		if (!row.IsNull(col_idx)) {
 			file_entry.row_id_start = row.GetValue<idx_t>(col_idx);

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -287,6 +287,12 @@ vector<DuckLakeFileListExtendedEntry> DuckLakeMultiFileList::GetFilesExtended() 
 		file_entry.file = GetFileData(file);
 		file_entry.delete_file = GetDeleteData(file);
 		file_entry.row_id_start = transaction_row_start;
+		for (auto &part_val : file.partition_values) {
+			DuckLakeFilePartitionInfo partition_value;
+			partition_value.partition_column_idx = part_val.partition_column_idx;
+			partition_value.partition_value = part_val.partition_value;
+			file_entry.partition_values.push_back(std::move(partition_value));
+		}
 		transaction_row_start += file.row_count;
 		result.push_back(std::move(file_entry));
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -149,13 +149,16 @@ void LocalTableChanges::DropTransactionLocalFile(ClientContext &context, TableIn
 	for (idx_t i = 0; i < table_files.size(); i++) {
 		auto &file = table_files[i];
 		if (file.file_name == path) {
+			auto created_by_ducklake = file.created_by_ducklake;
 			for (auto &del_file : file.delete_files) {
 				fs.RemoveFile(del_file.file_name);
 			}
 			file.delete_files.clear();
-			// found the file - delete it from the table list and from disk
+			// found the file - delete it from the table list and from disk if DuckLake owns it
 			table_files.erase_at(i);
-			fs.RemoveFile(path);
+			if (created_by_ducklake) {
+				fs.RemoveFile(path);
+			}
 			if (table_changes.IsEmpty()) {
 				// no more files remaining
 				changes.erase(entry);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1466,6 +1466,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	context.set_committed_snapshot_id = [&](idx_t snapshot_id) {
 		ducklake_catalog.SetCommittedSnapshotId(snapshot_id);
 	};
+	context.invalidate_table_stats_cache = [&](idx_t next_file_id, TableIndex table_id) {
+		ducklake_catalog.InvalidateTableStatsCache(next_file_id, table_id);
+	};
 	context.commit_info = state->commit_info;
 	state->Commit(transaction_snapshot, transaction_changes, retry_config, context);
 }
@@ -1779,9 +1782,13 @@ void DuckLakeTransaction::DropTableMacro(DuckLakeTableMacroEntry &macro) {
 	state->dropped_table_macros.insert(macro.GetIndex());
 }
 
-void DuckLakeTransaction::DropFile(TableIndex table_id, DataFileIndex data_file_id, string path) {
+void DuckLakeTransaction::DropFile(TableIndex table_id, DataFileIndex data_file_id, string path, idx_t row_count,
+                                   idx_t file_size_bytes) {
 	state->tables_deleted_from.insert(table_id);
 	state->dropped_files.emplace(std::move(path), data_file_id);
+	auto &stats = state->dropped_file_stats[table_id];
+	stats.row_count += row_count;
+	stats.file_size_bytes += file_size_bytes;
 }
 
 bool DuckLakeTransaction::HasDroppedFiles() const {

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -925,9 +925,73 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
 }
 
+static idx_t SaturatingSubtract(idx_t value, idx_t decrement) {
+	return decrement > value ? 0 : value - decrement;
+}
+
+void DuckLakeTransactionState::ApplyDroppedFileStats(TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
+                                                     map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+	auto entry = attempt_dropped_file_stats.find(table_id);
+	if (entry == attempt_dropped_file_stats.end()) {
+		return;
+	}
+	auto &stats = new_stats.stats;
+	stats.record_count = SaturatingSubtract(stats.record_count, entry->second.row_count);
+	stats.table_size_bytes = SaturatingSubtract(stats.table_size_bytes, entry->second.file_size_bytes);
+	attempt_dropped_file_stats.erase(entry);
+}
+
+string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
+    optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context,
+    map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+	if (attempt_dropped_file_stats.empty()) {
+		return string();
+	}
+
+	string result;
+	unique_ptr<DuckLakeStats> dl_stats;
+	if (stats) {
+		dl_stats = context.build_stats_map(*stats);
+	}
+
+	vector<TableIndex> table_ids;
+	for (auto &entry : attempt_dropped_file_stats) {
+		table_ids.push_back(entry.first);
+	}
+	for (auto &table_id : table_ids) {
+		if (attempt_dropped_file_stats.find(table_id) == attempt_dropped_file_stats.end()) {
+			continue;
+		}
+
+		optional_ptr<DuckLakeTableStats> current_stats;
+		shared_ptr<DuckLakeTableStats> current_stats_pin;
+		if (dl_stats) {
+			auto dl_stats_entry = dl_stats->table_stats.find(table_id);
+			if (dl_stats_entry != dl_stats->table_stats.end()) {
+				current_stats = dl_stats_entry->second.get();
+			}
+		} else {
+			current_stats_pin = context.get_table_stats(table_id);
+			current_stats = current_stats_pin.get();
+		}
+		if (!current_stats) {
+			continue;
+		}
+
+		DuckLakeNewGlobalStats new_globals;
+		new_globals.stats = *current_stats;
+		new_globals.initialized = true;
+		ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
+		result += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
+		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+	}
+	return result;
+}
+
 NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
                                                       optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                                      const DuckLakeCommitContext &context) {
+                                                      const DuckLakeCommitContext &context,
+                                                      map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
 	NewDataInfo result;
 	// get the global table stats
 	DuckLakeNewGlobalStats new_globals;
@@ -963,6 +1027,7 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckL
 			new_globals.stats = *current_stats;
 			new_globals.initialized = true;
 		}
+		ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
@@ -1374,7 +1439,8 @@ vector<DuckLakeSchemaInfo> DuckLakeTransactionState::GetNewSchemas(DuckLakeCommi
 string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state,
                                                TransactionChangeInformation &transaction_changes,
                                                optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                               const DuckLakeCommitContext &context) {
+                                               const DuckLakeCommitContext &context,
+                                               map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
 	auto &commit_snapshot = commit_state.commit_snapshot;
 
 	EnsureCommitInfoProvided(commit_info);
@@ -1483,7 +1549,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 	// write new data / data files
 	bool has_table_data_changes = local_changes.HasChanges();
 	if (has_table_data_changes) {
-		auto result = GetNewDataFiles(batch_queries, commit_state, stats, context);
+		auto result = GetNewDataFiles(batch_queries, commit_state, stats, context, attempt_dropped_file_stats);
 		batch_queries += write_data_files_sql(result.new_files);
 		batch_queries += context.write_inlined_data(commit_snapshot, result.new_inlined_data, new_tables_result,
 		                                            new_inlined_data_tables_result);
@@ -1501,6 +1567,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			dropped_indexes.insert(entry.second);
 		}
 		batch_queries += DuckLakeMetadataManager::DropDataFiles(dropped_indexes);
+		batch_queries += UpdateStatsForDroppedFiles(stats, context, attempt_dropped_file_stats);
 	}
 
 	if (has_table_data_changes) {
@@ -1697,6 +1764,7 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 	for (idx_t i = 0; i < retry_config.max_retry_count + 1; i++) {
 		bool can_retry;
 		auto attempt_changes = transaction_changes;
+		auto attempt_dropped_file_stats = dropped_file_stats;
 		try {
 			can_retry = false;
 			if (i > 0) {
@@ -1717,7 +1785,7 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			DuckLakeCommitState commit_state(commit_snapshot);
 			// write the new snapshot
 			string batch_queries = DuckLakeMetadataManager::InsertSnapshotSql();
-			batch_queries += CommitChanges(commit_state, attempt_changes, stats, context);
+			batch_queries += CommitChanges(commit_state, attempt_changes, stats, context, attempt_dropped_file_stats);
 			batch_queries += WriteSnapshotChanges(commit_state, attempt_changes, context.commit_info);
 			auto res = context.execute_commit_batch(commit_snapshot, batch_queries);
 			if (res->HasError()) {
@@ -1726,6 +1794,9 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			bool flushed_inlined = !flushed_inlined_tables.empty();
 			context.flush_cache_if_pending();
 			context.commit_connection();
+			for (auto &entry : dropped_file_stats) {
+				context.invalidate_table_stats_cache(commit_snapshot.next_file_id, entry.first);
+			}
 			if (flushed_inlined && !context.skip_drop_empty_inlined) {
 				DropEmptySupersededInlinedTables(context);
 			}

--- a/test/sql/delete/delete_partition_metadata.test
+++ b/test/sql/delete/delete_partition_metadata.test
@@ -1,0 +1,351 @@
+# name: test/sql/delete/delete_partition_metadata.test
+# description: partition-only DELETE retires matching DuckLake data files without row-level delete files
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/delete_partition_metadata/', METADATA_CATALOG 'metadata');
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE partitioned_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE partitioned_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO partitioned_t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30), (4, 'b', 40), (5, 'c', 50);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE end_snapshot IS NULL;
+----
+3
+
+query II
+EXPLAIN DELETE FROM partitioned_t WHERE source = 'a';
+----
+physical_plan	<REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM partitioned_t WHERE source = 'a';
+----
+2
+
+query II
+SELECT source, COUNT(*) FROM partitioned_t GROUP BY source ORDER BY source;
+----
+b	2
+c	1
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_delete_file;
+----
+0
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'partitioned_t') AND end_snapshot IS NOT NULL;
+----
+1
+
+statement ok
+CREATE TABLE partitioned_in_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE partitioned_in_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO partitioned_in_t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30), (4, 'c', 40);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM partitioned_in_t WHERE source IN ('a', 'b');
+----
+physical_plan	<REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM partitioned_in_t WHERE source IN ('a', 'b');
+----
+3
+
+query III
+SELECT id, source, value FROM partitioned_in_t ORDER BY id;
+----
+4	c	40
+
+statement ok
+CREATE TABLE same_column_and_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE same_column_and_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO same_column_and_t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30), (4, 'c', 40);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM same_column_and_t WHERE source IN ('a', 'b') AND source = 'a';
+----
+physical_plan	<REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM same_column_and_t WHERE source IN ('a', 'b') AND source = 'a';
+----
+2
+
+query III
+SELECT id, source, value FROM same_column_and_t ORDER BY id;
+----
+3	b	30
+4	c	40
+
+statement ok
+CREATE TABLE same_column_in_intersect_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE same_column_in_intersect_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO same_column_in_intersect_t VALUES (1, 'a', 10), (2, 'b', 20), (3, 'b', 30), (4, 'c', 40);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM same_column_in_intersect_t WHERE source IN ('a', 'b') AND source IN ('b', 'c');
+----
+physical_plan	<REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM same_column_in_intersect_t WHERE source IN ('a', 'b') AND source IN ('b', 'c');
+----
+2
+
+query III
+SELECT id, source, value FROM same_column_in_intersect_t ORDER BY id;
+----
+1	a	10
+4	c	40
+
+statement ok
+CREATE TABLE legacy_partitioned_t (id INT, source VARCHAR, value INT);
+
+statement ok
+INSERT INTO legacy_partitioned_t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30), (4, 'b', 40), (5, 'c', 50);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+ALTER TABLE legacy_partitioned_t SET PARTITIONED BY (source);
+
+query II
+EXPLAIN DELETE FROM legacy_partitioned_t WHERE source = 'a';
+----
+physical_plan	<!REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM legacy_partitioned_t WHERE source = 'a';
+----
+2
+
+query III
+SELECT id, source, value FROM legacy_partitioned_t ORDER BY id;
+----
+3	b	30
+4	b	40
+5	c	50
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'legacy_partitioned_t') AND end_snapshot IS NOT NULL;
+----
+0
+
+# A mixed partition + non-partition predicate must fall back to row-level deletes.
+query I
+DELETE FROM partitioned_t WHERE source = 'b' AND value > 30;
+----
+1
+
+query III
+SELECT id, source, value FROM partitioned_t ORDER BY id;
+----
+3	b	30
+5	c	50
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'partitioned_t') AND end_snapshot IS NOT NULL;
+----
+1
+
+# Existing row-level deletes make the visible row count differ from raw file rows, so this falls back.
+query II
+EXPLAIN DELETE FROM partitioned_t;
+----
+physical_plan	<!REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM partitioned_t;
+----
+2
+
+query I
+SELECT COUNT(*) FROM partitioned_t;
+----
+0
+
+# Full-table DELETE on a partitioned table with no existing deletes is metadata-only.
+statement ok
+CREATE TABLE full_partitioned_t (id INT, source VARCHAR);
+
+statement ok
+ALTER TABLE full_partitioned_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO full_partitioned_t VALUES (1, 'x'), (2, 'y');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM full_partitioned_t;
+----
+physical_plan	<REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM full_partitioned_t;
+----
+2
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'full_partitioned_t') AND end_snapshot IS NOT NULL;
+----
+2
+
+statement ok
+CREATE TABLE null_partitioned_t (id INT, source VARCHAR);
+
+statement ok
+ALTER TABLE null_partitioned_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO null_partitioned_t VALUES (1, NULL), (2, 'present');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM null_partitioned_t WHERE source IS NULL;
+----
+physical_plan	<!REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM null_partitioned_t WHERE source IS NULL;
+----
+1
+
+query II
+SELECT id, source FROM null_partitioned_t ORDER BY id;
+----
+2	present
+
+statement ok
+CREATE TABLE constant_false_t (id INT, source VARCHAR);
+
+statement ok
+ALTER TABLE constant_false_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO constant_false_t VALUES (1, 'a'), (2, 'b');
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+DELETE FROM constant_false_t WHERE 1 = 0;
+----
+0
+
+query I
+SELECT COUNT(*) FROM constant_false_t;
+----
+2
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'constant_false_t') AND end_snapshot IS NOT NULL;
+----
+0
+
+statement ok
+CREATE TABLE transformed_t (id INT, ts TIMESTAMP, value INT);
+
+statement ok
+ALTER TABLE transformed_t SET PARTITIONED BY (year(ts));
+
+statement ok
+INSERT INTO transformed_t VALUES (1, TIMESTAMP '2024-01-15 00:00:00', 10), (2, TIMESTAMP '2024-01-16 00:00:00', 20);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM transformed_t WHERE ts = TIMESTAMP '2024-01-15 00:00:00';
+----
+physical_plan	<!REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM transformed_t WHERE ts = TIMESTAMP '2024-01-15 00:00:00';
+----
+1
+
+query III
+SELECT id, ts, value FROM transformed_t ORDER BY id;
+----
+2	2024-01-16 00:00:00	20
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'transformed_t') AND end_snapshot IS NOT NULL;
+----
+0
+
+statement ok
+CREATE TABLE mixed_or_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE mixed_or_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO mixed_or_t VALUES (1, 'x', 10), (2, 'x', 20), (5, 'y', 50), (6, 'y', 60);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query II
+EXPLAIN DELETE FROM mixed_or_t WHERE source = 'x' OR id = 5;
+----
+physical_plan	<!REGEX>:.*DUCKLAKE_METADATA_DELETE.*
+
+query I
+DELETE FROM mixed_or_t WHERE source = 'x' OR id = 5;
+----
+3
+
+query III
+SELECT id, source, value FROM mixed_or_t ORDER BY id;
+----
+6	y	60

--- a/test/sql/delete/delete_partition_metadata_atomicity.test
+++ b/test/sql/delete/delete_partition_metadata_atomicity.test
@@ -1,0 +1,103 @@
+# name: test/sql/delete/delete_partition_metadata_atomicity.test
+# description: metadata partition DELETE composes atomically with ducklake_add_data_files
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/delete_partition_metadata_atomicity/', METADATA_CATALOG 'metadata');
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE partitioned_t (id INT, source VARCHAR, value INT);
+
+statement ok
+ALTER TABLE partitioned_t SET PARTITIONED BY (source);
+
+statement ok
+INSERT INTO partitioned_t VALUES (1, 'a', 10), (2, 'a', 20), (3, 'b', 30);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE before_replace_snapshot = (SELECT max(snapshot_id) FROM metadata.ducklake_snapshot);
+
+statement ok
+COPY (SELECT 100 AS id, 'a' AS source, 999 AS value) TO '{DATA_PATH}/delete_partition_metadata_atomicity/replace_a' (FORMAT parquet, PARTITION_BY (source));
+
+statement ok
+BEGIN;
+
+query I
+DELETE FROM partitioned_t WHERE source = 'a';
+----
+2
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'partitioned_t', '{DATA_PATH}/delete_partition_metadata_atomicity/replace_a/source=a/data_0.parquet');
+
+statement ok
+COMMIT;
+
+query I
+SELECT (max(snapshot_id) = getvariable('before_replace_snapshot') + 1)::INT FROM metadata.ducklake_snapshot;
+----
+1
+
+query III
+SELECT id, source, value FROM partitioned_t ORDER BY id;
+----
+3	b	30
+100	a	999
+
+query I
+SELECT COUNT(DISTINCT snap)
+FROM (
+  SELECT end_snapshot AS snap FROM metadata.ducklake_data_file WHERE end_snapshot IS NOT NULL
+  UNION
+  SELECT begin_snapshot AS snap FROM metadata.ducklake_data_file WHERE begin_snapshot = getvariable('before_replace_snapshot') + 1
+);
+----
+1
+
+# Transaction-local add_data_files data can be removed by DELETE before commit without deleting the external parquet.
+statement ok
+COPY (SELECT 300 AS id, 'c' AS source, 777 AS value) TO '{DATA_PATH}/delete_partition_metadata_atomicity/add_then_delete_c' (FORMAT parquet, PARTITION_BY (source));
+
+statement ok
+BEGIN;
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'partitioned_t', '{DATA_PATH}/delete_partition_metadata_atomicity/add_then_delete_c/source=c/data_0.parquet');
+
+query I
+SELECT COUNT(*) FROM partitioned_t WHERE source = 'c';
+----
+1
+
+query I
+DELETE FROM partitioned_t WHERE source = 'c';
+----
+1
+
+statement ok
+COMMIT;
+
+query I
+SELECT COUNT(*) FROM partitioned_t WHERE source = 'c';
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_parquet('{DATA_PATH}/delete_partition_metadata_atomicity/add_then_delete_c/source=c/data_0.parquet');
+----
+1

--- a/test/sql/delete/delete_partition_metadata_concurrent.test
+++ b/test/sql/delete/delete_partition_metadata_concurrent.test
@@ -1,0 +1,63 @@
+# name: test/sql/delete/delete_partition_metadata_concurrent.test
+# description: concurrent metadata partition DELETE conflicts on the same partition
+# group: [delete]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/delete_partition_metadata_concurrent/', BUSY_TIMEOUT 10000)
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE tbl (key INTEGER, grouping INTEGER);
+
+statement ok
+ALTER TABLE tbl SET PARTITIONED BY (grouping);
+
+statement ok
+INSERT INTO tbl SELECT i AS key, i % 10 AS grouping FROM range(0, 200) t(i);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+query I con1
+DELETE FROM ducklake.tbl WHERE grouping = 1
+----
+20
+
+query I con2
+DELETE FROM ducklake.tbl WHERE grouping = 1
+----
+20
+
+statement ok con1
+COMMIT
+
+statement error con2
+COMMIT
+----
+conflict
+
+query I
+SELECT COUNT(*) FROM ducklake.tbl WHERE grouping = 1;
+----
+0

--- a/test/sql/delete/full_file_delete_stats.test
+++ b/test/sql/delete/full_file_delete_stats.test
@@ -1,0 +1,78 @@
+# name: test/sql/delete/full_file_delete_stats.test
+# description: Deletes that drop a whole data file decrement table stats (and invalidate the stats cache)
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/full_file_delete_stats', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t AS SELECT range::INT id FROM range(100)
+
+# Materialize ids/sizes one scan at a time so the test also works against the
+# Postgres/SQLite metadata catalog (which cannot do multiple streaming scans per query).
+statement ok
+SET VARIABLE t_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 't')
+
+statement ok
+SET VARIABLE initial_size = (SELECT file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id'))
+
+# A partial delete writes a delete file and leaves the data file active, so table stats are unchanged.
+query I
+DELETE FROM ducklake.t WHERE id < 30
+----
+30
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE table_id = getvariable('t_id') AND end_snapshot IS NULL
+----
+1
+
+query III
+SELECT record_count, next_row_id, file_size_bytes = getvariable('initial_size') FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+100	100	true
+
+# Deleting the remaining rows fully deletes the file: it is dropped, the stats are decremented to
+# zero, and next_row_id stays monotonic (no double subtraction with the earlier partial delete).
+query I
+DELETE FROM ducklake.t WHERE id >= 30
+----
+70
+
+query I
+SELECT COUNT(*) FROM ducklake.t
+----
+0
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('t_id') AND end_snapshot IS NULL
+----
+0
+
+query III
+SELECT record_count, next_row_id, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+0	100	0
+
+# Re-insert after the drop in the same connection: the stats cache was invalidated, so the insert
+# starts from the decremented base (record_count 0), not the stale pre-delete value.
+statement ok
+INSERT INTO ducklake.t SELECT range::INT id FROM range(10)
+
+query I
+SELECT COUNT(*) FROM ducklake.t
+----
+10
+
+query II
+SELECT record_count, next_row_id FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+10	110


### PR DESCRIPTION
## Summary

This PR adds a metadata-only DELETE path for DuckLake tables when the DELETE can be proven to remove whole data files, and fixes table-statistics accounting when whole files are dropped.

## Metadata-only partition DELETE

For DELETE predicates over identity partition columns, DuckLake can retire matching data files by updating metadata instead of scanning files and writing row-level delete files.

This path is used only when all candidate files are safe to drop:

- the predicate is reducible to accepted constant values for identity partition columns (`=` / `IN`)
- every candidate file has recorded partition values matching the accepted set
- no candidate file has active row-level delete files
- no inlined data or active inlined deletion table is involved
- non-identity partition transforms, mixed non-partition predicates, NULL partition predicates, and legacy files without partition metadata fall back to the existing row-level delete path

Full-table DELETE on partitioned tables can also use this path when the scan selects whole active data files.

## Stats fix

Whole-file drops now decrement `ducklake_table_stats.record_count` and `file_size_bytes`.

Before this PR, full-file deletes retired data files but left global table stats unchanged, so repeated delete/reinsert cycles inflated:

- optimizer cardinality estimates via `GetCardinality`
- `duckdb_tables` size reporting

`next_row_id` remains monotonic. Column min/max stats are left unchanged because exact recomputation would require scanning remaining files.

The stats cache is also invalidated after delete-only commits that drop files, since `next_file_id` does not change for those commits.

## Tests

Adds coverage for:

- metadata-only partition DELETE with `=` and `IN`
- intersecting partition filters
- fallback for mixed predicates, NULL predicates, transformed partitions, legacy files, existing deletes, and inlined data
- atomic delete + `ducklake_add_data_files`
- concurrent conflicting metadata deletes
- table-stats decrement and stats-cache invalidation
