### PR TITLE
Add bucket-transform-aware partition pruning

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -345,6 +345,11 @@ private:
 	string GetDeleteFileSelectList(const string &prefix);
 	FilterPushdownQueryComponents GenerateFilterPushdownComponents(const FilterPushdownInfo &filter_info,
 	                                                               TableIndex table_id);
+	//! Build an additional WHERE fragment that prunes files by bucket() partition value.
+	//! Returns "" when no foldable equality / IN-list predicate exists on a bucket-partitioned column.
+	//! The fragment uses only string equality against ducklake_file_partition_value, so it works against
+	//! any metadata backend (DuckDB / Postgres / SQLite). Bucket hashes are pre-computed in C++.
+	string BuildBucketPartitionPruningClause(DuckLakeTableEntry &table, const FilterPushdownInfo &filter_info);
 	string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
 	                                          TableIndex table_id);
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1578,17 +1578,17 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		auto components = GenerateFilterPushdownComponents(*filter_info, table_id);
 		query = components.cte_section;
 		where_clause = components.where_clause;
-	}
 
-	// Add bucket-partition pruning for equality / IN-list predicates on bucket()-partitioned columns.
-	// This composes with the zone-map clause above — pruning narrows files, zone maps stay as a backstop.
-	if (filter_info) {
-		string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
-		if (!bucket_clause.empty()) {
-			if (!where_clause.empty()) {
-				where_clause += " AND ";
+		// Add bucket-partition pruning for equality / IN-list predicates on bucket()-partitioned columns.
+		// Composes with the zone-map clause above — pruning narrows files, zone maps stay as a backstop.
+		if (table.GetPartitionData()) {
+			string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
+			if (!bucket_clause.empty()) {
+				if (!where_clause.empty()) {
+					where_clause += " AND ";
+				}
+				where_clause += bucket_clause;
 			}
-			where_clause += bucket_clause;
 		}
 	}
 
@@ -1930,16 +1930,16 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 		auto components = GenerateFilterPushdownComponents(*filter_info, table_id);
 		query = components.cte_section;
 		where_clause = components.where_clause;
-	}
 
-	// Add bucket-partition pruning (see GetFilesForTable for rationale).
-	if (filter_info) {
-		string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
-		if (!bucket_clause.empty()) {
-			if (!where_clause.empty()) {
-				where_clause += " AND ";
+		// Add bucket-partition pruning (see GetFilesForTable for rationale).
+		if (table.GetPartitionData()) {
+			string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
+			if (!bucket_clause.empty()) {
+				if (!where_clause.empty()) {
+					where_clause += " AND ";
+				}
+				where_clause += bucket_clause;
 			}
-			where_clause += bucket_clause;
 		}
 	}
 

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -23,6 +23,9 @@
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
 #include "duckdb/planner/expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "storage/ducklake_partition_data.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/expression/cast_expression.hpp"
 
@@ -1382,6 +1385,131 @@ struct DynamicFilterColumn {
 	LogicalType column_type;
 };
 
+//! Fold a single constant through the bucket() transform, returning the resulting partition_value
+//! string ("6", "3", ...) that matches what the writer stores. Returns empty optional on any failure
+//! (cast error, evaluation error, NULL) so the caller can skip this filter and fall back to zone maps.
+static optional_idx FoldBucketValue(ClientContext &context, const Value &constant, const LogicalType &col_type,
+                                     idx_t bucket_count, string &out_partition_value) {
+	if (constant.IsNull()) {
+		return optional_idx();
+	}
+	Value casted;
+	if (!constant.DefaultTryCastAs(col_type, casted, nullptr)) {
+		return optional_idx();
+	}
+	auto const_expr = make_uniq<BoundConstantExpression>(std::move(casted));
+	auto bucket_expr = DuckLakePartitionUtils::ApplyBucketTransform(context, std::move(const_expr), bucket_count);
+	Value result;
+	if (!ExpressionExecutor::TryEvaluateScalar(context, *bucket_expr, result)) {
+		return optional_idx();
+	}
+	if (result.IsNull()) {
+		return optional_idx();
+	}
+	out_partition_value = result.ToString();
+	return optional_idx(1);
+}
+
+//! Walk a TableFilter and, for each foldable equality / IN-list constant, append the resulting
+//! partition_value string to `out`. Returns true if at least one valid constant was collected.
+//! Unsupported shapes (range comparisons, OR-conjunctions, dynamic filters, etc.) return false
+//! and pruning is skipped for this column — the existing zone-map path handles correctness.
+static bool CollectBucketEqualityValues(ClientContext &context, const TableFilter &filter,
+                                         const LogicalType &col_type, idx_t bucket_count, vector<string> &out) {
+	switch (filter.filter_type) {
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &cf = filter.Cast<ConstantFilter>();
+		if (cf.comparison_type != ExpressionType::COMPARE_EQUAL) {
+			return false;
+		}
+		string partition_value;
+		if (!FoldBucketValue(context, cf.constant, col_type, bucket_count, partition_value).IsValid()) {
+			return false;
+		}
+		out.push_back(std::move(partition_value));
+		return true;
+	}
+	case TableFilterType::IN_FILTER: {
+		auto &in_filter = filter.Cast<InFilter>();
+		for (auto &val : in_filter.values) {
+			string partition_value;
+			if (!FoldBucketValue(context, val, col_type, bucket_count, partition_value).IsValid()) {
+				continue;
+			}
+			out.push_back(std::move(partition_value));
+		}
+		return !out.empty();
+	}
+	case TableFilterType::OPTIONAL_FILTER:
+		return CollectBucketEqualityValues(context, *filter.Cast<OptionalFilter>().child_filter, col_type,
+		                                    bucket_count, out);
+	case TableFilterType::CONJUNCTION_AND: {
+		// A child equality on this column gives a valid (tighter) prune. Over-inclusion from
+		// contradictory ANDs (a = 1 AND a = 2) is correctness-safe — the residual filter still runs.
+		auto &conj = filter.Cast<ConjunctionAndFilter>();
+		for (auto &child : conj.child_filters) {
+			CollectBucketEqualityValues(context, *child, col_type, bucket_count, out);
+		}
+		return !out.empty();
+	}
+	default:
+		return false;
+	}
+}
+
+string DuckLakeMetadataManager::BuildBucketPartitionPruningClause(DuckLakeTableEntry &table,
+                                                                  const FilterPushdownInfo &filter_info) {
+	auto partition_data = table.GetPartitionData();
+	if (!partition_data) {
+		return string();
+	}
+	auto context_ptr = transaction.context.lock();
+	if (!context_ptr) {
+		return string();
+	}
+	auto &context = *context_ptr;
+	auto table_id = table.GetTableId();
+	string result;
+
+	for (auto &field : partition_data->fields) {
+		if (field.transform.type != DuckLakeTransformType::BUCKET) {
+			continue;
+		}
+		auto it = filter_info.column_filters.find(field.field_id.index);
+		if (it == filter_info.column_filters.end()) {
+			continue;
+		}
+		const auto &col_filter = it->second;
+
+		vector<string> bucket_values;
+		if (!CollectBucketEqualityValues(context, *col_filter.table_filter, col_filter.column_type,
+		                                  field.transform.bucket_count, bucket_values)) {
+			continue;
+		}
+		if (bucket_values.empty()) {
+			continue;
+		}
+
+		string in_list;
+		for (auto &v : bucket_values) {
+			if (!in_list.empty()) {
+				in_list += ", ";
+			}
+			in_list += StringUtil::Format("%s", SQLString(v));
+		}
+		string clause = StringUtil::Format(
+		    "data.data_file_id IN (SELECT data_file_id FROM {METADATA_CATALOG}.ducklake_file_partition_value "
+		    "WHERE table_id = %d AND partition_key_index = %d AND partition_value IN (%s))",
+		    table_id.index, field.partition_key_index, in_list);
+
+		if (!result.empty()) {
+			result += " AND ";
+		}
+		result += clause;
+	}
+	return result;
+}
+
 vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLakeTableEntry &table,
                                                                         DuckLakeSnapshot snapshot,
                                                                         const FilterPushdownInfo *filter_info) {
@@ -1450,6 +1578,18 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		auto components = GenerateFilterPushdownComponents(*filter_info, table_id);
 		query = components.cte_section;
 		where_clause = components.where_clause;
+	}
+
+	// Add bucket-partition pruning for equality / IN-list predicates on bucket()-partitioned columns.
+	// This composes with the zone-map clause above — pruning narrows files, zone maps stay as a backstop.
+	if (filter_info) {
+		string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
+		if (!bucket_clause.empty()) {
+			if (!where_clause.empty()) {
+				where_clause += " AND ";
+			}
+			where_clause += bucket_clause;
+		}
 	}
 
 	// Add base query
@@ -1790,6 +1930,17 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 		auto components = GenerateFilterPushdownComponents(*filter_info, table_id);
 		query = components.cte_section;
 		where_clause = components.where_clause;
+	}
+
+	// Add bucket-partition pruning (see GetFilesForTable for rationale).
+	if (filter_info) {
+		string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
+		if (!bucket_clause.empty()) {
+			if (!where_clause.empty()) {
+				where_clause += " AND ";
+			}
+			where_clause += bucket_clause;
+		}
 	}
 
 	// Add base query

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -170,6 +170,7 @@
         "test/sql/metadata/appender_partition_values.test",
         "test/sql/metadata/appender_variant_stats.test",
         "test/sql/partitioning/bucket_partitioning.test",
+        "test/sql/partitioning/bucket_pruning.test",
         "test/sql/partitioning/merge_adjacent_null_partition.test",
         "test/sql/partitioning/partition_rename_in_transaction.test",
         "test/sql/rewrite_data_files/test_rewrite_partitioning.test",

--- a/test/sql/partitioning/bucket_pruning.test
+++ b/test/sql/partitioning/bucket_pruning.test
@@ -1,0 +1,133 @@
+# name: test/sql/partitioning/bucket_pruning.test
+# description: Test transform-aware file pruning for bucket() partition transforms
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_bucket_prune', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE b1_no_stats (i INT);
+
+statement ok
+ALTER TABLE b1_no_stats SET PARTITIONED BY (bucket(10, i));
+
+statement ok
+INSERT INTO b1_no_stats SELECT i::INT FROM range(-10000, 10001) g(i);
+
+# All 10 bucket files must exist
+query I
+SELECT COUNT(DISTINCT fpv.partition_value)
+FROM ducklake_metadata.ducklake_file_partition_value fpv
+JOIN ducklake_metadata.ducklake_data_file df ON fpv.data_file_id = df.data_file_id
+JOIN ducklake_metadata.ducklake_table t ON df.table_id = t.table_id
+WHERE t.table_name = 'b1_no_stats' AND df.end_snapshot IS NULL
+----
+10
+
+# Correctness: pruning must not lose rows
+query I
+SELECT COUNT(*) FROM b1_no_stats WHERE i = 0
+----
+1
+
+query I
+SELECT i FROM b1_no_stats WHERE i = 0
+----
+0
+
+# Pruning: only one bucket file (bucket=6 for i=0 with bucket(10)) should be read
+query II
+EXPLAIN ANALYZE SELECT * FROM b1_no_stats WHERE i = 0
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# Pruning works for a different value too
+query II
+EXPLAIN ANALYZE SELECT * FROM b1_no_stats WHERE i = 42
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# IN-list: prunes to the union of matching buckets (at most 2 files for 2 distinct values)
+query I
+SELECT COUNT(*) FROM b1_no_stats WHERE i IN (0, 1)
+----
+2
+
+query II
+EXPLAIN ANALYZE SELECT * FROM b1_no_stats WHERE i IN (0, 1)
+----
+analyzed_plan	<REGEX>:.*Total Files Read: [12].*
+
+# Range predicates: cannot be folded across the bucket hash — must fall through to zone maps.
+# Correctness is the contract here; we don't assert a file count.
+query I
+SELECT COUNT(*) FROM b1_no_stats WHERE i > 9998
+----
+2
+
+# VARCHAR-typed bucket column — make sure pruning works for non-int input types
+statement ok
+CREATE TABLE bucketed_str (s VARCHAR);
+
+statement ok
+ALTER TABLE bucketed_str SET PARTITIONED BY (bucket(4, s));
+
+statement ok
+INSERT INTO bucketed_str SELECT 'value_' || i::VARCHAR FROM range(0, 200) g(i);
+
+query I
+SELECT COUNT(*) FROM bucketed_str WHERE s = 'value_0'
+----
+1
+
+query II
+EXPLAIN ANALYZE SELECT * FROM bucketed_str WHERE s = 'value_0'
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# Multi-key partition spec with bucket — each key adds its own IN-clause; both apply.
+statement ok
+CREATE TABLE multi_bucket (a INT, b INT);
+
+statement ok
+ALTER TABLE multi_bucket SET PARTITIONED BY (bucket(4, a), bucket(4, b));
+
+statement ok
+INSERT INTO multi_bucket SELECT i % 100, (i * 7) % 100 FROM range(0, 1000) g(i);
+
+query I
+SELECT COUNT(*) FROM multi_bucket WHERE a = 5 AND b = 35
+----
+10
+
+# With both keys pinned, we should hit a single (a-bucket, b-bucket) combination.
+query II
+EXPLAIN ANALYZE SELECT * FROM multi_bucket WHERE a = 5 AND b = 35
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# Identity partitioning continues to work (unaffected by the new code path).
+statement ok
+CREATE TABLE identity_tbl (g INT, payload INT);
+
+statement ok
+ALTER TABLE identity_tbl SET PARTITIONED BY (g);
+
+statement ok
+INSERT INTO identity_tbl SELECT i % 10, i FROM range(0, 1000) g(i);
+
+query II
+EXPLAIN ANALYZE SELECT * FROM identity_tbl WHERE g = 3
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*


### PR DESCRIPTION
Equality and IN-list predicates on `bucket()`-partitioned columns now prune files via `ducklake_file_partition_value` at scan-planning time. Bucket hashes are computed in C++ so the catalog SQL stays backend-agnostic. Range predicates fall through to the existing zone-map path.

Basically makes lookup queries useful with buckets. Zone-maps are not really effective for hashed transforms.