### PR TITLE
Scope Quack metadata attach and cache refresh

### DIFF
--- a/src/metadata_manager/quack_metadata_manager.cpp
+++ b/src/metadata_manager/quack_metadata_manager.cpp
@@ -72,6 +72,7 @@ void QuackMetadataManager::ClearCache() {
 		return;
 	}
 	auto raw_message = result->GetErrorObject().RawMessage();
+	// Older Quack builds only expose the zero-arg quack_clear_cache; fall back when the one-arg overload is missing.
 	if (!StringUtil::Contains(raw_message, "No function matches")) {
 		result->GetErrorObject().Throw("Failed to clear Quack metadata cache: ");
 	}

--- a/src/metadata_manager/quack_metadata_manager.cpp
+++ b/src/metadata_manager/quack_metadata_manager.cpp
@@ -64,8 +64,21 @@ string QuackMetadataManager::MetadataExistsQuery() const {
 }
 
 void QuackMetadataManager::ClearCache() {
-	string clear = "CALL quack_clear_cache();";
-	transaction.ExecuteRaw(clear);
+	auto &ducklake_catalog = transaction.GetCatalog();
+	string clear =
+	    StringUtil::Format("CALL quack_clear_cache(%s);", SQLString(ducklake_catalog.MetadataDatabaseName()));
+	auto result = transaction.ExecuteRaw(clear);
+	if (!result->HasError()) {
+		return;
+	}
+	auto raw_message = result->GetErrorObject().RawMessage();
+	if (!StringUtil::Contains(raw_message, "No function matches")) {
+		result->GetErrorObject().Throw("Failed to clear Quack metadata cache: ");
+	}
+	result = transaction.ExecuteRaw("CALL quack_clear_cache();");
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to clear Quack metadata cache: ");
+	}
 }
 
 bool QuackMetadataManager::MetadataExists() {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -20,6 +20,7 @@ DuckLakeInitializer::DuckLakeInitializer(ClientContext &context, DuckLakeCatalog
 
 string DuckLakeInitializer::GetAttachOptions() {
 	vector<string> attach_options;
+	const string metadata_type = catalog.MetadataType();
 	if (options.access_mode != AccessMode::AUTOMATIC) {
 		switch (options.access_mode) {
 		case AccessMode::READ_ONLY:
@@ -32,10 +33,13 @@ string DuckLakeInitializer::GetAttachOptions() {
 			throw InternalException("Unsupported access mode in DuckLake attach");
 		}
 	}
+	if ((metadata_type == "quack" || metadata_type == "quack_scanner") && !options.metadata_schema.empty() &&
+	    options.metadata_parameters.find("schema") == options.metadata_parameters.end()) {
+		attach_options.push_back("schema " + Value(options.metadata_schema).ToSQLString());
+	}
 	for (auto &option : options.metadata_parameters) {
 		attach_options.push_back(option.first + " " + option.second.ToSQLString());
 	}
-	const string metadata_type = catalog.MetadataType();
 	if (metadata_type.empty() || metadata_type == "duckdb") {
 		// this is duckdb, we always do latest storage
 		attach_options.push_back(StringUtil::Format("STORAGE_VERSION '%s'", "latest"));


### PR DESCRIPTION
Bridge DuckLake's `METADATA_SCHEMA` to Quack's generic `schema` attach option for Quack-backed metadata catalogs, leaving explicit `META_SCHEMA` / `metadata_parameters['schema']` overrides intact. Also pass the DuckLake metadata database name to `quack_clear_cache`, falling back to the zero-arg call for older Quack builds. Pairs with duckdb/duckdb-quack#147.