### PR TITLE
Fix stats merging for variant columns with incompatible shredded types

### DIFF
--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -72,7 +72,8 @@ DuckLakeColumnStats &DuckLakeColumnStats::operator=(const DuckLakeColumnStats &o
 }
 
 void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
-	if (type != new_stats.type) {
+	bool types_differ = type != new_stats.type;
+	if (types_differ) {
 		// handle type promotion - adopt the new type
 		type = new_stats.type;
 	}
@@ -100,6 +101,10 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 
 	if (!new_stats.AnyValid()) {
 		// all values in the source are NULL - don't update min/max
+		if (types_differ) {
+			has_min = false;
+			has_max = false;
+		}
 		return;
 	}
 	if (!AnyValid()) {
@@ -111,37 +116,43 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 		any_valid = true;
 		return;
 	}
-	if (!new_stats.has_min) {
+	if (types_differ) {
+		// min/max from different types cannot be compared - invalidate them
 		has_min = false;
-	} else if (has_min) {
-		// both stats have a min - select the smallest
-		if (RequiresValueComparison(type)) {
-			// for numerics/temporals we need to parse the stats
-			auto current_min = Value(min).DefaultCastAs(type);
-			auto new_min = Value(new_stats.min).DefaultCastAs(type);
-			if (new_min < current_min) {
+		has_max = false;
+	} else {
+		if (!new_stats.has_min) {
+			has_min = false;
+		} else if (has_min) {
+			// both stats have a min - select the smallest
+			if (RequiresValueComparison(type)) {
+				// for numerics/temporals we need to parse the stats
+				auto current_min = Value(min).DefaultCastAs(type);
+				auto new_min = Value(new_stats.min).DefaultCastAs(type);
+				if (new_min < current_min) {
+					min = new_stats.min;
+				}
+			} else if (new_stats.min < min) {
+				// for other types we can compare the strings directly
 				min = new_stats.min;
 			}
-		} else if (new_stats.min < min) {
-			// for other types we can compare the strings directly
-			min = new_stats.min;
 		}
-	}
 
-	if (!new_stats.has_max) {
-		has_max = false;
-	} else if (has_max) {
-		// both stats have a max - select the largest
-		if (RequiresValueComparison(type)) {
-			// for numerics/temporals we need to parse the stats
-			auto current_max = Value(max).DefaultCastAs(type);
-			auto new_max = Value(new_stats.max).DefaultCastAs(type);
-			if (new_max > current_max) {
+		if (!new_stats.has_max) {
+			has_max = false;
+		} else if (has_max) {
+			// both stats have a max - select the largest
+			if (RequiresValueComparison(type)) {
+				// for numerics/temporals we need to parse the stats
+				auto current_max = Value(max).DefaultCastAs(type);
+				auto new_max = Value(new_stats.max).DefaultCastAs(type);
+				if (new_max > current_max) {
+					max = new_stats.max;
+				}
+			} else if (new_stats.max > max) {
+				// for other types we can compare the strings directly
 				max = new_stats.max;
 			}
-		} else if (new_stats.max > max) {
-			// for other types we can compare the strings directly
-			max = new_stats.max;
 		}
 	}
 

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -74,7 +74,6 @@ DuckLakeColumnStats &DuckLakeColumnStats::operator=(const DuckLakeColumnStats &o
 void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 	bool types_differ = type != new_stats.type;
 	if (types_differ) {
-		// handle type promotion - adopt the new type
 		type = new_stats.type;
 	}
 	if (!new_stats.has_null_count) {

--- a/src/storage/statistics/ducklake_variant_stats.cpp
+++ b/src/storage/statistics/ducklake_variant_stats.cpp
@@ -37,6 +37,7 @@ void DuckLakeColumnVariantStats::Merge(const DuckLakeColumnExtraStats &new_stats
 		}
 		// merge stats
 		entry.second.field_stats.MergeStats(other_entry->second.field_stats);
+		entry.second.shredded_type = entry.second.field_stats.type;
 	}
 	// erase any stats that do not occur in both
 	for (auto &entry : stats_to_erase) {

--- a/src/storage/statistics/ducklake_variant_stats.cpp
+++ b/src/storage/statistics/ducklake_variant_stats.cpp
@@ -35,9 +35,13 @@ void DuckLakeColumnVariantStats::Merge(const DuckLakeColumnExtraStats &new_stats
 			stats_to_erase.push_back(entry.first);
 			continue;
 		}
+		if (entry.second.shredded_type != other_entry->second.shredded_type) {
+			// incompatible shredded types - drop the field
+			stats_to_erase.push_back(entry.first);
+			continue;
+		}
 		// merge stats
 		entry.second.field_stats.MergeStats(other_entry->second.field_stats);
-		entry.second.shredded_type = entry.second.field_stats.type;
 	}
 	// erase any stats that do not occur in both
 	for (auto &entry : stats_to_erase) {

--- a/test/sql/stats/variant_mixed_type_stats.test
+++ b/test/sql/stats/variant_mixed_type_stats.test
@@ -22,6 +22,12 @@ SELECT variant_path, shredded_type, min_value, max_value FROM __ducklake_metadat
 ----
 root	int32	42	42
 
+# with a single type, in-memory stats should show SHREDDED
+query I
+SELECT stats(v) FROM ducklake.tbl LIMIT 1
+----
+<REGEX>:.*SHREDDED.*INTEGER.*
+
 # file 2: varchar variant - different shredded type for the same field
 statement ok
 INSERT INTO ducklake.tbl SELECT 'hello'::VARIANT
@@ -44,23 +50,22 @@ SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
 42
 hello
 
-# stats() should not crash
+# in-memory stats should show INCONSISTENT after type mismatch
 query I
-SELECT count(*) FROM (SELECT stats(v) FROM ducklake.tbl LIMIT 1)
+SELECT stats(v) FROM ducklake.tbl LIMIT 1
 ----
-1
+<REGEX>:.*INCONSISTENT.*
 
-# after merging INT + VARCHAR, shredded_type should be varchar (not stale int32)
+# incompatible shredded types (INT vs VARCHAR) - shredded stats are dropped entirely
 query I
-SELECT extra_stats LIKE '%"varchar"%' FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
+SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
-true
+NULL
 
 # file 3: another integer variant
 statement ok
 INSERT INTO ducklake.tbl SELECT 7::VARIANT
 
-# table-level min/max should still be invalidated (can't recover without recomputing from all files)
 query II
 SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
@@ -80,13 +85,7 @@ DETACH ducklake
 statement ok
 ATTACH 'ducklake:__TEST_DIR__/ducklake_variant_mixed_type_stats.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_variant_mixed_type_stats_files', DATA_INLINING_ROW_LIMIT 0)
 
-query III
-SELECT min_value, max_value, extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
-----
-NULL	NULL	[{"field_name":"root","shredded_type":"int32","null_count":0,"num_values":3,"column_size_bytes":92,"any_valid":true}]
-
-# verify shredded_type in extra_stats JSON reflects the promoted type (not the stale original)
 query I
-SELECT extra_stats LIKE '%"varchar"%' FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
+SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
-true
+NULL

--- a/test/sql/stats/variant_mixed_type_stats.test
+++ b/test/sql/stats/variant_mixed_type_stats.test
@@ -1,0 +1,72 @@
+# name: test/sql/stats/variant_mixed_type_stats.test
+# description: test that variant stats are correct when merging files with different shredded types
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_variant_mixed_type_stats', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0)
+
+# file 1: integer variant
+statement ok
+CREATE TABLE ducklake.tbl(v VARIANT)
+
+statement ok
+INSERT INTO ducklake.tbl SELECT 42::VARIANT
+
+# per-file stats should have integer type
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM metadata.ducklake_file_variant_stats WHERE data_file_id=0
+----
+root	int32	42	42
+
+# file 2: varchar variant - different shredded type for the same field
+statement ok
+INSERT INTO ducklake.tbl SELECT 'hello'::VARIANT
+
+query IIII
+SELECT variant_path, shredded_type, min_value, max_value FROM metadata.ducklake_file_variant_stats WHERE data_file_id=1
+----
+root	varchar	hello	hello
+
+# table-level stats should have invalidated min/max due to type mismatch
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id=1
+----
+NULL	NULL
+
+# the table should still be queryable
+query I
+SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
+----
+42
+hello
+
+# stats() should not crash
+query I
+SELECT count(*) FROM (SELECT stats(v) FROM ducklake.tbl LIMIT 1)
+----
+1
+
+# file 3: another integer variant
+statement ok
+INSERT INTO ducklake.tbl SELECT 7::VARIANT
+
+# table-level min/max should still be invalidated (can't recover without recomputing from all files)
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id=1
+----
+NULL	NULL
+
+query I
+SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
+----
+42
+7
+hello

--- a/test/sql/stats/variant_mixed_type_stats.test
+++ b/test/sql/stats/variant_mixed_type_stats.test
@@ -54,6 +54,12 @@ SELECT count(*) FROM (SELECT stats(v) FROM ducklake.tbl LIMIT 1)
 ----
 1
 
+# verify shredded_type in extra_stats JSON reflects the promoted type (not the stale original)
+query I
+SELECT extra_stats LIKE '%"varchar"%' FROM metadata.ducklake_table_column_stats WHERE table_id=1
+----
+true
+
 # file 3: another integer variant
 statement ok
 INSERT INTO ducklake.tbl SELECT 7::VARIANT

--- a/test/sql/stats/variant_mixed_type_stats.test
+++ b/test/sql/stats/variant_mixed_type_stats.test
@@ -9,83 +9,162 @@ require parquet
 statement ok
 ATTACH 'ducklake:__TEST_DIR__/ducklake_variant_mixed_type_stats.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_variant_mixed_type_stats_files', DATA_INLINING_ROW_LIMIT 0)
 
-# file 1: integer variant
+# ----------------------------------------
+# Setup
+# ----------------------------------------
+
+# primitives: INT then VARCHAR then INT
 statement ok
-CREATE TABLE ducklake.tbl(v VARIANT)
+CREATE TABLE ducklake.primitives(v VARIANT)
 
 statement ok
-INSERT INTO ducklake.tbl SELECT 42::VARIANT
+INSERT INTO ducklake.primitives SELECT 42::VARIANT
 
-# per-file stats should have integer type
+# single type: in-memory stats should show SHREDDED
+query I
+SELECT stats(v) FROM ducklake.primitives LIMIT 1
+----
+<REGEX>:.*SHREDDED.*INTEGER.*
+
+statement ok
+INSERT INTO ducklake.primitives SELECT 'hello'::VARIANT
+
+# type mismatch: in-memory stats should transition to INCONSISTENT
+query I
+SELECT stats(v) FROM ducklake.primitives LIMIT 1
+----
+<REGEX>:.*INCONSISTENT.*
+
+statement ok
+INSERT INTO ducklake.primitives SELECT 7::VARIANT
+
+# structs: field "a" same type, field "b" different types
+statement ok
+CREATE TABLE ducklake.structs(v VARIANT)
+
+statement ok
+INSERT INTO ducklake.structs SELECT {'a': 1, 'b': 'hello'}::VARIANT
+
+statement ok
+INSERT INTO ducklake.structs SELECT {'a': 5, 'b': 100}::VARIANT
+
+# structs: completely disjoint fields
+statement ok
+CREATE TABLE ducklake.disjoint(v VARIANT)
+
+statement ok
+INSERT INTO ducklake.disjoint SELECT {'x': 1}::VARIANT
+
+statement ok
+INSERT INTO ducklake.disjoint SELECT {'y': 2}::VARIANT
+
+# lists: incompatible element types
+statement ok
+CREATE TABLE ducklake.lists(v VARIANT)
+
+statement ok
+INSERT INTO ducklake.lists SELECT [1, 2, 3]::VARIANT
+
+statement ok
+INSERT INTO ducklake.lists SELECT ['a', 'b']::VARIANT
+
+# struct vs primitive
+statement ok
+CREATE TABLE ducklake.shape_mismatch(v VARIANT)
+
+statement ok
+INSERT INTO ducklake.shape_mismatch SELECT {'a': 1}::VARIANT
+
+statement ok
+INSERT INTO ducklake.shape_mismatch SELECT 42::VARIANT
+
+# ----------------------------------------
+# Assertions - run twice: first in-memory, then after reload from disk
+# ----------------------------------------
+loop i 0 2
+
+# per-file stats preserve original shredded types
 query IIII
 SELECT variant_path, shredded_type, min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_file_variant_stats WHERE data_file_id=0
 ----
 root	int32	42	42
-
-# with a single type, in-memory stats should show SHREDDED
-query I
-SELECT stats(v) FROM ducklake.tbl LIMIT 1
-----
-<REGEX>:.*SHREDDED.*INTEGER.*
-
-# file 2: varchar variant - different shredded type for the same field
-statement ok
-INSERT INTO ducklake.tbl SELECT 'hello'::VARIANT
 
 query IIII
 SELECT variant_path, shredded_type, min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_file_variant_stats WHERE data_file_id=1
 ----
 root	varchar	hello	hello
 
-# table-level stats should have invalidated min/max due to type mismatch
-query II
-SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
+# primitives: incompatible types -> min/max and shredded stats dropped
+query III
+SELECT min_value, max_value, extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
-NULL	NULL
+NULL	NULL	NULL
 
-# the table should still be queryable
 query I
-SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
-----
-42
-hello
-
-# in-memory stats should show INCONSISTENT after type mismatch
-query I
-SELECT stats(v) FROM ducklake.tbl LIMIT 1
+SELECT stats(v) FROM ducklake.primitives LIMIT 1
 ----
 <REGEX>:.*INCONSISTENT.*
 
-# incompatible shredded types (INT vs VARCHAR) - shredded stats are dropped entirely
 query I
-SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
-----
-NULL
-
-# file 3: another integer variant
-statement ok
-INSERT INTO ducklake.tbl SELECT 7::VARIANT
-
-query II
-SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
-----
-NULL	NULL
-
-query I
-SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
+SELECT v FROM ducklake.primitives ORDER BY v::VARCHAR
 ----
 42
 7
 hello
 
-# detach and reattach to verify stats survive serialization round-trip
+# structs: field "a" (int32 both) kept, field "b" (varchar vs int32) dropped
+query III
+SELECT extra_stats IS NOT NULL, contains(extra_stats, '\"a\"'), contains(extra_stats, '\"b\"') FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=2
+----
+true	true	false
+
+query I
+SELECT v FROM ducklake.structs ORDER BY v::VARCHAR
+----
+{'a': 1, 'b': hello}
+{'a': 5, 'b': 100}
+
+# disjoint structs: no overlapping fields -> all stats dropped
+query I
+SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=3
+----
+NULL
+
+query I
+SELECT v FROM ducklake.disjoint ORDER BY v::VARCHAR
+----
+{'x': 1}
+{'y': 2}
+
+# lists: element type mismatch -> stats dropped
+query I
+SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=4
+----
+NULL
+
+query I
+SELECT v FROM ducklake.lists ORDER BY v::VARCHAR
+----
+[1, 2, 3]
+[a, b]
+
+# struct vs primitive: completely different shapes -> stats dropped
+query I
+SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=5
+----
+NULL
+
+query I
+SELECT v FROM ducklake.shape_mismatch ORDER BY v::VARCHAR
+----
+42
+{'a': 1}
+
+# reload from disk for next iteration
 statement ok
 DETACH ducklake
 
 statement ok
 ATTACH 'ducklake:__TEST_DIR__/ducklake_variant_mixed_type_stats.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_variant_mixed_type_stats_files', DATA_INLINING_ROW_LIMIT 0)
 
-query I
-SELECT extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
-----
-NULL
+endloop

--- a/test/sql/stats/variant_mixed_type_stats.test
+++ b/test/sql/stats/variant_mixed_type_stats.test
@@ -6,12 +6,8 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
-
-test-env DATA_PATH __TEST_DIR__
-
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_variant_mixed_type_stats', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:__TEST_DIR__/ducklake_variant_mixed_type_stats.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_variant_mixed_type_stats_files', DATA_INLINING_ROW_LIMIT 0)
 
 # file 1: integer variant
 statement ok
@@ -22,7 +18,7 @@ INSERT INTO ducklake.tbl SELECT 42::VARIANT
 
 # per-file stats should have integer type
 query IIII
-SELECT variant_path, shredded_type, min_value, max_value FROM metadata.ducklake_file_variant_stats WHERE data_file_id=0
+SELECT variant_path, shredded_type, min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_file_variant_stats WHERE data_file_id=0
 ----
 root	int32	42	42
 
@@ -31,13 +27,13 @@ statement ok
 INSERT INTO ducklake.tbl SELECT 'hello'::VARIANT
 
 query IIII
-SELECT variant_path, shredded_type, min_value, max_value FROM metadata.ducklake_file_variant_stats WHERE data_file_id=1
+SELECT variant_path, shredded_type, min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_file_variant_stats WHERE data_file_id=1
 ----
 root	varchar	hello	hello
 
 # table-level stats should have invalidated min/max due to type mismatch
 query II
-SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id=1
+SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
 NULL	NULL
 
@@ -54,9 +50,9 @@ SELECT count(*) FROM (SELECT stats(v) FROM ducklake.tbl LIMIT 1)
 ----
 1
 
-# verify shredded_type in extra_stats JSON reflects the promoted type (not the stale original)
+# after merging INT + VARCHAR, shredded_type should be varchar (not stale int32)
 query I
-SELECT extra_stats LIKE '%"varchar"%' FROM metadata.ducklake_table_column_stats WHERE table_id=1
+SELECT extra_stats LIKE '%"varchar"%' FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
 true
 
@@ -66,7 +62,7 @@ INSERT INTO ducklake.tbl SELECT 7::VARIANT
 
 # table-level min/max should still be invalidated (can't recover without recomputing from all files)
 query II
-SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id=1
+SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
 ----
 NULL	NULL
 
@@ -76,3 +72,21 @@ SELECT v FROM ducklake.tbl ORDER BY v::VARCHAR
 42
 7
 hello
+
+# detach and reattach to verify stats survive serialization round-trip
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_variant_mixed_type_stats.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_variant_mixed_type_stats_files', DATA_INLINING_ROW_LIMIT 0)
+
+query III
+SELECT min_value, max_value, extra_stats FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
+----
+NULL	NULL	[{"field_name":"root","shredded_type":"int32","null_count":0,"num_values":3,"column_size_bytes":92,"any_valid":true}]
+
+# verify shredded_type in extra_stats JSON reflects the promoted type (not the stale original)
+query I
+SELECT extra_stats LIKE '%"varchar"%' FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id=1
+----
+true


### PR DESCRIPTION
When different files shred the same variant field to different types (e.g., one file shreds as `INT`, another as `VARCHAR`), the stats merge would previously attempt to compare min/max values across incompatible types, and leave the `shredded_type` in an inconsistent state.

This fixes two things:
- When types differ, invalidate min/max instead of attempting cross-type comparison
- When a shredded field has incompatible types across files, drop it from the table-level shredded stats entirely. This matches how DuckDB core handles it. Fields with matching types across all files are preserved with correctly merged stats
