### PR TITLE
Derive DuckLakeCompactor hive partition prefix from partition spec + values

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -4,6 +4,7 @@
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_insert.hpp"
+#include "storage/ducklake_partition_data.hpp"
 #include "storage/ducklake_multi_file_reader.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
@@ -526,28 +527,9 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 
 	// generate the LogicalGet
 	auto &columns = table.GetColumns();
-	auto table_path = table.DataPath();
 	string data_path;
 	if (partition_id.IsValid()) {
-		data_path = actionable_source_files[0].file.data.path;
-		data_path = StringUtil::Replace(data_path, table_path, "");
-		auto path_result = StringUtil::Split(data_path, catalog.Separator());
-		data_path = "";
-		if (path_result.size() > 1) {
-			// This means we have a hive partition.
-			for (idx_t i = 0; i < path_result.size() - 1; i++) {
-				data_path += path_result[i];
-				if (i != path_result.size() - 2) {
-					data_path += catalog.Separator();
-				}
-			}
-			// If we do have a hive partition, let's verify all files have the same one.
-			for (idx_t i = 1; i < actionable_source_files.size(); i++) {
-				if (!StringUtil::Contains(actionable_source_files[i].file.data.path, data_path)) {
-					throw InternalException("DuckLakeCompactor: Files have different hive partition path");
-				}
-			}
-		}
+		data_path = DuckLakePartitionUtils::BuildHivePartitionPath(table, partition_values, catalog.Separator());
 	}
 
 	bool write_row_id = false;

--- a/src/include/storage/ducklake_partition_data.hpp
+++ b/src/include/storage/ducklake_partition_data.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 class BaseStatistics;
+class DuckLakeTableEntry;
 
 enum class DuckLakeTransformType { IDENTITY, BUCKET, YEAR, MONTH, DAY, HOUR };
 
@@ -56,6 +57,10 @@ struct DuckLakePartitionUtils {
 	//! Build a SQL WHERE filter matching the given partition values (e.g., "region = 'east' AND year(ts) = 2020")
 	static string BuildPartitionFilter(const vector<string> &partition_sql_exprs,
 	                                   const vector<Value> &partition_values);
+
+	//! Build a relative Hive partition path from the table partition spec and values (e.g., "region=east/year=2020/")
+	static string BuildHivePartitionPath(DuckLakeTableEntry &table, const vector<Value> &partition_values,
+	                                     const string &separator);
 
 	//! Wrap a column expression in a named scalar function (e.g. "year", "hash")
 	static unique_ptr<Expression> ApplyScalarFunction(ClientContext &context, const string &function_name,

--- a/src/storage/ducklake_partition_data.cpp
+++ b/src/storage/ducklake_partition_data.cpp
@@ -1,5 +1,7 @@
 #include "storage/ducklake_partition_data.hpp"
 #include "common/ducklake_murmur3.hpp"
+#include "storage/ducklake_table_entry.hpp"
+#include "duckdb/common/hive_partitioning.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression.hpp"
@@ -85,6 +87,47 @@ string DuckLakePartitionUtils::BuildPartitionFilter(const vector<string> &partit
 		}
 	}
 	return filter;
+}
+
+string DuckLakePartitionUtils::BuildHivePartitionPath(DuckLakeTableEntry &table, const vector<Value> &partition_values,
+                                                      const string &separator) {
+	auto partition_data = table.GetPartitionData();
+	if (!partition_data) {
+		return string();
+	}
+	if (partition_data->fields.size() != partition_values.size()) {
+		throw InternalException("DuckLake partition value count does not match partition spec");
+	}
+	string result;
+	case_insensitive_set_t used_names;
+	for (auto &field : partition_data->fields) {
+		if (field.partition_key_index >= partition_values.size()) {
+			throw InternalException("DuckLake partition key index is out of range");
+		}
+		auto field_id = table.GetFieldData().GetByFieldIndex(field.field_id);
+		if (!field_id) {
+			throw InternalException("DuckLake partition field id not found");
+		}
+		auto partition_key_name = GetPartitionKeyName(field.transform.type, field_id->Name(), used_names);
+		used_names.insert(partition_key_name);
+
+		auto &partition_value = partition_values[field.partition_key_index];
+		string partition_value_str;
+		if (partition_value.IsNull()) {
+			// Keep this in sync with DuckDB's HivePartitioning::IsNull parser.
+			partition_value_str = "__HIVE_DEFAULT_PARTITION__";
+		} else {
+			partition_value_str = partition_value.ToString();
+		}
+		if (!result.empty()) {
+			result += separator;
+		}
+		result += HivePartitioning::Escape(partition_key_name) + "=" + HivePartitioning::Escape(partition_value_str);
+	}
+	if (!result.empty()) {
+		result += separator;
+	}
+	return result;
 }
 
 unique_ptr<Expression> DuckLakePartitionUtils::ApplyScalarFunction(ClientContext &context, const string &function_name,

--- a/test/sql/compaction/merge_adjacent_external_hive_paths.test
+++ b/test/sql/compaction/merge_adjacent_external_hive_paths.test
@@ -1,0 +1,206 @@
+# name: test/sql/compaction/merge_adjacent_external_hive_paths.test
+# description: compaction writes hive-partitioned add_data_files output under the table path
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/canonical_files', METADATA_CATALOG 'metadata')
+
+statement ok
+CREATE TABLE ducklake.t(id INTEGER, source VARCHAR);
+
+statement ok
+ALTER TABLE ducklake.t SET PARTITIONED BY (source);
+
+# --- audio partition: add external files, compact, verify rewrite under table path ---
+
+statement ok
+COPY (SELECT 1 AS id, 'audio' AS source)
+TO '${DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source));
+
+statement ok
+COPY (SELECT 2 AS id, 'audio' AS source)
+TO '${DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source), APPEND);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/external_source/source=audio/*.parquet');
+
+query II
+SELECT id, source FROM ducklake.t ORDER BY ALL
+----
+1	audio
+2	audio
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
+----
+t	2	1
+
+query I
+SELECT path
+FROM metadata.ducklake_data_file
+WHERE end_snapshot IS NULL AND path_is_relative
+ORDER BY ALL
+----
+<REGEX>:source=audio/ducklake-.*\.parquet
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/t/source=audio/*.parquet')
+----
+1
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_source%'
+----
+0
+
+# --- NULL partition: separate round-trip so the compaction call has exactly one eligible group ---
+
+statement ok
+COPY (SELECT 3 AS id, NULL::VARCHAR AS source)
+TO '${DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source));
+
+statement ok
+COPY (SELECT 4 AS id, NULL::VARCHAR AS source)
+TO '${DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source), APPEND);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/external_null/source=__HIVE_DEFAULT_PARTITION__/*.parquet');
+
+query II
+SELECT id, source FROM ducklake.t ORDER BY ALL
+----
+1	audio
+2	audio
+3	NULL
+4	NULL
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake') ORDER BY ALL
+----
+t	2	1
+
+query I
+SELECT path
+FROM metadata.ducklake_data_file
+WHERE end_snapshot IS NULL AND path_is_relative AND path LIKE '%__HIVE_DEFAULT_PARTITION__%'
+ORDER BY ALL
+----
+<REGEX>:source=__HIVE_DEFAULT_PARTITION__/ducklake-.*\.parquet
+
+query I
+SELECT COUNT(*) FROM metadata.ducklake_file_partition_value WHERE partition_value IS NULL
+----
+1
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/t/source=__HIVE_DEFAULT_PARTITION__/*.parquet')
+----
+1
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_null%'
+----
+0
+
+# --- transformed partition: add external files, compact into transformed hive paths ---
+
+statement ok
+CREATE TABLE ducklake.transformed_t(id INTEGER, ts TIMESTAMP);
+
+statement ok
+ALTER TABLE ducklake.transformed_t SET PARTITIONED BY (year(ts), month(ts));
+
+statement ok
+COPY (
+	SELECT 10 AS id, TIMESTAMP '2024-05-01 00:00:00' AS ts, 2024 AS year, 5 AS month
+)
+TO '${DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month));
+
+statement ok
+COPY (
+	SELECT 11 AS id, TIMESTAMP '2024-05-02 00:00:00' AS ts, 2024 AS year, 5 AS month
+)
+TO '${DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month), APPEND);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'transformed_t', '${DATA_PATH}/external_transform/year=2024/month=5/*.parquet');
+
+query II
+SELECT id, ts::DATE FROM ducklake.transformed_t ORDER BY ALL
+----
+10	2024-05-01
+11	2024-05-02
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'transformed_t') ORDER BY ALL
+----
+transformed_t	2	1
+
+query I
+SELECT path
+FROM metadata.ducklake_data_file
+WHERE end_snapshot IS NULL AND path_is_relative AND path LIKE '%year=2024/month=5/%'
+ORDER BY ALL
+----
+<REGEX>:.*year=2024/month=5/ducklake-.*\.parquet
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/transformed_t/year=2024/month=5/*.parquet')
+----
+1
+
+# --- escaped string partition: compare DuckDB COPY and DuckLake compaction hive escaping ---
+
+statement ok
+CREATE TABLE ducklake.weird_t(id INTEGER, weird VARCHAR);
+
+statement ok
+ALTER TABLE ducklake.weird_t SET PARTITIONED BY (weird);
+
+statement ok
+COPY (SELECT 20 AS id, 'a/b=c% d' AS weird)
+TO '${DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird));
+
+statement ok
+COPY (SELECT 21 AS id, 'a/b=c% d' AS weird)
+TO '${DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird), APPEND);
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'weird_t', '${DATA_PATH}/external_weird/weird=*/*.parquet');
+
+query II
+SELECT id, weird FROM ducklake.weird_t ORDER BY ALL
+----
+20	a/b=c% d
+21	a/b=c% d
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'weird_t') ORDER BY ALL
+----
+weird_t	2	1
+
+query I
+SELECT COUNT(*)
+FROM (
+	SELECT regexp_extract(file, '(weird=[^/\\]*)[/\\]', 1) AS partition_segment
+	FROM glob('${DATA_PATH}/external_weird/weird=*/*.parquet')
+	INTERSECT
+	SELECT regexp_extract(path, '(weird=[^/\\]*)[/\\]', 1) AS partition_segment
+	FROM metadata.ducklake_data_file
+	WHERE end_snapshot IS NULL AND path_is_relative AND path LIKE '%weird=%'
+)
+----
+1
+
+query I
+SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/weird_t/weird=*/*.parquet')
+----
+1


### PR DESCRIPTION
`ducklake_merge_adjacent_files` reconstructed the hive partition prefix by string-manipulating the first file's path, which silently corrupted writes when the source file path didn't share `table.DataPath()` (e.g. files added via `ducklake_add_data_files` with absolute paths) — the absolute prefix was reused as a relative write target and the compacted file ended up nested at a junk S3 key. Derive the prefix from the partition spec and values instead, so the compactor always writes a relative `col=value/` under `table.DataPath()` regardless of where source files live.