### PR TITLE
Fix SET NOT NULL with deleted NULL rows

### DIFF
--- a/src/include/storage/ducklake_table_entry.hpp
+++ b/src/include/storage/ducklake_table_entry.hpp
@@ -104,7 +104,7 @@ public:
 
 	TableStorageInfo GetStorageInfo(ClientContext &context) override;
 
-	unique_ptr<CatalogEntry> Alter(DuckLakeTransaction &transaction, AlterTableInfo &info);
+	unique_ptr<CatalogEntry> Alter(ClientContext &context, DuckLakeTransaction &transaction, AlterTableInfo &info);
 	unique_ptr<CatalogEntry> Alter(DuckLakeTransaction &transaction, SetCommentInfo &info);
 	unique_ptr<CatalogEntry> Alter(DuckLakeTransaction &transaction, SetColumnCommentInfo &info);
 
@@ -128,7 +128,7 @@ public:
 private:
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, RenameTableInfo &info);
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, SetPartitionedByInfo &info);
-	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, SetNotNullInfo &info);
+	unique_ptr<CatalogEntry> AlterTable(ClientContext &context, DuckLakeTransaction &transaction, SetNotNullInfo &info);
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, DropNotNullInfo &info);
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, RenameColumnInfo &info);
 	unique_ptr<CatalogEntry> AlterTable(DuckLakeTransaction &transaction, AddColumnInfo &info);

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -205,7 +205,7 @@ void DuckLakeSchemaEntry::Alter(CatalogTransaction catalog_transaction, AlterInf
 			throw BinderException("Cannot use ALTER TABLE on entry %s - it is not a table", alter.name);
 		}
 		auto &table = table_entry->Cast<DuckLakeTableEntry>();
-		auto new_table = table.Alter(transaction, alter);
+		auto new_table = table.Alter(context, transaction, alter);
 		if (alter.alter_table_type == AlterTableType::RENAME_TABLE) {
 			// We must check if this view name does not yet exist.
 			auto existing_table = GetEntry(catalog_transaction, CatalogType::TABLE_ENTRY, new_table->name);

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -637,6 +637,20 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
 	auto &col = table_info.columns.GetColumn(info.column_name);
 	auto &field_id = GetFieldId(col.Physical());
 
+	// check if there is an existing constraint
+	auto existing_idx = FindNotNullConstraint(table_info, col.Logical());
+	if (existing_idx.IsValid()) {
+		throw CatalogException("Cannot SET NOT NULL on column %s - it already has a NOT NULL constraint",
+		                       col.GetName());
+	}
+
+	if (transaction.HasTransactionLocalInserts(GetTableId())) {
+		VerifyNoNullValues(context, transaction, *this, col);
+		table_info.constraints.push_back(make_uniq<NotNullConstraint>(col.Logical()));
+		auto new_entry = make_uniq<DuckLakeTableEntry>(*this, table_info, LocalChange::SetNull(field_id.GetFieldIndex()));
+		return std::move(new_entry);
+	}
+
 	// verify the column has no NULL values currently by looking at the stats
 	auto stats = GetTableStats(transaction);
 	if (!stats) {
@@ -656,12 +670,6 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
 		VerifyNoNullValues(context, transaction, *this, col);
 	}
 
-	// check if there is an existing constraint
-	auto existing_idx = FindNotNullConstraint(table_info, col.Logical());
-	if (existing_idx.IsValid()) {
-		throw CatalogException("Cannot SET NOT NULL on column %s - it already has a NOT NULL constraint",
-		                       col.GetName());
-	}
 	table_info.constraints.push_back(make_uniq<NotNullConstraint>(col.Logical()));
 
 	auto new_entry = make_uniq<DuckLakeTableEntry>(*this, table_info, LocalChange::SetNull(field_id.GetFieldIndex()));

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -8,7 +8,10 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/function/table_function.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/execution/execution_context.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -25,6 +28,64 @@
 #include "storage/ducklake_multi_file_reader.hpp"
 
 namespace duckdb {
+
+namespace {
+
+struct DuckLakeColumnScan {
+	TableFunction function;
+	unique_ptr<FunctionData> bind_data;
+	unique_ptr<GlobalTableFunctionState> global_state;
+	unique_ptr<LocalTableFunctionState> local_state;
+	unique_ptr<ThreadContext> thread_context;
+	unique_ptr<ExecutionContext> execution_context;
+
+	DuckLakeColumnScan(ClientContext &context, DuckLakeTransaction &transaction, DuckLakeTableEntry &table,
+	                   const ColumnDefinition &col) {
+		function = DuckLakeFunctions::GetDuckLakeScanFunction(*context.db);
+		function.function_info = DuckLakeFunctionInfo::Create(table, transaction, transaction.GetSnapshot());
+		bind_data = DuckLakeFunctions::BindDuckLakeScan(context, function);
+
+		vector<ColumnIndex> column_ids;
+		column_ids.emplace_back(col.Logical().index);
+		vector<idx_t> projection_ids;
+		TableFunctionInitInput init_input(bind_data.get(), column_ids, projection_ids, nullptr);
+
+		global_state = function.init_global(context, init_input);
+		thread_context = make_uniq<ThreadContext>(context);
+		execution_context = make_uniq<ExecutionContext>(context, *thread_context, nullptr);
+		local_state = function.init_local(*execution_context, init_input, global_state.get());
+	}
+
+	bool Scan(ClientContext &context, DataChunk &chunk) {
+		chunk.Reset();
+		TableFunctionInput input(bind_data.get(), local_state.get(), global_state.get());
+		input.async_result = AsyncResultType::IMPLICIT;
+		input.results_execution_mode = AsyncResultsExecutionMode::SYNCHRONOUS;
+		function.function(context, input, chunk);
+
+		auto result = input.async_result.GetResultType();
+		if (result == AsyncResultType::BLOCKED || result == AsyncResultType::INVALID) {
+			throw InternalException("Unexpected async table scan result while verifying NOT NULL constraint");
+		}
+		return result != AsyncResultType::FINISHED && chunk.size() > 0;
+	}
+};
+
+void VerifyNoNullValues(ClientContext &context, DuckLakeTransaction &transaction, DuckLakeTableEntry &table,
+                        const ColumnDefinition &col) {
+	DuckLakeColumnScan scan(context, transaction, table, col);
+	DataChunk chunk;
+	chunk.Initialize(context, {col.Type()});
+
+	while (scan.Scan(context, chunk)) {
+		if (VectorOperations::HasNull(chunk.data[0], chunk.size())) {
+			throw CatalogException("Cannot SET NOT NULL on column %s - the column has NULL values", col.GetName());
+		}
+	}
+}
+
+} // namespace
+
 constexpr column_t DuckLakeMultiFileReader::COLUMN_IDENTIFIER_SNAPSHOT_ID;
 
 void DuckLakeTableEntry::CheckSupportedTypes() {
@@ -566,7 +627,8 @@ optional_idx FindNotNullConstraint(CreateTableInfo &table_info, LogicalIndex ind
 	return optional_idx();
 }
 
-unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, SetNotNullInfo &info) {
+unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, DuckLakeTransaction &transaction,
+                                                        SetNotNullInfo &info) {
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	if (!table_info.columns.ColumnExists(info.column_name)) {
@@ -587,9 +649,11 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	if (column_stats == stats->column_stats.end()) {
 		throw CatalogException("Cannot SET NOT NULL on table %s - no column stats are available", name);
 	}
+
+	// The table could have null values deleted, so we should check real rows.
 	auto &col_stats = column_stats->second;
 	if (col_stats.has_null_count && col_stats.null_count > 0) {
-		throw CatalogException("Cannot SET NOT NULL on column %s - the column has NULL values", col.GetName());
+		VerifyNoNullValues(context, transaction, *this, col);
 	}
 
 	// check if there is an existing constraint
@@ -1226,7 +1290,8 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	return std::move(new_entry);
 }
 
-unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transaction, AlterTableInfo &info) {
+unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(ClientContext &context, DuckLakeTransaction &transaction,
+                                                   AlterTableInfo &info) {
 	if (transaction.HasTransactionInlinedData(GetTableId())) {
 		if (info.alter_table_type != AlterTableType::ADD_COLUMN &&
 		    info.alter_table_type != AlterTableType::REMOVE_COLUMN &&
@@ -1246,7 +1311,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::Alter(DuckLakeTransaction &transact
 	case AlterTableType::SET_PARTITIONED_BY:
 		return AlterTable(transaction, info.Cast<SetPartitionedByInfo>());
 	case AlterTableType::SET_NOT_NULL:
-		return AlterTable(transaction, info.Cast<SetNotNullInfo>());
+		return AlterTable(context, transaction, info.Cast<SetNotNullInfo>());
 	case AlterTableType::DROP_NOT_NULL:
 		return AlterTable(transaction, info.Cast<DropNotNullInfo>());
 	case AlterTableType::RENAME_COLUMN:

--- a/test/sql/constraints/not_null.test
+++ b/test/sql/constraints/not_null.test
@@ -108,3 +108,49 @@ has NULL values
 # after dropping the constraint - we can add NULL rows
 statement ok
 INSERT INTO ducklake.test VALUES (NULL, 84)
+
+# setting NOT NULL should inspect the live rows, not only stale insert-time stats
+statement ok
+CREATE TABLE ducklake.issue_1158(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.issue_1158 VALUES (NULL), (1);
+
+statement ok
+DELETE FROM ducklake.issue_1158 WHERE i IS NULL;
+
+query I
+SELECT count(*) FROM ducklake.issue_1158 WHERE i IS NULL;
+----
+0
+
+statement ok
+ALTER TABLE ducklake.issue_1158 ALTER i SET NOT NULL;
+
+statement error
+INSERT INTO ducklake.issue_1158 VALUES (NULL);
+----
+NOT NULL constraint failed
+
+statement ok
+CREATE TABLE ducklake.issue_1158_transaction(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.issue_1158_transaction VALUES (NULL), (1);
+
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM ducklake.issue_1158_transaction WHERE i IS NULL;
+
+statement ok
+ALTER TABLE ducklake.issue_1158_transaction ALTER i SET NOT NULL;
+
+statement ok
+COMMIT;
+
+statement error
+INSERT INTO ducklake.issue_1158_transaction VALUES (NULL);
+----
+NOT NULL constraint failed

--- a/test/sql/constraints/not_null.test
+++ b/test/sql/constraints/not_null.test
@@ -94,7 +94,7 @@ INSERT INTO ducklake.test VALUES (NULL, 84)
 statement error
 ALTER TABLE ducklake.test ALTER i SET NOT NULL;
 ----
-transaction-local
+has NULL values
 
 statement ok
 ROLLBACK
@@ -154,3 +154,32 @@ statement error
 INSERT INTO ducklake.issue_1158_transaction VALUES (NULL);
 ----
 NOT NULL constraint failed
+
+statement ok
+CREATE TABLE ducklake.not_null_after_local_insert(i INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.not_null_after_local_insert VALUES (1);
+
+statement ok
+ALTER TABLE ducklake.not_null_after_local_insert ALTER i SET NOT NULL;
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.not_null_after_local_insert VALUES (NULL);
+
+statement error
+ALTER TABLE ducklake.not_null_after_local_insert ALTER i SET NOT NULL;
+----
+has NULL values
+
+statement ok
+ROLLBACK;

--- a/test/sql/constraints/not_null.test
+++ b/test/sql/constraints/not_null.test
@@ -183,3 +183,65 @@ has NULL values
 
 statement ok
 ROLLBACK;
+
+statement ok
+CREATE TABLE ducklake.not_null_after_update(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.not_null_after_update VALUES (NULL), (1);
+
+statement ok
+UPDATE ducklake.not_null_after_update SET i = 2 WHERE i IS NULL;
+
+query I
+SELECT count(*) FROM ducklake.not_null_after_update WHERE i IS NULL;
+----
+0
+
+statement ok
+ALTER TABLE ducklake.not_null_after_update ALTER i SET NOT NULL;
+
+statement error
+INSERT INTO ducklake.not_null_after_update VALUES (NULL);
+----
+NOT NULL constraint failed
+
+# Conversely, updating a non-NULL row to NULL must block SET NOT NULL even though
+# the original insert-time stats had no NULLs.
+statement ok
+CREATE TABLE ducklake.not_null_update_introduces_null(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.not_null_update_introduces_null VALUES (1), (2);
+
+statement ok
+UPDATE ducklake.not_null_update_introduces_null SET i = NULL WHERE i = 1;
+
+statement error
+ALTER TABLE ducklake.not_null_update_introduces_null ALTER i SET NOT NULL;
+----
+has NULL values
+
+# Transaction-local UPDATE that removes the NULL rows should also be visible.
+statement ok
+CREATE TABLE ducklake.not_null_after_update_transaction(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.not_null_after_update_transaction VALUES (NULL), (1);
+
+statement ok
+BEGIN;
+
+statement ok
+UPDATE ducklake.not_null_after_update_transaction SET i = 2 WHERE i IS NULL;
+
+statement ok
+ALTER TABLE ducklake.not_null_after_update_transaction ALTER i SET NOT NULL;
+
+statement ok
+COMMIT;
+
+statement error
+INSERT INTO ducklake.not_null_after_update_transaction VALUES (NULL);
+----
+NOT NULL constraint failed


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1158

The bug is, when we tries to set NOT NULL and check feasibility, we directly check from stats whether we have null rows.
https://github.com/duckdb/ducklake/blob/d897bc5a35f887c9087403bc20efd92d99272e69/src/storage/ducklake_table_entry.cpp#L609

In the current implementation, we only populate stats when new data inserted -- we didn't updates stats when rows deleted. so the stats doesn't really reflect the latest actual status.

In this PR, I did a few things:
- Check transaction-local change
- Check stats, if indicates no NULL we could trust it
- Otherwise, the stats might not be latest enough, so we fallback to scan table