### PR TITLE
Improve schema cache entry estimated size

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -50,8 +50,6 @@ struct DuckLakeTableStatsCacheEntry : public ObjectCacheEntry {
 
 //! Cache entry for a DuckLake schema version
 struct DuckLakeSchemaCacheEntry : public ObjectCacheEntry {
-	static constexpr idx_t ESTIMATED_BYTES_PER_ENTRY = 4096;
-
 	explicit DuckLakeSchemaCacheEntry(unique_ptr<DuckLakeCatalogSet> catalog_set_p)
 	    : catalog_set(std::move(*catalog_set_p)) {
 	}

--- a/src/include/storage/ducklake_field_data.hpp
+++ b/src/include/storage/ducklake_field_data.hpp
@@ -108,7 +108,7 @@ public:
 	optional_ptr<const DuckLakeFieldId> GetByFieldIndex(FieldIndex id) const;
 	optional_ptr<const DuckLakeFieldId> GetByNames(PhysicalIndex id, const vector<string> &column_names,
 	                                               optional_ptr<optional_idx> name_offset = nullptr) const;
-	idx_t GetColumnCount() {
+	idx_t GetColumnCount() const {
 		return field_ids.size();
 	}
 	const vector<unique_ptr<DuckLakeFieldId>> &GetFieldIds() const {

--- a/src/include/storage/ducklake_schema_entry.hpp
+++ b/src/include/storage/ducklake_schema_entry.hpp
@@ -52,6 +52,7 @@ public:
 	void Alter(CatalogTransaction transaction, AlterInfo &info) override;
 	void Scan(ClientContext &context, CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
 	void Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
+	void Scan(CatalogType type, const std::function<void(const CatalogEntry &)> &callback) const;
 	void DropEntry(ClientContext &context, DropInfo &info) override;
 	optional_ptr<CatalogEntry> LookupEntry(CatalogTransaction transaction, const EntryLookupInfo &lookup_info) override;
 	SimilarCatalogEntry GetSimilarEntry(CatalogTransaction transaction, const EntryLookupInfo &lookup_info) override;
@@ -63,6 +64,7 @@ public:
 
 private:
 	DuckLakeCatalogSet &GetCatalogSet(CatalogType type);
+	const DuckLakeCatalogSet &GetCatalogSet(CatalogType type) const;
 	bool HandleCreateConflict(CatalogTransaction transaction, CatalogType type, const string &name,
 	                          OnCreateConflict on_conflict);
 

--- a/src/include/storage/ducklake_table_entry.hpp
+++ b/src/include/storage/ducklake_table_entry.hpp
@@ -55,12 +55,21 @@ public:
 	optional_ptr<DuckLakePartition> GetPartitionData() {
 		return partition_data.get();
 	}
+	optional_ptr<const DuckLakePartition> GetPartitionData() const {
+		return partition_data.get();
+	}
 	//! Returns SQL expressions for each partition field (e.g., "region", "year(ts)")
 	vector<string> GetPartitionSQLExpressions() const;
 	optional_ptr<DuckLakeSort> GetSortData() {
 		return sort_data.get();
 	}
+	optional_ptr<const DuckLakeSort> GetSortData() const {
+		return sort_data.get();
+	}
 	DuckLakeFieldData &GetFieldData() {
+		return *field_data;
+	}
+	const DuckLakeFieldData &GetFieldData() const {
 		return *field_data;
 	}
 	const ColumnChangeInfo &GetChangedFields() const {

--- a/src/include/storage/ducklake_view_entry.hpp
+++ b/src/include/storage/ducklake_view_entry.hpp
@@ -47,7 +47,7 @@ public:
 
 	void BindView(ClientContext &context, BindViewAction action = BindViewAction::BIND_IF_UNBOUND) override;
 
-	string GetQuerySQL();
+	string GetQuerySQL() const;
 
 public:
 	// ALTER VIEW

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -33,6 +33,118 @@
 
 namespace duckdb {
 
+namespace {
+
+idx_t EstimateStringMemory(const string &value) {
+	return sizeof(string) + value.length();
+}
+
+idx_t EstimateFieldIdCount(const DuckLakeFieldId &field_id) {
+	idx_t count = 1;
+	for (const auto &child : field_id.Children()) {
+		count += EstimateFieldIdCount(*child);
+	}
+	return count;
+}
+
+idx_t EstimateTagMemory(const CatalogEntry &entry) {
+	idx_t estimate = 0;
+	for (auto &tag : entry.tags) {
+		estimate += EstimateStringMemory(tag.first);
+		estimate += EstimateStringMemory(tag.second);
+	}
+	return estimate;
+}
+
+idx_t EstimateTableEntryMemory(const DuckLakeTableEntry &table) {
+	idx_t estimate = EstimateTagMemory(table);
+	estimate += table.GetColumns().LogicalColumnCount() * sizeof(ColumnDefinition);
+	for (const auto &column : table.GetColumns().Logical()) {
+		estimate += EstimateStringMemory(column.Name());
+	}
+	estimate += table.GetConstraints().size() * sizeof(Constraint);
+	for (const auto &field_id : table.GetFieldData().GetFieldIds()) {
+		estimate += EstimateFieldIdCount(*field_id) * sizeof(DuckLakeFieldId);
+	}
+	estimate += table.GetInlinedDataTables().size() * sizeof(DuckLakeInlinedTableInfo);
+	for (const auto &inlined_table : table.GetInlinedDataTables()) {
+		estimate += EstimateStringMemory(inlined_table.table_name);
+	}
+	auto partition = table.GetPartitionData();
+	if (partition) {
+		estimate += sizeof(DuckLakePartition) + partition->fields.size() * sizeof(DuckLakePartitionField);
+	}
+	auto sort = table.GetSortData();
+	if (sort) {
+		estimate += sizeof(DuckLakeSort) + sort->fields.size() * sizeof(DuckLakeSortField);
+		for (const auto &field : sort->fields) {
+			estimate += EstimateStringMemory(field.expression);
+			estimate += EstimateStringMemory(field.dialect);
+		}
+	}
+	return estimate;
+}
+
+idx_t EstimateViewEntryMemory(const DuckLakeViewEntry &view) {
+	idx_t estimate = EstimateTagMemory(view);
+	estimate += view.aliases.size() * sizeof(string);
+	for (const auto &alias : view.aliases) {
+		estimate += EstimateStringMemory(alias);
+	}
+	return estimate;
+}
+
+idx_t EstimateMacroEntryMemory(const MacroCatalogEntry &macro_entry) {
+	idx_t estimate = EstimateTagMemory(macro_entry);
+	estimate += macro_entry.macros.size() * sizeof(MacroFunction);
+	for (const auto &macro : macro_entry.macros) {
+		estimate += macro->ToSQL().size();
+		estimate += macro->parameters.size() * sizeof(ParsedExpression);
+		estimate += macro->types.size() * sizeof(LogicalType);
+	}
+	return estimate;
+}
+
+idx_t EstimateCatalogEntryMemory(const CatalogEntry &entry) {
+	switch (entry.type) {
+	case CatalogType::SCHEMA_ENTRY: {
+		return EstimateTagMemory(entry);
+	}
+	case CatalogType::TABLE_ENTRY:
+		return EstimateTableEntryMemory(entry.Cast<DuckLakeTableEntry>());
+	case CatalogType::VIEW_ENTRY:
+		return EstimateViewEntryMemory(entry.Cast<DuckLakeViewEntry>());
+	case CatalogType::MACRO_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return EstimateMacroEntryMemory(entry.Cast<MacroCatalogEntry>());
+	default:
+		return EstimateTagMemory(entry);
+	}
+}
+
+idx_t EstimateCatalogSetMemory(const DuckLakeCatalogSet &catalog_set) {
+	idx_t estimate = sizeof(DuckLakeCatalogSet);
+	estimate += catalog_set.GetEntries().size() * (sizeof(string) + sizeof(unique_ptr<CatalogEntry>));
+	estimate += catalog_set.TotalEntryCount() * (sizeof(idx_t) + sizeof(reference<CatalogEntry>));
+	for (auto &entry : catalog_set.GetEntries()) {
+		const auto &catalog_entry = *entry.second;
+		estimate += EstimateCatalogEntryMemory(catalog_entry);
+		if (catalog_entry.type != CatalogType::SCHEMA_ENTRY) {
+			continue;
+		}
+		const auto &schema = catalog_entry.Cast<DuckLakeSchemaEntry>();
+		schema.Scan(CatalogType::TABLE_ENTRY,
+		            [&](const CatalogEntry &child_entry) { estimate += EstimateCatalogEntryMemory(child_entry); });
+		schema.Scan(CatalogType::MACRO_ENTRY,
+		            [&](const CatalogEntry &child_entry) { estimate += EstimateCatalogEntryMemory(child_entry); });
+		schema.Scan(CatalogType::TABLE_MACRO_ENTRY,
+		            [&](const CatalogEntry &child_entry) { estimate += EstimateCatalogEntryMemory(child_entry); });
+	}
+	return estimate;
+}
+
+} // namespace
+
 optional_idx DuckLakeTableStatsCacheEntry::GetEstimatedCacheMemory() const {
 	idx_t estimate = sizeof(DuckLakeTableStats);
 	estimate += stats.column_stats.size() * ESTIMATED_BYTES_PER_COLUMN_STATS;
@@ -40,9 +152,7 @@ optional_idx DuckLakeTableStatsCacheEntry::GetEstimatedCacheMemory() const {
 }
 
 optional_idx DuckLakeSchemaCacheEntry::GetEstimatedCacheMemory() const {
-	idx_t estimate = sizeof(DuckLakeCatalogSet);
-	estimate += catalog_set.TotalEntryCount() * ESTIMATED_BYTES_PER_ENTRY;
-	return estimate;
+	return EstimateCatalogSetMemory(catalog_set);
 }
 
 void DuckLakeSchemaPinState::QueryEnd(ClientContext &context) {

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -57,7 +57,11 @@ idx_t EstimateTagMemory(const CatalogEntry &entry) {
 }
 
 idx_t EstimateTableEntryMemory(const DuckLakeTableEntry &table) {
-	idx_t estimate = EstimateTagMemory(table);
+	idx_t estimate = sizeof(DuckLakeTableEntry);
+	estimate += table.GetTableUUID().size();
+	estimate += table.DataPath().size();
+
+	estimate += EstimateTagMemory(table);
 	estimate += table.GetColumns().LogicalColumnCount() * sizeof(ColumnDefinition);
 	for (const auto &column : table.GetColumns().Logical()) {
 		estimate += EstimateStringMemory(column.Name());
@@ -86,7 +90,11 @@ idx_t EstimateTableEntryMemory(const DuckLakeTableEntry &table) {
 }
 
 idx_t EstimateViewEntryMemory(const DuckLakeViewEntry &view) {
-	idx_t estimate = EstimateTagMemory(view);
+	idx_t estimate = sizeof(DuckLakeViewEntry);
+	estimate += view.GetViewUUID().size();
+	estimate += view.GetQuerySQL().size();
+
+	estimate += EstimateTagMemory(view);
 	estimate += view.aliases.size() * sizeof(string);
 	for (const auto &alias : view.aliases) {
 		estimate += EstimateStringMemory(alias);

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -315,6 +315,13 @@ void DuckLakeSchemaEntry::Scan(CatalogType type, const std::function<void(Catalo
 	}
 }
 
+void DuckLakeSchemaEntry::Scan(CatalogType type, const std::function<void(const CatalogEntry &)> &callback) const {
+	auto &catalog_set = GetCatalogSet(type);
+	for (auto &entry : catalog_set.GetEntries()) {
+		callback(*entry.second);
+	}
+}
+
 void DuckLakeSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 	if (info.cascade) {
 		throw NotImplementedException("Cascade Drop not supported in DuckLake");
@@ -544,6 +551,22 @@ void DuckLakeSchemaEntry::TryDropSchema(DuckLakeTransaction &transaction, bool c
 }
 
 DuckLakeCatalogSet &DuckLakeSchemaEntry::GetCatalogSet(CatalogType type) {
+	switch (type) {
+	case CatalogType::TABLE_ENTRY:
+	case CatalogType::VIEW_ENTRY:
+		return tables;
+	case CatalogType::MACRO_ENTRY:
+	case CatalogType::SCALAR_FUNCTION_ENTRY:
+		return scalar_macros;
+	case CatalogType::TABLE_FUNCTION_ENTRY:
+	case CatalogType::TABLE_MACRO_ENTRY:
+		return table_macros;
+	default:
+		throw NotImplementedException("Unsupported catalog type %s for DuckLake", CatalogTypeToString(type));
+	}
+}
+
+const DuckLakeCatalogSet &DuckLakeSchemaEntry::GetCatalogSet(CatalogType type) const {
 	switch (type) {
 	case CatalogType::TABLE_ENTRY:
 	case CatalogType::VIEW_ENTRY:

--- a/src/storage/ducklake_view_entry.cpp
+++ b/src/storage/ducklake_view_entry.cpp
@@ -104,7 +104,7 @@ const SelectStatement &DuckLakeViewEntry::GetQuery() {
 	return *query;
 }
 
-string DuckLakeViewEntry::GetQuerySQL() {
+string DuckLakeViewEntry::GetQuerySQL() const {
 	return query_sql;
 }
 


### PR DESCRIPTION
Followup PR for https://github.com/duckdb/ducklake/pull/1033

In the last implementation, the memory consumption estimation is kinda coarse, it uses a [fixed size](https://github.com/duckdb/ducklake/blob/d897bc5a35f887c9087403bc20efd92d99272e69/src/storage/ducklake_catalog.cpp#L44-L48) for each catalog entry, which could be far off if people using tags, or wide table. etc.
This PR improves estimation by check the detailed table/view/macro entry.