### PR TITLE
Min max pushdown

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -256,6 +256,13 @@ public:
 	virtual unique_ptr<QueryResult> ReadAllInlinedDataForFlush(DuckLakeSnapshot snapshot,
 	                                                           const string &inlined_table_name,
 	                                                           const vector<string> &columns_to_read);
+	//! Read pre-built per-column aggregates (e.g. MIN/MAX/COUNT) over the committed rows of an inlined-data table.
+	virtual unique_ptr<QueryResult> ReadInlinedDataAggregates(DuckLakeSnapshot snapshot,
+	                                                          const string &inlined_table_name,
+	                                                          const string &select_list);
+	//! Read per-file column stats for all visible data files of a table at the given snapshot.
+	//! Used to recompute global table stats after a delete-rewriting compaction.
+	virtual unique_ptr<QueryResult> ReadFileColumnStatsForTable(DuckLakeSnapshot snapshot, TableIndex table_id);
 	virtual shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
 	                                                             const vector<LogicalType> &expected_types);
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -214,6 +214,11 @@ public:
 	virtual idx_t GetBeginSnapshotForSchemaVersion(TableIndex table_id, idx_t schema_version);
 	virtual idx_t GetNetDataFileRowCount(TableIndex table_id, DuckLakeSnapshot snapshot);
 	virtual idx_t GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot);
+	//! SQL builders for stats-refresh metadata lookups; caller substitutes placeholders + executes.
+	static string GetNetDataFileRowCountSql(TableIndex table_id, const string &inlined_deletion_table);
+	static string GetNetInlinedRowCountSql(const string &inlined_table_name);
+	static string GetTableColumnSchemaSql(TableIndex table_id);
+	static string GetInlinedTableNamesSql(TableIndex table_id);
 	virtual vector<DuckLakeFileForCleanup> GetOldFilesForCleanup(const string &filter);
 	virtual vector<DuckLakeFileForCleanup> GetOrphanFilesForCleanup(const string &filter, const string &separator);
 	virtual vector<DuckLakeFileForCleanup> GetFilesForCleanup(const string &filter, CleanupType type,

--- a/src/include/storage/ducklake_server_side_commit.hpp
+++ b/src/include/storage/ducklake_server_side_commit.hpp
@@ -82,6 +82,8 @@ private:
 	string BuildInlinedDataInserts(const vector<DuckLakeInlinedDataInfo> &new_data);
 	//! Resolve and cache the latest inlined-data table name.
 	const string &ResolveInlinedTableName(TableIndex table_id);
+	//! All inlined-data table names registered for a table id (any schema version).
+	vector<string> LookupInlinedTableNames(TableIndex table_id);
 	//! Replace {METADATA_CATALOG}, {SNAPSHOT_ID}, etc. in SQL.
 	string SubstitutePlaceholders(string sql, const DuckLakeSnapshot &snapshot) const;
 	//! Execute a query on the fresh connection; throw on error.

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -332,6 +332,17 @@ private:
 	                    reference<CatalogEntry> table_entry, NewTableInfo &result,
 	                    TransactionChangeInformation &transaction_changes);
 	CompactionInformation GetCompactionChanges(DuckLakeCommitState &commit_state, CompactionType type);
+	//! After a REWRITE_DELETES compaction, recompute EXACT global stats for `table_id` from the post-rewrite file set
+	//! (+ committed inlined data) and append the UpdateGlobalTableStats SQL to `batch_query`. No-op (leaving the
+	//! existing stale stats, and the scan fallback) if the table is not fully delete-free post-rewrite or the
+	//! inlined data cannot be accounted for exactly.
+	void RecomputeGlobalStatsAfterRewrite(string &batch_query, TableIndex table_id,
+	                                      const CompactionInformation &rewrite_changes,
+	                                      const set<DataFileIndex> &removed_source_ids);
+	//! Merge committed inlined data's per-column min/max into `target` via typed SQL aggregates. Returns false if the
+	//! inlined data cannot be accounted for exactly (e.g. a non-scalar column), in which case the caller must not
+	//! claim the recomputed stats are exact.
+	bool TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot, DuckLakeTableStats &target);
 
 	void AlterEntryInternal(DuckLakeTableEntry &old_entry, unique_ptr<CatalogEntry> new_entry);
 	void AlterEntryInternal(DuckLakeViewEntry &old_entry, unique_ptr<CatalogEntry> new_entry);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -13,6 +13,12 @@
 
 namespace duckdb {
 
+struct DuckLakeColumnSchemaEntry {
+	FieldIndex field_index;
+	string column_name;
+	LogicalType column_type;
+};
+
 struct DuckLakeCommitContext {
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
@@ -56,10 +62,15 @@ struct DuckLakeCommitContext {
 	    write_inlined_data;
 	//! Returns the current global table stats for a single table id (first-attempt path).
 	std::function<shared_ptr<DuckLakeTableStats>(TableIndex)> get_table_stats;
-	//! Resolves a DuckLakeTableEntry for the given table id at the commit snapshot — needed by
-	//! table-shaped stats work (field metadata, inlined-data tables). Returns nullptr if not visible.
-	std::function<optional_ptr<DuckLakeTableEntry>(TableIndex)> get_table_entry = [](TableIndex) {
-		return nullptr;
+	//! Top-level columns of a table at the commit snapshot — needed by stats-refresh to iterate
+	//! columns and look up types when merging per-file stats.
+	std::function<vector<DuckLakeColumnSchemaEntry>(TableIndex)> get_table_column_schema =
+	    [](TableIndex) {
+		    return vector<DuckLakeColumnSchemaEntry>{};
+	    };
+	//! Names of the inlined-data tables associated with a table id at the commit snapshot.
+	std::function<vector<string>(TableIndex)> get_inlined_table_names = [](TableIndex) {
+		return vector<string>{};
 	};
 	//! Net (delete-adjusted) row count of a table's regular data files.
 	std::function<idx_t(TableIndex)> get_net_data_file_row_count = [](TableIndex) {
@@ -136,8 +147,9 @@ public:
 	//! Merge committed inlined data's per-column min/max into `target` via typed SQL aggregates. Returns false if the
 	//! inlined data cannot be accounted for exactly (e.g. a non-scalar column), in which case the caller must not
 	//! claim the recomputed stats are exact.
-	bool TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot, DuckLakeTableStats &target,
-	                          const DuckLakeCommitContext &context);
+	bool TryMergeInlinedStats(const vector<DuckLakeColumnSchemaEntry> &columns,
+	                          const vector<string> &inlined_table_names, DuckLakeSnapshot snapshot,
+	                          DuckLakeTableStats &target, const DuckLakeCommitContext &context);
 	vector<DuckLakeDeleteFileInfo>
 	GetNewDeleteFiles(const DuckLakeCommitState &commit_state,
 	                  vector<DuckLakeOverwrittenDeleteFile> &overwritten_delete_files) const;

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -17,6 +17,10 @@ struct DuckLakeColumnSchemaEntry {
 	FieldIndex field_index;
 	string column_name;
 	LogicalType column_type;
+	//! false for nested struct/list/map/array leaves. Only top-level roots are safe to feed to the inlined-data
+	//! aggregate merge (which references the column by name); nested leaves still carry their own per-file stats.
+	//! (No default initializer: this struct must stay a C++11 aggregate; both producers set it explicitly.)
+	bool is_root;
 };
 
 struct DuckLakeCommitContext {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -492,17 +492,12 @@ WHERE table_id = {TABLE_ID} AND schema_version = {SCHEMA_VERSION})";
 	return GetBeginSnapshotForTable(table_id);
 }
 
-idx_t DuckLakeMetadataManager::GetNetDataFileRowCount(TableIndex table_id, DuckLakeSnapshot snapshot) {
-	// Compute sum(record_count) - sum(delete_count) - inlined_deletions in a single query
-	// Delete files are only counted if their corresponding data file is still visible
-	// This handles TRUNCATE correctly: when a data file's end_snapshot is set,
-	// its associated delete files are no longer counted
-
-	// Check if inlined deletion table exists
-	auto inlined_table_name = GetInlinedDeletionTableName(table_id, snapshot);
-
+string DuckLakeMetadataManager::GetNetDataFileRowCountSql(TableIndex table_id, const string &inlined_deletion_table) {
+	// Compute sum(record_count) - sum(delete_count) - inlined_deletions in a single query.
+	// Delete files are only counted if their corresponding data file is still visible.
+	// (When a data file's end_snapshot is set — e.g. TRUNCATE — associated deletes don't count.)
 	string inlined_deletion_subquery = "0";
-	if (!inlined_table_name.empty()) {
+	if (!inlined_deletion_table.empty()) {
 		inlined_deletion_subquery = StringUtil::Format(R"(
 COALESCE((SELECT COUNT(*) FROM {METADATA_CATALOG}.%s del
           JOIN {METADATA_CATALOG}.ducklake_data_file data ON del.file_id = data.data_file_id
@@ -510,9 +505,8 @@ COALESCE((SELECT COUNT(*) FROM {METADATA_CATALOG}.%s del
             AND data.table_id = {TABLE_ID}
             AND {SNAPSHOT_ID} >= data.begin_snapshot
             AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)), 0))",
-		                                               inlined_table_name);
+		                                               inlined_deletion_table);
 	}
-
 	string query = StringUtil::Format(R"(
 SELECT
   COALESCE((SELECT SUM(record_count) FROM {METADATA_CATALOG}.ducklake_data_file
@@ -530,7 +524,11 @@ SELECT
   -
   %s)",
 	                                  inlined_deletion_subquery);
-	query = StringUtil::Replace(query, "{TABLE_ID}", to_string(table_id.index));
+	return StringUtil::Replace(query, "{TABLE_ID}", to_string(table_id.index));
+}
+
+idx_t DuckLakeMetadataManager::GetNetDataFileRowCount(TableIndex table_id, DuckLakeSnapshot snapshot) {
+	auto query = GetNetDataFileRowCountSql(table_id, GetInlinedDeletionTableName(table_id, snapshot));
 	auto result = transaction.Query(snapshot, query);
 	for (auto &row : *result) {
 		return row.GetValue<idx_t>(0);
@@ -538,18 +536,41 @@ SELECT
 	return 0;
 }
 
-idx_t DuckLakeMetadataManager::GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot) {
-	string query = StringUtil::Format(R"(
+string DuckLakeMetadataManager::GetNetInlinedRowCountSql(const string &inlined_table_name) {
+	return StringUtil::Format(R"(
 SELECT COUNT(*)
 FROM {METADATA_CATALOG}.%s
 WHERE {SNAPSHOT_ID} >= begin_snapshot
   AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL))",
-	                                  inlined_table_name);
-	auto result = transaction.Query(snapshot, query);
+	                          inlined_table_name);
+}
+
+idx_t DuckLakeMetadataManager::GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot) {
+	auto result = transaction.Query(snapshot, GetNetInlinedRowCountSql(inlined_table_name));
 	for (auto &row : *result) {
 		return row.GetValue<idx_t>(0);
 	}
 	return 0;
+}
+
+string DuckLakeMetadataManager::GetTableColumnSchemaSql(TableIndex table_id) {
+	return StringUtil::Format(R"(
+SELECT column_id, column_name, column_type
+FROM {METADATA_CATALOG}.ducklake_column
+WHERE table_id = %d
+  AND parent_column IS NULL
+  AND {SNAPSHOT_ID} >= begin_snapshot
+  AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
+ORDER BY column_order)",
+	                          table_id.index);
+}
+
+string DuckLakeMetadataManager::GetInlinedTableNamesSql(TableIndex table_id) {
+	return StringUtil::Format(R"(
+SELECT DISTINCT table_name
+FROM {METADATA_CATALOG}.ducklake_inlined_data_tables
+WHERE table_id = %d)",
+	                          table_id.index);
 }
 
 DuckLakeCatalogInfo DuckLakeMetadataManager::GetCatalogForSnapshot(DuckLakeSnapshot snapshot) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -554,11 +554,13 @@ idx_t DuckLakeMetadataManager::GetNetInlinedRowCount(const string &inlined_table
 }
 
 string DuckLakeMetadataManager::GetTableColumnSchemaSql(TableIndex table_id) {
+	// Return the full flattened schema: top-level roots (parent_column IS NULL) and every nested leaf, each with its
+	// own column_id (== FieldIndex) and its own leaf column_type. Callers distinguish roots from leaves via
+	// parent_column. column_order == column_id for every row, so the ordering stays deterministic.
 	return StringUtil::Format(R"(
-SELECT column_id, column_name, column_type
+SELECT column_id, column_name, column_type, parent_column
 FROM {METADATA_CATALOG}.ducklake_column
 WHERE table_id = %d
-  AND parent_column IS NULL
   AND {SNAPSHOT_ID} >= begin_snapshot
   AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
 ORDER BY column_order)",

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2991,6 +2991,33 @@ ORDER BY row_id, begin_snapshot;)",
 	return result;
 }
 
+unique_ptr<QueryResult> DuckLakeMetadataManager::ReadInlinedDataAggregates(DuckLakeSnapshot snapshot,
+                                                                           const string &inlined_table_name,
+                                                                           const string &select_list) {
+	return transaction.Query(snapshot, StringUtil::Format(R"(
+SELECT %s
+FROM {METADATA_CATALOG}.%s
+WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL);
+)",
+	                                                      select_list, inlined_table_name));
+}
+
+unique_ptr<QueryResult> DuckLakeMetadataManager::ReadFileColumnStatsForTable(DuckLakeSnapshot snapshot,
+                                                                              TableIndex table_id) {
+	return transaction.Query(snapshot, StringUtil::Format(R"(
+SELECT data.data_file_id, data.record_count, data.file_size_bytes,
+       stats.column_id, stats.value_count, stats.null_count, stats.min_value, stats.max_value,
+       stats.contains_nan, stats.extra_stats
+FROM {METADATA_CATALOG}.ducklake_data_file data
+LEFT JOIN {METADATA_CATALOG}.ducklake_file_column_stats stats ON stats.data_file_id = data.data_file_id
+WHERE data.table_id = %d
+  AND {SNAPSHOT_ID} >= data.begin_snapshot
+  AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
+ORDER BY data.data_file_id;
+)",
+	                                                      table_id.index));
+}
+
 string DuckLakeMetadataManager::GetPathForSchema(SchemaIndex schema_id,
                                                  vector<DuckLakeSchemaInfo> &new_schemas_result) {
 	for (auto &schema : new_schemas_result) {

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -128,6 +128,31 @@ vector<column_t> DuckLakeGetRowIdColumn(ClientContext &context, optional_ptr<Fun
 	return result;
 }
 
+// Exposes DuckLake catalog column statistics to the optimizer's MIN/MAX aggregate pushdown.
+// DuckDB's StatisticsPropagator::TryExecuteAggregates folds MIN(col)/MAX(col) over a single scan into a
+// constant when the partition exposes (exact) column statistics through this interface.
+struct DuckLakePartitionRowGroup : public PartitionRowGroup {
+	DuckLakePartitionRowGroup(ClientContext &context, DuckLakeTableEntry &table, bool min_max_exact)
+	    : context(context), table(table), min_max_exact(min_max_exact) {
+	}
+
+	ClientContext &context;
+	DuckLakeTableEntry &table;
+	bool min_max_exact;
+
+	unique_ptr<BaseStatistics> GetColumnStatistics(const StorageIndex &storage_index) override {
+		if (storage_index.HasChildren()) {
+			// MIN/MAX over a nested sub-field - we only track stats for top-level columns, fall back to a scan
+			return nullptr;
+		}
+		return table.GetStatistics(context, storage_index.GetPrimaryIndex());
+	}
+
+	bool MinMaxIsExact(const BaseStatistics &stats, const StorageIndex &storage_index) override {
+		return min_max_exact;
+	}
+};
+
 vector<PartitionStatistics> DuckLakeGetPartitionStats(ClientContext &context, GetPartitionStatsInput &input) {
 	vector<PartitionStatistics> result;
 
@@ -171,12 +196,21 @@ vector<PartitionStatistics> DuckLakeGetPartitionStats(ClientContext &context, Ge
 		return result;
 	}
 
-	idx_t count = table.GetNetDataFileRowCount(*transaction) + table.GetNetInlinedRowCount(*transaction);
+	idx_t net_count = table.GetNetDataFileRowCount(*transaction) + table.GetNetInlinedRowCount(*transaction);
+
+	// MIN/MAX can be answered from the catalog column stats, but only when those stats are exact.
+	// Global column stats only ever widen on insert (via MergeStats) and are never tightened by deletes
+	// or compaction - so they are exact for the live data iff no row has ever been deleted, i.e. the gross
+	// record_count (total ever inserted) equals the net (delete-adjusted) row count. count(*) is unaffected
+	// either way: it does not consult MinMaxIsExact and subtracts delete counts independently.
+	auto table_stats = table.GetTableStats(*transaction);
+	bool min_max_exact = table_stats && table_stats->record_count == net_count;
 
 	// Return single partition with total count
 	PartitionStatistics stats;
-	stats.count = count;
+	stats.count = net_count;
 	stats.count_type = CountType::COUNT_EXACT;
+	stats.partition_row_group = make_shared_ptr<DuckLakePartitionRowGroup>(context, table, min_max_exact);
 	result.push_back(std::move(stats));
 	return result;
 }

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -612,10 +612,7 @@ vector<string> DuckLakeServerSideCommit::LookupInlinedTableNames(TableIndex tabl
 	vector<string> names;
 	auto sql =
 	    SubstitutePlaceholders(DuckLakeMetadataManager::GetInlinedTableNamesSql(table_id), transaction_snapshot);
-	auto result = fresh_conn.Query(sql);
-	if (!result || result->HasError()) {
-		return names;
-	}
+	auto result = RunQuery(sql, "lookup inlined table names");
 	for (auto &row : *result) {
 		names.push_back(row.GetValue<string>(0));
 	}
@@ -721,10 +718,7 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		vector<DuckLakeColumnSchemaEntry> schema;
 		auto sql = SubstitutePlaceholders(DuckLakeMetadataManager::GetTableColumnSchemaSql(table_id),
 		                                  transaction_snapshot);
-		auto result = fresh_conn.Query(sql);
-		if (!result || result->HasError()) {
-			return schema;
-		}
+		auto result = RunQuery(sql, "read table column schema");
 		for (auto &row : *result) {
 			schema.push_back({FieldIndex(static_cast<idx_t>(row.GetValue<int64_t>(0))),
 			                  row.GetValue<string>(1), DuckLakeTypes::FromString(row.GetValue<string>(2))});
@@ -747,10 +741,7 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		}
 		auto sql = SubstitutePlaceholders(
 		    DuckLakeMetadataManager::GetNetDataFileRowCountSql(table_id, inlined_deletion_table), transaction_snapshot);
-		auto result = fresh_conn.Query(sql);
-		if (!result || result->HasError()) {
-			return 0;
-		}
+		auto result = RunQuery(sql, "read net data file row count");
 		for (auto &row : *result) {
 			return row.GetValue<idx_t>(0);
 		}
@@ -761,10 +752,7 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		for (auto &name : LookupInlinedTableNames(table_id)) {
 			auto sql =
 			    SubstitutePlaceholders(DuckLakeMetadataManager::GetNetInlinedRowCountSql(name), transaction_snapshot);
-			auto result = fresh_conn.Query(sql);
-			if (!result || result->HasError()) {
-				continue;
-			}
+			auto result = RunQuery(sql, "read net inlined row count");
 			for (auto &row : *result) {
 				total += row.GetValue<idx_t>(0);
 				break;

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -720,8 +720,10 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		                                  transaction_snapshot);
 		auto result = RunQuery(sql, "read table column schema");
 		for (auto &row : *result) {
-			schema.push_back({FieldIndex(static_cast<idx_t>(row.GetValue<int64_t>(0))),
-			                  row.GetValue<string>(1), DuckLakeTypes::FromString(row.GetValue<string>(2))});
+			// parent_column IS NULL => top-level root; otherwise a nested leaf carrying its own leaf type.
+			bool is_root = row.IsNull(3);
+			schema.push_back({FieldIndex(static_cast<idx_t>(row.GetValue<int64_t>(0))), row.GetValue<string>(1),
+			                  DuckLakeTypes::FromString(row.GetValue<string>(2)), is_root});
 		}
 		return schema;
 	};

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -608,6 +608,20 @@ unique_ptr<DuckLakeStats> DuckLakeServerSideCommit::BuildStatsMap(vector<DuckLak
 	return result;
 }
 
+vector<string> DuckLakeServerSideCommit::LookupInlinedTableNames(TableIndex table_id) {
+	vector<string> names;
+	auto sql =
+	    SubstitutePlaceholders(DuckLakeMetadataManager::GetInlinedTableNamesSql(table_id), transaction_snapshot);
+	auto result = fresh_conn.Query(sql);
+	if (!result || result->HasError()) {
+		return names;
+	}
+	for (auto &row : *result) {
+		names.push_back(row.GetValue<string>(0));
+	}
+	return names;
+}
+
 const string &DuckLakeServerSideCommit::ResolveInlinedTableName(TableIndex table_id) {
 	auto it = inlined_table_name_cache.find(table_id.index);
 	if (it != inlined_table_name_cache.end()) {
@@ -702,6 +716,61 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 	};
 	ctx.build_stats_map = [this](vector<DuckLakeGlobalStatsInfo> &stats) {
 		return BuildStatsMap(stats);
+	};
+	ctx.get_table_column_schema = [this](TableIndex table_id) {
+		vector<DuckLakeColumnSchemaEntry> schema;
+		auto sql = SubstitutePlaceholders(DuckLakeMetadataManager::GetTableColumnSchemaSql(table_id),
+		                                  transaction_snapshot);
+		auto result = fresh_conn.Query(sql);
+		if (!result || result->HasError()) {
+			return schema;
+		}
+		for (auto &row : *result) {
+			schema.push_back({FieldIndex(static_cast<idx_t>(row.GetValue<int64_t>(0))),
+			                  row.GetValue<string>(1), DuckLakeTypes::FromString(row.GetValue<string>(2))});
+		}
+		return schema;
+	};
+	ctx.get_inlined_table_names = [this](TableIndex table_id) {
+		return LookupInlinedTableNames(table_id);
+	};
+	ctx.get_net_data_file_row_count = [this](TableIndex table_id) -> idx_t {
+		// The inlined-file-deletion table is deterministically named but created lazily.
+		// Probe its existence; if absent, the SQL omits the inlined-deletion subterm.
+		auto inlined_deletion_table = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
+		auto probe_sql = SubstitutePlaceholders(
+		    StringUtil::Format("SELECT 1 FROM {METADATA_CATALOG}.%s LIMIT 0", inlined_deletion_table),
+		    transaction_snapshot);
+		auto probe = fresh_conn.Query(probe_sql);
+		if (!probe || probe->HasError()) {
+			inlined_deletion_table.clear();
+		}
+		auto sql = SubstitutePlaceholders(
+		    DuckLakeMetadataManager::GetNetDataFileRowCountSql(table_id, inlined_deletion_table), transaction_snapshot);
+		auto result = fresh_conn.Query(sql);
+		if (!result || result->HasError()) {
+			return 0;
+		}
+		for (auto &row : *result) {
+			return row.GetValue<idx_t>(0);
+		}
+		return 0;
+	};
+	ctx.get_net_inlined_row_count = [this](TableIndex table_id) -> idx_t {
+		idx_t total = 0;
+		for (auto &name : LookupInlinedTableNames(table_id)) {
+			auto sql =
+			    SubstitutePlaceholders(DuckLakeMetadataManager::GetNetInlinedRowCountSql(name), transaction_snapshot);
+			auto result = fresh_conn.Query(sql);
+			if (!result || result->HasError()) {
+				continue;
+			}
+			for (auto &row : *result) {
+				total += row.GetValue<idx_t>(0);
+				break;
+			}
+		}
+		return total;
 	};
 	ctx.set_catalog_version = [&committed_schema_version](idx_t v) {
 		committed_schema_version = v;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2595,7 +2595,8 @@ bool DuckLakeTransaction::TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLa
 			auto col = DuckLakeUtil::SQLIdentifierToString(field_id->Name());
 			bool is_float =
 			    field_id->Type().id() == LogicalTypeId::FLOAT || field_id->Type().id() == LogicalTypeId::DOUBLE;
-			string nan_expr = is_float ? StringUtil::Format("COALESCE(BOOL_OR(isnan(%s)), false)", col) : string("false");
+			string nan_expr =
+			    is_float ? StringUtil::Format("COALESCE(BOOL_OR(isnan(%s)), false)", col) : string("false");
 			select_list +=
 			    StringUtil::Format(", MIN(%s)::VARCHAR, MAX(%s)::VARCHAR, COUNT(%s), %s", col, col, col, nan_expr);
 		}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2448,6 +2448,20 @@ string DuckLakeTransaction::CommitChanges(DuckLakeCommitState &commit_state,
 		    commit_snapshot, compaction_rewrite_delete_changes.new_files, new_tables_result, new_schemas_result);
 		batch_queries += metadata_manager->WriteCompactions(compaction_rewrite_delete_changes.compacted_files,
 		                                                    CompactionType::REWRITE_DELETES);
+
+		// Rewriting deletes physically removes deleted rows, so the affected tables can become delete-free
+		// again. Recompute their EXACT global stats from the post-rewrite file set so MIN/MAX can once more be answered
+		// from metadata (see DuckLakeGetPartitionStats). Safe no-op when a table is not fully delete-free post-rewrite.
+		if (!compaction_rewrite_delete_changes.compacted_files.empty()) {
+			map<TableIndex, set<DataFileIndex>> removed_source_ids_by_table;
+			for (auto &compacted : compaction_rewrite_delete_changes.compacted_files) {
+				removed_source_ids_by_table[compacted.table_index].insert(compacted.source_id);
+			}
+			for (auto &table_entry : removed_source_ids_by_table) {
+				RecomputeGlobalStatsAfterRewrite(batch_queries, table_entry.first, compaction_rewrite_delete_changes,
+				                                 table_entry.second);
+			}
+		}
 	}
 
 	// Tracking for tables that had schema changes
@@ -2553,6 +2567,214 @@ CompactionInformation DuckLakeTransaction::GetCompactionChanges(DuckLakeCommitSt
 		}
 	}
 	return result;
+}
+
+static bool IsFoldableScalarType(const LogicalType &type) {
+	if (type.IsNumeric() || type.IsTemporal()) {
+		return true;
+	}
+	auto id = type.id();
+	return id == LogicalTypeId::VARCHAR || id == LogicalTypeId::BOOLEAN;
+}
+
+bool DuckLakeTransaction::TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot,
+                                               DuckLakeTableStats &target) {
+	auto &field_data = table.GetFieldData();
+	auto &field_ids = field_data.GetFieldIds();
+	// We can only compute exact inlined min/max for top-level foldable scalar columns. If any column is nested or a
+	// non-scalar type we cannot account for the inlined rows exactly - bail (caller keeps the scan fallback).
+	for (auto &field_id : field_ids) {
+		if (field_id->HasChildren() || !IsFoldableScalarType(field_id->Type())) {
+			return false;
+		}
+	}
+	for (auto &inlined_table : table.GetInlinedDataTables()) {
+		// Build one aggregate query: COUNT(*) followed by (MIN, MAX, COUNT(col), nan-flag) per column.
+		string select_list = "COUNT(*)";
+		for (auto &field_id : field_ids) {
+			auto col = DuckLakeUtil::SQLIdentifierToString(field_id->Name());
+			bool is_float =
+			    field_id->Type().id() == LogicalTypeId::FLOAT || field_id->Type().id() == LogicalTypeId::DOUBLE;
+			string nan_expr = is_float ? StringUtil::Format("COALESCE(BOOL_OR(isnan(%s)), false)", col) : string("false");
+			select_list +=
+			    StringUtil::Format(", MIN(%s)::VARCHAR, MAX(%s)::VARCHAR, COUNT(%s), %s", col, col, col, nan_expr);
+		}
+		string query = StringUtil::Format(R"(
+SELECT %s
+FROM {METADATA_CATALOG}.%s
+WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL);
+)",
+		                                  select_list, DuckLakeUtil::SQLIdentifierToString(inlined_table.table_name));
+		auto result = Query(snapshot, query);
+		if (result->HasError()) {
+			return false;
+		}
+		for (auto &row : *result) {
+			auto total = static_cast<idx_t>(row.template GetValue<int64_t>(0));
+			if (total == 0) {
+				break;
+			}
+			idx_t col_offset = 1;
+			for (auto &field_id : field_ids) {
+				bool is_float =
+				    field_id->Type().id() == LogicalTypeId::FLOAT || field_id->Type().id() == LogicalTypeId::DOUBLE;
+				bool contains_nan = !row.IsNull(col_offset + 3) && row.template GetValue<bool>(col_offset + 3);
+				DuckLakeColumnStats col_stats(field_id->Type());
+				auto non_null = static_cast<idx_t>(row.template GetValue<int64_t>(col_offset + 2));
+				col_stats.has_num_values = true;
+				col_stats.num_values = total;
+				col_stats.has_null_count = true;
+				col_stats.null_count = total - non_null;
+				if (is_float) {
+					col_stats.has_contains_nan = true;
+					col_stats.contains_nan = contains_nan;
+				}
+				// do not record float min/max if NaN is present (matches the parquet stats behaviour)
+				if (!(is_float && contains_nan)) {
+					if (!row.IsNull(col_offset + 0)) {
+						col_stats.has_min = true;
+						col_stats.min = row.template GetValue<string>(col_offset + 0);
+					}
+					if (!row.IsNull(col_offset + 1)) {
+						col_stats.has_max = true;
+						col_stats.max = row.template GetValue<string>(col_offset + 1);
+					}
+				}
+				target.MergeStats(field_id->GetFieldIndex(), col_stats);
+				col_offset += 4;
+			}
+			break;
+		}
+	}
+	return true;
+}
+
+void DuckLakeTransaction::RecomputeGlobalStatsAfterRewrite(string &batch_query, TableIndex table_id,
+                                                           const CompactionInformation &rewrite_changes,
+                                                           const set<DataFileIndex> &removed_source_ids) {
+	auto snapshot = GetSnapshot();
+	auto entry = ducklake_catalog.GetEntryById(*this, snapshot, table_id);
+	if (!entry) {
+		return;
+	}
+	auto &table = entry->Cast<DuckLakeTableEntry>();
+	auto current_stats = ducklake_catalog.GetTableStats(*this, table_id);
+	if (!current_stats) {
+		// no committed stats row exists yet - the UPDATE path of UpdateGlobalTableStats only refreshes existing rows
+		return;
+	}
+
+	DuckLakeTableStats new_stats;
+	new_stats.next_row_id = current_stats->next_row_id; // monotonic - carried forward, never recomputed
+	idx_t parquet_gross_rows = 0;
+
+	// 1. Merge the per-file stats of the post-rewrite parquet files = (pre-commit visible files - removed) + new files.
+	string query = StringUtil::Format(R"(
+SELECT data.data_file_id, data.record_count, data.file_size_bytes,
+       stats.column_id, stats.value_count, stats.null_count, stats.min_value, stats.max_value,
+       stats.contains_nan, stats.extra_stats
+FROM {METADATA_CATALOG}.ducklake_data_file data
+LEFT JOIN {METADATA_CATALOG}.ducklake_file_column_stats stats ON stats.data_file_id = data.data_file_id
+WHERE data.table_id = %d
+  AND {SNAPSHOT_ID} >= data.begin_snapshot
+  AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
+ORDER BY data.data_file_id;
+)",
+	                                  table_id.index);
+	auto result = Query(snapshot, query);
+	if (result->HasError()) {
+		return;
+	}
+	bool have_file = false;
+	idx_t last_file_id = 0;
+	for (auto &row : *result) {
+		auto data_file_id = static_cast<idx_t>(row.GetValue<int64_t>(0));
+		if (removed_source_ids.find(DataFileIndex(data_file_id)) != removed_source_ids.end()) {
+			continue; // this file is being rewritten away
+		}
+		if (!have_file || data_file_id != last_file_id) {
+			have_file = true;
+			last_file_id = data_file_id;
+			new_stats.record_count += static_cast<idx_t>(row.GetValue<int64_t>(1));
+			new_stats.table_size_bytes += static_cast<idx_t>(row.GetValue<int64_t>(2));
+			parquet_gross_rows += static_cast<idx_t>(row.GetValue<int64_t>(1));
+		}
+		if (row.IsNull(3)) {
+			continue; // file without column stats
+		}
+		FieldIndex field_idx(static_cast<idx_t>(row.GetValue<int64_t>(3)));
+		auto field = table.GetFieldId(field_idx);
+		if (!field) {
+			continue; // column no longer exists
+		}
+		DuckLakeColumnStats col_stats(field->Type());
+		if (!row.IsNull(4) && !row.IsNull(5)) {
+			auto value_count = static_cast<idx_t>(row.GetValue<int64_t>(4));
+			auto null_count = static_cast<idx_t>(row.GetValue<int64_t>(5));
+			col_stats.has_num_values = true;
+			col_stats.num_values = value_count + null_count;
+			col_stats.has_null_count = true;
+			col_stats.null_count = null_count;
+		}
+		if (!row.IsNull(6)) {
+			col_stats.has_min = true;
+			col_stats.min = row.GetValue<string>(6);
+		}
+		if (!row.IsNull(7)) {
+			col_stats.has_max = true;
+			col_stats.max = row.GetValue<string>(7);
+		}
+		if (!row.IsNull(8)) {
+			col_stats.has_contains_nan = true;
+			col_stats.contains_nan = row.GetValue<bool>(8);
+		}
+		if (!row.IsNull(9) && col_stats.extra_stats) {
+			col_stats.extra_stats->Deserialize(row.GetValue<string>(9));
+		}
+		new_stats.MergeStats(field_idx, col_stats);
+	}
+
+	// add the new (rewritten, delete-free) files - their stats are available in memory
+	for (auto &file : rewrite_changes.new_files) {
+		if (file.table_id != table_id) {
+			continue;
+		}
+		new_stats.record_count += file.row_count;
+		new_stats.table_size_bytes += file.file_size_bytes;
+		parquet_gross_rows += file.row_count;
+		for (auto &col_entry : file.column_stats) {
+			new_stats.MergeStats(col_entry.first, col_entry.second);
+		}
+	}
+
+	// 2. Delete-free gate: the merged parquet stats are exact only if no deletions remain on the table's data files.
+	//    That holds iff the gross row count of the post-rewrite files equals the net (delete-adjusted) data-file count.
+	//    (Covers partial rewrites with delete_threshold > 0, leftover delete files, and inlined file deletions.)
+	if (parquet_gross_rows != table.GetNetDataFileRowCount(*this)) {
+		return;
+	}
+
+	// 3. Fold in committed inlined data (REWRITE_DELETES does not rewrite inlined data).
+	idx_t net_inlined = table.GetNetInlinedRowCount(*this);
+	if (net_inlined > 0) {
+		if (!TryMergeInlinedStats(table, snapshot, new_stats)) {
+			return; // cannot account for inlined data exactly - keep the existing stats and the scan fallback
+		}
+		new_stats.record_count += net_inlined;
+	}
+
+	// 4. Make sure every committed leaf column appears so its global row is refreshed (a column with no live data
+	//    becomes "unknown" -> it is scanned at query time, which is correct).
+	for (auto &col_entry : current_stats->column_stats) {
+		if (new_stats.column_stats.find(col_entry.first) == new_stats.column_stats.end()) {
+			new_stats.column_stats.insert(make_pair(col_entry.first, DuckLakeColumnStats(col_entry.second.type)));
+		}
+	}
+
+	DuckLakeNewGlobalStats new_globals;
+	new_globals.initialized = true;
+	new_globals.stats = std::move(new_stats);
+	batch_query += UpdateGlobalTableStats(table_id, new_globals);
 }
 
 bool RetryOnError(const string &original_message) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2603,7 +2603,7 @@ bool DuckLakeTransaction::TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLa
 		auto result = GetMetadataManager().ReadInlinedDataAggregates(
 		    snapshot, DuckLakeUtil::SQLIdentifierToString(inlined_table.table_name), select_list);
 		if (result->HasError()) {
-			return false;
+			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
 		}
 		for (auto &row : *result) {
 			auto total = static_cast<idx_t>(row.template GetValue<int64_t>(0));
@@ -2667,7 +2667,7 @@ void DuckLakeTransaction::RecomputeGlobalStatsAfterRewrite(string &batch_query, 
 	// 1. Merge the per-file stats of the post-rewrite parquet files = (pre-commit visible files - removed) + new files.
 	auto result = GetMetadataManager().ReadFileColumnStatsForTable(snapshot, table_id);
 	if (result->HasError()) {
-		return;
+		result->GetErrorObject().Throw("Failed to read per-file column stats for rewrite from DuckLake: ");
 	}
 	bool have_file = false;
 	idx_t last_file_id = 0;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1390,12 +1390,29 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	context.get_table_stats = [&](TableIndex table_id) {
 		return ducklake_catalog.GetTableStats(*this, table_id);
 	};
-	context.get_table_entry = [&](TableIndex table_id) -> optional_ptr<DuckLakeTableEntry> {
+	context.get_table_column_schema = [&](TableIndex table_id) {
+		// All top-level columns at the commit snapshot — including nested STRUCT/LIST roots.
+		// The IsFoldableScalarType check in TryMergeInlinedStats bails on any non-scalar root.
+		vector<DuckLakeColumnSchemaEntry> schema;
 		auto entry = ducklake_catalog.GetEntryById(*this, transaction_snapshot, table_id);
 		if (!entry) {
-			return nullptr;
+			return schema;
 		}
-		return &entry->Cast<DuckLakeTableEntry>();
+		for (auto &field : entry->Cast<DuckLakeTableEntry>().GetFieldData().GetFieldIds()) {
+			schema.push_back({field->GetFieldIndex(), field->Name(), field->Type()});
+		}
+		return schema;
+	};
+	context.get_inlined_table_names = [&](TableIndex table_id) {
+		vector<string> names;
+		auto entry = ducklake_catalog.GetEntryById(*this, transaction_snapshot, table_id);
+		if (!entry) {
+			return names;
+		}
+		for (auto &t : entry->Cast<DuckLakeTableEntry>().GetInlinedDataTables()) {
+			names.push_back(t.table_name);
+		}
+		return names;
 	};
 	context.get_net_data_file_row_count = [&](TableIndex table_id) -> idx_t {
 		auto entry = ducklake_catalog.GetEntryById(*this, transaction_snapshot, table_id);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2600,13 +2600,8 @@ bool DuckLakeTransaction::TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLa
 			select_list +=
 			    StringUtil::Format(", MIN(%s)::VARCHAR, MAX(%s)::VARCHAR, COUNT(%s), %s", col, col, col, nan_expr);
 		}
-		string query = StringUtil::Format(R"(
-SELECT %s
-FROM {METADATA_CATALOG}.%s
-WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL);
-)",
-		                                  select_list, DuckLakeUtil::SQLIdentifierToString(inlined_table.table_name));
-		auto result = Query(snapshot, query);
+		auto result = GetMetadataManager().ReadInlinedDataAggregates(
+		    snapshot, DuckLakeUtil::SQLIdentifierToString(inlined_table.table_name), select_list);
 		if (result->HasError()) {
 			return false;
 		}
@@ -2670,19 +2665,7 @@ void DuckLakeTransaction::RecomputeGlobalStatsAfterRewrite(string &batch_query, 
 	idx_t parquet_gross_rows = 0;
 
 	// 1. Merge the per-file stats of the post-rewrite parquet files = (pre-commit visible files - removed) + new files.
-	string query = StringUtil::Format(R"(
-SELECT data.data_file_id, data.record_count, data.file_size_bytes,
-       stats.column_id, stats.value_count, stats.null_count, stats.min_value, stats.max_value,
-       stats.contains_nan, stats.extra_stats
-FROM {METADATA_CATALOG}.ducklake_data_file data
-LEFT JOIN {METADATA_CATALOG}.ducklake_file_column_stats stats ON stats.data_file_id = data.data_file_id
-WHERE data.table_id = %d
-  AND {SNAPSHOT_ID} >= data.begin_snapshot
-  AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
-ORDER BY data.data_file_id;
-)",
-	                                  table_id.index);
-	auto result = Query(snapshot, query);
+	auto result = GetMetadataManager().ReadFileColumnStatsForTable(snapshot, table_id);
 	if (result->HasError()) {
 		return;
 	}

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1391,15 +1391,24 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 		return ducklake_catalog.GetTableStats(*this, table_id);
 	};
 	context.get_table_column_schema = [&](TableIndex table_id) {
-		// All top-level columns at the commit snapshot — including nested STRUCT/LIST roots.
-		// The IsFoldableScalarType check in TryMergeInlinedStats bails on any non-scalar root.
+		// The full flattened schema at the commit snapshot: top-level roots (is_root=true) plus every nested
+		// struct/list/map/array leaf (is_root=false). Roots carry the inlined-data merge (TryMergeInlinedStats
+		// references columns by name and bails on any non-scalar root); leaves carry their own per-file stats keyed
+		// by leaf FieldIndex, which the rewrite recompute must merge. Each node uses its authoritative stored
+		// FieldIndex (ALTER ADD FIELD makes nested leaf ids non-contiguous, so they cannot be re-derived).
 		vector<DuckLakeColumnSchemaEntry> schema;
 		auto entry = ducklake_catalog.GetEntryById(*this, transaction_snapshot, table_id);
 		if (!entry) {
 			return schema;
 		}
+		std::function<void(const DuckLakeFieldId &, bool)> add_field = [&](const DuckLakeFieldId &field, bool is_root) {
+			schema.push_back({field.GetFieldIndex(), field.Name(), field.Type(), is_root});
+			for (auto &child : field.Children()) {
+				add_field(*child, false);
+			}
+		};
 		for (auto &field : entry->Cast<DuckLakeTableEntry>().GetFieldData().GetFieldIds()) {
-			schema.push_back({field->GetFieldIndex(), field->Name(), field->Type()});
+			add_field(*field, true);
 		}
 		return schema;
 	};

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -801,7 +801,9 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 		return;
 	}
 
-	// Build a field_index -> column_type map for per-file stats merge below.
+	// Build a field_index -> column_type map for the per-file stats merge below. `columns` is the full flattened
+	// schema (roots + nested leaves), so per-file stats keyed by a nested-leaf FieldIndex resolve here too - without
+	// the leaves, an un-rewritten file's nested-leaf stats would be dropped and the global min/max corrupted.
 	map<FieldIndex, LogicalType> type_by_field;
 	for (auto &col : columns) {
 		type_by_field.insert(make_pair(col.field_index, col.column_type));
@@ -886,20 +888,29 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 		return;
 	}
 
-	// 3. Fold in committed inlined data (REWRITE_DELETES does not rewrite inlined data).
+	// 3. Fold in committed inlined data (REWRITE_DELETES does not rewrite inlined data). Pass only the top-level
+	//    roots: TryMergeInlinedStats references each column by name against the inlined table and bails on any
+	//    non-scalar root; feeding it nested leaves would emit MIN("<leaf>") against a column that does not exist.
 	idx_t net_inlined = context.get_net_inlined_row_count(table_id);
 	if (net_inlined > 0) {
+		vector<DuckLakeColumnSchemaEntry> root_columns;
+		for (auto &col : columns) {
+			if (col.is_root) {
+				root_columns.push_back(col);
+			}
+		}
 		auto inlined_table_names = context.get_inlined_table_names(table_id);
-		if (!TryMergeInlinedStats(columns, inlined_table_names, snapshot, new_stats, context)) {
+		if (!TryMergeInlinedStats(root_columns, inlined_table_names, snapshot, new_stats, context)) {
 			return; // cannot account for inlined data exactly - keep the existing stats and the scan fallback
 		}
 		new_stats.record_count += net_inlined;
 	}
 
-	// 4. Make sure every committed top-level column appears so its global row is refreshed (a column with no
-	//    live data becomes "unknown" -> it is scanned at query time, which is correct). Use the snapshot
-	//    schema instead of current_stats->column_stats: the server-side stats cache is only populated for
-	//    tables with staged inserts, so a pure-rewrite commit can see an empty current_stats.column_stats.
+	// 4. Make sure every committed column (root or nested leaf) appears so its global row is refreshed (a column with
+	//    no live data becomes "unknown" -> it is scanned at query time, which is correct). UpdateGlobalTableStatsSql
+	//    only UPDATEs existing rows, so entries with no committed stats row (e.g. struct containers) are harmless
+	//    no-ops. Use the snapshot schema instead of current_stats->column_stats: the server-side stats cache is only
+	//    populated for tables with staged inserts, so a pure-rewrite commit can see an empty current_stats.column_stats.
 	for (auto &col : columns) {
 		if (new_stats.column_stats.find(col.field_index) == new_stats.column_stats.end()) {
 			new_stats.column_stats.insert(make_pair(col.field_index, DuckLakeColumnStats(col.column_type)));

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -717,31 +717,31 @@ static bool IsFoldableScalarType(const LogicalType &type) {
 	return id == LogicalTypeId::VARCHAR || id == LogicalTypeId::BOOLEAN;
 }
 
-bool DuckLakeTransactionState::TryMergeInlinedStats(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot,
-                                                    DuckLakeTableStats &target, const DuckLakeCommitContext &context) {
-	auto &field_data = table.GetFieldData();
-	auto &field_ids = field_data.GetFieldIds();
-	// We can only compute exact inlined min/max for top-level foldable scalar columns. If any column is nested or a
+bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnSchemaEntry> &columns,
+                                                    const vector<string> &inlined_table_names,
+                                                    DuckLakeSnapshot snapshot, DuckLakeTableStats &target,
+                                                    const DuckLakeCommitContext &context) {
+	// We can only compute exact inlined min/max for top-level foldable scalar columns. If any column is a
 	// non-scalar type we cannot account for the inlined rows exactly - bail (caller keeps the scan fallback).
-	for (auto &field_id : field_ids) {
-		if (field_id->HasChildren() || !IsFoldableScalarType(field_id->Type())) {
+	for (auto &col : columns) {
+		if (!IsFoldableScalarType(col.column_type)) {
 			return false;
 		}
 	}
-	for (auto &inlined_table : table.GetInlinedDataTables()) {
+	for (auto &inlined_table_name : inlined_table_names) {
 		// Build one aggregate query: COUNT(*) followed by (MIN, MAX, COUNT(col), nan-flag) per column.
 		string select_list = "COUNT(*)";
-		for (auto &field_id : field_ids) {
-			auto col = DuckLakeUtil::SQLIdentifierToString(field_id->Name());
+		for (auto &col : columns) {
+			auto col_ident = DuckLakeUtil::SQLIdentifierToString(col.column_name);
 			bool is_float =
-			    field_id->Type().id() == LogicalTypeId::FLOAT || field_id->Type().id() == LogicalTypeId::DOUBLE;
+			    col.column_type.id() == LogicalTypeId::FLOAT || col.column_type.id() == LogicalTypeId::DOUBLE;
 			string nan_expr =
-			    is_float ? StringUtil::Format("COALESCE(BOOL_OR(isnan(%s)), false)", col) : string("false");
-			select_list +=
-			    StringUtil::Format(", MIN(%s)::VARCHAR, MAX(%s)::VARCHAR, COUNT(%s), %s", col, col, col, nan_expr);
+			    is_float ? StringUtil::Format("COALESCE(BOOL_OR(isnan(%s)), false)", col_ident) : string("false");
+			select_list += StringUtil::Format(", MIN(%s)::VARCHAR, MAX(%s)::VARCHAR, COUNT(%s), %s", col_ident,
+			                                  col_ident, col_ident, nan_expr);
 		}
 		auto sql = DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(
-		    DuckLakeUtil::SQLIdentifierToString(inlined_table.table_name), select_list);
+		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list);
 		auto result = context.query_metadata_with_snapshot(snapshot, sql);
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
@@ -752,11 +752,11 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(DuckLakeTableEntry &table, D
 				break;
 			}
 			idx_t col_offset = 1;
-			for (auto &field_id : field_ids) {
+			for (auto &col : columns) {
 				bool is_float =
-				    field_id->Type().id() == LogicalTypeId::FLOAT || field_id->Type().id() == LogicalTypeId::DOUBLE;
+				    col.column_type.id() == LogicalTypeId::FLOAT || col.column_type.id() == LogicalTypeId::DOUBLE;
 				bool contains_nan = !row.IsNull(col_offset + 3) && row.template GetValue<bool>(col_offset + 3);
-				DuckLakeColumnStats col_stats(field_id->Type());
+				DuckLakeColumnStats col_stats(col.column_type);
 				auto non_null = static_cast<idx_t>(row.template GetValue<int64_t>(col_offset + 2));
 				col_stats.has_num_values = true;
 				col_stats.num_values = total;
@@ -777,7 +777,7 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(DuckLakeTableEntry &table, D
 						col_stats.max = row.template GetValue<string>(col_offset + 1);
 					}
 				}
-				target.MergeStats(field_id->GetFieldIndex(), col_stats);
+				target.MergeStats(col.field_index, col_stats);
 				col_offset += 4;
 			}
 			break;
@@ -791,14 +791,20 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
                                                                  const CompactionInformation &rewrite_changes,
                                                                  const set<DataFileIndex> &removed_source_ids,
                                                                  const DuckLakeCommitContext &context) {
-	auto table = context.get_table_entry(table_id);
-	if (!table) {
-		return;
+	auto columns = context.get_table_column_schema(table_id);
+	if (columns.empty()) {
+		return; // no schema visible at the commit snapshot
 	}
 	auto current_stats = context.get_table_stats(table_id);
 	if (!current_stats) {
 		// no committed stats row exists yet - the UPDATE path of UpdateGlobalTableStats only refreshes existing rows
 		return;
+	}
+
+	// Build a field_index -> column_type map for per-file stats merge below.
+	map<FieldIndex, LogicalType> type_by_field;
+	for (auto &col : columns) {
+		type_by_field.insert(make_pair(col.field_index, col.column_type));
 	}
 
 	DuckLakeTableStats new_stats;
@@ -829,11 +835,11 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 			continue; // file without column stats
 		}
 		FieldIndex field_idx(static_cast<idx_t>(row.GetValue<int64_t>(3)));
-		auto field = table->GetFieldId(field_idx);
-		if (!field) {
-			continue; // column no longer exists
+		auto type_it = type_by_field.find(field_idx);
+		if (type_it == type_by_field.end()) {
+			continue; // column no longer exists or is nested
 		}
-		DuckLakeColumnStats col_stats(field->Type());
+		DuckLakeColumnStats col_stats(type_it->second);
 		if (!row.IsNull(4) && !row.IsNull(5)) {
 			auto value_count = static_cast<idx_t>(row.GetValue<int64_t>(4));
 			auto null_count = static_cast<idx_t>(row.GetValue<int64_t>(5));
@@ -883,7 +889,8 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	// 3. Fold in committed inlined data (REWRITE_DELETES does not rewrite inlined data).
 	idx_t net_inlined = context.get_net_inlined_row_count(table_id);
 	if (net_inlined > 0) {
-		if (!TryMergeInlinedStats(*table, snapshot, new_stats, context)) {
+		auto inlined_table_names = context.get_inlined_table_names(table_id);
+		if (!TryMergeInlinedStats(columns, inlined_table_names, snapshot, new_stats, context)) {
 			return; // cannot account for inlined data exactly - keep the existing stats and the scan fallback
 		}
 		new_stats.record_count += net_inlined;

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -896,11 +896,13 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 		new_stats.record_count += net_inlined;
 	}
 
-	// 4. Make sure every committed leaf column appears so its global row is refreshed (a column with no live data
-	//    becomes "unknown" -> it is scanned at query time, which is correct).
-	for (auto &col_entry : current_stats->column_stats) {
-		if (new_stats.column_stats.find(col_entry.first) == new_stats.column_stats.end()) {
-			new_stats.column_stats.insert(make_pair(col_entry.first, DuckLakeColumnStats(col_entry.second.type)));
+	// 4. Make sure every committed top-level column appears so its global row is refreshed (a column with no
+	//    live data becomes "unknown" -> it is scanned at query time, which is correct). Use the snapshot
+	//    schema instead of current_stats->column_stats: the server-side stats cache is only populated for
+	//    tables with staged inserts, so a pure-rewrite commit can see an empty current_stats.column_stats.
+	for (auto &col : columns) {
+		if (new_stats.column_stats.find(col.field_index) == new_stats.column_stats.end()) {
+			new_stats.column_stats.insert(make_pair(col.field_index, DuckLakeColumnStats(col.column_type)));
 		}
 	}
 

--- a/test/sql/stats/min_max_nested_leaf_rewrite_corruption.test
+++ b/test/sql/stats/min_max_nested_leaf_rewrite_corruption.test
@@ -1,0 +1,77 @@
+# name: test/sql/stats/min_max_nested_leaf_rewrite_corruption.test
+# description: REWRITE_DELETES recompute must keep nested-leaf stats of un-rewritten files (struct/list/map)
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/nested_rewrite', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 100);
+
+statement ok
+CREATE TABLE ducklake.t(i INTEGER, s STRUCT(a INTEGER), l INTEGER[], m MAP(INTEGER, INTEGER));
+
+# File A: every nested leaf in the low range [1,50]. This file holds the global leaf MINs.
+# It has NO deletes, so REWRITE_DELETES will NOT rewrite it -> its per-file stats are read back
+# via SQL (ReadFileColumnStatsForTableSql) during the post-rewrite stats recompute.
+statement ok
+INSERT INTO ducklake.t SELECT x, {'a': x}, [x], MAP([x], [x * 2]) FROM range(1, 51) t(x);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# File B: every nested leaf in the high range [51,100]. This file WILL be rewritten (it gets a delete).
+statement ok
+INSERT INTO ducklake.t SELECT x, {'a': x}, [x], MAP([x], [x * 2]) FROM range(51, 101) t(x);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+# Delete one row that lives in File B only -> only File B has deletes.
+statement ok
+DELETE FROM ducklake.t WHERE i = 75;
+
+# Rewrite deletes away. Only File B is rewritten; File A is left untouched. The recompute then
+# recomputes EXACT global stats and replaces them. Before the fix, the nested leaves (s.a, l.element,
+# m.key, m.value) of File A were dropped (their leaf column_id was absent from the schema map), so
+# their global stat collapsed to File B's range and the optimizer pruned File A -> wrong results.
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+# WRONG RESULT before the fix: File A (s.a in [1,50]) was pruned by the corrupt [51,100] stat.
+query I
+SELECT count(*) FROM ducklake.t WHERE s.a < 51;
+----
+50
+
+# WRONG RESULT before the fix: row with s.a = 10 lives in File A and was pruned away.
+query I
+SELECT count(*) FROM ducklake.t WHERE s.a = 10;
+----
+1
+
+# Control: the root scalar i (whose stat IS recomputed correctly) was always fine.
+query I
+SELECT count(*) FROM ducklake.t WHERE i < 51;
+----
+50
+
+# Stored global stats: every nested leaf must keep its full range, not the rewritten-file-only range.
+#   column_id 1 = i           -> [1,100]
+#   column_id 3 = s.a         -> [1,100]
+#   column_id 5 = l.element   -> [1,100]
+#   column_id 7 = m.key       -> [1,100]
+#   column_id 8 = m.value     -> [2,200]
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats ORDER BY column_id;
+----
+1	1	100
+3	1	100
+5	1	100
+7	1	100
+8	2	200

--- a/test/sql/stats/min_max_optimization_basic.test
+++ b/test/sql/stats/min_max_optimization_basic.test
@@ -68,15 +68,13 @@ CREATE TABLE ducklake.strings(v VARCHAR);
 statement ok
 INSERT INTO ducklake.strings VALUES ('banana'), ('apple'), ('cherry'), ('date');
 
+# NOTE: we only assert the value here, not that it folds. String min/max statistics may be stored as a
+# truncated prefix, so the optimizer conservatively refuses to answer string MIN/MAX from stats (it falls
+# back to a scan). The result must still be correct either way.
 query II
 SELECT MIN(v), MAX(v) FROM ducklake.strings;
 ----
 apple	date
-
-query II
-EXPLAIN ANALYZE SELECT MIN(v), MAX(v) FROM ducklake.strings;
-----
-analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
 
 # ============================================
 # 3. Filtered MIN/MAX falls back to scanning but stays correct

--- a/test/sql/stats/min_max_optimization_basic.test
+++ b/test/sql/stats/min_max_optimization_basic.test
@@ -1,0 +1,131 @@
+# name: test/sql/stats/min_max_optimization_basic.test
+# description: Test metadata-only MIN/MAX optimization
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_optimization')
+
+# ============================================
+# 1. MIN/MAX answered from catalog metadata
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test FROM range(1, 1001);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.test;
+----
+1	1000	1000
+
+# the MIN/MAX/COUNT(*) are folded to constants - no files are read
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+query II
+EXPLAIN ANALYZE SELECT MAX(i) FROM ducklake.test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# the optimization still holds after additional inserts (stats widen)
+statement ok
+INSERT INTO ducklake.test VALUES (-50), (5000);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.test;
+----
+-50	5000	1002
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 2. String MIN/MAX
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.strings(v VARCHAR);
+
+statement ok
+INSERT INTO ducklake.strings VALUES ('banana'), ('apple'), ('cherry'), ('date');
+
+query II
+SELECT MIN(v), MAX(v) FROM ducklake.strings;
+----
+apple	date
+
+query II
+EXPLAIN ANALYZE SELECT MIN(v), MAX(v) FROM ducklake.strings;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 3. Filtered MIN/MAX falls back to scanning but stays correct
+# ============================================
+
+# always-true filter over the whole range still folds
+query I
+SELECT MIN(i) FROM ducklake.test WHERE i >= -50;
+----
+-50
+
+# partial filter -> falls back to a scan
+query I
+SELECT MIN(i) FROM ducklake.test WHERE i > 50;
+----
+51
+
+# always-false filter -> empty result, must be NULL (and must not crash)
+query I
+SELECT MIN(i) FROM ducklake.test WHERE i > 100000;
+----
+NULL
+
+# ============================================
+# 4. All-NULL column -> MIN/MAX is NULL (via fallback)
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.nulls(n INTEGER);
+
+statement ok
+INSERT INTO ducklake.nulls VALUES (NULL), (NULL), (NULL);
+
+query II
+SELECT MIN(n), MAX(n) FROM ducklake.nulls;
+----
+NULL	NULL
+
+# ============================================
+# 5. FLOAT/DOUBLE MIN/MAX are correct (fold or fallback, value must match)
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.doubles(d DOUBLE);
+
+statement ok
+INSERT INTO ducklake.doubles VALUES (1.5), (-3.25), (2.0), (100.125);
+
+query II
+SELECT MIN(d), MAX(d) FROM ducklake.doubles;
+----
+-3.25	100.125

--- a/test/sql/stats/min_max_optimization_basic.test
+++ b/test/sql/stats/min_max_optimization_basic.test
@@ -92,6 +92,11 @@ SELECT MIN(i) FROM ducklake.test WHERE i > 50;
 ----
 51
 
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.test WHERE i > 50;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
 # always-false filter -> empty result, must be NULL (and must not crash)
 query I
 SELECT MIN(i) FROM ducklake.test WHERE i > 100000;

--- a/test/sql/stats/min_max_optimization_compaction.test
+++ b/test/sql/stats/min_max_optimization_compaction.test
@@ -169,3 +169,41 @@ query I
 SELECT MIN(i) FROM ducklake.nested WHERE s.a > 500;
 ----
 51
+
+# ============================================
+# 5. All-in-one transaction: CREATE / INSERT / DELETE / rewrite / COMMIT in one BEGIN/COMMIT
+#    The rewrite is a no-op (transactional isolation hides the in-transaction delete), and the
+#    Phase 2 stats refresh is skipped because no committed stats row exists yet at recompute time.
+#    Correctness is preserved via the Phase 1 fallback.
+# ============================================
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE ducklake.single_tx(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.single_tx FROM range(1, 201);
+
+statement ok
+DELETE FROM ducklake.single_tx WHERE i = 1;
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+statement ok
+COMMIT;
+
+# values are correct
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.single_tx;
+----
+2	200	199
+
+# MIN/MAX fell back to a scan: the Phase 2 recompute was skipped (no current_stats row at commit time),
+# so record_count (gross 200) != net_count (199), and the Phase 1 exactness guard forces a scan.
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.single_tx;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*

--- a/test/sql/stats/min_max_optimization_compaction.test
+++ b/test/sql/stats/min_max_optimization_compaction.test
@@ -24,9 +24,6 @@ statement ok
 INSERT INTO ducklake.t FROM range(1, 201);
 
 statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
-statement ok
 DELETE FROM ducklake.t WHERE i = 1;
 
 statement ok
@@ -69,9 +66,6 @@ CREATE TABLE ducklake.mixed(i INTEGER);
 # large insert -> parquet file
 statement ok
 INSERT INTO ducklake.mixed FROM range(1, 201);
-
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 # small insert -> stays inlined
 statement ok

--- a/test/sql/stats/min_max_optimization_compaction.test
+++ b/test/sql/stats/min_max_optimization_compaction.test
@@ -1,0 +1,171 @@
+# name: test/sql/stats/min_max_optimization_compaction.test
+# description: REWRITE_DELETES recomputes exact global stats so MIN/MAX fold from metadata again
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_compaction', DATA_INLINING_ROW_LIMIT 100)
+
+# ============================================
+# 1. After rewriting deletes away, MIN/MAX fold again
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.t(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.t FROM range(1, 201);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+DELETE FROM ducklake.t WHERE i = 1;
+
+statement ok
+DELETE FROM ducklake.t WHERE i = 200;
+
+# before the rewrite: deletes present -> MIN falls back to a scan (but is correct)
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.t;
+----
+2	199	198
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.t;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+# rewrite the deletes away
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+# values unchanged
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.t;
+----
+2	199	198
+
+# ...and MIN/MAX now fold from the recomputed metadata (no scan)
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.t;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 2. Inlined data is folded into the recompute (parquet + inlined coexisting)
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.mixed(i INTEGER);
+
+# large insert -> parquet file
+statement ok
+INSERT INTO ducklake.mixed FROM range(1, 201);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# small insert -> stays inlined
+statement ok
+INSERT INTO ducklake.mixed FROM range(201, 251);
+
+# delete the min (parquet) and the max (inlined)
+statement ok
+DELETE FROM ducklake.mixed WHERE i = 1;
+
+statement ok
+DELETE FROM ducklake.mixed WHERE i = 250;
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.mixed;
+----
+2	249	248
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+# correct values, including the inlined contribution, fold from metadata
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.mixed;
+----
+2	249	248
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.mixed;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 3. Partial rewrite (deletes remain) -> recompute is skipped, MIN/MAX stay correct via fallback
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.partial(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.partial FROM range(1, 101);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+DELETE FROM ducklake.partial WHERE i = 1;
+
+# high threshold: the lightly-deleted file is NOT rewritten, so deletes remain
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0.9);
+
+# value still correct
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.partial;
+----
+2	100	99
+
+# deletes remain -> recompute skipped -> MIN still falls back to a scan
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.partial;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 4. Nested columns: scalar MIN/MAX still fold after a rewrite; nested column stays correct
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.nested(i INTEGER, s STRUCT(a INTEGER, b VARCHAR));
+
+statement ok
+INSERT INTO ducklake.nested SELECT x, {'a': x * 10, 'b': 'v' || x} FROM range(1, 101) t(x);
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+DELETE FROM ducklake.nested WHERE i = 1;
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.nested;
+----
+2	100	99
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.nested;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# filter on the nested field still returns correct results
+query I
+SELECT MIN(i) FROM ducklake.nested WHERE s.a > 500;
+----
+51

--- a/test/sql/stats/min_max_optimization_deletes.test
+++ b/test/sql/stats/min_max_optimization_deletes.test
@@ -1,0 +1,130 @@
+# name: test/sql/stats/min_max_optimization_deletes.test
+# description: MIN/MAX falls back to scanning (but stays correct) when deletes exist
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_deletes', DATA_INLINING_ROW_LIMIT 100)
+
+# ============================================
+# 1. Data-file deletes
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.big(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.big FROM range(1, 101);
+
+# flush to parquet so the deletes below are data-file deletes
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# baseline: no deletes -> MIN/MAX fold from metadata
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
+----
+1	100	100
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.big;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# delete the current minimum value
+statement ok
+DELETE FROM ducklake.big WHERE i = 1;
+
+# result is still correct (computed via a scan, since global stats are not tightened on delete)
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
+----
+2	100	99
+
+# MIN now falls back to a real scan
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.big;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+# ...but COUNT(*) is NOT regressed - it still folds from metadata
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.big;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# deleting the maximum is reflected too
+statement ok
+DELETE FROM ducklake.big WHERE i = 100;
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
+----
+2	99	98
+
+# ============================================
+# 2. Post-compaction: deletes rewritten away, but stats remain over-wide
+#    -> MIN/MAX must STILL fall back (guard keys off record_count != net_count,
+#       not the presence of delete files), and must STILL be correct.
+# ============================================
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', delete_threshold => 0);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
+----
+2	99	98
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.big;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+# count(*) still folds after compaction
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.big;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# 3. Inlined deletes
+# ============================================
+
+statement ok
+CREATE TABLE ducklake.small(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.small FROM range(1, 51);
+
+# baseline folds (committed inlined data)
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.small;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+statement ok
+DELETE FROM ducklake.small WHERE i = 1;
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.small;
+----
+2	50	49
+
+# MIN falls back, COUNT(*) still folds
+query II
+EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.small;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.small;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*

--- a/test/sql/stats/min_max_optimization_deletes.test
+++ b/test/sql/stats/min_max_optimization_deletes.test
@@ -70,9 +70,8 @@ SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
 2	99	98
 
 # ============================================
-# 2. Post-compaction: deletes rewritten away, but stats remain over-wide
-#    -> MIN/MAX must STILL fall back (guard keys off record_count != net_count,
-#       not the presence of delete files), and must STILL be correct.
+# 2. Post-compaction: rewriting the deletes away makes the table delete-free again, so the global
+#    stats are recomputed and MIN/MAX fold once more (see min_max_optimization_compaction.test).
 # ============================================
 
 statement ok
@@ -84,13 +83,7 @@ SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.big;
 2	99	98
 
 query II
-EXPLAIN ANALYZE SELECT MIN(i) FROM ducklake.big;
-----
-analyzed_plan	<REGEX>:.*TABLE_SCAN.*
-
-# count(*) still folds after compaction
-query II
-EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.big;
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.big;
 ----
 analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
 

--- a/test/sql/stats/min_max_optimization_inlined.test
+++ b/test/sql/stats/min_max_optimization_inlined.test
@@ -1,0 +1,57 @@
+# name: test/sql/stats/min_max_optimization_inlined.test
+# description: Test metadata-only MIN/MAX optimization with inlined data
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_inlined', DATA_INLINING_ROW_LIMIT 100)
+
+# data small enough to be inlined (never flushed to parquet)
+statement ok
+CREATE TABLE ducklake.inlined_test AS SELECT * FROM range(10, 60) t(i);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.inlined_test;
+----
+10	59	50
+
+# committed inlined data is reflected in the global stats - MIN/MAX fold from metadata
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.inlined_test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# insert more inlined data that widens the range
+statement ok
+INSERT INTO ducklake.inlined_test VALUES (5), (100);
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.inlined_test;
+----
+5	100	52
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.inlined_test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# flushing inlined data to parquet must not change MIN/MAX and must still fold
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+query III
+SELECT MIN(i), MAX(i), COUNT(*) FROM ducklake.inlined_test;
+----
+5	100	52
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.inlined_test;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*

--- a/test/sql/stats/min_max_optimization_time_travel.test
+++ b/test/sql/stats/min_max_optimization_time_travel.test
@@ -62,6 +62,12 @@ SELECT MIN(i), MAX(i) FROM ducklake.tt;
 ----
 -5	9999
 
+# transaction-local data forces fallback via HasTransactionLocalData()
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.tt;
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
 statement ok
 ROLLBACK;
 

--- a/test/sql/stats/min_max_optimization_time_travel.test
+++ b/test/sql/stats/min_max_optimization_time_travel.test
@@ -1,0 +1,97 @@
+# name: test/sql/stats/min_max_optimization_time_travel.test
+# description: MIN/MAX with time travel and transaction-local changes (fall back, stay correct)
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_time_travel')
+
+statement ok
+CREATE TABLE ducklake.tt(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.tt FROM range(1, 101);
+
+# snapshot 2 == after the first insert (1..100)
+query I
+SELECT MAX(snapshot_id) FROM ducklake.snapshots();
+----
+2
+
+statement ok
+INSERT INTO ducklake.tt FROM range(101, 201);
+
+# current MIN/MAX over all rows
+query II
+SELECT MIN(i), MAX(i) FROM ducklake.tt;
+----
+1	200
+
+# time travel to snapshot 2 -> MAX should be 100, not 200 (falls back to scanning)
+query II
+SELECT MIN(i), MAX(i) FROM ducklake.tt AT (VERSION => 2);
+----
+1	100
+
+# the time travel query reads files (it cannot be folded from current metadata)
+query II
+EXPLAIN ANALYZE SELECT MAX(i) FROM ducklake.tt AT (VERSION => 2);
+----
+analyzed_plan	<REGEX>:.*TABLE_SCAN.*
+
+# ============================================
+# Transaction-local changes
+# ============================================
+
+# uncommitted insert that widens the range
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.tt VALUES (-5), (9999);
+
+query II
+SELECT MIN(i), MAX(i) FROM ducklake.tt;
+----
+-5	9999
+
+statement ok
+ROLLBACK;
+
+# after rollback the committed MIN/MAX are visible again (and fold from metadata)
+query II
+SELECT MIN(i), MAX(i) FROM ducklake.tt;
+----
+1	200
+
+query II
+EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.tt;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+# uncommitted delete of the current minimum
+statement ok
+BEGIN;
+
+statement ok
+DELETE FROM ducklake.tt WHERE i = 1;
+
+query I
+SELECT MIN(i) FROM ducklake.tt;
+----
+2
+
+statement ok
+ROLLBACK;
+
+query I
+SELECT MIN(i) FROM ducklake.tt;
+----
+1


### PR DESCRIPTION
Simplest part (1st commit) just exposes the min/max values to the optimizer via `DuckLakePartitionRowGroup`. This will allow the optimizer to do a bunch of optimizations (besides answering min/max queries from stats). This does not work in table with deletes.

The second part focuses on updating statistics for tables with deletes whenever a user runs `ducklake_rewrite_data_files`. Basically whenever a table is rewritten (and independently of whether it has inlined data or not), DuckLake recalculates the stats. This generally means that if you do maintenance operations regularly after doing UPDATES/DELETES in your lakehouse, stats will be up to date and therefore the optimizer will be able to do its job better. 

The complexity of the second part lies on adding inlined data stats, which right now is done via `TryMergeInlinedStats`, which queries the inlined tables for min/max values.