### PR TITLE
[Experimental] Vortex file format support

### DIFF
--- a/docs/vortex_backend_spec.md
+++ b/docs/vortex_backend_spec.md
@@ -1,0 +1,80 @@
+# DuckLake Data File Backends
+
+## Goal
+
+DuckLake data files are selectable by format. Parquet remains the default for
+compatibility, and Vortex can be selected for new data files at DuckLake, schema,
+or table scope.
+
+## User Surface
+
+DuckLake adds a `data_file_format` option with two accepted values:
+
+- `parquet`
+- `vortex`
+
+The option follows the existing DuckLake option precedence:
+
+1. table option
+2. schema option
+3. global DuckLake option
+4. default `parquet`
+
+Examples:
+
+```sql
+CALL ducklake_set_option('ducklake', 'data_file_format', 'vortex');
+CALL ducklake_set_option('ducklake', 'data_file_format', 'parquet', table_name => 'orders');
+ATTACH 'ducklake:metadata.db' AS ducklake (DATA_PATH 'files', DATA_FILE_FORMAT 'vortex');
+```
+
+The selected format applies to newly written data files only. Existing files
+keep their original file format in metadata and remain readable. An attach-time
+`DATA_FILE_FORMAT` initializes the global DuckLake option when creating a new
+DuckLake; existing DuckLakes should use `ducklake_set_option` to change the
+persisted global default.
+
+## Metadata
+
+`ducklake_data_file.file_format` is the source of truth for each data file.
+Existing catalogs without a value, or with `parquet`, are interpreted as Parquet.
+New Vortex files store `vortex`.
+
+Delete files are unchanged. Positional delete files continue to be Parquet, and
+deletion-vector files continue to be Puffin.
+
+## Write Path
+
+Insert, CTAS, flush-inlined-data, merge, and compaction resolve the target data
+file format using `data_file_format`.
+
+For Parquet, all current writer behavior and Parquet-specific options remain
+unchanged.
+
+For Vortex:
+
+- DuckDB's `vortex` copy function is used.
+- Files use the `.vortex` extension.
+- Parquet-specific options are not passed.
+- Vortex writes are rejected for encrypted DuckLakes until the Vortex writer
+  exposes an equivalent encryption API.
+
+## Read Path
+
+DuckLake scan planning continues to use DuckLake's multi-file reader so file
+deletes, row ids, snapshot filtering, inlined data, and mixed-format tables are
+handled in one path.
+
+Parquet files use the existing Parquet file reader. Vortex files use a
+DuckLake-owned Vortex file reader backed by DuckDB's `read_vortex` table
+function.
+
+## Compatibility Notes
+
+Parquet files keep field-id metadata. Vortex files currently do not expose
+DuckLake field ids through the DuckDB Vortex extension, so DuckLake-created
+Vortex files use the existing field-id-missing fallback mapping path.
+
+This supports straightforward append/read workloads and column renames, but
+complex schema evolution across Vortex files should be treated as experimental
+until field-id metadata is available in Vortex.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(
   ducklake_types.cpp
   ducklake_util.cpp
   ducklake_version.cpp
-  parquet_file_scanner.cpp)
+  parquet_file_scanner.cpp
+  vortex_file_scanner.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_common>
     PARENT_SCOPE)

--- a/src/common/ducklake_data_file.cpp
+++ b/src/common/ducklake_data_file.cpp
@@ -3,6 +3,26 @@
 
 namespace duckdb {
 
+string DuckLakeDataFileFormatToString(DuckLakeDataFileFormat format) {
+	switch (format) {
+	case DuckLakeDataFileFormat::PARQUET:
+		return "parquet";
+	case DuckLakeDataFileFormat::VORTEX:
+		return "vortex";
+	default:
+		throw InternalException("Unknown DuckLakeDataFileFormat");
+	}
+}
+
+DuckLakeDataFileFormat DuckLakeDataFileFormatFromString(const string &str) {
+	if (StringUtil::CIEquals(str, "parquet")) {
+		return DuckLakeDataFileFormat::PARQUET;
+	} else if (StringUtil::CIEquals(str, "vortex")) {
+		return DuckLakeDataFileFormat::VORTEX;
+	}
+	throw InvalidInputException("Unknown data file format: %s", str);
+}
+
 string DeleteFileFormatToString(DeleteFileFormat format) {
 	switch (format) {
 	case DeleteFileFormat::PARQUET:
@@ -25,6 +45,7 @@ DeleteFileFormat DeleteFileFormatFromString(const string &str) {
 
 DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 	file_name = other.file_name;
+	format = other.format;
 	row_count = other.row_count;
 	file_size_bytes = other.file_size_bytes;
 	footer_size = other.footer_size;
@@ -42,6 +63,7 @@ DuckLakeDataFile::DuckLakeDataFile(const DuckLakeDataFile &other) {
 
 DuckLakeDataFile &DuckLakeDataFile::operator=(const DuckLakeDataFile &other) {
 	file_name = other.file_name;
+	format = other.format;
 	row_count = other.row_count;
 	file_size_bytes = other.file_size_bytes;
 	footer_size = other.footer_size;

--- a/src/common/vortex_file_scanner.cpp
+++ b/src/common/vortex_file_scanner.cpp
@@ -1,0 +1,90 @@
+#include "common/vortex_file_scanner.hpp"
+#include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/extension_helper.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
+
+namespace duckdb {
+
+VortexFileScanner::VortexFileScanner(ClientContext &context, const DuckLakeFileData &file) : context(context) {
+	auto &instance = DatabaseInstance::GetDatabase(context);
+	ExtensionHelper::TryAutoLoadExtension(instance, "vortex");
+	ExtensionLoader loader(instance, "ducklake");
+	auto &vortex_scan_entry = loader.GetTableFunction("read_vortex");
+	vortex_scan = vortex_scan_entry.functions.functions[0];
+
+	vector<Value> children;
+	children.push_back(Value(file.path));
+	named_parameter_map_t named_params;
+	vector<LogicalType> input_types;
+	vector<string> input_names;
+
+	TableFunctionRef empty;
+	TableFunction dummy_table_function;
+	dummy_table_function.name = "VortexFileScanner";
+
+	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr,
+	                                  dummy_table_function, empty);
+
+	bind_data = vortex_scan.bind(context, bind_input, return_types, return_names);
+}
+
+const vector<LogicalType> &VortexFileScanner::GetTypes() const {
+	return return_types;
+}
+
+const vector<string> &VortexFileScanner::GetNames() const {
+	return return_names;
+}
+
+optional_idx VortexFileScanner::FindColumn(const string &name) const {
+	for (idx_t i = 0; i < return_names.size(); i++) {
+		if (return_names[i] == name) {
+			return i;
+		}
+	}
+	return optional_idx();
+}
+
+void VortexFileScanner::SetFilters(unique_ptr<TableFilterSet> filters_p) {
+	filters = std::move(filters_p);
+}
+
+void VortexFileScanner::SetColumnIds(vector<column_t> column_ids_p) {
+	column_ids = std::move(column_ids_p);
+}
+
+void VortexFileScanner::InitializeScan() {
+	if (initialized) {
+		return;
+	}
+
+	if (column_ids.empty()) {
+		for (idx_t i = 0; i < return_types.size(); i++) {
+			column_ids.push_back(i);
+		}
+	}
+
+	thread_context = make_uniq<ThreadContext>(context);
+	execution_context = make_uniq<ExecutionContext>(context, *thread_context, nullptr);
+
+	TableFunctionInitInput input(bind_data.get(), column_ids, vector<idx_t>(), filters.get());
+	global_state = vortex_scan.init_global(context, input);
+	local_state = vortex_scan.init_local(*execution_context, input, global_state.get());
+
+	initialized = true;
+}
+
+bool VortexFileScanner::Scan(DataChunk &chunk) {
+	if (!initialized) {
+		InitializeScan();
+	}
+
+	TableFunctionInput function_input(bind_data.get(), local_state.get(), global_state.get());
+	chunk.Reset();
+	vortex_scan.function(context, function_input, chunk);
+
+	return chunk.size() > 0;
+}
+
+} // namespace duckdb

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -76,10 +76,12 @@ DuckLakeCompaction::DuckLakeCompaction(PhysicalPlan &physical_plan, const vector
                                        DuckLakeTableEntry &table, vector<DuckLakeCompactionFileEntry> source_files_p,
                                        string encryption_key_p, optional_idx partition_id,
                                        vector<Value> partition_values_p, optional_idx row_id_start,
-                                       PhysicalOperator &child, CompactionType type)
+                                       DuckLakeDataFileFormat file_format_p, PhysicalOperator &child,
+                                       CompactionType type)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 0), table(table),
       source_files(std::move(source_files_p)), encryption_key(std::move(encryption_key_p)), partition_id(partition_id),
-      partition_values(std::move(partition_values_p)), row_id_start(row_id_start), type(type) {
+      partition_values(std::move(partition_values_p)), row_id_start(row_id_start), file_format(file_format_p),
+      type(type) {
 	children.push_back(child);
 }
 
@@ -132,7 +134,7 @@ unique_ptr<GlobalSinkState> DuckLakeCompaction::GetGlobalSinkState(ClientContext
 
 SinkResultType DuckLakeCompaction::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
-	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id);
+	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id, file_format);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -593,7 +595,8 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	                                         std::move(copy_options.info));
 
 	auto &fs = FileSystem::GetFileSystem(context);
-	copy->file_path = copy_options.filename_pattern.CreateFilename(fs, copy_options.file_path, "parquet", 0);
+	copy->file_path =
+	    copy_options.filename_pattern.CreateFilename(fs, copy_options.file_path, copy_options.file_extension, 0);
 	copy->use_tmp_file = copy_options.use_tmp_file;
 	copy->filename_pattern = std::move(copy_options.filename_pattern);
 	copy->file_extension = std::move(copy_options.file_extension);
@@ -624,7 +627,7 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	// followed by the compaction operator (that writes the results back to the
 	auto compaction = make_uniq<DuckLakeLogicalCompaction>(
 	    binder.GenerateTableIndex(), table, std::move(actionable_source_files), std::move(copy_input.encryption_key),
-	    partition_id, std::move(partition_values), target_row_id_start, type);
+	    partition_id, std::move(partition_values), target_row_id_start, copy_input.file_format, type);
 	compaction->children.push_back(std::move(copy));
 	return std::move(compaction);
 }

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -52,10 +52,10 @@ static void AttachDeleteFilesToWrittenFiles(vector<DuckLakeDeleteFile> &delete_f
 DuckLakeFlushData::DuckLakeFlushData(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
                                      DuckLakeTableEntry &table, DuckLakeInlinedTableInfo inlined_table_p,
                                      string encryption_key_p, optional_idx partition_id, string sort_order_sql_p,
-                                     PhysicalOperator &child)
+                                     DuckLakeDataFileFormat file_format_p, PhysicalOperator &child)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 0), table(table),
       inlined_table(std::move(inlined_table_p)), encryption_key(std::move(encryption_key_p)),
-      partition_id(partition_id), sort_order_sql(std::move(sort_order_sql_p)) {
+      partition_id(partition_id), sort_order_sql(std::move(sort_order_sql_p)), file_format(file_format_p) {
 	children.push_back(child);
 }
 
@@ -101,7 +101,7 @@ unique_ptr<GlobalSinkState> DuckLakeFlushData::GetGlobalSinkState(ClientContext 
 
 SinkResultType DuckLakeFlushData::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
-	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id, true);
+	DuckLakeInsert::AddWrittenFiles(global_state, chunk, encryption_key, partition_id, file_format, true);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -212,10 +212,11 @@ string DuckLakeFlushData::GetName() const {
 class DuckLakeLogicalFlush : public LogicalExtensionOperator {
 public:
 	DuckLakeLogicalFlush(TableIndex table_index, DuckLakeTableEntry &table, DuckLakeInlinedTableInfo inlined_table_p,
-	                     string encryption_key_p, optional_idx partition_id_p, string sort_order_sql_p)
+	                     string encryption_key_p, optional_idx partition_id_p, string sort_order_sql_p,
+	                     DuckLakeDataFileFormat file_format_p)
 	    : table_index(table_index), table(table), inlined_table(std::move(inlined_table_p)),
 	      encryption_key(std::move(encryption_key_p)), partition_id(partition_id_p),
-	      sort_order_sql(std::move(sort_order_sql_p)) {
+	      sort_order_sql(std::move(sort_order_sql_p)), file_format(file_format_p) {
 	}
 
 	TableIndex table_index;
@@ -224,12 +225,13 @@ public:
 	string encryption_key;
 	optional_idx partition_id;
 	string sort_order_sql;
+	DuckLakeDataFileFormat file_format;
 
 public:
 	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override {
 		auto &child = planner.CreatePlan(*children[0]);
 		return planner.Make<DuckLakeFlushData>(types, table, std::move(inlined_table), std::move(encryption_key),
-		                                       partition_id, std::move(sort_order_sql), child);
+		                                       partition_id, std::move(sort_order_sql), file_format, child);
 	}
 
 	string GetName() const override {
@@ -391,7 +393,8 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	// followed by the compaction operator (that writes the results back to the
 	auto compaction =
 	    make_uniq<DuckLakeLogicalFlush>(binder.GenerateTableIndex(), table, inlined_table,
-	                                    std::move(copy_input.encryption_key), partition_id, std::move(sort_order_sql));
+	                                    std::move(copy_input.encryption_key), partition_id, std::move(sort_order_sql),
+	                                    copy_input.file_format);
 	compaction->children.push_back(std::move(copy));
 	return std::move(compaction);
 }

--- a/src/functions/ducklake_options.cpp
+++ b/src/functions/ducklake_options.cpp
@@ -40,7 +40,8 @@ static constexpr const ducklake_option_array DUCKLAKE_OPTIONS = {
      {"per_thread_output", "Whether to create separate output files per thread during parallel insertion"},
      {"write_deletion_vectors", "[EXPERIMENTAL - do not use outside testing] Whether to write Iceberg V3 deletion "
                                 "vectors (puffin) instead of positional delete files (parquet)"},
-     {"sort_on_insert", "Whether to sort data on INSERT according to SET SORTED BY (default: true)"}}};
+     {"sort_on_insert", "Whether to sort data on INSERT according to SET SORTED BY (default: true)"},
+     {"data_file_format", "Format used for new data files (parquet or vortex)"}}};
 
 struct DuckLakeOptionsData : public TableFunctionData {
 	explicit DuckLakeOptionsData(Catalog &catalog) : catalog(catalog) {

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -100,6 +100,9 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
 	} else if (option == "sort_on_insert") {
 		value = val.CastAs(context, LogicalType::BOOLEAN).GetValue<bool>() ? "true" : "false";
+	} else if (option == "data_file_format") {
+		auto format = val.DefaultCastAs(LogicalType::VARCHAR).GetValue<string>();
+		value = DuckLakeDataFileFormatToString(DuckLakeDataFileFormatFromString(format));
 	} else {
 		throw NotImplementedException("Unsupported option %s", option);
 	}

--- a/src/include/common/ducklake_data_file.hpp
+++ b/src/include/common/ducklake_data_file.hpp
@@ -20,6 +20,14 @@ struct DuckLakeFilePartition {
 	Value partition_value;
 };
 
+enum class DuckLakeDataFileFormat : uint8_t {
+	PARQUET,
+	VORTEX
+};
+
+string DuckLakeDataFileFormatToString(DuckLakeDataFileFormat format);
+DuckLakeDataFileFormat DuckLakeDataFileFormatFromString(const string &str);
+
 enum class DeleteFileFormat : uint8_t {
 	PARQUET, //! Positional delete file in Parquet format
 	PUFFIN   //! Deletion vector in Puffin format (Iceberg V3)
@@ -62,6 +70,7 @@ struct DuckLakeDataFile {
 	DuckLakeDataFile &operator=(const DuckLakeDataFile &);
 
 	string file_name;
+	DuckLakeDataFileFormat format = DuckLakeDataFileFormat::PARQUET;
 	idx_t row_count;
 	idx_t file_size_bytes;
 	optional_idx footer_size;

--- a/src/include/common/vortex_file_scanner.hpp
+++ b/src/include/common/vortex_file_scanner.hpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// common/vortex_file_scanner.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/parallel/thread_context.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
+#include "storage/ducklake_metadata_info.hpp"
+
+namespace duckdb {
+
+//! Utility class for scanning Vortex files directly
+class VortexFileScanner {
+public:
+	VortexFileScanner(ClientContext &context, const DuckLakeFileData &file);
+
+	const vector<LogicalType> &GetTypes() const;
+	const vector<string> &GetNames() const;
+
+	//! Find a column by name, returns invalid index if not found
+	optional_idx FindColumn(const string &name) const;
+
+	//! Set filters to push down to the scan
+	void SetFilters(unique_ptr<TableFilterSet> filters);
+
+	//! Set which columns to read (by index). If not called, reads all columns.
+	void SetColumnIds(vector<column_t> column_ids);
+
+	//! Initialize the scan
+	void InitializeScan();
+
+	//! Scan the next chunk. Returns false when done.
+	bool Scan(DataChunk &chunk);
+
+private:
+	ClientContext &context;
+	TableFunction vortex_scan;
+	unique_ptr<FunctionData> bind_data;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+
+	unique_ptr<TableFilterSet> filters;
+	vector<column_t> column_ids;
+
+	unique_ptr<ThreadContext> thread_context;
+	unique_ptr<ExecutionContext> execution_context;
+	unique_ptr<GlobalTableFunctionState> global_state;
+	unique_ptr<LocalTableFunctionState> local_state;
+
+	bool initialized = false;
+};
+
+} // namespace duckdb

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -34,10 +34,11 @@ public:
 	DuckLakeLogicalCompaction(TableIndex table_index, DuckLakeTableEntry &table,
 	                          vector<DuckLakeCompactionFileEntry> source_files_p, string encryption_key_p,
 	                          optional_idx partition_id, vector<Value> partition_values_p, optional_idx row_id_start,
-	                          CompactionType type)
+	                          DuckLakeDataFileFormat file_format_p, CompactionType type)
 	    : table_index(table_index), table(table), source_files(std::move(source_files_p)),
 	      encryption_key(std::move(encryption_key_p)), partition_id(partition_id),
-	      partition_values(std::move(partition_values_p)), row_id_start(row_id_start), type(type) {
+	      partition_values(std::move(partition_values_p)), row_id_start(row_id_start), file_format(file_format_p),
+	      type(type) {
 	}
 
 	TableIndex table_index;
@@ -47,13 +48,15 @@ public:
 	optional_idx partition_id;
 	vector<Value> partition_values;
 	optional_idx row_id_start;
+	DuckLakeDataFileFormat file_format;
 	CompactionType type;
 
 public:
 	PhysicalOperator &CreatePlan(ClientContext &context, PhysicalPlanGenerator &planner) override {
 		auto &child = planner.CreatePlan(*children[0]);
 		return planner.Make<DuckLakeCompaction>(types, table, std::move(source_files), std::move(encryption_key),
-		                                        partition_id, std::move(partition_values), row_id_start, child, type);
+		                                        partition_id, std::move(partition_values), row_id_start, file_format,
+		                                        child, type);
 	}
 
 	string GetName() const override {

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/ducklake_data_file.hpp"
 #include "common/ducklake_encryption.hpp"
 #include "common/ducklake_options.hpp"
 #include "common/ducklake_name_map.hpp"
@@ -199,6 +200,8 @@ public:
 		auto write_dv = GetConfigOption<string>("write_deletion_vectors", schema_id, table_id, "false");
 		return write_dv == "true";
 	}
+
+	DuckLakeDataFileFormat GetDataFileFormat(SchemaIndex schema_id, TableIndex table_id) const;
 
 	void SetEncryption(DuckLakeEncryption encryption);
 	// Generate an encryption key for writing (or empty if encryption is disabled)

--- a/src/include/storage/ducklake_compaction.hpp
+++ b/src/include/storage/ducklake_compaction.hpp
@@ -23,7 +23,7 @@ public:
 	DuckLakeCompaction(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
 	                   vector<DuckLakeCompactionFileEntry> source_files_p, string encryption_key,
 	                   optional_idx partition_id, vector<Value> partition_values, optional_idx row_id_start,
-	                   PhysicalOperator &child, CompactionType type);
+	                   DuckLakeDataFileFormat file_format, PhysicalOperator &child, CompactionType type);
 
 	DuckLakeTableEntry &table;
 	vector<DuckLakeCompactionFileEntry> source_files;
@@ -31,6 +31,7 @@ public:
 	optional_idx partition_id;
 	vector<Value> partition_values;
 	optional_idx row_id_start;
+	DuckLakeDataFileFormat file_format;
 	CompactionType type;
 
 public:

--- a/src/include/storage/ducklake_flush_data.hpp
+++ b/src/include/storage/ducklake_flush_data.hpp
@@ -22,13 +22,14 @@ class DuckLakeFlushData : public PhysicalOperator {
 public:
 	DuckLakeFlushData(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
 	                  DuckLakeInlinedTableInfo inlined_table, string encryption_key, optional_idx partition_id,
-	                  string sort_order_sql, PhysicalOperator &child);
+	                  string sort_order_sql, DuckLakeDataFileFormat file_format, PhysicalOperator &child);
 
 	DuckLakeTableEntry &table;
 	DuckLakeInlinedTableInfo inlined_table;
 	string encryption_key;
 	optional_idx partition_id;
 	string sort_order_sql;
+	DuckLakeDataFileFormat file_format;
 
 public:
 	// // Source interface

--- a/src/include/storage/ducklake_insert.hpp
+++ b/src/include/storage/ducklake_insert.hpp
@@ -43,11 +43,11 @@ class DuckLakeInsert : public PhysicalOperator {
 public:
 	//! INSERT INTO
 	DuckLakeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
-	               optional_idx partition_id, string encryption_key);
+	               optional_idx partition_id, string encryption_key, DuckLakeDataFileFormat file_format);
 	//! CREATE TABLE AS
 	DuckLakeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, SchemaCatalogEntry &schema,
 	               unique_ptr<BoundCreateTableInfo> info, string table_uuid, string table_data_path,
-	               string encryption_key);
+	               string encryption_key, DuckLakeDataFileFormat file_format);
 
 	//! The table to insert into
 	optional_ptr<DuckLakeTableEntry> table;
@@ -61,8 +61,10 @@ public:
 	string table_data_path;
 	//! The partition id we are writing into (if any)
 	optional_idx partition_id;
-	//! The encryption key used for writing the Parquet files
+	//! The encryption key used for writing data files
 	string encryption_key;
+	//! The format used for data files written by this insert
+	DuckLakeDataFileFormat file_format;
 
 public:
 	// // Source interface
@@ -82,9 +84,11 @@ public:
 	static PhysicalOperator &PlanCopyForInsert(ClientContext &context, PhysicalPlanGenerator &planner,
 	                                           DuckLakeCopyInput &copy_input, optional_ptr<PhysicalOperator> plan);
 	static PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
-	                                    DuckLakeTableEntry &table, string encryption_key);
+	                                    DuckLakeTableEntry &table, string encryption_key,
+	                                    DuckLakeDataFileFormat file_format);
 	static void AddWrittenFiles(DuckLakeInsertGlobalState &gstate, DataChunk &chunk, const string &encryption_key,
-	                            optional_idx partition_id, bool set_snapshot_id = false);
+	                            optional_idx partition_id, DuckLakeDataFileFormat file_format,
+	                            bool set_snapshot_id = false);
 
 	static const DuckLakeFieldId &GetTopLevelColumn(DuckLakeCopyInput &copy_input, FieldIndex field_id,
 	                                                optional_idx &index);
@@ -130,6 +134,7 @@ struct DuckLakeCopyOptions {
 	bool partition_output;
 	bool write_partition_columns;
 	bool write_empty_file = true;
+	DuckLakeDataFileFormat file_format = DuckLakeDataFileFormat::PARQUET;
 	vector<idx_t> partition_columns;
 	vector<string> names;
 	vector<LogicalType> expected_types;
@@ -149,6 +154,7 @@ struct DuckLakeCopyInput {
 	const ColumnList &columns;
 	const string data_path;
 	string encryption_key;
+	DuckLakeDataFileFormat file_format = DuckLakeDataFileFormat::PARQUET;
 	SchemaIndex schema_id;
 	TableIndex table_id;
 	InsertVirtualColumns virtual_columns = InsertVirtualColumns::NONE;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -149,6 +149,7 @@ struct DuckLakeFileInfo {
 	DataFileIndex id;
 	TableIndex table_id;
 	string file_name;
+	DuckLakeDataFileFormat format = DuckLakeDataFileFormat::PARQUET;
 	idx_t row_count;
 	idx_t file_size_bytes;
 	optional_idx footer_size;
@@ -352,6 +353,7 @@ struct DuckLakeFileData {
 	string encryption_key;
 	idx_t file_size_bytes = 0;
 	optional_idx footer_size;
+	DuckLakeDataFileFormat data_file_format = DuckLakeDataFileFormat::PARQUET;
 	DeleteFileFormat format = DeleteFileFormat::PARQUET;
 };
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -326,6 +326,7 @@ private:
 
 	bool IsEncrypted() const;
 	string GetFileSelectList(const string &prefix);
+	string GetDataFileSelectList(const string &prefix);
 	string GetDeleteFileSelectList(const string &prefix);
 	FilterPushdownQueryComponents GenerateFilterPushdownComponents(const FilterPushdownInfo &filter_info,
 	                                                               DuckLakeTableEntry &table);

--- a/src/include/storage/ducklake_multi_file_reader.hpp
+++ b/src/include/storage/ducklake_multi_file_reader.hpp
@@ -80,6 +80,7 @@ public:
 
 private:
 	shared_ptr<BaseFileReader> TryCreateInlinedDataReader(const OpenFileInfo &file);
+	shared_ptr<BaseFileReader> TryCreateVortexFileReader(ClientContext &context, const OpenFileInfo &file);
 	//! For deletion scans we need to get the snapshot_id values using per-row snapshot information
 	void GatherDeletionScanSnapshots(BaseFileReader &reader, const MultiFileReaderData &reader_data, DataChunk &chunk,
 	                                 optional_idx rowid_col_override = optional_idx()) const;

--- a/src/include/storage/ducklake_vortex_file_reader.hpp
+++ b/src/include/storage/ducklake_vortex_file_reader.hpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_vortex_file_reader.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common/vortex_file_scanner.hpp"
+#include "duckdb/common/multi_file/base_file_reader.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+
+namespace duckdb {
+
+enum class VortexReaderColumn { NONE, FILE_ROW_NUMBER, EMPTY };
+
+class DuckLakeVortexFileReader : public BaseFileReader {
+public:
+	DuckLakeVortexFileReader(ClientContext &context, const OpenFileInfo &info, DuckLakeFileData file_data);
+
+	bool TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+	                       LocalTableFunctionState &lstate) override;
+	AsyncResult Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+	                 LocalTableFunctionState &local_state, DataChunk &chunk) override;
+
+	string GetReaderType() const override;
+
+	void AddVirtualColumn(column_t virtual_column_id) override;
+
+private:
+	bool TryEvaluateExpression(ClientContext &context, idx_t virtual_col_idx, Vector &input_vector,
+	                           const LogicalType &input_type, Vector &output_vector);
+
+private:
+	mutex lock;
+	DuckLakeFileData file_data;
+	unique_ptr<VortexFileScanner> scanner;
+	bool initialized_scan = false;
+	vector<VortexReaderColumn> projected_columns;
+	vector<column_t> scan_column_ids;
+	DataChunk scan_chunk;
+	int64_t file_row_number = 0;
+	unordered_map<column_t, unique_ptr<ExpressionExecutor>> expression_executors;
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   ducklake_sort_data.cpp
   ducklake_stats.cpp
   ducklake_table_entry.cpp
+  ducklake_vortex_file_reader.cpp
   ducklake_initializer.cpp
   ducklake_autoload_helper.cpp
   ducklake_update.cpp

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -883,6 +883,11 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 	return TryGetConfigOption(option, result, schema_id, table_id);
 }
 
+DuckLakeDataFileFormat DuckLakeCatalog::GetDataFileFormat(SchemaIndex schema_id, TableIndex table_id) const {
+	auto format = GetConfigOption<string>("data_file_format", schema_id, table_id, "parquet");
+	return DuckLakeDataFileFormatFromString(format);
+}
+
 idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
 	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 10);
 }

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -159,6 +159,13 @@ void DuckLakeInitializer::InitializeNewDuckLake(DuckLakeTransaction &transaction
 	SetVersionedMetadataManager(transaction, version);
 	auto &metadata_manager = transaction.GetMetadataManager();
 	metadata_manager.InitializeDuckLake(has_explicit_schema, catalog.Encryption());
+	auto data_file_format = options.config_options.find("data_file_format");
+	if (data_file_format != options.config_options.end()) {
+		DuckLakeConfigOption option;
+		option.option.key = data_file_format->first;
+		option.option.value = data_file_format->second;
+		transaction.SetConfigOption(option);
+	}
 	if (catalog.Encryption() == DuckLakeEncryption::AUTOMATIC) {
 		// default to unencrypted
 		catalog.SetEncryption(DuckLakeEncryption::UNENCRYPTED);

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -35,17 +35,17 @@
 namespace duckdb {
 
 DuckLakeInsert::DuckLakeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
-                               optional_idx partition_id, string encryption_key_p)
+                               optional_idx partition_id, string encryption_key_p, DuckLakeDataFileFormat file_format_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), table(&table), schema(nullptr),
-      partition_id(partition_id), encryption_key(std::move(encryption_key_p)) {
+      partition_id(partition_id), encryption_key(std::move(encryption_key_p)), file_format(file_format_p) {
 }
 
 DuckLakeInsert::DuckLakeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
                                SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info, string table_uuid_p,
-                               string table_data_path_p, string encryption_key_p)
+                               string table_data_path_p, string encryption_key_p, DuckLakeDataFileFormat file_format_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), table(nullptr), schema(&schema),
       info(std::move(info)), table_uuid(std::move(table_uuid_p)), table_data_path(std::move(table_data_path_p)),
-      encryption_key(std::move(encryption_key_p)) {
+      encryption_key(std::move(encryption_key_p)), file_format(file_format_p) {
 }
 
 //===--------------------------------------------------------------------===//
@@ -111,13 +111,18 @@ DuckLakeColumnStats DuckLakeInsert::ParseColumnStats(const LogicalType &type, co
 }
 
 void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, DataChunk &chunk,
-                                     const string &encryption_key, optional_idx partition_id, bool set_snapshot_id) {
+                                     const string &encryption_key, optional_idx partition_id,
+                                     DuckLakeDataFileFormat file_format, bool set_snapshot_id) {
 	for (idx_t r = 0; r < chunk.size(); r++) {
 		DuckLakeDataFile data_file;
 		data_file.file_name = chunk.GetValue(0, r).GetValue<string>();
+		data_file.format = file_format;
 		data_file.row_count = chunk.GetValue(1, r).GetValue<idx_t>();
 		data_file.file_size_bytes = chunk.GetValue(2, r).GetValue<idx_t>();
-		data_file.footer_size = chunk.GetValue(3, r).GetValue<idx_t>();
+		auto footer_size = chunk.GetValue(3, r);
+		if (!footer_size.IsNull()) {
+			data_file.footer_size = footer_size.GetValue<idx_t>();
+		}
 		data_file.encryption_key = encryption_key;
 		if (partition_id.IsValid()) {
 			data_file.partition_id = partition_id.GetIndex();
@@ -125,68 +130,70 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 
 		// extract the column stats
 		auto column_stats = chunk.GetValue(4, r);
-		auto &map_children = MapValue::GetChildren(column_stats);
 		auto &table = global_state.table;
 		map<FieldIndex, PartialVariantStats> variant_stats;
-		for (idx_t col_idx = 0; col_idx < map_children.size(); col_idx++) {
-			auto &struct_children = StructValue::GetChildren(map_children[col_idx]);
-			auto &col_name = StringValue::Get(struct_children[0]);
-			auto &col_stats = MapValue::GetChildren(struct_children[1]);
-			auto column_names = DuckLakeUtil::ParseQuotedList(col_name, '.');
-			// FIXME: this should be checked differently
-			if (column_names[0] == "_ducklake_internal_snapshot_id") {
-				if (set_snapshot_id) {
-					// set start snapshot id based on the minimum written to the file
-					auto snapshot_stats = ParseColumnStats(LogicalType::UBIGINT, col_stats);
-					if (snapshot_stats.has_min) {
-						data_file.begin_snapshot = StringUtil::ToUnsigned(snapshot_stats.min);
+		if (!column_stats.IsNull()) {
+			auto &map_children = MapValue::GetChildren(column_stats);
+			for (idx_t col_idx = 0; col_idx < map_children.size(); col_idx++) {
+				auto &struct_children = StructValue::GetChildren(map_children[col_idx]);
+				auto &col_name = StringValue::Get(struct_children[0]);
+				auto &col_stats = MapValue::GetChildren(struct_children[1]);
+				auto column_names = DuckLakeUtil::ParseQuotedList(col_name, '.');
+				// FIXME: this should be checked differently
+				if (column_names[0] == "_ducklake_internal_snapshot_id") {
+					if (set_snapshot_id) {
+						// set start snapshot id based on the minimum written to the file
+						auto snapshot_stats = ParseColumnStats(LogicalType::UBIGINT, col_stats);
+						if (snapshot_stats.has_min) {
+							data_file.begin_snapshot = StringUtil::ToUnsigned(snapshot_stats.min);
+						}
+						if (snapshot_stats.has_max) {
+							data_file.max_partial_file_snapshot = StringUtil::ToUnsigned(snapshot_stats.max);
+						}
 					}
-					if (snapshot_stats.has_max) {
-						data_file.max_partial_file_snapshot = StringUtil::ToUnsigned(snapshot_stats.max);
-					}
+					continue;
 				}
-				continue;
-			}
-			if (column_names[0] == "_ducklake_internal_row_id") {
-				if (set_snapshot_id) {
-					// extract the min row_id so flushed files preserve the original row_id_start
-					auto row_id_stats = ParseColumnStats(LogicalType::BIGINT, col_stats);
-					if (row_id_stats.has_min) {
-						data_file.flush_row_id_start = StringUtil::ToUnsigned(row_id_stats.min);
+				if (column_names[0] == "_ducklake_internal_row_id") {
+					if (set_snapshot_id) {
+						// extract the min row_id so flushed files preserve the original row_id_start
+						auto row_id_stats = ParseColumnStats(LogicalType::BIGINT, col_stats);
+						if (row_id_stats.has_min) {
+							data_file.flush_row_id_start = StringUtil::ToUnsigned(row_id_stats.min);
+						}
 					}
+					continue;
 				}
-				continue;
-			}
 
-			optional_idx name_offset;
-			auto &field_id = table.GetFieldId(column_names, &name_offset);
-			if (name_offset.IsValid()) {
-				if (field_id.Type().id() != LogicalTypeId::VARIANT) {
-					throw InternalException("name_offset can only be set for variant columns");
+				optional_idx name_offset;
+				auto &field_id = table.GetFieldId(column_names, &name_offset);
+				if (name_offset.IsValid()) {
+					if (field_id.Type().id() != LogicalTypeId::VARIANT) {
+						throw InternalException("name_offset can only be set for variant columns");
+					}
+					// variant stats are constructed iteratively as they are provided per-field
+					auto entry = variant_stats.find(field_id.GetFieldIndex());
+					if (entry == variant_stats.end()) {
+						// insert empty stats for variants if this is the first stats we encounter for variants
+						auto insert_entry =
+						    variant_stats.insert(make_pair(field_id.GetFieldIndex(), PartialVariantStats()));
+						entry = insert_entry.first;
+					}
+					entry->second.ParseVariantStats(column_names, name_offset.GetIndex(), col_stats);
+					continue;
 				}
-				// variant stats are constructed iteratively as they are provided per-field
-				auto entry = variant_stats.find(field_id.GetFieldIndex());
-				if (entry == variant_stats.end()) {
-					// insert empty stats for variants if this is the first stats we encounter for variants
-					auto insert_entry =
-					    variant_stats.insert(make_pair(field_id.GetFieldIndex(), PartialVariantStats()));
-					entry = insert_entry.first;
+				if (field_id.Type().id() == LogicalTypeId::VARIANT) {
+					throw InvalidInputException("Top-level variant cannot have stats");
 				}
-				entry->second.ParseVariantStats(column_names, name_offset.GetIndex(), col_stats);
-				continue;
-			}
-			if (field_id.Type().id() == LogicalTypeId::VARIANT) {
-				throw InvalidInputException("Top-level variant cannot have stats");
-			}
-			auto column_stats = ParseColumnStats(field_id.Type(), col_stats);
-			if (column_stats.null_count > 0 && column_names.size() == 1) {
-				// we wrote NULL values to a base column - verify NOT NULL constraint
-				if (global_state.not_null_fields.count(column_names[0])) {
-					throw ConstraintException("NOT NULL constraint failed: %s.%s", table.name, column_names[0]);
+				auto column_stats = ParseColumnStats(field_id.Type(), col_stats);
+				if (column_stats.null_count > 0 && column_names.size() == 1) {
+					// we wrote NULL values to a base column - verify NOT NULL constraint
+					if (global_state.not_null_fields.count(column_names[0])) {
+						throw ConstraintException("NOT NULL constraint failed: %s.%s", table.name, column_names[0]);
+					}
 				}
-			}
 
-			data_file.column_stats.insert(make_pair(field_id.GetFieldIndex(), std::move(column_stats)));
+				data_file.column_stats.insert(make_pair(field_id.GetFieldIndex(), std::move(column_stats)));
+			}
 		}
 		// finalize variant stats
 		for (auto &entry : variant_stats) {
@@ -219,7 +226,7 @@ void DuckLakeInsert::AddWrittenFiles(DuckLakeInsertGlobalState &global_state, Da
 
 SinkResultType DuckLakeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
-	AddWrittenFiles(global_state, chunk, encryption_key, partition_id);
+	AddWrittenFiles(global_state, chunk, encryption_key, partition_id, file_format);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -341,6 +348,7 @@ DuckLakeCopyInput::DuckLakeCopyInput(ClientContext &context, DuckLakeTableEntry 
 	schema_id = table.ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId();
 	table_id = table.GetTableId();
 	encryption_key = catalog.GenerateEncryptionKey(context);
+	file_format = catalog.GetDataFileFormat(schema_id, table_id);
 }
 
 DuckLakeCopyInput::DuckLakeCopyInput(ClientContext &context, DuckLakeSchemaEntry &schema, const ColumnList &columns,
@@ -348,6 +356,7 @@ DuckLakeCopyInput::DuckLakeCopyInput(ClientContext &context, DuckLakeSchemaEntry
     : catalog(schema.ParentCatalog().Cast<DuckLakeCatalog>()), columns(columns), data_path(data_path_p) {
 	schema_id = schema.GetSchemaId();
 	encryption_key = catalog.GenerateEncryptionKey(context);
+	file_format = catalog.GetDataFileFormat(schema_id, table_id);
 }
 
 static void StripTrailingSeparator(FileSystem &fs, string &path) {
@@ -356,6 +365,17 @@ static void StripTrailingSeparator(FileSystem &fs, string &path) {
 		return;
 	}
 	path = path.substr(0, path.size() - sep.size());
+}
+
+static string DataFileFormatExtension(DuckLakeDataFileFormat format) {
+	switch (format) {
+	case DuckLakeDataFileFormat::PARQUET:
+		return "parquet";
+	case DuckLakeDataFileFormat::VORTEX:
+		return "vortex";
+	default:
+		throw InternalException("Unknown DuckLakeDataFileFormat");
+	}
 }
 
 const DuckLakeFieldId &DuckLakeInsert::GetTopLevelColumn(DuckLakeCopyInput &copy_input, FieldIndex field_id,
@@ -467,47 +487,56 @@ static void GeneratePartitionExpressions(ClientContext &context, DuckLakeCopyInp
 DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckLakeCopyInput &copy_input) {
 	auto info = make_uniq<CopyInfo>();
 	auto &catalog = copy_input.catalog;
+	auto file_format = copy_input.file_format;
+	if (file_format == DuckLakeDataFileFormat::VORTEX && !copy_input.encryption_key.empty()) {
+		throw NotImplementedException("Vortex data files are not supported for encrypted DuckLakes yet");
+	}
+	auto format_name = DuckLakeDataFileFormatToString(file_format);
 	info->file_path = copy_input.data_path;
-	info->format = "parquet";
+	info->format = format_name;
 	info->is_from = false;
-	// generate the field ids to be written by the parquet writer
 	shared_ptr<DuckLakeFieldData> generated_ids;
-	if (!copy_input.field_data) {
+	if (file_format == DuckLakeDataFileFormat::PARQUET && !copy_input.field_data) {
 		// CTAS - generate new ids from columns
 		generated_ids = DuckLakeFieldData::FromColumns(copy_input.columns);
 	}
-	auto &field_ids = copy_input.field_data ? *copy_input.field_data : *generated_ids;
-	vector<Value> field_input;
-	field_input.push_back(WrittenFieldIds(field_ids, copy_input.virtual_columns));
-	info->options["field_ids"] = std::move(field_input);
-	if (!copy_input.encryption_key.empty()) {
-		child_list_t<Value> values;
-		values.emplace_back("footer_key_value", Value::BLOB_RAW(copy_input.encryption_key));
-		vector<Value> encryption_input;
-		encryption_input.push_back(Value::STRUCT(std::move(values)));
-		info->options["encryption_config"] = std::move(encryption_input);
-	}
 	auto &schema_id = copy_input.schema_id;
 	auto &table_id = copy_input.table_id;
-	string parquet_compression;
-	if (catalog.TryGetConfigOption("parquet_compression", parquet_compression, schema_id, table_id)) {
-		info->options["compression"].emplace_back(parquet_compression);
-	}
-	string parquet_version;
-	if (catalog.TryGetConfigOption("parquet_version", parquet_version, schema_id, table_id)) {
-		info->options["parquet_version"].emplace_back(parquet_version);
-	}
-	string parquet_compression_level;
-	if (catalog.TryGetConfigOption("parquet_compression_level", parquet_compression_level, schema_id, table_id)) {
-		info->options["compression_level"].emplace_back(parquet_compression_level);
-	}
-	string row_group_size;
-	if (catalog.TryGetConfigOption("parquet_row_group_size", row_group_size, schema_id, table_id)) {
-		info->options["row_group_size"].emplace_back(row_group_size);
-	}
-	string row_group_size_bytes;
-	if (catalog.TryGetConfigOption("parquet_row_group_size_bytes", row_group_size_bytes, schema_id, table_id)) {
-		info->options["row_group_size_bytes"].emplace_back(row_group_size_bytes + " bytes");
+	if (file_format == DuckLakeDataFileFormat::PARQUET) {
+		// generate the field ids to be written by the parquet writer
+		auto &field_ids = copy_input.field_data ? *copy_input.field_data : *generated_ids;
+		vector<Value> field_input;
+		field_input.push_back(WrittenFieldIds(field_ids, copy_input.virtual_columns));
+		info->options["field_ids"] = std::move(field_input);
+		if (!copy_input.encryption_key.empty()) {
+			child_list_t<Value> values;
+			values.emplace_back("footer_key_value", Value::BLOB_RAW(copy_input.encryption_key));
+			vector<Value> encryption_input;
+			encryption_input.push_back(Value::STRUCT(std::move(values)));
+			info->options["encryption_config"] = std::move(encryption_input);
+		}
+		string parquet_compression;
+		if (catalog.TryGetConfigOption("parquet_compression", parquet_compression, schema_id, table_id)) {
+			info->options["compression"].emplace_back(parquet_compression);
+		}
+		string parquet_version;
+		if (catalog.TryGetConfigOption("parquet_version", parquet_version, schema_id, table_id)) {
+			info->options["parquet_version"].emplace_back(parquet_version);
+		}
+		string parquet_compression_level;
+		if (catalog.TryGetConfigOption("parquet_compression_level", parquet_compression_level, schema_id, table_id)) {
+			info->options["compression_level"].emplace_back(parquet_compression_level);
+		}
+		string row_group_size;
+		if (catalog.TryGetConfigOption("parquet_row_group_size", row_group_size, schema_id, table_id)) {
+			info->options["row_group_size"].emplace_back(row_group_size);
+		}
+		string row_group_size_bytes;
+		if (catalog.TryGetConfigOption("parquet_row_group_size_bytes", row_group_size_bytes, schema_id, table_id)) {
+			info->options["row_group_size_bytes"].emplace_back(row_group_size_bytes + " bytes");
+		}
+		// Always use native parquet geometry for writing
+		info->options["geoparquet_version"].emplace_back("NONE");
 	}
 	string per_thread_output_str;
 	bool per_thread_output = false;
@@ -517,11 +546,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	idx_t target_file_size = catalog.GetConfigOption<idx_t>("target_file_size", schema_id, table_id,
 	                                                        DuckLakeCatalog::DEFAULT_TARGET_FILE_SIZE);
 
-	// Always use native parquet geometry for writing
-	info->options["geoparquet_version"].emplace_back("NONE");
-
-	// Get Parquet Copy function
-	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(context, "parquet");
+	auto &copy_fun = DuckLakeFunctions::GetCopyFunction(context, format_name);
 
 	auto &fs = FileSystem::GetFileSystem(context);
 	DuckLakeUtil::EnsureDirectoryExists(fs, copy_input.data_path);
@@ -553,6 +578,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 
 	DuckLakeCopyOptions result(std::move(info), copy_fun.function);
 	result.bind_data = std::move(function_data);
+	result.file_format = file_format;
 
 	result.use_tmp_file = false;
 	if (copy_input.partition_data) {
@@ -570,7 +596,7 @@ DuckLakeCopyOptions DuckLakeInsert::GetCopyOptions(ClientContext &context, DuckL
 	}
 	result.file_path = copy_input.data_path;
 	StripTrailingSeparator(fs, result.file_path);
-	result.file_extension = "parquet";
+	result.file_extension = DataFileFormatExtension(file_format);
 	result.overwrite_mode = CopyOverwriteMode::COPY_OVERWRITE_OR_IGNORE;
 	result.per_thread_output = per_thread_output;
 	result.write_partition_columns = true;
@@ -709,7 +735,8 @@ PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(ClientContext &context, Phys
 }
 
 PhysicalOperator &DuckLakeInsert::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner,
-                                             DuckLakeTableEntry &table, string encryption_key) {
+                                             DuckLakeTableEntry &table, string encryption_key,
+                                             DuckLakeDataFileFormat file_format) {
 	auto partition_data = table.GetPartitionData();
 	optional_idx partition_id;
 	if (partition_data) {
@@ -717,7 +744,7 @@ PhysicalOperator &DuckLakeInsert::PlanInsert(ClientContext &context, PhysicalPla
 	}
 	vector<LogicalType> return_types;
 	return_types.emplace_back(LogicalType::BIGINT);
-	return planner.Make<DuckLakeInsert>(return_types, table, partition_id, std::move(encryption_key));
+	return planner.Make<DuckLakeInsert>(return_types, table, partition_id, std::move(encryption_key), file_format);
 }
 
 string DuckLakeCatalog::GenerateEncryptionKey(ClientContext &context) const {
@@ -824,7 +851,8 @@ PhysicalOperator &DuckLakeCatalog::PlanInsert(ClientContext &context, PhysicalPl
 	}
 	DuckLakeCopyInput copy_input(context, ducklake_table);
 	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
-	auto &insert = DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
+	auto &insert = DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key),
+	                                         copy_input.file_format);
 	if (inline_data) {
 		inline_data->insert = insert.Cast<DuckLakeInsert>();
 	}
@@ -856,7 +884,8 @@ PhysicalOperator &DuckLakeCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	DuckLakeCopyInput copy_input(context, duck_schema, columns, table_data_path);
 	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, root.get());
 	auto &insert = planner.Make<DuckLakeInsert>(op.types, op.schema, std::move(op.info), std::move(table_uuid),
-	                                            std::move(table_data_path), std::move(copy_input.encryption_key));
+	                                            std::move(table_data_path), std::move(copy_input.encryption_key),
+	                                            copy_input.file_format);
 	if (inline_data) {
 		inline_data->insert = insert.Cast<DuckLakeInsert>();
 	}

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -465,7 +465,8 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		auto &copy_dummy = planner.Make<PhysicalDummyScan>(copy_op.Cast<PhysicalCopyToFile>().expected_types, 1);
 		copy_op.children.push_back(copy_dummy);
 		auto &insert_op =
-		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
+		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key),
+		                               copy_input.file_format);
 		if (inline_data) {
 			inline_data->insert = insert_op.Cast<DuckLakeInsert>();
 		}
@@ -524,7 +525,8 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		    planner.Make<PhysicalDummyScan>(physical_copy.Cast<PhysicalCopyToFile>().expected_types, 1);
 		physical_copy.children.push_back(copy_dummy);
 		auto &insert =
-		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
+		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key),
+		                               copy_input.file_format);
 		insert.children.push_back(physical_copy);
 
 		auto &merge_insert =

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -945,6 +945,10 @@ string DuckLakeMetadataManager::GetFileSelectList(const string &prefix) {
 	return result;
 }
 
+string DuckLakeMetadataManager::GetDataFileSelectList(const string &prefix) {
+	return GetFileSelectList(prefix) + ", " + prefix + ".file_format AS " + prefix + "_file_format";
+}
+
 string DuckLakeMetadataManager::GetDeleteFileSelectList(const string &prefix) {
 	return GetFileSelectList(prefix) + ", " + prefix + ".format AS " + prefix + "_format";
 }
@@ -959,6 +963,7 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table
 		if (is_encrypted) {
 			col_idx++;
 		}
+		col_idx++;
 		return data;
 	}
 	DuckLakePath path;
@@ -978,13 +983,43 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table
 		}
 		data.encryption_key = Blob::FromBase64(row.template GetValue<string>(col_idx++));
 	}
+	if (!row.IsNull(col_idx)) {
+		data.data_file_format = DuckLakeDataFileFormatFromString(row.template GetValue<string>(col_idx));
+	}
+	col_idx++;
 	return data;
 }
 
 template <class T>
 DuckLakeFileData DuckLakeMetadataManager::ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx,
                                                          bool is_encrypted) {
-	auto data = ReadDataFile(table, row, col_idx, is_encrypted);
+	DuckLakeFileData data;
+	if (row.IsNull(col_idx)) {
+		// file is not there
+		col_idx += 4;
+		if (is_encrypted) {
+			col_idx++;
+		}
+		col_idx++;
+		return data;
+	}
+	DuckLakePath path;
+	path.path = row.template GetValue<string>(col_idx++);
+	path.path_is_relative = row.template GetValue<bool>(col_idx++);
+
+	data.path = FromRelativePath(path, table.DataPath());
+	data.file_size_bytes = row.template GetValue<idx_t>(col_idx++);
+	if (!row.IsNull(col_idx)) {
+		data.footer_size = row.template GetValue<idx_t>(col_idx);
+	}
+	col_idx++;
+	if (is_encrypted) {
+		if (row.IsNull(col_idx)) {
+			throw InvalidInputException("Database is encrypted, but file %s does not have an encryption key",
+			                            data.path);
+		}
+		data.encryption_key = Blob::FromBase64(row.template GetValue<string>(col_idx++));
+	}
 	if (!row.IsNull(col_idx)) {
 		data.format = DeleteFileFormatFromString(row.template GetValue<string>(col_idx));
 	}
@@ -1432,7 +1467,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		}
 	}
 
-	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
+	string select_list = "data.data_file_id, " + GetDataFileSelectList("data") +
 	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
 	                     GetDeleteFileSelectList("del") + stats_select_list;
 
@@ -1526,7 +1561,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetTableInsertions(DuckLa
                                                                           DuckLakeSnapshot start_snapshot,
                                                                           DuckLakeSnapshot end_snapshot) {
 	auto table_id = table.GetTableId();
-	string select_list = GetFileSelectList("data") +
+	string select_list = GetDataFileSelectList("data") +
 	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
 	                     GetDeleteFileSelectList("del");
 	// Files either match the exact snapshot range
@@ -1591,7 +1626,7 @@ vector<DuckLakeDeleteScanEntry> DuckLakeMetadataManager::GetTableDeletions(DuckL
                                                                            DuckLakeSnapshot start_snapshot,
                                                                            DuckLakeSnapshot end_snapshot) {
 	auto table_id = table.GetTableId();
-	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
+	string select_list = "data.data_file_id, " + GetDataFileSelectList("data") +
 	                     ", data.row_id_start, data.record_count, data.mapping_id, " +
 	                     GetDeleteFileSelectList("current_delete") + ", " + GetDeleteFileSelectList("previous_delete");
 
@@ -1708,7 +1743,7 @@ WHERE data.table_id = %d
   )
   AND (data.end_snapshot IS NULL OR data.end_snapshot < %d OR data.end_snapshot > {SNAPSHOT_ID})
 )",
-		                            GetFileSelectList("data"), null_file_cols, null_file_cols, table_id.index,
+		                            GetDataFileSelectList("data"), null_file_cols, null_file_cols, table_id.index,
 		                            table_id.index, start_snapshot.snapshot_id);
 	}
 
@@ -1779,7 +1814,7 @@ vector<DuckLakeFileListExtendedEntry>
 DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, DuckLakeSnapshot snapshot,
                                                   const FilterPushdownInfo *filter_info) {
 	auto table_id = table.GetTableId();
-	string select_list = GetFileSelectList("data") + ", data.row_id_start, data.mapping_id, " +
+	string select_list = GetDataFileSelectList("data") + ", data.row_id_start, data.mapping_id, " +
 	                     GetDeleteFileSelectList("del") + ", del.begin_snapshot";
 
 	string query;
@@ -1855,7 +1890,7 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	string data_select_list = "data.data_file_id, data.record_count, data.row_id_start, data.begin_snapshot, "
 	                          "data.end_snapshot, data.mapping_id, sr.schema_version , data.partial_max, "
 	                          "data.partition_id, partition_info.keys, " +
-	                          GetFileSelectList("data");
+	                          GetDataFileSelectList("data");
 	string delete_select_list = "del.data_file_id AS del_data_file_id,"
 	                            "del.delete_file_id AS del_delete_file_id, "
 	                            "del.delete_count, "
@@ -3044,7 +3079,7 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 		data_file_appender.Append(Value());                                             // file_order (NULL)
 		data_file_appender.Append<string_t>(string_t(path.path));                       // path
 		data_file_appender.Append<bool>(path.path_is_relative);                         // path_is_relative
-		data_file_appender.Append<string_t>(string_t("parquet"));                       // file_format
+		data_file_appender.Append<string_t>(string_t(DuckLakeDataFileFormatToString(file.format))); // file_format
 		data_file_appender.Append<int64_t>(static_cast<int64_t>(file.row_count));       // record_count
 		data_file_appender.Append<int64_t>(static_cast<int64_t>(file.file_size_bytes)); // file_size_bytes
 		if (file.footer_size.IsValid()) {
@@ -3261,9 +3296,10 @@ string DuckLakeMetadataManager::WriteNewDataFiles(DuckLakeSnapshot &commit_snaps
 		string mapping = file.mapping_id.IsValid() ? to_string(file.mapping_id.index) : "NULL";
 		auto path = GetRelativePath(file.table_id, file.file_name, new_tables, new_schemas_result);
 		data_file_insert_query += StringUtil::Format(
-		    "(%d, %d, %s, NULL, NULL, %s, %s, 'parquet', %d, %d, %s, %s, %s, %s, %s, %s)", data_file_index, table_id,
-		    begin_snapshot, SQLString(path.path), path.path_is_relative ? "true" : "false", file.row_count,
-		    file.file_size_bytes, footer_size, row_id, partition_id, encryption_key, mapping, partial_max);
+		    "(%d, %d, %s, NULL, NULL, %s, %s, %s, %d, %d, %s, %s, %s, %s, %s, %s)", data_file_index, table_id,
+		    begin_snapshot, SQLString(path.path), path.path_is_relative ? "true" : "false",
+		    SQLString(DuckLakeDataFileFormatToString(file.format)), file.row_count, file.file_size_bytes, footer_size,
+		    row_id, partition_id, encryption_key, mapping, partial_max);
 		for (auto &raw_stats : file.column_stats) {
 			// Stringify stats to construct insert queries
 			auto column_stats = DuckLakeColumnStatsInfo::FromColumnStats(raw_stats.first, raw_stats.second);
@@ -4066,7 +4102,7 @@ vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup
                                                                                  const string &separator) {
 	auto query = R"(SELECT filename
 FROM read_blob({DATA_PATH} || '**')
-WHERE suffix(filename, '.parquet')
+WHERE (suffix(filename, '.parquet') OR suffix(filename, '.vortex'))
 AND REPLACE(filename, '\', '/') NOT IN (
 SELECT REPLACE(
            CASE

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -182,6 +182,7 @@ OpenFileInfo DuckLakeMultiFileList::GetFile(idx_t i) const {
 		if (file.footer_size.IsValid()) {
 			extended_info->options["footer_size"] = Value::UBIGINT(file.footer_size.GetIndex());
 		}
+		extended_info->options["data_file_format"] = Value(DuckLakeDataFileFormatToString(file.data_file_format));
 		if (files[i].row_id_start.IsValid()) {
 			extended_info->options["row_id_start"] = Value::UBIGINT(files[i].row_id_start.GetIndex());
 		}
@@ -237,6 +238,7 @@ DuckLakeFileData GetFileData(const DuckLakeDataFile &file) {
 	result.encryption_key = file.encryption_key;
 	result.file_size_bytes = file.file_size_bytes;
 	result.footer_size = file.footer_size;
+	result.data_file_format = file.format;
 	return result;
 }
 

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -25,6 +25,7 @@
 #include "storage/ducklake_delete.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "storage/ducklake_inlined_data_reader.hpp"
+#include "storage/ducklake_vortex_file_reader.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
@@ -400,11 +401,43 @@ shared_ptr<BaseFileReader> DuckLakeMultiFileReader::TryCreateInlinedDataReader(c
 	                                                  std::move(columns));
 }
 
+shared_ptr<BaseFileReader> DuckLakeMultiFileReader::TryCreateVortexFileReader(ClientContext &context,
+                                                                              const OpenFileInfo &file) {
+	if (!file.extended_info) {
+		return nullptr;
+	}
+	auto format_entry = file.extended_info->options.find("data_file_format");
+	if (format_entry == file.extended_info->options.end()) {
+		return nullptr;
+	}
+	auto format = DuckLakeDataFileFormatFromString(format_entry->second.GetValue<string>());
+	if (format != DuckLakeDataFileFormat::VORTEX) {
+		return nullptr;
+	}
+
+	DuckLakeFileData file_data;
+	file_data.path = file.path;
+	file_data.data_file_format = format;
+	auto file_size_entry = file.extended_info->options.find("file_size");
+	if (file_size_entry != file.extended_info->options.end()) {
+		file_data.file_size_bytes = file_size_entry->second.GetValue<idx_t>();
+	}
+	auto footer_size_entry = file.extended_info->options.find("footer_size");
+	if (footer_size_entry != file.extended_info->options.end()) {
+		file_data.footer_size = footer_size_entry->second.GetValue<idx_t>();
+	}
+	return make_shared_ptr<DuckLakeVortexFileReader>(context, file, std::move(file_data));
+}
+
 shared_ptr<BaseFileReader> DuckLakeMultiFileReader::CreateReader(ClientContext &context,
                                                                  GlobalTableFunctionState &gstate,
                                                                  const OpenFileInfo &file, idx_t file_idx,
                                                                  const MultiFileBindData &bind_data) {
 	auto reader = TryCreateInlinedDataReader(file);
+	if (reader) {
+		return reader;
+	}
+	reader = TryCreateVortexFileReader(context, file);
 	if (reader) {
 		return reader;
 	}
@@ -416,6 +449,10 @@ shared_ptr<BaseFileReader> DuckLakeMultiFileReader::CreateReader(ClientContext &
                                                                  const MultiFileOptions &file_options,
                                                                  MultiFileReaderInterface &interface) {
 	auto reader = TryCreateInlinedDataReader(file);
+	if (reader) {
+		return reader;
+	}
+	reader = TryCreateVortexFileReader(context, file);
 	if (reader) {
 		return reader;
 	}

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -50,6 +50,10 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 	} else if (lcase == "write_deletion_vectors") {
 		options.config_options["write_deletion_vectors"] =
 		    BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN)) ? "true" : "false";
+	} else if (lcase == "data_file_format") {
+		auto format = value.DefaultCastAs(LogicalType::VARCHAR).GetValue<string>();
+		options.config_options["data_file_format"] =
+		    DuckLakeDataFileFormatToString(DuckLakeDataFileFormatFromString(format));
 	} else if (lcase == "create_if_not_exists") {
 		options.create_if_not_exists = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "automatic_migration") {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -2041,6 +2041,7 @@ DuckLakeFileInfo DuckLakeTransaction::GetNewDataFile(const DuckLakeDataFile &fil
 	data_file.id = DataFileIndex(commit_snapshot.next_file_id++);
 	data_file.table_id = table_id;
 	data_file.file_name = file.file_name;
+	data_file.format = file.format;
 	data_file.row_count = file.row_count;
 	data_file.file_size_bytes = file.file_size_bytes;
 	data_file.footer_size = file.footer_size;

--- a/src/storage/ducklake_update.cpp
+++ b/src/storage/ducklake_update.cpp
@@ -279,7 +279,8 @@ PhysicalOperator &DuckLakeCatalog::PlanUpdate(ClientContext &context, PhysicalPl
 	}
 
 	auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, plan);
-	auto &insert_op = DuckLakeInsert::PlanInsert(context, planner, table, std::move(copy_input.encryption_key));
+	auto &insert_op = DuckLakeInsert::PlanInsert(context, planner, table, std::move(copy_input.encryption_key),
+	                                            copy_input.file_format);
 	if (inline_data) {
 		inline_data->insert = insert_op.Cast<DuckLakeInsert>();
 	}

--- a/src/storage/ducklake_vortex_file_reader.cpp
+++ b/src/storage/ducklake_vortex_file_reader.cpp
@@ -1,0 +1,187 @@
+#include "storage/ducklake_vortex_file_reader.hpp"
+
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/planner/filter/expression_filter.hpp"
+#include "duckdb/planner/table_filter_state.hpp"
+#include "duckdb/storage/table/column_segment.hpp"
+
+namespace duckdb {
+
+DuckLakeVortexFileReader::DuckLakeVortexFileReader(ClientContext &context, const OpenFileInfo &info,
+                                                   DuckLakeFileData file_data_p)
+    : BaseFileReader(info), file_data(std::move(file_data_p)) {
+	if (!file_data.encryption_key.empty()) {
+		throw NotImplementedException("Reading encrypted Vortex data files is not supported yet");
+	}
+	scanner = make_uniq<VortexFileScanner>(context, file_data);
+	auto &names = scanner->GetNames();
+	auto &types = scanner->GetTypes();
+	for (idx_t i = 0; i < names.size(); i++) {
+		columns.emplace_back(names[i], types[i]);
+		if (names[i] == "_ducklake_internal_row_id") {
+			columns.back().identifier = Value::INTEGER(MultiFileReader::ROW_ID_FIELD_ID);
+		} else if (names[i] == "_ducklake_internal_snapshot_id") {
+			columns.back().identifier = Value::INTEGER(MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID);
+		}
+	}
+}
+
+bool DuckLakeVortexFileReader::TryInitializeScan(ClientContext &context, GlobalTableFunctionState &gstate,
+                                                 LocalTableFunctionState &lstate) {
+	{
+		lock_guard<mutex> guard(lock);
+		if (initialized_scan) {
+			return false;
+		}
+		initialized_scan = true;
+	}
+
+	vector<LogicalType> scan_types;
+	for (idx_t i = 0; i < column_indexes.size(); i++) {
+		auto col_id = column_indexes[i].GetPrimaryIndex();
+		if (col_id < columns.size() && columns[col_id].identifier.type().id() == LogicalTypeId::INTEGER &&
+		    IntegerValue::Get(columns[col_id].identifier) == MultiFileReader::ORDINAL_FIELD_ID) {
+			projected_columns.push_back(VortexReaderColumn::FILE_ROW_NUMBER);
+			continue;
+		}
+		if (col_id >= columns.size()) {
+			throw InternalException("Vortex reader column index out of range");
+		}
+		scan_column_ids.push_back(col_id);
+		scan_types.push_back(columns[col_id].type);
+		projected_columns.push_back(VortexReaderColumn::NONE);
+	}
+	if (projected_columns.empty()) {
+		if (columns.empty()) {
+			throw InvalidInputException("Cannot scan an empty-column Vortex file");
+		}
+		scan_column_ids.push_back(0);
+		scan_types.push_back(columns[0].type);
+		projected_columns.push_back(VortexReaderColumn::EMPTY);
+	}
+	if (scan_column_ids.empty() && !columns.empty()) {
+		scan_column_ids.push_back(0);
+		scan_types.push_back(columns[0].type);
+	}
+	scan_chunk.Initialize(context, scan_types);
+	scanner->SetColumnIds(scan_column_ids);
+	scanner->InitializeScan();
+
+	for (auto &entry : expression_map) {
+		expression_executors[entry.first] = make_uniq<ExpressionExecutor>(context, *entry.second);
+	}
+	return true;
+}
+
+bool DuckLakeVortexFileReader::TryEvaluateExpression(ClientContext &context, idx_t virtual_col_idx,
+                                                     Vector &input_vector, const LogicalType &input_type,
+                                                     Vector &output_vector) {
+	if (expression_map.empty() || virtual_col_idx >= column_ids.size()) {
+		return false;
+	}
+	auto local_id = column_ids[MultiFileLocalIndex(virtual_col_idx)];
+	auto expr_it = expression_executors.find(local_id);
+	if (expr_it == expression_executors.end()) {
+		return false;
+	}
+	DataChunk expr_input;
+	expr_input.Initialize(Allocator::Get(context), {input_type});
+	expr_input.Reset();
+	expr_input.data[0].Reference(input_vector);
+	expr_input.SetChildCardinality(scan_chunk.size());
+	expr_it->second->ExecuteExpression(expr_input, output_vector);
+	return true;
+}
+
+AsyncResult DuckLakeVortexFileReader::Scan(ClientContext &context, GlobalTableFunctionState &global_state,
+                                           LocalTableFunctionState &local_state, DataChunk &chunk) {
+	scan_chunk.Reset();
+	if (!scanner->Scan(scan_chunk)) {
+		return AsyncResult(SourceResultType::FINISHED);
+	}
+
+	idx_t source_idx = 0;
+	for (idx_t c = 0; c < projected_columns.size(); c++) {
+		switch (projected_columns[c]) {
+		case VortexReaderColumn::NONE: {
+			auto column_id = source_idx++;
+			if (TryEvaluateExpression(context, c, scan_chunk.data[column_id], scan_chunk.data[column_id].GetType(),
+			                          chunk.data[c])) {
+				break;
+			}
+			if (chunk.data[c].GetType() != scan_chunk.data[column_id].GetType()) {
+				VectorOperations::Cast(context, scan_chunk.data[column_id], chunk.data[c], scan_chunk.size());
+			} else {
+				chunk.data[c].Reference(scan_chunk.data[column_id]);
+			}
+			break;
+		}
+		case VortexReaderColumn::FILE_ROW_NUMBER: {
+			Vector ordinal_vector(LogicalType::BIGINT);
+			auto ordinal_data = FlatVector::GetDataMutable<int64_t>(ordinal_vector);
+			for (idx_t r = 0; r < scan_chunk.size(); r++) {
+				ordinal_data[r] = file_row_number + NumericCast<int64_t>(r);
+			}
+			FlatVector::SetSize(ordinal_vector, scan_chunk.size());
+			if (TryEvaluateExpression(context, c, ordinal_vector, LogicalType::BIGINT, chunk.data[c])) {
+				break;
+			}
+			auto row_id_data = FlatVector::GetDataMutable<int64_t>(chunk.data[c]);
+			for (idx_t r = 0; r < scan_chunk.size(); r++) {
+				row_id_data[r] = ordinal_data[r];
+			}
+			break;
+		}
+		case VortexReaderColumn::EMPTY:
+			break;
+		}
+	}
+
+	chunk.SetChildCardinality(scan_chunk.size());
+	auto scan_count = chunk.size();
+	if (filters || deletion_filter) {
+		SelectionVector sel;
+		idx_t approved_tuple_count = scan_count;
+		if (deletion_filter) {
+			approved_tuple_count = deletion_filter->Filter(file_row_number, approved_tuple_count, sel);
+		}
+		if (filters) {
+			for (auto &entry : *filters) {
+				auto &filter = entry.Filter();
+				if (ExpressionFilter::IsRootOptionalFilter(filter)) {
+					continue;
+				}
+				auto column_id = entry.GetIndex().GetIndex();
+				auto &vec = chunk.data[column_id];
+
+				UnifiedVectorFormat vdata;
+				vec.ToUnifiedFormat(chunk.size(), vdata);
+
+				auto filter_state = TableFilterState::Initialize(context, filter);
+
+				approved_tuple_count = ColumnSegment::FilterSelection(sel, vec, vdata, filter, *filter_state,
+				                                                      chunk.size(), approved_tuple_count);
+			}
+		}
+		if (approved_tuple_count != chunk.size()) {
+			chunk.Slice(sel, approved_tuple_count);
+		}
+	}
+	file_row_number += NumericCast<int64_t>(scan_count);
+	return AsyncResult(SourceResultType::HAVE_MORE_OUTPUT);
+}
+
+void DuckLakeVortexFileReader::AddVirtualColumn(column_t virtual_column_id) {
+	if (virtual_column_id == MultiFileReader::COLUMN_IDENTIFIER_FILE_ROW_NUMBER) {
+		columns.back().identifier = Value::INTEGER(MultiFileReader::ORDINAL_FIELD_ID);
+		return;
+	}
+	throw InternalException("Unsupported virtual column id %d for Vortex file reader", virtual_column_id);
+}
+
+string DuckLakeVortexFileReader::GetReaderType() const {
+	return "DuckLake Vortex Data";
+}
+
+} // namespace duckdb

--- a/test/sql/settings/data_file_format.test
+++ b/test/sql/settings/data_file_format.test
@@ -1,0 +1,72 @@
+# name: test/sql/settings/data_file_format.test
+# description: Test selectable DuckLake data file formats
+# group: [settings]
+
+require ducklake
+
+require parquet
+
+require vortex
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_data_file_format.db' AS ducklake (
+    DATA_PATH '{TEST_DIR}/ducklake_data_file_format_files',
+    METADATA_CATALOG 'meta',
+    DATA_INLINING_ROW_LIMIT 0,
+    DATA_FILE_FORMAT 'vortex'
+)
+
+query I
+SELECT value FROM meta.ducklake_metadata WHERE key = 'data_file_format'
+----
+vortex
+
+statement ok
+CREATE TABLE ducklake.t(i INTEGER, s VARCHAR)
+
+query I
+INSERT INTO ducklake.t VALUES (1, 'one'), (2, 'two')
+----
+2
+
+query II
+SELECT i, s FROM ducklake.t ORDER BY i
+----
+1	one
+2	two
+
+query I
+SELECT COUNT(*) FROM glob('{TEST_DIR}/ducklake_data_file_format_files/**/*.vortex')
+----
+1
+
+query II
+SELECT file_format, COUNT(*) FROM meta.ducklake_data_file GROUP BY ALL ORDER BY ALL
+----
+vortex	1
+
+statement ok
+CALL ducklake.set_option('data_file_format', 'parquet', table_name => 't')
+
+query I
+INSERT INTO ducklake.t VALUES (3, 'three')
+----
+1
+
+query II
+SELECT i, s FROM ducklake.t ORDER BY i
+----
+1	one
+2	two
+3	three
+
+query II
+SELECT file_format, COUNT(*) FROM meta.ducklake_data_file GROUP BY ALL ORDER BY ALL
+----
+parquet	1
+vortex	1
+
+statement error
+CALL ducklake.set_option('data_file_format', 'orc')
+----
+Unknown data file format


### PR DESCRIPTION
 ## Overview

  Adds support for Vortex data files in DuckLake.

  Parquet remains the default. New data files can now be written as either Parquet or Vortex, and DuckLake tracks the format per file so mixed-format tables continue to work.

  ## What changed

  - Added a `data_file_format` DuckLake option.
    - Accepted values: `parquet`, `vortex`.
    - Invalid values are rejected.
    - Uses existing option precedence: table, schema, DuckLake/global, then default `parquet`.

  - Added attach-time support for `DATA_FILE_FORMAT`.
    - `ATTACH ... (DATA_FILE_FORMAT 'vortex')` initializes the persisted global option for a new DuckLake.
    - Existing DuckLakes can change the persisted setting through `ducklake.set_option`.

  - Added per-data-file format tracking.
    - `DuckLakeDataFile` and related metadata structs now carry the data file format.
    - Metadata reads select `ducklake_data_file.file_format`.
    - Metadata writes persist the actual format instead of hardcoding `parquet`.
    - Existing/null metadata still defaults to Parquet.

  - Updated write paths to use the selected format.
    - INSERT
    - CTAS
    - MERGE INTO inserts
    - UPDATE rewrite inserts
    - flush inlined data
    - compaction

  - Updated COPY planning for format-specific behavior.
    - Parquet keeps existing field-id, encryption, compression, row group, version, and GeoParquet settings.
    - Vortex uses DuckDB’s `vortex` copy function.
    - Vortex files use the `.vortex` extension.
    - Parquet-only options are not passed to Vortex.
    - Vortex writes are rejected for encrypted DuckLakes for now.

  - Added Vortex read support.
    - Added `VortexFileScanner`, which binds DuckDB’s `read_vortex`.
    - Added `DuckLakeVortexFileReader`.
    - Integrated Vortex into DuckLake’s multi-file reader path.
    - Mixed Parquet/Vortex scans are supported through per-file reader selection.
    - Row IDs, casts, virtual columns, delete filtering, and scan filters are handled in the DuckLake reader path.

  - Fixed empty-projection Vortex scans.
    - Added an explicit `EMPTY` reader-column state so scans that do not project physical columns still read enough data to produce the correct row count.
    - This covers cases like count-style scans where the scan output has no regular data columns.

  - Updated metadata/file plumbing.
    - Multi-file list entries include `data_file_format` in extended file info.
    - Data file metadata queries now select data file format separately from delete file format.
    - Delete files remain unchanged: positional deletes are Parquet, deletion vectors are Puffin.

  - Updated cleanup.
    - Orphan file cleanup now considers both `.parquet` and `.vortex` files.

  - Added documentation.
    - `docs/vortex_backend_spec.md` describes the option surface, metadata behavior, write/read paths, compatibility notes, and current limitations.

  ## Limitations

  - Vortex data files do not currently store DuckLake field-id metadata through the DuckDB Vortex extension.
  - Vortex uses the existing missing-field-id fallback mapping path.
  - Straight append/read workloads and column renames are supported, but complex schema evolution across Vortex files is still experimental.
  - Encrypted Vortex data files are not supported yet.

  ## Testing

  Added `test/sql/settings/data_file_format.test`, covering:

  - attach-time `DATA_FILE_FORMAT 'vortex'`
  - persisted `data_file_format` metadata
  - writing and reading Vortex data files
  - `.vortex` file creation
  - `ducklake_data_file.file_format` tracking
  - switching a table back to Parquet
  - mixed Parquet/Vortex reads in the same table
  - invalid format rejection