### PR TITLE
Fix remote execution of ducklake_delete_orphaned_files() for quack

### DIFF
--- a/src/include/metadata_manager/quack_metadata_manager.hpp
+++ b/src/include/metadata_manager/quack_metadata_manager.hpp
@@ -33,7 +33,6 @@ public:
 	unique_ptr<QueryResult> Query(string &query) override;
 	unique_ptr<QueryResult> AttachMetadata(const string &attach_query) override;
 	void ClearCache() override;
-	vector<DuckLakeFileForCleanup> GetOrphanFilesForCleanup(const string &filter, const string &separator) override;
 
 	bool MetadataExists() override;
 

--- a/src/include/metadata_manager/quack_metadata_manager.hpp
+++ b/src/include/metadata_manager/quack_metadata_manager.hpp
@@ -33,6 +33,7 @@ public:
 	unique_ptr<QueryResult> Query(string &query) override;
 	unique_ptr<QueryResult> AttachMetadata(const string &attach_query) override;
 	void ClearCache() override;
+	vector<DuckLakeFileForCleanup> GetOrphanFilesForCleanup(const string &filter, const string &separator) override;
 
 	bool MetadataExists() override;
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -401,6 +401,7 @@ public:
 protected:
 	string GetInlinedTableQuery(const DuckLakeTableInfo &table, const string &table_name);
 	string GetColumnType(const DuckLakeColumnInfo &col);
+	string GetKnownFilesForCleanupQuery(const string &separator) const;
 
 	//! Optimized data file writing using DuckDB Appender API (only for DuckDB metadata manager)
 	string WriteNewDataFilesWithAppender(DuckLakeSnapshot &commit_snapshot, const vector<DuckLakeFileInfo> &new_files,

--- a/src/metadata_manager/quack_metadata_manager.cpp
+++ b/src/metadata_manager/quack_metadata_manager.cpp
@@ -1,5 +1,9 @@
 #include "metadata_manager/quack_metadata_manager.hpp"
 #include "common/ducklake_util.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/main/appender.hpp"
+#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_staged_commit.hpp"
@@ -132,6 +136,71 @@ void QuackMetadataManager::FlushChangesServerSide(DuckLakeTransaction &flush_tra
 	// We got clear the cache, if this creates inlined tables (e.g., `ducklake_inlined_data_<id>_<v>` or
 	// `ducklake_inlined_delete_<id>`)
 	ClearCache();
+}
+
+vector<DuckLakeFileForCleanup> QuackMetadataManager::GetOrphanFilesForCleanup(const string &filter,
+                                                                              const string &separator) {
+	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
+	auto known_files_res = Query(known_files_query);
+	if (known_files_res->HasError()) {
+		known_files_res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+	}
+
+	vector<string> known_files;
+	for (auto &row : *known_files_res) {
+		known_files.push_back(row.GetValue<string>(0));
+	}
+
+	auto temp_table =
+	    "__ducklake_known_cleanup_files_" + StringUtil::Replace(UUID::ToString(UUID::GenerateRandomUUID()), "-", "_");
+	auto temp_table_identifier = DuckLakeUtil::SQLIdentifierToString(temp_table);
+
+	auto create_temp_query = StringUtil::Format("CREATE TEMPORARY TABLE %s(full_path VARCHAR)", temp_table_identifier);
+	auto create_temp_res = transaction.ExecuteRaw(create_temp_query);
+	if (create_temp_res->HasError()) {
+		create_temp_res->GetErrorObject().Throw("Failed to create temporary file list for DuckLake cleanup: ");
+	}
+
+	auto drop_temp_table = [&]() {
+		auto drop_temp_query = StringUtil::Format("DROP TABLE IF EXISTS %s", temp_table_identifier);
+		transaction.ExecuteRaw(drop_temp_query);
+	};
+
+	try {
+		Appender appender(transaction.GetConnection(), temp_table);
+		for (auto &known_file : known_files) {
+			appender.AppendRow(known_file.c_str());
+		}
+		appender.Close();
+	} catch (...) {
+		drop_temp_table();
+		throw;
+	}
+
+	// Keep the anti-join local while allowing the known-file list to use Quack's metadata query path.
+	auto query = StringUtil::Format(R"(SELECT filename
+FROM read_blob({DATA_PATH} || '**') files
+WHERE suffix(filename, '.parquet')
+AND NOT EXISTS (
+	SELECT 1 FROM %s known_files WHERE known_files.full_path = files.filename
+)
+%s)",
+	                                temp_table_identifier, filter);
+	SubstituteCatalogPlaceholders(query);
+	auto res = transaction.ExecuteRaw(query);
+	if (res->HasError()) {
+		drop_temp_table();
+		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+	}
+
+	vector<DuckLakeFileForCleanup> result;
+	for (auto &row : *res) {
+		DuckLakeFileForCleanup info;
+		info.path = row.GetValue<string>(0);
+		result.push_back(std::move(info));
+	}
+	drop_temp_table();
+	return result;
 }
 
 bool QuackMetadataManager::MetadataExists() {

--- a/src/metadata_manager/quack_metadata_manager.cpp
+++ b/src/metadata_manager/quack_metadata_manager.cpp
@@ -1,9 +1,6 @@
 #include "metadata_manager/quack_metadata_manager.hpp"
 #include "common/ducklake_util.hpp"
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/common/types/uuid.hpp"
-#include "duckdb/main/appender.hpp"
-#include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_staged_commit.hpp"
@@ -136,71 +133,6 @@ void QuackMetadataManager::FlushChangesServerSide(DuckLakeTransaction &flush_tra
 	// We got clear the cache, if this creates inlined tables (e.g., `ducklake_inlined_data_<id>_<v>` or
 	// `ducklake_inlined_delete_<id>`)
 	ClearCache();
-}
-
-vector<DuckLakeFileForCleanup> QuackMetadataManager::GetOrphanFilesForCleanup(const string &filter,
-                                                                              const string &separator) {
-	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
-	auto known_files_res = Query(known_files_query);
-	if (known_files_res->HasError()) {
-		known_files_res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
-	}
-
-	vector<string> known_files;
-	for (auto &row : *known_files_res) {
-		known_files.push_back(row.GetValue<string>(0));
-	}
-
-	auto temp_table =
-	    "__ducklake_known_cleanup_files_" + StringUtil::Replace(UUID::ToString(UUID::GenerateRandomUUID()), "-", "_");
-	auto temp_table_identifier = DuckLakeUtil::SQLIdentifierToString(temp_table);
-
-	auto create_temp_query = StringUtil::Format("CREATE TEMPORARY TABLE %s(full_path VARCHAR)", temp_table_identifier);
-	auto create_temp_res = transaction.ExecuteRaw(create_temp_query);
-	if (create_temp_res->HasError()) {
-		create_temp_res->GetErrorObject().Throw("Failed to create temporary file list for DuckLake cleanup: ");
-	}
-
-	auto drop_temp_table = [&]() {
-		auto drop_temp_query = StringUtil::Format("DROP TABLE IF EXISTS %s", temp_table_identifier);
-		transaction.ExecuteRaw(drop_temp_query);
-	};
-
-	try {
-		Appender appender(transaction.GetConnection(), temp_table);
-		for (auto &known_file : known_files) {
-			appender.AppendRow(known_file.c_str());
-		}
-		appender.Close();
-	} catch (...) {
-		drop_temp_table();
-		throw;
-	}
-
-	// Keep the anti-join local while allowing the known-file list to use Quack's metadata query path.
-	auto query = StringUtil::Format(R"(SELECT filename
-FROM read_blob({DATA_PATH} || '**') files
-WHERE suffix(filename, '.parquet')
-AND NOT EXISTS (
-	SELECT 1 FROM %s known_files WHERE known_files.full_path = files.filename
-)
-%s)",
-	                                temp_table_identifier, filter);
-	SubstituteCatalogPlaceholders(query);
-	auto res = transaction.ExecuteRaw(query);
-	if (res->HasError()) {
-		drop_temp_table();
-		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
-	}
-
-	vector<DuckLakeFileForCleanup> result;
-	for (auto &row : *res) {
-		DuckLakeFileForCleanup info;
-		info.path = row.GetValue<string>(0);
-		result.push_back(std::move(info));
-	}
-	drop_temp_table();
-	return result;
 }
 
 bool QuackMetadataManager::MetadataExists() {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4497,13 +4497,9 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 	}
 	return result;
 }
-vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
-                                                                                 const string &separator) {
-	auto query = R"(SELECT filename
-FROM read_blob({DATA_PATH} || '**')
-WHERE suffix(filename, '.parquet')
-AND filename NOT IN (
-SELECT REPLACE(
+
+string DuckLakeMetadataManager::GetKnownFilesForCleanupQuery(const string &separator) const {
+	auto query = R"(SELECT REPLACE(
            CASE
                WHEN NOT file_relative THEN file_path
                ELSE CASE
@@ -4537,9 +4533,19 @@ SELECT REPLACE(
            '{SEPARATOR}'
 ) AS full_path
 FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
-)
-)" + filter;
-	query = StringUtil::Replace(query, "{SEPARATOR}", separator);
+)";
+	return StringUtil::Replace(query, "{SEPARATOR}", separator);
+}
+
+vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
+                                                                                 const string &separator) {
+	auto query = R"(SELECT filename
+FROM read_blob({DATA_PATH} || '**')
+WHERE suffix(filename, '.parquet')
+AND filename NOT IN (
+)" + GetKnownFilesForCleanupQuery(separator) +
+	             R"(
+))" + filter;
 	auto res = transaction.Query(query);
 	if (res->HasError()) {
 		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4539,25 +4539,68 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
 
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
                                                                                  const string &separator) {
-	auto query = R"(SELECT filename
-FROM read_blob({DATA_PATH} || '**')
+	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
+	auto known_files_res = transaction.Query(known_files_query);
+	if (known_files_res->HasError()) {
+		known_files_res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+	}
+
+	vector<string> known_files;
+	for (auto &row : *known_files_res) {
+		known_files.push_back(row.GetValue<string>(0));
+	}
+
+	const string temp_table = "__ducklake_known_cleanup_files";
+	auto temp_table_identifier = DuckLakeUtil::SQLIdentifierToString(temp_table);
+
+	auto create_temp_query =
+	    StringUtil::Format("CREATE OR REPLACE TEMPORARY TABLE %s(full_path VARCHAR)", temp_table_identifier);
+	auto create_temp_res = transaction.ExecuteRaw(create_temp_query);
+	if (create_temp_res->HasError()) {
+		create_temp_res->GetErrorObject().Throw("Failed to create temporary file list for DuckLake cleanup: ");
+	}
+
+	auto drop_temp_table = [&]() {
+		try {
+			auto drop_temp_query = StringUtil::Format("DROP TABLE IF EXISTS %s", temp_table_identifier);
+			transaction.ExecuteRaw(drop_temp_query);
+		} catch (...) {
+		}
+	};
+
+	try {
+		Appender appender(transaction.GetConnection(), temp_table);
+		for (auto &known_file : known_files) {
+			appender.AppendRow(known_file.c_str());
+		}
+		appender.Close();
+
+		auto query = StringUtil::Format(R"(SELECT filename
+FROM read_blob({DATA_PATH} || '**') files
 WHERE suffix(filename, '.parquet')
-AND filename NOT IN (
-)" + GetKnownFilesForCleanupQuery(separator) +
-	             R"(
-))" + filter;
-	auto res = transaction.Query(query);
-	if (res->HasError()) {
-		res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+AND NOT EXISTS (
+	SELECT 1 FROM %s known_files WHERE known_files.full_path = files.filename
+)
+%s)",
+		                                temp_table_identifier, filter);
+		SubstituteCatalogPlaceholders(query);
+		auto res = transaction.ExecuteRaw(query);
+		if (res->HasError()) {
+			res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+		}
+
+		vector<DuckLakeFileForCleanup> result;
+		for (auto &row : *res) {
+			DuckLakeFileForCleanup info;
+			info.path = row.GetValue<string>(0);
+			result.push_back(std::move(info));
+		}
+		drop_temp_table();
+		return result;
+	} catch (...) {
+		drop_temp_table();
+		throw;
 	}
-	auto context = transaction.context.lock();
-	vector<DuckLakeFileForCleanup> result;
-	for (auto &row : *res) {
-		DuckLakeFileForCleanup info;
-		info.path = row.GetValue<string>(0);
-		result.push_back(std::move(info));
-	}
-	return result;
 }
 
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetFilesForCleanup(const string &filter, CleanupType type,

--- a/test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test
+++ b/test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test
@@ -1,0 +1,68 @@
+# name: test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test
+# description: Test concurrent inserts while orphan cleanup runs
+# group: [remove_orphans]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/concurrent_insert_orphan_cleanup', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.tbl(id INTEGER);
+
+statement ok
+INSERT INTO ducklake.tbl SELECT i FROM range(10) t(i);
+
+# Add a known orphan before the concurrent workload starts.
+statement ok
+COPY ducklake.tbl TO '${DATA_PATH}/concurrent_insert_orphan_cleanup/main/tbl/orphan.parquet';
+
+query I
+SELECT count(*) FROM ducklake_delete_orphaned_files('ducklake', cleanup_all => true, dry_run => true);
+----
+1
+
+# Run the cleanup function concurrently with writers. The cleanup calls use the
+# normal age guard rather than cleanup_all, so fresh in-flight files are not
+# intentionally eligible for deletion.
+concurrentloop threadid 0 10
+
+loop j 0 5
+
+statement maybe
+INSERT INTO ducklake.tbl VALUES (1000 + ${threadid} * 100 + ${j});
+----
+
+statement maybe
+CALL ducklake_delete_orphaned_files('ducklake');
+----
+
+endloop
+
+endloop
+
+statement ok
+CALL ducklake_delete_orphaned_files('ducklake', cleanup_all => true);
+
+query I
+SELECT count(*) FROM ducklake_delete_orphaned_files('ducklake', cleanup_all => true, dry_run => true);
+----
+0
+
+query I
+SELECT count(*) FROM (SELECT id, count(*) cnt FROM ducklake.tbl GROUP BY id HAVING count(*) > 1);
+----
+0
+
+query I
+SELECT count(*) BETWEEN 10 AND 60 FROM ducklake.tbl;
+----
+true


### PR DESCRIPTION
## Summary

Fixes Quack-backed `ducklake_delete_orphaned_files()` so filesystem discovery runs in the attaching DuckDB client instead of on the remote Quack backend.

The base metadata manager keeps the existing single-query implementation used by local/SQLite/Postgres catalogs. Quack now overrides `GetOrphanFilesForCleanup()` and handles the mixed local/remote query shape explicitly:

- fetch known DuckLake data/delete/scheduled file paths through Quack's normal metadata query path
- materialize those known paths into a local temporary DuckDB table
- run `read_blob({DATA_PATH} || '**')` locally in the client
- use a local SQL anti-join against the temp table to return only orphaned files

This preserves the original `read_blob(...) NOT IN (...)` semantics while avoiding remote execution of the client data-path scan.

## Motivation

For Postgres and local catalogs, `ducklake_delete_orphaned_files()` is planned by the client DuckDB process: `read_blob(...)` scans the local data path and metadata tables are accessed as catalog scans.

Quack overrides metadata `Query(...)` by wrapping the full SQL string in `quack_query_by_name(...)`. As a result, the original orphan cleanup query sent the entire statement to the remote Quack backend, including:

```sql
read_blob({DATA_PATH} || '**')
```

That makes the remote backend scan for files that belong to the attaching client. This PR keeps Quack metadata access remote, but forces the physical file listing and orphan anti-join to happen locally.

## Tests

```sh
cmake --build build/release --config Release
make test
scripts/run_quack_tests.py --slow --no-install
```

Results:

- `make test`: all tests passed, 440 test cases, 94,500 assertions, 16 skipped
- `run_quack_tests.py --slow --no-install`: 392 passed, 0 failed, 0 timeouts, 0 infra errors

Fixes #1169.

## Disclaimer

This PR was created with the help of Codex / GPT-5.5 xhigh. Feel free to close it if this isn't acceptable.