### PR TITLE
Allow Tables that are not inlined to use reserved names.

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -27,20 +27,20 @@ jobs:
   duckdb-next-build:
     name: Build extension binaries
     needs: get-duckdb-version
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       duckdb_version: ${{ needs.get-duckdb-version.outputs.duckdb_version }}
-      ci_tools_version: main
+      ci_tools_version: v1.5-variegata
       extension_name: ducklake
 
   duckdb-next-deploy:
     name: Deploy extension binaries
     needs: [get-duckdb-version, duckdb-next-build]
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.5-variegata
     secrets: inherit
     with:
       extension_name: ducklake
       duckdb_version: ${{ needs.get-duckdb-version.outputs.duckdb_version }}
-      ci_tools_version: main
+      ci_tools_version: v1.5-variegata
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') || github.ref == 'refs/heads/main' }}

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -349,13 +349,17 @@ void DuckLakeUtil::ValidateNoInlinedSystemColumns(const ColumnList &columns, con
 	for (auto &col : columns.Logical()) {
 		if (IsInlinedSystemColumn(col.Name())) {
 			if (table_name.empty()) {
-				throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining "
-				                      "is enabled - disable inlining by setting data_inlining_row_limit to 0",
-				                      col.Name());
+				throw BinderException(
+				    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
+				    "you must use this column name, disable inlining by calling "
+				    "ducklake_set_option('data_inlining_row_limit', 0).",
+				    col.Name());
 			}
-			throw BinderException("Cannot enable data inlining for table \"%s\" - column \"%s\" conflicts with a "
-			                      "reserved DuckLake internal column name used for inlining",
-			                      table_name, col.Name());
+			throw BinderException(
+			    "Cannot enable data inlining for table \"%s\". Column \"%s\" conflicts with a reserved DuckLake "
+			    "internal column name used for inlining. To enable inlining for this table, rename or drop column "
+			    "\"%s\".",
+			    table_name, col.Name(), col.Name());
 		}
 	}
 }

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -1,4 +1,5 @@
 #include "common/ducklake_util.hpp"
+#include "duckdb/parser/column_list.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -342,6 +343,21 @@ bool DuckLakeUtil::IsInlinedSystemColumn(const string &name) {
 	return StringUtil::CIEquals(name, "row_id") || StringUtil::CIEquals(name, "begin_snapshot") ||
 	       StringUtil::CIEquals(name, "end_snapshot") || StringUtil::CIEquals(name, "_ducklake_internal_snapshot_id") ||
 	       StringUtil::CIEquals(name, "_ducklake_internal_row_id");
+}
+
+void DuckLakeUtil::ValidateNoInlinedSystemColumns(const ColumnList &columns, const string &table_name) {
+	for (auto &col : columns.Logical()) {
+		if (IsInlinedSystemColumn(col.Name())) {
+			if (table_name.empty()) {
+				throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining "
+				                      "is enabled - disable inlining by setting data_inlining_row_limit to 0",
+				                      col.Name());
+			}
+			throw BinderException("Cannot enable data inlining for table \"%s\" - column \"%s\" conflicts with a "
+			                      "reserved DuckLake internal column name used for inlining",
+			                      table_name, col.Name());
+		}
+	}
 }
 
 string DuckLakeUtil::ReplaceSkippingQuotes(const string &sql, const string &from, const string &to) {

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -1,10 +1,69 @@
 #include "functions/ducklake_table_functions.hpp"
+#include "common/ducklake_util.hpp"
 #include "storage/ducklake_transaction.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 
 namespace duckdb {
+// -------------------------------------------------------------------------//
+// Group of functions to validate if it's safe to change the inline option
+// ------------------------------------------------------------------------//
+
+static void ValidateTableScope(ClientContext &context, Catalog &catalog, const string &schema_name,
+                               const string &table_name) {
+	auto table_catalog_entry =
+	    catalog.GetEntry<TableCatalogEntry>(context, schema_name, table_name, OnEntryNotFound::THROW_EXCEPTION);
+	auto &ducklake_table = table_catalog_entry->Cast<DuckLakeTableEntry>();
+	DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(), ducklake_table.name);
+}
+
+static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck_catalog,
+                                   DuckLakeSchemaEntry &schema_entry, SchemaIndex override_scope_id) {
+	schema_entry.Scan(context, CatalogType::TABLE_ENTRY, [&](CatalogEntry &entry) {
+		auto &ducklake_table = entry.Cast<DuckLakeTableEntry>();
+		string override_val;
+		if (duck_catalog.TryGetScopedConfigOption("data_inlining_row_limit", override_val, override_scope_id,
+		                                          ducklake_table.GetTableId()) &&
+		    std::stoull(override_val) == 0) {
+			return;
+		}
+		DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(), ducklake_table.name);
+	});
+}
+
+static void ValidateSchemaScope(ClientContext &context, Catalog &catalog, const string &schema_name) {
+	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
+	auto schema_catalog_entry = catalog.GetSchema(context, schema_name, OnEntryNotFound::THROW_EXCEPTION);
+	ValidateTablesInSchema(context, duck_catalog, schema_catalog_entry->Cast<DuckLakeSchemaEntry>(), SchemaIndex());
+}
+
+static void ValidateGlobalScope(ClientContext &context, Catalog &catalog) {
+	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
+	duck_catalog.ScanSchemas(context, [&](SchemaCatalogEntry &schema) {
+		auto &schema_entry = schema.Cast<DuckLakeSchemaEntry>();
+		ValidateTablesInSchema(context, duck_catalog, schema_entry, schema_entry.GetSchemaId());
+	});
+}
+
+static void ValidateNoReservedInliningColumns(ClientContext &context, Catalog &catalog,
+                                              const TableFunctionBindInput &input) {
+	auto table_name_entry = input.named_parameters.find("table_name");
+	auto schema_param = input.named_parameters.find("schema");
+	bool has_table = table_name_entry != input.named_parameters.end() && !table_name_entry->second.IsNull();
+	bool has_schema = schema_param != input.named_parameters.end() && !schema_param->second.IsNull();
+	if (has_table) {
+		string schema_name = has_schema ? StringValue::Get(schema_param->second) : "";
+		ValidateTableScope(context, catalog, schema_name, StringValue::Get(table_name_entry->second));
+	} else if (has_schema) {
+		ValidateSchemaScope(context, catalog, StringValue::Get(schema_param->second));
+	} else {
+		ValidateGlobalScope(context, catalog);
+	}
+}
+
+// ------------------------------------------------------------------------//
+// ------------------------------------------------------------------------//
 
 struct DuckLakeSetOptionData : public TableFunctionData {
 	DuckLakeSetOptionData(Catalog &catalog, DuckLakeConfigOption option_p)
@@ -69,6 +128,9 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 	} else if (option == "data_inlining_row_limit") {
 		auto data_inlining_row_limit = val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
 		value = to_string(data_inlining_row_limit);
+		if (data_inlining_row_limit > 0) {
+			ValidateNoReservedInliningColumns(context, catalog, input);
+		}
 	} else if (option == "require_commit_message") {
 		value = val.GetValue<bool>() ? "true" : "false";
 	} else if (option == "rewrite_delete_threshold") {

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
+class ColumnList;
 class DuckLakeMetadataManager;
 class FileSystem;
 class TableFilter;
@@ -47,6 +48,8 @@ public:
 
 	//! Returns true if the given column name conflicts with inlined data system columns
 	static bool IsInlinedSystemColumn(const string &name);
+	//! Throws if any column in the list conflicts with inlined data system columns
+	static void ValidateNoInlinedSystemColumns(const ColumnList &columns, const string &table_name = "");
 };
 
 } // namespace duckdb

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -123,6 +123,9 @@ public:
 	}
 	void SetConfigOption(const DuckLakeConfigOption &option);
 	bool TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id, TableIndex table_id) const;
+	//! Check if a config option has a table-level or schema-level override (excluding global scope)
+	bool TryGetScopedConfigOption(const string &option, string &result, SchemaIndex schema_id,
+	                              TableIndex table_id) const;
 	template <class T>
 	T GetConfigOption(const string &option, SchemaIndex schema_id, TableIndex table_id, T default_value) const {
 		string value_str;

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -841,8 +841,8 @@ void DuckLakeCatalog::SetConfigOption(const DuckLakeConfigOption &option) {
 	options.config_options[key] = value;
 }
 
-bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id,
-                                         TableIndex table_id) const {
+bool DuckLakeCatalog::TryGetScopedConfigOption(const string &option, string &result, SchemaIndex schema_id,
+                                               TableIndex table_id) const {
 	lock_guard<mutex> guard(config_lock);
 	// search options in-order
 	// table scope
@@ -867,8 +867,16 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, S
 			}
 		}
 	}
+	return false;
+}
 
-	// global scope
+bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, SchemaIndex schema_id,
+                                         TableIndex table_id) const {
+	// search options in-order: table scope, schema scope, then global scope
+	if (TryGetScopedConfigOption(option, result, schema_id, table_id)) {
+		return true;
+	}
+	lock_guard<mutex> guard(config_lock);
 	auto entry = options.config_options.find(option);
 	if (entry == options.config_options.end()) {
 		return false;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1309,16 +1309,14 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 		// Files that have no stats entry for this column (i.e., written before the column was added) must
 		// NOT be pruned, we cannot determine filter satisfaction without stats.
 		if (needs_value_count_guard) {
-			conditions += StringUtil::Format(
-			    "(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
-			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
-			    "(value_count IS NULL OR value_count > 0) AND (%s(%s))))",
-			    cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
+			conditions += StringUtil::Format("(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
+			                                 "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
+			                                 "(value_count IS NULL OR value_count > 0) AND (%s(%s))))",
+			                                 cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
 		} else {
-			conditions += StringUtil::Format(
-			    "(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
-			    "data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s)))",
-			    cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
+			conditions += StringUtil::Format("(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
+			                                 "data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s)))",
+			                                 cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
 		}
 
 		CTERequirement req(column_filter.column_field_index, referenced_stats);

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -70,11 +70,10 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateTableExtended(CatalogTrans
 	if (!HandleCreateConflict(transaction, CatalogType::TABLE_ENTRY, base_info.table, base_info.on_conflict)) {
 		return nullptr;
 	}
-	// reject columns with reserved DuckLake internal names
-	for (auto &col : base_info.columns.Logical()) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name())) {
-			throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use", col.Name());
-		}
+	// reject columns with reserved DuckLake internal names when inlining is enabled
+	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
+	if (duck_catalog.DataInliningRowLimit(transaction.GetContext(), schema_id, TableIndex()) > 0) {
+		DuckLakeUtil::ValidateNoInlinedSystemColumns(base_info.columns);
 	}
 	//! get a local table-id
 	auto table_id = TableIndex(duck_transaction.GetLocalCatalogId());

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -11,9 +11,9 @@
 namespace duckdb {
 
 // Round-trip user sort expressions through the parser so non-bare-column expressions (e.g.
-// `(id + 0)`) survive into the deletes-position query. 
+// `(id + 0)`) survive into the deletes-position query.
 
-// FIXME: TODO: Macros and other user-catalog references will fail at bind time on the metadata connection 
+// FIXME: TODO: Macros and other user-catalog references will fail at bind time on the metadata connection
 string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
                                        const ColumnList &inlined_columns) {
 	// Build rename map: current physical name -> inlined physical name (only entries that differ).

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -630,9 +630,11 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
 	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name) &&
 	    duck_catalog.DataInliningRowLimit(duck_schema.GetSchemaId(), GetTableId()) > 0) {
-		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining is "
-		                       "enabled - disable inlining by setting data_inlining_row_limit to 0",
-		                       info.new_name);
+		throw CatalogException(
+		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
+		    "you must use this column name, disable inlining by calling "
+		    "ducklake_set_option('data_inlining_row_limit', 0).",
+		    info.new_name);
 	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
@@ -674,9 +676,11 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
 	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name()) &&
 	    duck_catalog.DataInliningRowLimit(duck_schema.GetSchemaId(), GetTableId()) > 0) {
-		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining is "
-		                       "enabled - disable inlining by setting data_inlining_row_limit to 0",
-		                       info.new_column.Name());
+		throw CatalogException(
+		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
+		    "you must use this column name, disable inlining by calling "
+		    "ducklake_set_option('data_inlining_row_limit', 0).",
+		    info.new_column.Name());
 	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -2,6 +2,7 @@
 #include "common/ducklake_util.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_scan.hpp"
 #include "storage/ducklake_transaction.hpp"
 
@@ -625,8 +626,13 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 }
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, RenameColumnInfo &info) {
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name)) {
-		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use", info.new_name);
+	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
+	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name) &&
+	    duck_catalog.DataInliningRowLimit(duck_schema.GetSchemaId(), GetTableId()) > 0) {
+		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining is "
+		                       "enabled - disable inlining by setting data_inlining_row_limit to 0",
+		                       info.new_name);
 	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
@@ -664,8 +670,13 @@ void DuckLakeTableEntry::RequireNextColumnId(DuckLakeTransaction &transaction) {
 }
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, AddColumnInfo &info) {
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name())) {
-		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use", info.new_column.Name());
+	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
+	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name()) &&
+	    duck_catalog.DataInliningRowLimit(duck_schema.GetSchemaId(), GetTableId()) > 0) {
+		throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use when data inlining is "
+		                       "enabled - disable inlining by setting data_inlining_row_limit to 0",
+		                       info.new_column.Name());
 	}
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -13,6 +13,13 @@
       "paths": [
         "test/sql/general/missing_parquet.test"
       ]
+    },
+    {
+      "reason": "Test asserts reserved column names are rejected, which requires inlining to be enabled",
+      "paths": [
+        "test/sql/data_inlining/inlining_reserved_column_names.test",
+        "test/sql/alter/issue_944.test"
+      ]
     }
   ]
 }

--- a/test/sql/data_inlining/inlining_reserved_column_names.test
+++ b/test/sql/data_inlining/inlining_reserved_column_names.test
@@ -1,0 +1,154 @@
+# name: test/sql/data_inlining/inlining_reserved_column_names.test
+# description: test that reserved inlining column names are allowed when inlining is disabled
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_reserved_cols.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_reserved_cols_files')
+
+statement error
+CREATE TABLE ducklake.t1(row_id INTEGER, v INTEGER);
+----
+reserved
+
+statement error
+CREATE TABLE ducklake.t1(begin_snapshot INTEGER, v INTEGER);
+----
+reserved
+
+statement error
+CREATE TABLE ducklake.t1(end_snapshot INTEGER, v INTEGER);
+----
+reserved
+
+# disable inlining globally, now reserved names should be allowed
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+CREATE TABLE ducklake.t1(row_id INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (1, 10), (2, 20);
+
+query II
+SELECT * FROM ducklake.t1
+----
+1	10
+2	20
+
+# adding a reserved column name should work when inlining is disabled
+statement ok
+ALTER TABLE ducklake.t1 ADD COLUMN begin_snapshot INTEGER;
+
+query III
+SELECT * FROM ducklake.t1
+----
+1	10	NULL
+2	20	NULL
+
+# renaming to a reserved column name should work when inlining is disabled
+statement ok
+ALTER TABLE ducklake.t1 RENAME COLUMN v TO end_snapshot;
+
+query III
+SELECT * FROM ducklake.t1
+----
+1	10	NULL
+2	20	NULL
+
+# trying to enable inlining on a table with reserved column names should fail
+statement error
+CALL ducklake.set_option('data_inlining_row_limit', 10, table_name => 't1');
+----
+Cannot enable data inlining
+
+# trying to enable inlining globally should also fail because t1 has reserved column names
+statement error
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+----
+Cannot enable data inlining
+
+# disable inlining specifically for t1 at the table level
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 't1');
+
+# now enabling inlining globally should succeed - t1 has a table-level override of 0
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10);
+
+# count existing files (t1 has data files since inlining was disabled for it)
+query I
+SELECT COUNT(*) AS baseline FROM GLOB('__TEST_DIR__/ducklake_reserved_cols_files/**')
+----
+1
+
+# create another table without reserved names - it should use inlining
+statement ok
+CREATE TABLE ducklake.t2(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO ducklake.t2 VALUES (1, 2), (3, 4);
+
+# t2 data should be inlined - no new files created
+query I
+SELECT COUNT(*) FROM GLOB('__TEST_DIR__/ducklake_reserved_cols_files/**')
+----
+1
+
+# t1 should still work with its reserved column names
+statement ok
+INSERT INTO ducklake.t1 VALUES (3, 30, 300);
+
+query III
+SELECT * FROM ducklake.t1
+----
+1	10	NULL
+2	20	NULL
+3	30	300
+
+query II
+SELECT * FROM ducklake.t2
+----
+1	2
+3	4
+
+statement ok
+DETACH ducklake
+
+# test per-table inlining disable: global inlining on, table inlining off
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/ducklake_reserved_cols2.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_reserved_cols2_files')
+
+statement ok
+CREATE TABLE ducklake.t_normal(i INTEGER, j INTEGER);
+
+# disable inlining only for a specific table
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 't_normal');
+
+# now we should be able to add a column with a reserved name to this table
+statement ok
+ALTER TABLE ducklake.t_normal ADD COLUMN row_id INTEGER;
+
+# but creating a new table (governed by global inlining=10) should still fail with reserved names
+statement error
+CREATE TABLE ducklake.t_fail(row_id INTEGER, v INTEGER);
+----
+reserved
+
+# create a normal table without reserved names
+statement ok
+CREATE TABLE ducklake.t_ok(i INTEGER, j INTEGER);
+
+# this table should still have inlining enabled
+statement ok
+INSERT INTO ducklake.t_ok VALUES (1, 2);
+
+query II
+SELECT * FROM ducklake.t_ok
+----
+1	2

--- a/test/sql/data_inlining/inlining_reserved_column_names.test
+++ b/test/sql/data_inlining/inlining_reserved_column_names.test
@@ -152,3 +152,28 @@ query II
 SELECT * FROM ducklake.t_ok
 ----
 1	2
+
+
+# CREATE TABLE with reserved name while inlining is enabled - suggest disabling inlining
+statement error
+CREATE TABLE ducklake.t_msg(row_id INTEGER);
+----
+Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
+
+# ALTER TABLE ADD COLUMN with reserved name while inlining is enabled - suggest disabling inlining
+statement error
+ALTER TABLE ducklake.t_ok ADD COLUMN row_id INTEGER;
+----
+Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
+
+# ALTER TABLE RENAME COLUMN to reserved name while inlining is enabled - suggest disabling inlining
+statement error
+ALTER TABLE ducklake.t_ok RENAME COLUMN i TO row_id;
+----
+Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
+
+# enabling inlining on a table that already has reserved column names - suggest renaming or dropping
+statement error
+CALL ducklake.set_option('data_inlining_row_limit', 10, table_name => 't_normal');
+----
+Cannot enable data inlining for table "t_normal". Column "row_id" conflicts with a reserved DuckLake internal column name used for inlining. To enable inlining for this table, rename or drop column "row_id".


### PR DESCRIPTION
Inlining requires certain reserved column names. (i.e., `row_id`, `begin_snapshot`, `end_snapshot`), we currently error if a user tries to create or modify a table that has a column with any of these names. This PR makes it more flexible. If inlining is disabled for a given table, that table can then use reserved names. This workes for inlining at any scope, either table, schema, or database.