### PR TITLE
fix: correct delete snapshot_id under virtual-column projection reordering (#1199)

### DIFF
--- a/src/include/storage/ducklake_multi_file_reader.hpp
+++ b/src/include/storage/ducklake_multi_file_reader.hpp
@@ -89,9 +89,12 @@ private:
 	unique_ptr<MultiFileColumnDefinition> snapshot_id_column;
 	//! Inlined transaction-local data
 	shared_ptr<DuckLakeInlinedData> transaction_local_data;
-	//! For deletion scans: track which output column is snapshot_id (if any)
+	//! For deletion scans: output_chunk column index of snapshot_id in global_column_ids order, if projected.
+	//! This is the OUTPUT position (set in CreateMapping), NOT the per-file local virtual-column index -- the
+	//! latter diverges from the output layout when snapshot_id is projected before rowid (see issue #1199).
 	optional_idx deletion_scan_snapshot_col;
-	//! For deletion scans: track which output column is rowid (if any)
+	//! For deletion scans: output_chunk column index of rowid in global_column_ids order, if projected.
+	//! Same OUTPUT-position semantics as deletion_scan_snapshot_col (see issue #1199).
 	optional_idx deletion_scan_rowid_col;
 	//! Whether row_id was internally projected (not in user's query)
 	//! This is necessary for DCF queries over inlined deletions

--- a/src/include/storage/ducklake_multi_file_reader.hpp
+++ b/src/include/storage/ducklake_multi_file_reader.hpp
@@ -89,12 +89,11 @@ private:
 	unique_ptr<MultiFileColumnDefinition> snapshot_id_column;
 	//! Inlined transaction-local data
 	shared_ptr<DuckLakeInlinedData> transaction_local_data;
-	//! For deletion scans: output_chunk column index of snapshot_id in global_column_ids order, if projected.
-	//! This is the OUTPUT position (set in CreateMapping), NOT the per-file local virtual-column index -- the
-	//! latter diverges from the output layout when snapshot_id is projected before rowid (see issue #1199).
+	//! For deletion scans: output_chunk column index of snapshot_id in global_column_ids order, if projected
+	//! (set in CreateMapping).
 	optional_idx deletion_scan_snapshot_col;
 	//! For deletion scans: output_chunk column index of rowid in global_column_ids order, if projected.
-	//! Same OUTPUT-position semantics as deletion_scan_snapshot_col (see issue #1199).
+	//! Same semantics as deletion_scan_snapshot_col.
 	optional_idx deletion_scan_rowid_col;
 	//! Whether row_id was internally projected (not in user's query)
 	//! This is necessary for DCF queries over inlined deletions

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -497,12 +497,23 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 	auto &file_list = multi_file_list.Cast<DuckLakeMultiFileList>();
 	bool needs_internal_rowid = false;
 	if (file_list.IsDeleteScan()) {
-		// Check if row_id is already in global_column_ids
+		// Locate the output positions of the rowid and snapshot_id virtual columns. global_column_ids is the
+		// order in which the columns appear in the FinalizeChunk output_chunk, so these positions are what
+		// GatherDeletionScanSnapshots must use. We must NOT rely on the per-file local virtual-column index
+		// (the old behavior): the snapshot_id virtual column is emitted as a constant expression and therefore
+		// does not advance the local column counter, so when the projection puts snapshot_id before rowid the
+		// local index no longer lines up with the output_chunk layout and the per-row snapshot overwrite
+		// silently targets the wrong column (issue #1199).
+		deletion_scan_rowid_col = optional_idx();
+		deletion_scan_snapshot_col = optional_idx();
 		bool has_rowid = false;
-		for (auto &col_id : global_column_ids) {
-			if (col_id.GetPrimaryIndex() == COLUMN_IDENTIFIER_ROW_ID) {
+		for (idx_t out_idx = 0; out_idx < global_column_ids.size(); out_idx++) {
+			auto primary_index = global_column_ids[out_idx].GetPrimaryIndex();
+			if (primary_index == COLUMN_IDENTIFIER_ROW_ID) {
 				has_rowid = true;
-				break;
+				deletion_scan_rowid_col = out_idx;
+			} else if (primary_index == COLUMN_IDENTIFIER_SNAPSHOT_ID) {
+				deletion_scan_snapshot_col = out_idx;
 			}
 		}
 		// We need internal row_id if it's not in the user's query
@@ -558,7 +569,6 @@ unique_ptr<Expression> DuckLakeMultiFileReader::GetVirtualColumnExpression(
     idx_t &column_id, const LogicalType &type, MultiFileLocalIndex local_idx,
     optional_ptr<MultiFileColumnDefinition> &global_column_reference) {
 	if (column_id == COLUMN_IDENTIFIER_ROW_ID) {
-		deletion_scan_rowid_col = local_idx.GetIndex();
 		// row id column
 		// this is computed as row_id_start + file_row_number OR read from the file
 		// first check if the row id is explicitly defined in this file
@@ -598,7 +608,6 @@ unique_ptr<Expression> DuckLakeMultiFileReader::GetVirtualColumnExpression(
 		return function_expr;
 	}
 	if (column_id == COLUMN_IDENTIFIER_SNAPSHOT_ID) {
-		deletion_scan_snapshot_col = local_idx.GetIndex();
 		if (TryFindColumnByFieldId(local_columns, MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID,
 		                           snapshot_id_column.get(), global_column_reference)) {
 			return nullptr;

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -497,13 +497,10 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
 	auto &file_list = multi_file_list.Cast<DuckLakeMultiFileList>();
 	bool needs_internal_rowid = false;
 	if (file_list.IsDeleteScan()) {
-		// Locate the output positions of the rowid and snapshot_id virtual columns. global_column_ids is the
-		// order in which the columns appear in the FinalizeChunk output_chunk, so these positions are what
-		// GatherDeletionScanSnapshots must use. We must NOT rely on the per-file local virtual-column index
-		// (the old behavior): the snapshot_id virtual column is emitted as a constant expression and therefore
-		// does not advance the local column counter, so when the projection puts snapshot_id before rowid the
-		// local index no longer lines up with the output_chunk layout and the per-row snapshot overwrite
-		// silently targets the wrong column (issue #1199).
+		// Locate the rowid and snapshot_id virtual columns by their position in global_column_ids, which is the
+		// order in which the columns appear in the FinalizeChunk output_chunk. The per-file local virtual-column
+		// index cannot be used: the snapshot_id virtual column is emitted as a constant expression and does not
+		// advance the local column counter, so it does not line up with the output_chunk layout.
 		deletion_scan_rowid_col = optional_idx();
 		deletion_scan_snapshot_col = optional_idx();
 		bool has_rowid = false;

--- a/test/configs/deletion_vectors.json
+++ b/test/configs/deletion_vectors.json
@@ -20,6 +20,8 @@
         "test/sql/delete/multi_deletes.test",
         "test/sql/table_changes/ducklake_table_deletions_compacted.test",
         "test/sql/table_changes/ducklake_table_deletions_large.test",
+        "test/sql/table_changes/ducklake_table_deletions_partial_files.test",
+        "test/sql/table_changes/ducklake_table_deletions_projection_order.test",
         "test/sql/rewrite_data_files/last_snapshot_multiple_inserts.test",
         "test/sql/rewrite_data_files/test_last_snapshot_merge_rewrite.test",
         "test/sql/rewrite_data_files/test_last_snapshot_rewrite.test",

--- a/test/sql/table_changes/ducklake_table_deletions_partial_files.test
+++ b/test/sql/table_changes/ducklake_table_deletions_partial_files.test
@@ -12,7 +12,7 @@ test-env DATA_PATH __TEST_DIR__
 
 # DATA_INLINING_ROW_LIMIT 0 forces deletes onto the real delete-file path (ducklake_delete_file),
 # which is what the "partial files" in this test's name actually refers to. Without it the deletes
-# are inlined and the real delete-file code path is never exercised (issue #1199).
+# are inlined and the real delete-file code path is never exercised.
 statement ok
 ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partial_deletions_files', DATA_INLINING_ROW_LIMIT 0)
 
@@ -125,10 +125,9 @@ SELECT rowid, i FROM ducklake_table_deletions('ducklake', 'main', 'test', 0, 10)
 11	21
 13	23
 
-# Same queries with snapshot_id projected BEFORE rowid (as the table_changes macro does).
-# This is the projection order that mis-attributed accumulated deletes before issue #1199 was
-# fixed: rows 3/8/13 (the second delete in each file, snapshots 8/9/10) would wrongly report
-# their delete file's begin_snapshot (5/6/7).
+# Same queries with snapshot_id projected BEFORE rowid (the order the table_changes macro uses).
+# Rows 3/8/13 (the second delete in each file, snapshots 8/9/10) must report their own delete
+# snapshot, not their delete file's begin_snapshot (5/6/7).
 query III
 SELECT snapshot_id, rowid, i FROM ducklake_table_deletions('ducklake', 'main', 'test', 5, 10) ORDER BY rowid
 ----

--- a/test/sql/table_changes/ducklake_table_deletions_partial_files.test
+++ b/test/sql/table_changes/ducklake_table_deletions_partial_files.test
@@ -10,8 +10,11 @@ test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
 
 test-env DATA_PATH __TEST_DIR__
 
+# DATA_INLINING_ROW_LIMIT 0 forces deletes onto the real delete-file path (ducklake_delete_file),
+# which is what the "partial files" in this test's name actually refers to. Without it the deletes
+# are inlined and the real delete-file code path is never exercised (issue #1199).
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partial_deletions_files')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partial_deletions_files', DATA_INLINING_ROW_LIMIT 0)
 
 # snapshot 1 - Create table and insert data into multiple files
 statement ok
@@ -121,6 +124,25 @@ SELECT rowid, i FROM ducklake_table_deletions('ducklake', 'main', 'test', 0, 10)
 8	13
 11	21
 13	23
+
+# Same queries with snapshot_id projected BEFORE rowid (as the table_changes macro does).
+# This is the projection order that mis-attributed accumulated deletes before issue #1199 was
+# fixed: rows 3/8/13 (the second delete in each file, snapshots 8/9/10) would wrongly report
+# their delete file's begin_snapshot (5/6/7).
+query III
+SELECT snapshot_id, rowid, i FROM ducklake_table_deletions('ducklake', 'main', 'test', 5, 10) ORDER BY rowid
+----
+5	1	1
+8	3	3
+6	6	11
+9	8	13
+7	11	21
+10	13	23
+
+query III
+SELECT snapshot_id, rowid, i FROM ducklake_table_deletions('ducklake', 'main', 'test', 8, 8) ORDER BY rowid
+----
+8	3	3
 
 statement ok
 DELETE FROM ducklake.test WHERE i < 10

--- a/test/sql/table_changes/ducklake_table_deletions_projection_order.test
+++ b/test/sql/table_changes/ducklake_table_deletions_projection_order.test
@@ -1,5 +1,5 @@
 # name: test/sql/table_changes/ducklake_table_deletions_projection_order.test
-# description: ducklake_table_deletions must report the correct per-row delete snapshot_id on the real delete-file path (DATA_INLINING_ROW_LIMIT 0) regardless of virtual-column projection order (issue #1199)
+# description: ducklake_table_deletions must report the correct per-row delete snapshot_id on the real delete-file path (DATA_INLINING_ROW_LIMIT 0) regardless of virtual-column projection order
 # group: [table_changes]
 
 require ducklake
@@ -33,29 +33,29 @@ DELETE FROM d WHERE k=1
 statement ok
 DELETE FROM d WHERE k=2
 
-# CORRECT (rowid before snapshot_id) - already worked before the fix, must stay correct
+# rowid projected before snapshot_id: each deleted row reports its own delete snapshot
 query III
 SELECT rowid, snapshot_id, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY rowid
 ----
 0	3	1
 1	4	2
 
-# THE BUG: snapshot_id before rowid (as the table_changes macro projects).
-# Before the fix row 1 wrongly reports snapshot 3 (the delete file's begin_snapshot).
+# snapshot_id projected before rowid (the order the table_changes macro uses): each row must still
+# report its own delete snapshot, not the delete file's begin_snapshot (3)
 query III
 SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY rowid
 ----
 3	0	1
 4	1	2
 
-# CORRECT (no rowid projected) - internally-projected-rowid branch, must stay correct
+# no rowid projected: exercises the internally-projected-rowid branch
 query II
 SELECT snapshot_id, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY snapshot_id
 ----
 3	1
 4	2
 
-# Per-snapshot filtering must keep working (guards against the fix breaking filtering)
+# Per-snapshot filtering must keep working
 query III
 SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',4,4) ORDER BY rowid
 ----
@@ -67,8 +67,8 @@ SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',2,3) 
 3	0	1
 
 # ---------------------------------------------------------------------------
-# table_changes: an in-place UPDATE must be a matched preimage/postimage pair
-# at the row's own snapshot, NOT split into delete@wrong-snapshot + insert.
+# table_changes: an in-place UPDATE must surface as a matched preimage/postimage
+# pair at the row's own snapshot.
 # ---------------------------------------------------------------------------
 
 # snapshot 5 - create second table
@@ -88,9 +88,8 @@ statement ok
 UPDATE c SET v=222 WHERE k=2
 
 # The range includes the snapshot-6 INSERT, so the three original inserts appear.
-# The key assertion is that BOTH updates are matched preimage/postimage pairs at
-# their own update snapshot. Before the fix, k=2 (rowid 1) was split into
-# delete@7 + insert@8 instead of an update_preimage/update_postimage@8 pair.
+# Both updates must surface as matched preimage/postimage pairs at their own
+# update snapshot (k=1 at snapshot 7, k=2 at snapshot 8).
 query IIIII
 SELECT snapshot_id, rowid, change_type, k, v
 FROM ducklake_table_changes('dl','main','c',6,8) ORDER BY rowid, change_type
@@ -104,7 +103,6 @@ FROM ducklake_table_changes('dl','main','c',6,8) ORDER BY rowid, change_type
 6	2	insert	3	300
 
 # An in-place UPDATE must never surface as a bare delete in this range.
-# A non-zero count here is the exact symptom of issue #1199 (delete@wrong-snapshot).
 query I
 SELECT count(*) FROM ducklake_table_changes('dl','main','c',6,8) WHERE change_type = 'delete'
 ----

--- a/test/sql/table_changes/ducklake_table_deletions_projection_order.test
+++ b/test/sql/table_changes/ducklake_table_deletions_projection_order.test
@@ -1,0 +1,111 @@
+# name: test/sql/table_changes/ducklake_table_deletions_projection_order.test
+# description: ducklake_table_deletions must report the correct per-row delete snapshot_id on the real delete-file path (DATA_INLINING_ROW_LIMIT 0) regardless of virtual-column projection order (issue #1199)
+# group: [table_changes]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+# DATA_INLINING_ROW_LIMIT 0 forces deletes onto the real delete-file path
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '${DATA_PATH}/ducklake_projection_order', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE dl
+
+# snapshot 1 - create table
+statement ok
+CREATE TABLE d (k INTEGER, v INTEGER)
+
+# snapshot 2 - insert three rows into one data file (positions 0,1,2)
+statement ok
+INSERT INTO d VALUES (1,100),(2,200),(3,300)
+
+# snapshot 3 - delete pos 0 (k=1)
+statement ok
+DELETE FROM d WHERE k=1
+
+# snapshot 4 - delete pos 1 (k=2); accumulates into the SAME delete file (begin_snapshot stays 3)
+statement ok
+DELETE FROM d WHERE k=2
+
+# CORRECT (rowid before snapshot_id) - already worked before the fix, must stay correct
+query III
+SELECT rowid, snapshot_id, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY rowid
+----
+0	3	1
+1	4	2
+
+# THE BUG: snapshot_id before rowid (as the table_changes macro projects).
+# Before the fix row 1 wrongly reports snapshot 3 (the delete file's begin_snapshot).
+query III
+SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY rowid
+----
+3	0	1
+4	1	2
+
+# CORRECT (no rowid projected) - internally-projected-rowid branch, must stay correct
+query II
+SELECT snapshot_id, k FROM ducklake_table_deletions('dl','main','d',2,4) ORDER BY snapshot_id
+----
+3	1
+4	2
+
+# Per-snapshot filtering must keep working (guards against the fix breaking filtering)
+query III
+SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',4,4) ORDER BY rowid
+----
+4	1	2
+
+query III
+SELECT snapshot_id, rowid, k FROM ducklake_table_deletions('dl','main','d',2,3) ORDER BY rowid
+----
+3	0	1
+
+# ---------------------------------------------------------------------------
+# table_changes: an in-place UPDATE must be a matched preimage/postimage pair
+# at the row's own snapshot, NOT split into delete@wrong-snapshot + insert.
+# ---------------------------------------------------------------------------
+
+# snapshot 5 - create second table
+statement ok
+CREATE TABLE c (k INTEGER, v INTEGER)
+
+# snapshot 6 - insert three rows
+statement ok
+INSERT INTO c VALUES (1,100),(2,200),(3,300)
+
+# snapshot 7 - update k=1
+statement ok
+UPDATE c SET v=111 WHERE k=1
+
+# snapshot 8 - update k=2 (same data file, later snapshot)
+statement ok
+UPDATE c SET v=222 WHERE k=2
+
+# The range includes the snapshot-6 INSERT, so the three original inserts appear.
+# The key assertion is that BOTH updates are matched preimage/postimage pairs at
+# their own update snapshot. Before the fix, k=2 (rowid 1) was split into
+# delete@7 + insert@8 instead of an update_preimage/update_postimage@8 pair.
+query IIIII
+SELECT snapshot_id, rowid, change_type, k, v
+FROM ducklake_table_changes('dl','main','c',6,8) ORDER BY rowid, change_type
+----
+6	0	insert	1	100
+7	0	update_postimage	1	111
+7	0	update_preimage	1	100
+6	1	insert	2	200
+8	1	update_postimage	2	222
+8	1	update_preimage	2	200
+6	2	insert	3	300
+
+# An in-place UPDATE must never surface as a bare delete in this range.
+# A non-zero count here is the exact symptom of issue #1199 (delete@wrong-snapshot).
+query I
+SELECT count(*) FROM ducklake_table_changes('dl','main','c',6,8) WHERE change_type = 'delete'
+----
+0


### PR DESCRIPTION
## Summary

Fixes #1199.

`ducklake_table_deletions` — and therefore the `ducklake_table_changes` macro built on it — reported the **wrong per-row delete `snapshot_id`** on the real delete-file path (`DATA_INLINING_ROW_LIMIT 0`) whenever the `snapshot_id` virtual column was projected **before** `rowid`. The `table_changes` macro always projects `snapshot_id` first, so an in-place `UPDATE` whose rows were deleted across multiple snapshots into one accumulated delete file was mis-reported as `delete`@wrong-snapshot + `insert` instead of a matched `update_preimage`/`update_postimage` pair.

The per-row snapshot is stored correctly on disk (`_ducklake_internal_snapshot_id`) and used correctly for filtering — only the value written into the output `snapshot_id` column was wrong, falling back to the delete file's `begin_snapshot`.

## Root cause

`deletion_scan_rowid_col` / `deletion_scan_snapshot_col` were set in `GetVirtualColumnExpression` from the per-file **local** virtual-column index (`local_idx`). But `GatherDeletionScanSnapshots` uses them to index `output_chunk`, which is laid out in **output projection order**. The `snapshot_id` virtual column is emitted as a constant expression and never advances the local column counter (`local_idx = MultiFileLocalIndex(reader.column_ids.size())` in the column mapper), so the two index spaces diverge as soon as `snapshot_id` precedes `rowid`:

| Projection (delete scan)          | Before this PR        |
|-----------------------------------|-----------------------|
| `rowid, snapshot_id` (rowid 1st)  | ✅ correct (indices happen to align) |
| `snapshot_id, rowid` (snap 1st)   | ❌ falls back to `begin_snapshot` |
| `snapshot_id` only (no rowid)     | ✅ correct (internally-projected-rowid path) |

## Fix

Resolve the rowid/snapshot **output** positions from `global_column_ids` (which matches the `output_chunk` layout) in `CreateMapping`, mirroring the existing column-search in `InitializeReader`, and drop the stale `local_idx` assignments in `GetVirtualColumnExpression`. This makes both `FinalizeChunk` branches index `output_chunk` correctly regardless of projection order. No on-disk format, metadata, or filtering behavior changes.

## Tests

- New `test/sql/table_changes/ducklake_table_deletions_projection_order.test`: exercises rowid-first, snapshot-first, and no-rowid projections plus per-snapshot filtering on the real delete-file path, and a `table_changes` UPDATE scenario asserting matched preimage/postimage pairs with no spurious delete/insert split. Confirmed red before the fix, green after.
- Strengthened `test/sql/table_changes/ducklake_table_deletions_partial_files.test`: it was named for partial delete files but ran the inlined path with a rowid-first projection, so it never reached this code. Added `DATA_INLINING_ROW_LIMIT 0` and snapshot-first assertions over the multi-file accumulation. All prior assertions still pass (logical rowids are unchanged), confirming the real delete-file path produces identical rowid-first results.

The full `table_changes` group and the `update`/`insert`/`rowid`/`merge`/`delete`/`compaction` groups pass.

## Out of scope (separate, pre-existing)

While reviewing this I found an **unrelated, pre-existing** crash on the delete-file path: a query that **filters on a column not present in its SELECT projection** (e.g. `... ducklake_table_deletions(...) WHERE v > 0` where `v` is not projected) triggers DuckDB's filter-column-removal, which narrows `output_chunk` via `projection_ids`, and `GatherDeletionScanSnapshots` then indexes the wrong/out-of-range column → `INTERNAL Error`. This reproduces identically on unpatched code with both projection orders, is orthogonal to the projection-order bug fixed here, and a correct fix needs to map positions through `projection_ids` (not reachable in `FinalizeChunk` today). Left for a separate change to keep this PR focused on #1199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)