### PR TITLE
fix: prevent deleted rows reappearing when parquet and inlined tombstones overlap

### DIFF
--- a/src/storage/ducklake_delete_filter.cpp
+++ b/src/storage/ducklake_delete_filter.cpp
@@ -265,6 +265,10 @@ void DuckLakeDeleteFilter::Initialize(const DuckLakeInlinedDataDeletes &inlined_
 	delete_data->snapshot_ids.clear();
 	std::inplace_merge(delete_data->deleted_rows.begin(), delete_data->deleted_rows.begin() + mid_idx,
 	                   delete_data->deleted_rows.end());
+	// a position can appear in both the delete file and the inlined deletes - drop duplicates so
+	// deleted_rows stays strictly increasing, otherwise Filter() gets stuck on the repeated value
+	delete_data->deleted_rows.erase(std::unique(delete_data->deleted_rows.begin(), delete_data->deleted_rows.end()),
+	                                delete_data->deleted_rows.end());
 }
 
 unordered_map<idx_t, idx_t> DuckLakeDeleteFilter::ScanDataFileRowIds(ClientContext &context,

--- a/test/sql/issues/issue_1084_parquet_inlined_delete_overlap.test
+++ b/test/sql/issues/issue_1084_parquet_inlined_delete_overlap.test
@@ -1,0 +1,85 @@
+# name: test/sql/issues/issue_1084_parquet_inlined_delete_overlap.test
+# description: deleted rows must not reappear when parquet delete files and inlined tombstones overlap (issue #1084)
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+# use a fixed connection path (not {UUID}) so the re-attach below resolves to the same catalog
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/issue_1084_parquet_inlined_delete_overlap.db
+
+test-env DATA_PATH {TEST_DIR}
+
+# disable data inlining so the data lands in a parquet data file and the deletes
+# produce a parquet delete file (rather than inlined deletes)
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_1084_parquet_inlined_delete_overlap', DATA_INLINING_ROW_LIMIT 0, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t AS SELECT range AS a FROM range(100);
+
+# delete positions 10..39 -> written to a parquet delete file
+statement ok
+DELETE FROM t WHERE a >= 10 AND a < 40;
+
+# sanity: one data file (id 0) and one parquet delete file covering 30 positions
+query II
+SELECT data_file_id, record_count FROM ducklake_meta.ducklake_data_file
+----
+0	100
+
+query I
+SELECT delete_count FROM ducklake_meta.ducklake_delete_file
+----
+30
+
+# inject inlined tombstones that OVERLAP positions already in the parquet delete file.
+# this overlap cannot be produced through normal SQL (a deleted row cannot be re-deleted),
+# so we write it directly into the catalog to mirror the corrupted state from issue #1084.
+statement ok
+CREATE TABLE IF NOT EXISTS ducklake_meta.ducklake_inlined_delete_1(file_id BIGINT, row_id BIGINT, begin_snapshot BIGINT);
+
+statement ok
+INSERT INTO ducklake_meta.ducklake_inlined_delete_1 VALUES (0, 10, 2), (0, 15, 2);
+
+# re-attach so the catalog re-reads the now-existing inlined-deletion table
+statement ok
+USE memory
+
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_1084_parquet_inlined_delete_overlap', METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+USE ducklake
+
+# the core correctness property: every position in 10..39 is deleted (by parquet and/or inlined
+# tombstones), so NONE of those values may be visible to a scan. Before the fix the duplicate
+# position gets the read filter stuck and rows 11..39 leak back into the result.
+# NB: this filter forces an actual scan; a bare count(*) is answered from catalog stats and is
+# a separate (unfixed) discrepancy - see the PR notes on COUNT(*)/stats reconciliation.
+query I
+SELECT count(*) FROM t WHERE a >= 10 AND a < 40;
+----
+0
+
+# the surviving rows around the deletion boundary are exactly 0..9 and 40..99
+query I
+SELECT a FROM t WHERE a >= 5 AND a < 45 ORDER BY a;
+----
+5
+6
+7
+8
+9
+40
+41
+42
+43
+44


### PR DESCRIPTION
Closes #1084

## What happens

When a single data file has the same row position recorded in **both** a parquet delete file and the inlined-delete catalog table (`ducklake_inlined_delete_<table_id>`), deleted rows reappear in scans.

`DuckLakeDeleteFilter::Initialize(const DuckLakeInlinedDataDeletes &)` merges the two sorted position ranges with `std::inplace_merge` but does **not** deduplicate, so `deleted_rows` can end up with a repeated value (e.g. `[10, 10, 11, ...]`). `DuckLakeDeleteData::Filter` advances its cursor only on an exact match, so once the scan passes the duplicated value the cursor gets stuck on it: every later tombstoned position in the chunk is compared against the stale value, never matches, and leaks through to the caller.

## The fix

Deduplicate `deleted_rows` after the merge so it stays strictly increasing — the same invariant the parquet delete path already enforces (it asserts strictly-increasing positions on read). This restores the precondition `Filter` relies on.

```cpp
delete_data->deleted_rows.erase(
    std::unique(delete_data->deleted_rows.begin(), delete_data->deleted_rows.end()),
    delete_data->deleted_rows.end());
```

## Test

Adds `test/sql/issues/issue_1084_parquet_inlined_delete_overlap.test`. The overlap cannot be produced through normal SQL (a deleted row cannot be re-deleted), so the test reproduces the corrupted state by injecting an overlapping row directly into the inlined-delete catalog table via `METADATA_CATALOG`, then re-attaches (the catalog caches inlined-table existence) and asserts that the deleted positions are not visible to a scan. Verified the test fails without the fix and passes with it.

## Scope / follow-up

This fixes the **scan** correctness bug (deleted rows leaking into results). It does **not** address the related symptom that stats-based `SELECT COUNT(*)` double-subtracts the overlapping positions: that path sums `delete_count + inlined_delete_count` from the catalog and cannot dedupe, because the parquet delete positions live in the parquet file, not the catalog. Reconciling `COUNT(*)` needs separate write-path or stats-semantics work (and is entangled with how such overlaps get created in the first place — see #1085). Calling it out here rather than silently implying both paths now agree.
