### PR TITLE
Evict DuckLake schema cache on snapshot expiration

### DIFF
--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -111,6 +111,10 @@ void DuckLakeExpireSnapshotsExecute(ClientContext &context, TableFunctionInput &
 	if (!state.executed && !data.dry_run) {
 		auto &transaction = DuckLakeTransaction::Get(context, data.catalog);
 		transaction.DeleteSnapshots(data.snapshots);
+		auto &ducklake_catalog = data.catalog.Cast<DuckLakeCatalog>();
+		for (auto &snapshot : data.snapshots) {
+			ducklake_catalog.InvalidateSchemaCache(snapshot.schema_version);
+		}
 		state.executed = true;
 	}
 

--- a/test/sql/issues/issue_852_schema_cache_growth.test
+++ b/test/sql/issues/issue_852_schema_cache_growth.test
@@ -1,0 +1,82 @@
+# name: test/sql/issues/issue_852_schema_cache_growth.test
+# description: https://github.com/duckdb/ducklake/issues/852 - DuckLakeCatalog::GetSchemaCacheEntry inserts into the ObjectCache keyed by schema_version. On a long-lived connection, repeated DDL grows the cache, and ducklake_expire_snapshots should release entries for expired schema versions.
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_852_schema_cache_growth')
+
+statement ok
+CREATE TABLE ducklake.anchor (id INTEGER)
+
+# Force one schema cache entry to be materialized so baseline > 0
+statement ok
+SELECT * FROM ducklake.anchor LIMIT 0
+
+# Baseline: snapshot ObjectCache memory after the initial schema load.
+statement ok
+CREATE TEMP TABLE baseline AS SELECT memory_usage_bytes AS bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE'
+
+# Churn a few schema versions. Each CREATE / DROP creates a new schema_version,
+# and each lookup forces a fresh DuckLakeSchemaCacheEntry into the ObjectCache.
+loop i 0 3
+
+statement ok
+CREATE TABLE ducklake.stage_{i} AS SELECT * FROM ducklake.anchor LIMIT 0
+
+statement ok
+SELECT * FROM ducklake.anchor LIMIT 0
+
+statement ok
+DROP TABLE ducklake.stage_{i}
+
+statement ok
+SELECT * FROM ducklake.anchor LIMIT 0
+
+endloop
+
+# Schema churn grows ObjectCache memory.
+query I
+SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') > (SELECT bytes FROM baseline)
+----
+true
+
+# Snapshot the post-churn cache memory so we can compare dry-run and real expiration.
+statement ok
+CREATE TEMP TABLE post_churn AS SELECT memory_usage_bytes AS bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE'
+
+# Dry-run expiration must not evict cache entries.
+statement ok
+CALL ducklake_expire_snapshots('ducklake', dry_run => true, older_than => now())
+
+query I
+SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') >= (SELECT bytes FROM post_churn)
+----
+true
+
+# Maintenance: CHECKPOINT does not evict ObjectCache entries, but real snapshot
+# expiration should invalidate schema cache entries for the expired versions.
+statement ok
+CHECKPOINT
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+# expire_snapshots releases schema cache entries.
+query I
+SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') < (SELECT bytes FROM post_churn)
+----
+true
+
+# Sanity-check: snapshot table itself was pruned.
+query I
+SELECT count(*) = 1 FROM ducklake_snapshots('ducklake')
+----
+true


### PR DESCRIPTION
## Summary

This fixes part of the cache growth described in #852 by evicting DuckLake schema ObjectCache entries that become unreachable after `ducklake_expire_snapshots` removes snapshots.

- retarget to `v1.5-variegata`
- reuse the existing `DuckLakeCatalog::InvalidateSchemaCache` helper
- invalidate each expired snapshot `schema_version` after snapshot deletion succeeds
- add a small regression test that verifies dry-run expiration leaves cache memory intact and real expiration reduces ObjectCache memory

## Tests

- `cmake --build build/reldebug --target ducklake_loadable_extension unittest --parallel 8`
- `build/reldebug/test/unittest test/sql/issues/issue_852_schema_cache_growth.test --durations yes`
- `build/reldebug/test/unittest test/sql/compaction/expire_snapshots.test --durations yes`
- `build/reldebug/test/unittest test/sql/compaction/expire_snapshots_metadata_cleanup.test --durations yes`
- `build/reldebug/test/unittest test/sql/compaction/expire_snapshots_invalid_params.test --durations yes`
- `git diff --check`