### PR TITLE
Fix NULL interpret

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2330,7 +2330,15 @@ static void ColumnToSQLRecursive(const DuckLakeColumnInfo &column, TableIndex ta
 	if (!column.default_value.IsNull()) {
 		auto value = column.default_value.GetValue<string>();
 		if (column.default_value_type == "literal") {
-			default_val = KeywordHelper::WriteQuoted(value, '\'');
+			// Special handle "NULL" literal default value for VARCHAR columns.
+			// Normally we store constant default as literal type, but it's not enough to tell apart from (1) VARCHAR
+			// column with default value NULL; and (2) VARCHAR coluimn with default "NULL".
+			if (column.default_value.type().id() == LogicalTypeId::VARCHAR && value == "NULL") {
+				default_val = KeywordHelper::WriteQuoted(column.default_value.ToSQLString(), '\'');
+				default_val_type = "'expression'";
+			} else {
+				default_val = KeywordHelper::WriteQuoted(value, '\'');
+			}
 		} else if (column.default_value_type == "expression") {
 			if (value.empty()) {
 				default_val = "''";

--- a/test/sql/default/default_values.test
+++ b/test/sql/default/default_values.test
@@ -36,7 +36,7 @@ SELECT * FROM ducklake.test
 42	200
 
 statement ok
-CREATE TABLE ducklake.test_special_values(i INTEGER, s1 VARCHAR DEFAULT '', s2 VARCHAR DEFAULT 'NULL');
+CREATE TABLE ducklake.test_special_values(i INTEGER, s1 VARCHAR DEFAULT '', s2 VARCHAR DEFAULT NULL);
 
 statement ok
 INSERT INTO ducklake.test_special_values (i) VALUES (100)

--- a/test/sql/issues/issue_1212.test
+++ b/test/sql/issues/issue_1212.test
@@ -1,0 +1,42 @@
+# name: test/sql/issues/issue_1212.test
+# description: Regression test for issue #1212, VARCHAR DEFAULT 'NULL' should not become SQL NULL
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/issue_1212')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t (id INTEGER, t0 VARCHAR, t1 VARCHAR DEFAULT 'NULL');
+
+statement ok
+INSERT INTO t (id) VALUES (1);
+
+query III
+FROM t;
+----
+1	NULL	NULL
+
+query III
+FROM t WHERE t0 IS NULL;
+----
+1	NULL	NULL
+
+query III
+FROM t WHERE t1 IS NULL;
+----
+
+query I
+SELECT count(*) FROM t WHERE t1 = 'NULL';
+----
+1


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1212

The issue description has already pointed out the root cause, but I found read side doesn't have enough information to tell apart between `'NULL'` and `NULL`, the easiest fix might be making column type an expression instead of literal.