### PR TITLE
Add relassert and re-run tests to stabilize CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -45,3 +45,46 @@ jobs:
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/heads/v') }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/heads/v') }}
+
+  relassert:
+    name: Build relassert
+    runs-on: ${{ github.repository_owner == 'duckdb' && 'namespace-profile-linux-x64' || 'ubuntu-latest' }}
+    env:
+      GEN: ninja
+      CC: clang-20
+      CXX: clang++-20
+      # Enable -DDEBUG slow verifiers (expression verifier, operator
+      # round-trips, etc.) without changing the optimization level.
+      FORCE_DEBUG: 1
+      FORCE_ASSERT: 1
+      ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=0"
+      UBSAN_OPTIONS: "halt_on_error=1:print_stacktrace=1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+      - name: Install tools
+        run: python3 duckdb/scripts/ci/retry.py -- make -C duckdb toolsci
+      - name: Fix ASan runtime
+        # libclang_rt.asan_static.a is missing in ubuntu 24.04 — workaround
+        # mirrored from upstream Main.yml.
+        run: |
+          asan_static_dir="/usr/lib/llvm-20/lib/clang/20/lib/x86_64-pc-linux-gnu"
+          asan_static_target="/usr/lib/llvm-20/lib/clang/20/lib/linux/libclang_rt.asan_static-x86_64.a"
+          if [[ ! -e "${asan_static_dir}/libclang_rt.asan_static.a" && -e "${asan_static_target}" ]]; then
+            sudo mkdir -p "${asan_static_dir}"
+            sudo ln -sf "${asan_static_target}" "${asan_static_dir}/libclang_rt.asan_static.a"
+          fi
+      - name: Setup Ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          max-size: 5GB
+          evict-old-files: job
+      - name: Build (relassert → ASan + UBSan + LSan)
+        uses: duckdb/duckdb-ci/build-duckdb@main
+        with:
+          build-type: relassert
+          build: python3 duckdb/scripts/ci/retry.py -- make relassert
+          test: make unittest_relassert
+          vcpkg-commit: 84bab45d415d22042bd0b9081aea57f362da3f35

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ DEFAULT_TEST_EXTENSION_DEPS=
 # For cloud testing we also need these extensions
 FULL_TEST_EXTENSION_DEPS=httpfs
 
+# Stabilize all tests in CI
+ifdef CI
+TEST_FLAGS:=--stabilize-tests
+endif
+T ?= $(TEST_FLAGS) "test/*"
+
 # Aws and Azure have vcpkg dependencies and therefore need vcpkg merging
 ifeq (${BUILD_EXTENSION_TEST_DEPS}, full)
 	USE_MERGED_VCPKG_MANIFEST:=1
@@ -16,3 +22,6 @@ endif
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+unittest_relassert:
+	python3 duckdb/scripts/ci/run_tests.py build/relassert/test/unittest $(T)

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -681,7 +681,7 @@ PhysicalOperator &DuckLakeCatalog::PlanDelete(ClientContext &context, PhysicalPl
 	vector<idx_t> row_id_indexes;
 	for (idx_t i = 0; i < 3; i++) {
 		auto &bound_ref = op.expressions[i + 1]->Cast<BoundReferenceExpression>();
-		row_id_indexes.push_back(bound_ref.index);
+		row_id_indexes.push_back(bound_ref.Index());
 	}
 	return DuckLakeDelete::PlanDelete(context, planner, op.table.Cast<DuckLakeTableEntry>(), child_plan,
 	                                  std::move(row_id_indexes), std::move(encryption_key));

--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -739,7 +739,7 @@ static void ResolveColumnRefs(unique_ptr<Expression> &expr) {
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {
 		auto &col_ref = expr->Cast<BoundColumnRefExpression>();
 		expr = make_uniq<BoundReferenceExpression>(col_ref.GetReturnType(),
-		                                           NumericCast<storage_t>(col_ref.binding.column_index.GetIndex()));
+		                                           NumericCast<storage_t>(col_ref.Binding().column_index.GetIndex()));
 		return;
 	}
 	ExpressionIterator::EnumerateChildren(*expr, [](unique_ptr<Expression> &child) { ResolveColumnRefs(child); });

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1151,15 +1151,15 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		} else {
 			return string();
 		}
-		const auto &target_type = type ? *type : constant_expr->value.type();
+		const auto &target_type = type ? *type : constant_expr->GetValue().type();
 		switch (target_type.id()) {
 		case LogicalTypeId::BLOB:
 			return string();
 		case LogicalTypeId::FLOAT:
 		case LogicalTypeId::DOUBLE:
-			return GenerateConstantFilterDouble(comparison_type, constant_expr->value, target_type, referenced_stats);
+			return GenerateConstantFilterDouble(comparison_type, constant_expr->GetValue(), target_type, referenced_stats);
 		default:
-			return GenerateConstantFilter(comparison_type, constant_expr->value, target_type, referenced_stats);
+			return GenerateConstantFilter(comparison_type, constant_expr->GetValue(), target_type, referenced_stats);
 		}
 	}
 	switch (expr.GetExpressionClass()) {
@@ -1167,28 +1167,28 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		auto &op_expr = expr.Cast<BoundOperatorExpression>();
 		switch (expr.GetExpressionType()) {
 		case ExpressionType::OPERATOR_IS_NULL:
-			if (op_expr.children.size() != 1 || !IsSimpleFilterSubject(*op_expr.children[0])) {
+			if (op_expr.GetChildren().size() != 1 || !IsSimpleFilterSubject(*op_expr.GetChildren()[0])) {
 				return string();
 			}
 			referenced_stats.insert("null_count");
 			return "null_count > 0";
 		case ExpressionType::OPERATOR_IS_NOT_NULL:
-			if (op_expr.children.size() != 1 || !IsSimpleFilterSubject(*op_expr.children[0])) {
+			if (op_expr.GetChildren().size() != 1 || !IsSimpleFilterSubject(*op_expr.GetChildren()[0])) {
 				return string();
 			}
 			referenced_stats.insert("value_count");
 			return "value_count > 0";
 		case ExpressionType::COMPARE_IN: {
-			if (op_expr.children.size() < 2 || !IsSimpleFilterSubject(*op_expr.children[0])) {
+			if (op_expr.GetChildren().size() < 2 || !IsSimpleFilterSubject(*op_expr.GetChildren()[0])) {
 				return string();
 			}
 			string result;
-			for (idx_t i = 1; i < op_expr.children.size(); i++) {
-				auto &child = *op_expr.children[i];
+			for (idx_t i = 1; i < op_expr.GetChildren().size(); i++) {
+				auto &child = *op_expr.GetChildren()[i];
 				if (child.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
 					return string();
 				}
-				auto &constant_value = child.Cast<BoundConstantExpression>().value;
+				auto &constant_value = child.Cast<BoundConstantExpression>().GetValue();
 				if (constant_value.IsNull()) {
 					return string();
 				}
@@ -1225,7 +1225,7 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		auto &conjunction = expr.Cast<BoundConjunctionExpression>();
 		string result;
 		const auto conjunction_type = expr.GetExpressionType();
-		for (auto &child : conjunction.children) {
+		for (auto &child : conjunction.GetChildren()) {
 			auto child_str = GenerateFilterFromExpression(*child, type, referenced_stats);
 			if (child_str.empty()) {
 				if (conjunction_type == ExpressionType::CONJUNCTION_OR) {
@@ -1242,14 +1242,14 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 	}
 	case ExpressionClass::BOUND_FUNCTION: {
 		auto &func = expr.Cast<BoundFunctionExpression>();
-		if (func.function.GetName() == OptionalFilterScalarFun::NAME && func.bind_info) {
-			auto &data = func.bind_info->Cast<OptionalFilterFunctionData>();
+		if (func.Function().GetName() == OptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<OptionalFilterFunctionData>();
 			return data.child_filter_expr
 			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
 			           : string();
 		}
-		if (func.function.GetName() == SelectivityOptionalFilterScalarFun::NAME && func.bind_info) {
-			auto &data = func.bind_info->Cast<SelectivityOptionalFilterFunctionData>();
+		if (func.Function().GetName() == SelectivityOptionalFilterScalarFun::NAME && func.BindInfo()) {
+			auto &data = func.BindInfo()->Cast<SelectivityOptionalFilterFunctionData>();
 			return data.child_filter_expr
 			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
 			           : string();
@@ -2103,7 +2103,7 @@ string GetExpressionType(ParsedExpression &expression) {
 	switch (expression.GetExpressionType()) {
 	case ExpressionType::OPERATOR_CAST: {
 		auto &cast_expression = expression.Cast<CastExpression>();
-		if (cast_expression.child->GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
+		if (cast_expression.Child().GetExpressionType() == ExpressionType::VALUE_CONSTANT) {
 			return "literal";
 		}
 		return "expression";

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -31,10 +31,9 @@ static InsertionOrderPreservingMap<string> DuckLakeFunctionToString(TableFunctio
 	return result;
 }
 
-static InsertionOrderPreservingMap<string> DuckLakeDynamicToString(TableFunctionDynamicToStringInput &input) {
-	InsertionOrderPreservingMap<string> result;
+static void DuckLakeGetMetrics(TableFunctionGetMetricsInput &input) {
 	if (!input.global_state) {
-		return result;
+		return;
 	}
 	auto &gstate = input.global_state->Cast<MultiFileGlobalState>();
 	auto &file_list = gstate.file_list.Cast<DuckLakeMultiFileList>();
@@ -64,12 +63,12 @@ static InsertionOrderPreservingMap<string> DuckLakeDynamicToString(TableFunction
 		}
 	}
 
-	result.insert(make_pair("Total Files Read", std::to_string(data_files_read)));
+	input.operator_metrics.AddExtraInfo("Total Files Read", std::to_string(data_files_read));
 	if (data_files_skipped > 0) {
-		result.insert(make_pair("Total Files Skipped", std::to_string(data_files_skipped)));
+		input.operator_metrics.AddExtraInfo("Total Files Skipped", std::to_string(data_files_skipped));
 	}
 	if (inlined_tables_read > 0) {
-		result.insert(make_pair("Inlined Tables Read", std::to_string(inlined_tables_read)));
+		input.operator_metrics.AddExtraInfo("Inlined Tables Read", std::to_string(inlined_tables_read));
 	}
 
 	// Build filename list showing only actual data files (not inlined data tables)
@@ -85,10 +84,8 @@ static InsertionOrderPreservingMap<string> DuckLakeDynamicToString(TableFunction
 			file_path_names.resize(FILE_NAME_LIST_LIMIT);
 			file_path_names.push_back("...");
 		}
-		auto list_of_files = StringUtil::Join(file_path_names, ", ");
-		result.insert(make_pair("Filename(s)", list_of_files));
+		input.operator_metrics.AddExtraInfo("Filename(s)", StringUtil::Join(file_path_names, ", "));
 	}
-	return result;
 }
 
 unique_ptr<BaseStatistics> DuckLakeStatistics(ClientContext &context, const FunctionData *bind_data,
@@ -213,7 +210,7 @@ TableFunction DuckLakeFunctions::GetDuckLakeScanFunction(DatabaseInstance &insta
 	function.deserialize = DuckLakeScanDeserialize;
 
 	function.to_string = DuckLakeFunctionToString;
-	function.dynamic_to_string = DuckLakeDynamicToString;
+	function.get_metrics = DuckLakeGetMetrics;
 
 	function.name = "ducklake_scan";
 	return function;
@@ -248,12 +245,18 @@ shared_ptr<DuckLakeTransaction> DuckLakeFunctionInfo::GetTransaction() {
 void DuckLakeScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                            const TableFunction &function) {
 	auto &func_info = function.function_info->Cast<DuckLakeFunctionInfo>();
-	D_ASSERT(func_info.scan_type == DuckLakeScanType::SCAN_TABLE);
 	auto &catalog = func_info.table.ParentCatalog();
 	serializer.WriteProperty(100, "catalog_name", catalog.GetName());
 	serializer.WriteProperty(101, "schema_name", func_info.table.ParentSchema().name);
 	serializer.WriteProperty(102, "table_name", func_info.table_name);
 	serializer.WriteObject(103, "snapshot", [&](Serializer &obj) { func_info.snapshot.Serialize(obj); });
+	serializer.WriteProperty(104, "scan_type", static_cast<uint8_t>(func_info.scan_type));
+	bool has_start_snapshot = func_info.start_snapshot != nullptr;
+	serializer.WriteProperty(105, "has_start_snapshot", has_start_snapshot);
+	if (has_start_snapshot) {
+		serializer.WriteObject(106, "start_snapshot",
+		                       [&](Serializer &obj) { func_info.start_snapshot->Serialize(obj); });
+	}
 }
 
 unique_ptr<FunctionData> DuckLakeScanDeserialize(Deserializer &deserializer, TableFunction &function) {
@@ -263,6 +266,15 @@ unique_ptr<FunctionData> DuckLakeScanDeserialize(Deserializer &deserializer, Tab
 	auto table_name = deserializer.ReadProperty<string>(102, "table_name");
 	DuckLakeSnapshot snapshot;
 	deserializer.ReadObject(103, "snapshot", [&](Deserializer &obj) { snapshot = DuckLakeSnapshot::Deserialize(obj); });
+	auto scan_type = static_cast<DuckLakeScanType>(deserializer.ReadPropertyWithExplicitDefault<uint8_t>(
+	    104, "scan_type", static_cast<uint8_t>(DuckLakeScanType::SCAN_TABLE)));
+	bool has_start_snapshot = deserializer.ReadPropertyWithExplicitDefault<bool>(105, "has_start_snapshot", false);
+	unique_ptr<DuckLakeSnapshot> start_snapshot;
+	if (has_start_snapshot) {
+		start_snapshot = make_uniq<DuckLakeSnapshot>();
+		deserializer.ReadObject(106, "start_snapshot",
+		                        [&](Deserializer &obj) { *start_snapshot = DuckLakeSnapshot::Deserialize(obj); });
+	}
 
 	// If ducklake_scan was registered before parquet was loaded, we set it now
 	if (!function.bind) {
@@ -280,6 +292,9 @@ unique_ptr<FunctionData> DuckLakeScanDeserialize(Deserializer &deserializer, Tab
 	    Catalog::GetEntry<TableCatalogEntry>(context, catalog_name, schema_name, table_name).Cast<DuckLakeTableEntry>();
 
 	function.function_info = DuckLakeFunctionInfo::Create(table_entry, transaction, snapshot);
+	auto &func_info = function.function_info->Cast<DuckLakeFunctionInfo>();
+	func_info.scan_type = scan_type;
+	func_info.start_snapshot = std::move(start_snapshot);
 
 	return DuckLakeFunctions::BindDuckLakeScan(context, function);
 }

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -112,7 +112,7 @@ static void ReplaceColumnRefName(ParsedExpression &expr, const string &old_name,
 	if (expr.GetExpressionType() == ExpressionType::COLUMN_REF) {
 		auto &colref = expr.Cast<ColumnRefExpression>();
 		if (!colref.IsQualified() && StringUtil::CIEquals(colref.GetColumnName(), old_name)) {
-			colref.column_names.back() = new_name;
+			colref.ColumnNamesMutable().back() = new_name;
 		}
 		return;
 	}
@@ -417,7 +417,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	return make_uniq<DuckLakeTableEntry>(*this, table_info, LocalChangeType::RENAMED);
 }
 
-string GetPartitionColumnName(ColumnRefExpression &colref) {
+string GetPartitionColumnName(const ColumnRefExpression &colref) {
 	if (colref.IsQualified()) {
 		throw InvalidInputException("Unexpected qualified column reference - only unqualified columns are supported");
 	}
@@ -468,22 +468,22 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 	}
 	case ExpressionType::FUNCTION: {
 		auto &function = expr.Cast<FunctionExpression>();
-		auto name = StringUtil::Lower(function.function_name);
+		auto name = StringUtil::Lower(function.FunctionName());
 
 		// BUCKET logic is different from the other transforms because it has two arguments.
 		if (name == "bucket") {
 			field.transform.type = DuckLakeTransformType::BUCKET;
-			if (function.children.size() != 2) {
+			if (function.GetArguments().size() != 2) {
 				throw InvalidInputException("Expected bucket(bucket_count, column), but got %s", expr.ToString());
 			}
-			if (function.children[0]->GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
+			if (function.GetArguments()[0].GetExpression().GetExpressionType() != ExpressionType::VALUE_CONSTANT) {
 				throw InvalidInputException("Bucket count must be a constant integer, got %s", expr.ToString());
 			}
-			if (function.children[1]->GetExpressionType() != ExpressionType::COLUMN_REF) {
+			if (function.GetArguments()[1].GetExpression().GetExpressionType() != ExpressionType::COLUMN_REF) {
 				throw InvalidInputException("Expected bucket(bucket_count, column), but got %s", expr.ToString());
 			}
 
-			auto &bucket_expr = function.children[0]->Cast<ConstantExpression>();
+			auto &bucket_expr = function.GetArguments()[0].GetExpression().Cast<ConstantExpression>();
 			auto bucket_value = bucket_expr.GetValue();
 			if (!bucket_value.DefaultTryCastAs(LogicalType::BIGINT)) {
 				throw InvalidInputException("Bucket count must be an integer");
@@ -494,7 +494,7 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 			}
 
 			field.transform.bucket_count = bucket_count;
-			column_name = GetPartitionColumnName(function.children[1]->Cast<ColumnRefExpression>());
+			column_name = GetPartitionColumnName(function.GetArguments()[1].GetExpression().Cast<ColumnRefExpression>());
 			break;
 		}
 
@@ -512,11 +512,11 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 			    "Unsupported partition function %s - only year, month, day, hour, and bucket are supported", name);
 		}
 
-		if (function.children.size() != 1 || function.children[0]->GetExpressionType() != ExpressionType::COLUMN_REF) {
+		if (function.GetArguments().size() != 1 || function.GetArguments()[0].GetExpression().GetExpressionType() != ExpressionType::COLUMN_REF) {
 			throw NotImplementedException("Expected %s(column), but got %s", name, expr.ToString());
 		}
 
-		column_name = GetPartitionColumnName(function.children[0]->Cast<ColumnRefExpression>());
+		column_name = GetPartitionColumnName(function.GetArguments()[0].GetExpression().Cast<ColumnRefExpression>());
 		break;
 	}
 	default:
@@ -870,7 +870,7 @@ bool IsSimpleCast(const ParsedExpression &expr) {
 		return false;
 	}
 	auto &cast = expr.Cast<CastExpression>();
-	if (cast.child->GetExpressionType() != ExpressionType::COLUMN_REF) {
+	if (cast.Child().GetExpressionType() != ExpressionType::COLUMN_REF) {
 		return false;
 	}
 	return true;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -730,6 +730,7 @@ Connection &DuckLakeTransaction::GetConnection() {
 			connection->Query("SET pg_experimental_filter_pushdown=false");
 		}
 		connection->BeginTransaction();
+		connection->Query("SET current_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE'");
 	}
 	return *connection;
 }

--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
+++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
@@ -4,6 +4,8 @@
 
 require ducklake
 
+require notmusl
+
 require parquet
 
 test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db

--- a/test/sql/alter/many_schema_versions_low_memory.test_slow
+++ b/test/sql/alter/many_schema_versions_low_memory.test_slow
@@ -2,6 +2,8 @@
 # description: test that many DDL operations work under a low memory limit with schema cache eviction
 # group: [alter]
 
+mode skip slow
+
 require ducklake
 
 require notmusl

--- a/test/sql/alter/rename_table_dbt_workload.test
+++ b/test/sql/alter/rename_table_dbt_workload.test
@@ -11,6 +11,9 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 test-env DATA_PATH {TEST_DIR}
 
 statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS my_ducklake (DATA_PATH '{DATA_PATH}/ducklake_rename_files', METADATA_CATALOG 'ducklake_meta')
 
 statement ok

--- a/test/sql/alter/rename_table_within_transaction.test
+++ b/test/sql/alter/rename_table_within_transaction.test
@@ -11,6 +11,9 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 test-env DATA_PATH {TEST_DIR}
 
 statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_rename_files', METADATA_CATALOG 'ducklake_meta')
 
 statement ok

--- a/test/sql/catalog/drop_entry_same_schema.test
+++ b/test/sql/catalog/drop_entry_same_schema.test
@@ -10,6 +10,8 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_drop_same_schema')

--- a/test/sql/catalog/drop_schema_transaction_local_entries.test
+++ b/test/sql/catalog/drop_schema_transaction_local_entries.test
@@ -13,6 +13,9 @@ test-env DATA_PATH {TEST_DIR}
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_drop_schema_txn_local')
 
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
 # Test when there's transaction-local table in the schema, it cannot be dropped.
 statement ok
 BEGIN

--- a/test/sql/catalog/drop_table.test
+++ b/test/sql/catalog/drop_table.test
@@ -10,6 +10,8 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_drop_files')

--- a/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
+++ b/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
@@ -4,6 +4,8 @@
 
 require ducklake
 
+require notmusl
+
 require parquet
 
 test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db

--- a/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
+++ b/test/sql/deletion_inlining/test_multiple_files_flush.test_slow
@@ -2,6 +2,8 @@
 # description: test ducklake flushing deletion on inserted inline, but the flush produces multiple files
 # group: [deletion_inlining]
 
+mode skip slow
+
 require ducklake
 
 require notmusl

--- a/test/sql/insert/insert_wide_table_low_memory.test_slow
+++ b/test/sql/insert/insert_wide_table_low_memory.test_slow
@@ -2,6 +2,8 @@
 # description: test that many small inserts into a wide table work under low memory limit
 # group: [insert]
 
+mode skip slow
+
 require ducklake
 
 require notmusl

--- a/test/sql/insert/insert_wide_table_low_memory.test_slow
+++ b/test/sql/insert/insert_wide_table_low_memory.test_slow
@@ -4,6 +4,8 @@
 
 require ducklake
 
+require notmusl
+
 require parquet
 
 test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db

--- a/test/sql/macros/test_macro_transactions.test
+++ b/test/sql/macros/test_macro_transactions.test
@@ -11,6 +11,9 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 test-env DATA_PATH {TEST_DIR}
 
 statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
+
+statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/test_macro_transactions');
 
 statement ok

--- a/test/sql/settings/max_retry_count.test
+++ b/test/sql/settings/max_retry_count.test
@@ -51,9 +51,9 @@ SELECT current_setting('ducklake_max_retry_count')
 statement ok
 INSERT INTO retry_test VALUES (2, 'test with retry count 7');
 
-# Test 5: Test session scope
+# Test 5: Set to 2
 statement ok
-SET SESSION ducklake_max_retry_count = 2;
+SET ducklake_max_retry_count = 2;
 
 query I
 SELECT current_setting('ducklake_max_retry_count')

--- a/test/sql/view/ducklake_rename_view.test
+++ b/test/sql/view/ducklake_rename_view.test
@@ -10,6 +10,8 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_rename_view_files')

--- a/test/sql/view/ducklake_view.test
+++ b/test/sql/view/ducklake_view.test
@@ -10,6 +10,8 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
+statement ok
+SET default_transaction_invalidation_policy='SYNTACTIC_ERRORS_DO_NOT_INVALIDATE';
 
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_view_files')


### PR DESCRIPTION
- Add `relassert` and re-run tests to stabilize CI.
- Update duckdb and extension-ci-tools submodule.
- Apply all patches from duckdb main.