### PR TITLE
Fix data-file partition id remapping on commit retry

### DIFF
--- a/src/include/storage/ducklake_partition_data.hpp
+++ b/src/include/storage/ducklake_partition_data.hpp
@@ -39,6 +39,10 @@ struct DuckLakePartitionField {
 
 struct DuckLakePartition {
 	idx_t partition_id = 0;
+	//! The transaction-local id this partition was assigned when it was created. Data files written in
+	//! the same transaction reference this id. Commit attempts overwrite partition_id with the id of
+	//! that attempt, so on retry the data-file remap must key off the original transaction-local id.
+	optional_idx local_partition_id;
 	vector<DuckLakePartitionField> fields;
 };
 

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -623,6 +623,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 	// create a complete copy of this table with the partition info added
 	auto partition_data = make_uniq<DuckLakePartition>();
 	partition_data->partition_id = transaction.GetLocalCatalogId();
+	partition_data->local_partition_id = partition_data->partition_id;
 	for (idx_t expr_idx = 0; expr_idx < info.partition_keys.size(); expr_idx++) {
 		auto &expr = *info.partition_keys[expr_idx];
 		auto partition_field = GetPartitionField(*this, expr);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1018,7 +1018,11 @@ DuckLakePartitionInfo DuckLakeTransaction::GetNewPartitionKey(DuckLakeCommitStat
 		// dropping partition data - insert the empty partition key data for this table
 		return partition_key;
 	}
-	auto local_partition_id = partition_data->partition_id;
+	// key the remap off the original transaction-local id: a previous failed commit attempt may have
+	// already overwritten partition_id, while data files still reference the transaction-local id
+	auto local_partition_id = partition_data->local_partition_id.IsValid()
+	                              ? partition_data->local_partition_id.GetIndex()
+	                              : partition_data->partition_id;
 	auto partition_id = commit_state.commit_snapshot.next_catalog_id++;
 	partition_key.id = partition_id;
 	partition_data->partition_id = partition_id;

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -515,6 +515,10 @@ DuckLakeFileInfo DuckLakeTransactionState::GetNewDataFile(const DuckLakeDataFile
                                                           optional_idx row_id_start) {
 	auto data_file = DuckLakeTransaction::BuildDataFileInfo(file, commit_state.commit_snapshot, table_id, row_id_start);
 	commit_state.RemapPartitionId(data_file.partition_id);
+	if (data_file.partition_id.IsValid() &&
+	    data_file.partition_id.GetIndex() >= DuckLakeConstants::TRANSACTION_LOCAL_ID_START) {
+		throw InternalException("Cannot commit data file with transaction-local partition id");
+	}
 	commit_state.RemapMappingIndex(data_file.mapping_id);
 	return data_file;
 }

--- a/test/sql/partitioning/partition_nop.test
+++ b/test/sql/partitioning/partition_nop.test
@@ -59,18 +59,19 @@ INSERT INTO partitioned_tbl VALUES (0, 'replacement_a'), (0, 'replacement_b');
 statement ok
 COMMIT;
 
+statement ok
+SET VARIABLE expected_partition_id = (
+    SELECT partition_id
+    FROM ducklake_metadata.ducklake_partition_info
+    WHERE table_id = 1
+);
+
 query I
 SELECT COUNT(*)
-FROM ducklake_metadata.ducklake_data_file df
-WHERE df.table_id = 1
-  AND df.end_snapshot IS NULL
-  AND df.partition_id IS NOT NULL
-  AND NOT EXISTS (
-      SELECT 1
-      FROM ducklake_metadata.ducklake_partition_info pi
-      WHERE pi.table_id = df.table_id
-        AND pi.partition_id = df.partition_id
-  );
+FROM ducklake_metadata.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL
+  AND partition_id IS DISTINCT FROM getvariable('expected_partition_id');
 ----
 0
 

--- a/test/sql/partitioning/partition_nop.test
+++ b/test/sql/partitioning/partition_nop.test
@@ -13,7 +13,7 @@ test-env DATA_PATH {TEST_DIR}
 
 
 statement ok
-ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_partitioning_nop', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_partitioning_nop', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -41,6 +41,52 @@ query I
 select count(*) FROM ducklake_metadata.ducklake_partition_info
 ----
 1
+
+# A redundant partition change in a transaction that also writes files should keep
+# using the existing partition id.
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+DELETE FROM partitioned_tbl WHERE part_key = 0;
+
+statement ok
+INSERT INTO partitioned_tbl VALUES (0, 'replacement_a'), (0, 'replacement_b');
+
+statement ok
+COMMIT;
+
+query I
+SELECT COUNT(*)
+FROM ducklake_metadata.ducklake_data_file df
+WHERE df.table_id = 1
+  AND df.end_snapshot IS NULL
+  AND df.partition_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM ducklake_metadata.ducklake_partition_info pi
+      WHERE pi.table_id = df.table_id
+        AND pi.partition_id = df.partition_id
+  );
+----
+0
+
+query I
+SELECT COUNT(DISTINCT partition_id)
+FROM ducklake_metadata.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT MAX(schema_version)
+FROM ducklake_metadata.ducklake_snapshot;
+----
+2
 
 # This should now change the partition, since it's different
 statement ok
@@ -123,4 +169,3 @@ query I
 select count(*) FROM ducklake_metadata.ducklake_partition_info
 ----
 7
-

--- a/test/sql/quack/noop_partition_alter_data_files.test
+++ b/test/sql/quack/noop_partition_alter_data_files.test
@@ -1,0 +1,63 @@
+# name: test/sql/quack/noop_partition_alter_data_files.test
+# description: Redundant partition alters must not poison Quack data-file metadata
+# group: [quack]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/quack_noop_partition_alter_data_files', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE partitioned_tbl(part_key INTEGER, values VARCHAR);
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+INSERT INTO partitioned_tbl SELECT i % 2, concat('value_', i) FROM range(5) t(i);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+DELETE FROM partitioned_tbl WHERE part_key = 0;
+
+statement ok
+INSERT INTO partitioned_tbl VALUES (0, 'replacement_a'), (0, 'replacement_b');
+
+statement ok
+COMMIT;
+
+query I
+SELECT COUNT(*)
+FROM __ducklake_metadata_ducklake.ducklake_partition_info
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT COUNT(DISTINCT partition_id)
+FROM __ducklake_metadata_ducklake.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT MAX(schema_version)
+FROM __ducklake_metadata_ducklake.ducklake_snapshot;
+----
+2

--- a/test/sql/transaction/partition_commit_retry_remap.test
+++ b/test/sql/transaction/partition_commit_retry_remap.test
@@ -71,11 +71,19 @@ WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
 0
 
 # every committed data file must reference a partition id that exists
+# (materialize the partition ids first - scanner-backed metadata catalogs do not
+# support multiple streaming scans in one query)
+statement ok
+SET VARIABLE known_partition_ids = (
+    SELECT LIST(partition_id)
+    FROM metadata.ducklake_partition_info
+);
+
 query I
 SELECT COUNT(*)
 FROM metadata.ducklake_data_file
 WHERE partition_id IS NOT NULL
-  AND partition_id NOT IN (SELECT partition_id FROM metadata.ducklake_partition_info);
+  AND NOT list_contains(getvariable('known_partition_ids'), partition_id);
 ----
 0
 
@@ -107,10 +115,16 @@ WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
 ----
 0
 
+statement ok
+SET VARIABLE known_partition_ids = (
+    SELECT LIST(partition_id)
+    FROM metadata.ducklake_partition_info
+);
+
 query I
 SELECT COUNT(*)
 FROM metadata.ducklake_data_file
 WHERE partition_id IS NOT NULL
-  AND partition_id NOT IN (SELECT partition_id FROM metadata.ducklake_partition_info);
+  AND NOT list_contains(getvariable('known_partition_ids'), partition_id);
 ----
 0

--- a/test/sql/transaction/partition_commit_retry_remap.test
+++ b/test/sql/transaction/partition_commit_retry_remap.test
@@ -1,0 +1,116 @@
+# name: test/sql/transaction/partition_commit_retry_remap.test
+# description: data files keep a valid partition id when a commit attempt is retried after a concurrent snapshot
+# group: [transaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/repro_partition_retry/', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+statement ok
+USE ducklake;
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+COPY (
+    SELECT 1 AS id, 'google_ads_data_hub' AS source, 10 AS value
+    UNION ALL
+    SELECT 2 AS id, 'google_ads_data_hub' AS source, 20 AS value
+    UNION ALL
+    SELECT 3 AS id, 'bing' AS source, 30 AS value
+) TO '{DATA_PATH}/repro_slice.parquet' (FORMAT parquet);
+
+statement ok con1
+USE ducklake;
+
+statement ok con2
+USE ducklake;
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+CREATE TABLE first_write AS SELECT * FROM read_parquet('{DATA_PATH}/repro_slice.parquet') LIMIT 0;
+
+statement ok con1
+ALTER TABLE first_write SET PARTITIONED BY (source);
+
+query I con1
+DELETE FROM first_write WHERE source IN ('google_ads_data_hub');
+----
+0
+
+statement ok con1
+INSERT INTO first_write BY NAME SELECT * FROM read_parquet('{DATA_PATH}/repro_slice.parquet');
+
+# concurrent unrelated commit forces con1's first commit attempt to fail retryably
+statement ok con2
+CREATE TABLE unrelated_table(i INTEGER);
+
+statement ok con1
+COMMIT;
+
+query I con1
+SELECT COUNT(*) FROM first_write;
+----
+3
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
+----
+0
+
+# every committed data file must reference a partition id that exists
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE partition_id IS NOT NULL
+  AND partition_id NOT IN (SELECT partition_id FROM metadata.ducklake_partition_info);
+----
+0
+
+# same scenario on a pre-existing table: re-partition + insert with a concurrent snapshot mid-transaction
+statement ok con1
+BEGIN;
+
+statement ok con1
+ALTER TABLE first_write SET PARTITIONED BY (id);
+
+statement ok con1
+INSERT INTO first_write BY NAME SELECT * FROM read_parquet('{DATA_PATH}/repro_slice.parquet');
+
+statement ok con2
+INSERT INTO unrelated_table VALUES (1);
+
+statement ok con1
+COMMIT;
+
+query I con1
+SELECT COUNT(*) FROM first_write;
+----
+6
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
+----
+0
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE partition_id IS NOT NULL
+  AND partition_id NOT IN (SELECT partition_id FROM metadata.ducklake_partition_info);
+----
+0


### PR DESCRIPTION
## Summary

This PR originally also made identical `SET PARTITIONED BY` alters a no-op; after retargeting and rebasing onto `main`, that part is already covered there (fd4d186), so the PR now contains the remaining fixes:

- **Fix partition id remapping on commit retry.** `GetNewPartitionKey` overwrites `partition_data->partition_id` with the committed id during a commit attempt. If that attempt fails retryably (e.g. a snapshot id collision with a concurrent committer), the retry records the remap as `committed_partition_ids[previous_attempt_id] = new_id`, while data files written by the transaction still carry the original transaction-local partition id — the remap misses and the file is committed referencing a nonexistent partition (found in production). The fix preserves the original transaction-local id on `DuckLakePartition` and keys the commit-time remap off it, making the remap idempotent across commit retries.
- **Defensive commit-time check** that a data file never retains a transaction-local partition id after remapping, raising an `InternalException` instead of silently corrupting metadata.
- **Tests.** `test/sql/transaction/partition_commit_retry_remap.test` deterministically reproduces both retry scenarios (first-time `SET PARTITIONED BY` + INSERT, and re-partition + INSERT, each with a concurrent commit forcing a retry); without the fix the retried commit fails. Also extends `partition_nop.test` to cover a redundant partition alter combined with writes in the same transaction.
