### PR TITLE
Fix checkpoint with SET-based credentials

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -10,6 +10,8 @@
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/table_filter_functions.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 
 #include <cmath>
 
@@ -446,6 +448,25 @@ string DuckLakeUtil::ChunkRowToSQL(DuckLakeMetadataManager &metadata_manager, Cl
 		result += ValueToSQL(metadata_manager, context, chunk.GetValue(c, row));
 	}
 	return result;
+}
+
+void DuckLakeUtil::CopyExtensionSettings(ClientContext &from, ClientContext &to) {
+	auto &db_config = DBConfig::GetConfig(from);
+	for (auto &entry : db_config.GetExtensionSettings()) {
+		auto &option = entry.second;
+		if (!option.setting_index.IsValid()) {
+			continue;
+		}
+		auto setting_index = option.setting_index.GetIndex();
+		if (!from.config.user_settings.IsSet(setting_index)) {
+			continue;
+		}
+		Value value;
+		if (!from.TryGetCurrentSetting(entry.first, value)) {
+			continue;
+		}
+		to.config.user_settings.SetUserSetting(setting_index, value);
+	}
 }
 
 } // namespace duckdb

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -66,6 +66,10 @@ public:
 	                            idx_t row);
 	//! Throws if any column in the list conflicts with inlined data system columns
 	static void ValidateNoInlinedSystemColumns(const ColumnList &columns, const string &table_name = "");
+
+	//! Copy extension-registered settings from one context onto another. Core engine settings
+	//! are not copied.
+	static void CopyExtensionSettings(ClientContext &from, ClientContext &to);
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_checkpoint.cpp
+++ b/src/storage/ducklake_checkpoint.cpp
@@ -1,16 +1,19 @@
 #include "ducklake_extension.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/connection.hpp"
 #include "storage/ducklake_transaction_manager.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_schema_entry.hpp"
 #include "storage/ducklake_table_entry.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/common/sql_identifier.hpp"
+#include "common/ducklake_util.hpp"
 
 namespace duckdb {
 
 void DuckLakeTransactionManager::Checkpoint(ClientContext &context, bool force) {
 	auto conn = make_uniq<Connection>(ducklake_catalog.GetDatabase());
+	DuckLakeUtil::CopyExtensionSettings(context, *conn->context);
 	// 1. We first flush inlined data, since these can generate many files, which would be important for compaction
 	// 2. We expire snapshots since these can create more compaction opportunities.
 	// 3. We call the compaction functions, merge_adjacent and rewrite, unclear what is the best order here.

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -760,6 +760,10 @@ Connection &DuckLakeTransaction::GetConnection() {
 	lock_guard<mutex> lock(connection_lock);
 	if (!connection) {
 		connection = make_uniq<Connection>(db);
+		auto caller_context = context.lock();
+		if (caller_context) {
+			DuckLakeUtil::CopyExtensionSettings(*caller_context, *connection->context);
+		}
 		// set the search path to the metadata catalog
 		auto &client_data = ClientData::Get(*connection->context);
 		// ensure we are only looking in the ducklake catalog schema during querying

--- a/test/sql/checkpoint/checkpoint_set_credentials.test
+++ b/test/sql/checkpoint/checkpoint_set_credentials.test
@@ -1,0 +1,100 @@
+# name: test/sql/checkpoint/checkpoint_set_credentials.test
+# description: Test that CHECKPOINT works when S3 credentials are configured via SET statements (not CREATE SECRET)
+# group: [checkpoint]
+
+require ducklake
+
+require parquet
+
+require httpfs
+
+require icu
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+# Drop any pre-existing S3 secret (e.g. from the minio test config's on_init)
+# so that SET statements are the only credential source.
+statement ok
+DROP SECRET IF EXISTS __default_s3;
+
+# Configure S3 credentials via SET statements (not CREATE SECRET)
+statement ok
+SET s3_access_key_id = 'admin';
+
+statement ok
+SET s3_secret_access_key = 'password';
+
+statement ok
+SET s3_endpoint = '127.0.0.1:9000';
+
+statement ok
+SET s3_url_style = 'path';
+
+statement ok
+SET s3_use_ssl = false;
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH 's3://mybucket/checkpoint_set_creds')
+
+statement ok
+USE ducklake;
+
+# Create table with expire_snapshot/delete old_file
+statement ok
+CREATE TABLE test(i INTEGER)
+
+statement ok
+INSERT INTO test FROM range(1000)
+
+statement ok
+DELETE FROM test
+
+statement ok
+DROP TABLE test
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', dry_run => false, versions => [2])
+
+# Create table with inlined and merge adjacent possibility
+statement ok
+CREATE TABLE t (a INTEGER)
+
+statement ok
+INSERT INTO t VALUES (1), (2)
+
+statement ok
+INSERT INTO t VALUES (2), (3)
+
+statement ok
+INSERT INTO t VALUES (4)
+
+# Create table with data rewrite
+statement ok
+CREATE TABLE t_2 (a INTEGER)
+
+statement ok
+INSERT INTO t_2 SELECT i FROM range(100) t(i)
+
+statement ok
+DELETE FROM t_2 WHERE a < 98;
+
+# Create orphan file
+statement ok
+COPY t_2 TO 's3://mybucket/checkpoint_set_creds/main/t/orphan.parquet';
+
+statement ok
+CALL ducklake.set_option('delete_older_than', '1 millisecond');
+
+# CHECKPOINT must succeed with credentials configured via SET.
+statement ok
+CHECKPOINT;
+
+# Verify orphan was cleaned up
+query I
+SELECT COUNT(*)
+FROM GLOB('s3://mybucket/checkpoint_set_creds/main/**')
+WHERE file LIKE '%orphan%';
+----
+0


### PR DESCRIPTION
fixes #1222 

Copies the user's extension-registered settings onto some new connections created when doing Checkpoint to ensure settings are available.

An earlier version copied all settings. This caused tests to break as it copied some query-level settings like disable optimizer to internal transactions, causing those tests to fail.


```
User's session (ClientContext A)
  has: SET s3_access_key_id = 'admin', SET s3_secret_access_key = 'password', etc.
  runs: CHECKPOINT;

then

DuckLakeTransactionManager::Checkpoint(context=A)
  creates: Connection #1 (new ClientContext B — empty settings)
  ───── FIX #1: copy A's extension settings → B ─────
  runs: conn->Query("CALL ducklake_delete_orphaned_files('ducklake')")

then

ducklake_delete_orphaned_files executes
  needs to query DuckLake metadata + S3
  calls: DuckLakeTransaction::Get(context=B, catalog)
         gets/creates a DuckLakeTransaction where weak_ptr context == B

then

DuckLakeTransaction::GetConnection()
  creates: Connection #2 (new ClientContext C — empty settings)
  ───── FIX #2: copy B's extension settings → C ─────
  runs metadata query including: read_blob 

then
       
httpfs resolves S3 credentials
  calls ClientContext C → TryGetCurrentSetting("s3_access_key_id")
  looks in: C.config.user_settings
  WITHOUT fixes: empty == 403 Forbidden
  WITH fixes: finds 'admin' (copied A to B to C) == success
```

Tests all pass locally. 

