### PR TITLE
fix: default to ASCENDING when sort direction is omitted in SET SORTED BY (#1205)

### DIFF
--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1304,7 +1304,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 		sort_field.sort_key_index = order_node_idx;
 		sort_field.expression = order_node.expression->ToString();
 		sort_field.dialect = "duckdb";
-		sort_field.sort_direction = order_node.type;
+		sort_field.sort_direction = order_node.type == OrderType::DESCENDING ? OrderType::DESCENDING : OrderType::ASCENDING;
 		sort_field.null_order = order_node.null_order;
 		sort_data->fields.push_back(sort_field);
 	}

--- a/test/sql/sorted_table/insert_sorted_default_direction.test
+++ b/test/sql/sorted_table/insert_sorted_default_direction.test
@@ -1,0 +1,47 @@
+# name: test/sql/sorted_table/insert_sorted_default_direction.test
+# description: test that omitted sort direction defaults to ascending for sorted inserts
+# group: [sorted_table]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+COPY (
+    SELECT (DATE '2011-01-03' + (i::INTEGER))::DATE AS date, 0.0::FLOAT AS value FROM range(0, 20) t(i)
+    UNION ALL
+    SELECT (DATE '2025-10-20' + (i::INTEGER))::DATE AS date, 0.0::FLOAT AS value FROM range(0, 20) t(i)
+) TO '{DATA_PATH}/insert_sorted_default_direction.csv' (HEADER, DELIMITER ',')
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/insert_sorted_default_direction')
+
+statement ok
+USE ducklake
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE data (date DATE, value FLOAT)
+
+statement ok
+ALTER TABLE data SET SORTED BY (date)
+
+statement ok
+INSERT INTO data SELECT * FROM '{DATA_PATH}/insert_sorted_default_direction.csv' ORDER BY date
+
+statement ok
+COMMIT
+
+query T
+SELECT date FROM data ORDER BY rowid LIMIT 1
+----
+2011-01-03


### PR DESCRIPTION
Closes #1205.

This PR fixes an issue where `ALTER TABLE ... SET SORTED BY (col)` preserved DuckDB's `ORDER_DEFAULT` sort direction in DuckLake's transaction-local sort metadata. That default could later be interpreted as descending during sorted inserts, instead of following the expected default behavior of ascending order.

## Changes

- Normalize omitted sort direction to `ASCENDING` in `src/storage/ducklake_table_entry.cpp`.
- Preserve explicit `DESCENDING` behavior unchanged.
- Add a regression test at `test/sql/sorted_table/insert_sorted_default_direction.test`.

## Testing

- Verified locally that `insert_sorted_default_direction.test` fails on HEAD before the patch.
- Verified locally that `insert_sorted_default_direction.test` passes after the patch.
- Verified locally that `insert_sorted_basic.test` still passes.

## Note to Maintainers

I attempted broader debug-suite testing locally, but full execution was blocked by an existing ASAN stack-overflow failure in parser/init paths on `main`. The focused regression test and a related sorted insert test are green locally, and I’m relying on CI for the full verification matrix.