### PR TITLE
Fix add-files partition key lookup for repeated transforms

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -113,6 +113,22 @@ struct HivePartition {
 	DuckLakeTransformType transform_type;
 };
 
+struct HivePartitionLookupKey {
+	FieldIndex field_index;
+	DuckLakeTransformType transform_type;
+
+	bool operator==(const HivePartitionLookupKey &other) const {
+		return field_index.index == other.field_index.index && transform_type == other.transform_type;
+	}
+};
+
+struct HivePartitionLookupKeyHash {
+	hash_t operator()(const HivePartitionLookupKey &key) const {
+		auto result = Hash(key.field_index.index);
+		return CombineHash(result, Hash(static_cast<uint8_t>(key.transform_type)));
+	}
+};
+
 struct ParquetFileMetadata {
 	string filename;
 	vector<unique_ptr<ParquetColumn>> columns;
@@ -1217,7 +1233,8 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 			for (const auto &hive_partition_value : file.hive_partition_values) {
 				bool found_field = false;
 				for (const auto &field : partition_data->fields) {
-					if (field.field_id.index == hive_partition_value.field_index.index) {
+					if (field.field_id.index == hive_partition_value.field_index.index &&
+					    field.transform.type == hive_partition_value.transform_type) {
 						found_field = true;
 						break;
 					}
@@ -1232,13 +1249,19 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 			throw InvalidInputException("File \"%s\" contains an invalid partition value for the table configuration.",
 			                            file.filename);
 		}
-		unordered_map<idx_t, idx_t> field_partition_key_map;
+		unordered_map<HivePartitionLookupKey, idx_t, HivePartitionLookupKeyHash> field_partition_key_map;
 		for (auto &partition_fields : partition_data->fields) {
-			field_partition_key_map[partition_fields.field_id.index] = partition_fields.partition_key_index;
+			field_partition_key_map[{partition_fields.field_id, partition_fields.transform.type}] =
+			    partition_fields.partition_key_index;
 		}
 		for (auto &hive_partition : file.hive_partition_values) {
+			auto partition_key =
+			    field_partition_key_map.find({hive_partition.field_index, hive_partition.transform_type});
+			if (partition_key == field_partition_key_map.end()) {
+				throw InternalException("Missing partition key index for hive partition");
+			}
 			result.partition_values.push_back(
-			    {field_partition_key_map[hive_partition.field_index.index], hive_partition.hive_value});
+			    {partition_key->second, hive_partition.hive_value});
 		}
 		result.partition_id = partition_data->partition_id;
 	}

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -110,23 +110,8 @@ struct HivePartition {
 	FieldIndex field_index;
 	LogicalType field_type;
 	Value hive_value;
-	DuckLakeTransformType transform_type;
-};
-
-struct HivePartitionLookupKey {
-	FieldIndex field_index;
-	DuckLakeTransformType transform_type;
-
-	bool operator==(const HivePartitionLookupKey &other) const {
-		return field_index.index == other.field_index.index && transform_type == other.transform_type;
-	}
-};
-
-struct HivePartitionLookupKeyHash {
-	hash_t operator()(const HivePartitionLookupKey &key) const {
-		auto result = Hash(key.field_index.index);
-		return CombineHash(result, Hash(static_cast<uint8_t>(key.transform_type)));
-	}
+	DuckLakeTransform transform;
+	optional_idx partition_key_index;
 };
 
 struct ParquetFileMetadata {
@@ -923,6 +908,19 @@ static bool SupportsHivePartitioning(const LogicalType &type) {
 	return true;
 }
 
+static optional_idx GetIdentityPartitionKeyIndex(optional_ptr<DuckLakePartition> partition_data,
+                                                 FieldIndex field_index) {
+	if (!partition_data) {
+		return optional_idx();
+	}
+	for (auto &field : partition_data->fields) {
+		if (field.field_id == field_index && field.transform.type == DuckLakeTransformType::IDENTITY) {
+			return optional_idx(field.partition_key_index);
+		}
+	}
+	return optional_idx();
+}
+
 unique_ptr<DuckLakeNameMapEntry> DuckLakeFileProcessor::MapHiveColumn(ParquetFileMetadata &file_metadata,
                                                                       const DuckLakeFieldId &field_id,
                                                                       const Value &hive_value) {
@@ -942,8 +940,11 @@ unique_ptr<DuckLakeNameMapEntry> DuckLakeFileProcessor::MapHiveColumn(ParquetFil
 	}
 
 	// Store the hive partition information for later statistics processing
+	DuckLakeTransform transform;
+	transform.type = DuckLakeTransformType::IDENTITY;
+	auto partition_key_index = GetIdentityPartitionKeyIndex(table.GetPartitionData(), target_field_id);
 	file_metadata.hive_partition_values.emplace_back(
-	    HivePartition {target_field_id, field_id.Type(), hive_value, DuckLakeTransformType::IDENTITY});
+	    HivePartition {target_field_id, field_id.Type(), hive_value, transform, partition_key_index});
 
 	// return the map - the name is empty on purpose to signal this comes from a partition
 	auto result = make_uniq<DuckLakeNameMapEntry>();
@@ -1076,7 +1077,7 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 
 	// Process statistics for hive partition columns
 	for (auto &entry : file_metadata.hive_partition_values) {
-		if (entry.transform_type == DuckLakeTransformType::BUCKET) {
+		if (entry.transform.type == DuckLakeTransformType::BUCKET) {
 			// Bucket partitioning uses the result of the hash for the folder names, so we can't get statistics from it
 			continue;
 		}
@@ -1194,7 +1195,8 @@ void DuckLakeFileProcessor::MapPartitionColumns(ParquetFileMetadata &file) {
 		auto hive_value =
 		    HivePartitioning::GetValue(context, partition_key_name, hive_entry->second, partition_key_type);
 		file.hive_partition_values.emplace_back(
-		    HivePartition {partition_field.field_id, partition_key_type, hive_value, partition_field.transform.type});
+		    HivePartition {partition_field.field_id, partition_key_type, hive_value, partition_field.transform,
+		                   optional_idx(partition_field.partition_key_index)});
 	}
 }
 
@@ -1230,38 +1232,39 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 		if (file.hive_partition_values.size() != partition_data->fields.size()) {
 			invalid_partition = true;
 		} else {
+			vector<bool> found_partition_keys(partition_data->fields.size(), false);
 			for (const auto &hive_partition_value : file.hive_partition_values) {
-				bool found_field = false;
-				for (const auto &field : partition_data->fields) {
-					if (field.field_id.index == hive_partition_value.field_index.index &&
-					    field.transform.type == hive_partition_value.transform_type) {
-						found_field = true;
-						break;
-					}
-				}
-				if (!found_field) {
+				if (!hive_partition_value.partition_key_index.IsValid()) {
 					invalid_partition = true;
 					break;
 				}
+				auto partition_key_index = hive_partition_value.partition_key_index.GetIndex();
+				if (partition_key_index >= partition_data->fields.size() || found_partition_keys[partition_key_index]) {
+					invalid_partition = true;
+					break;
+				}
+				optional_ptr<const DuckLakePartitionField> partition_field;
+				for (const auto &field : partition_data->fields) {
+					if (field.partition_key_index == partition_key_index) {
+						partition_field = &field;
+						break;
+					}
+				}
+				if (!partition_field || partition_field->field_id != hive_partition_value.field_index ||
+				    !(partition_field->transform == hive_partition_value.transform)) {
+					invalid_partition = true;
+					break;
+				}
+				found_partition_keys[partition_key_index] = true;
 			}
 		}
 		if (invalid_partition) {
 			throw InvalidInputException("File \"%s\" contains an invalid partition value for the table configuration.",
 			                            file.filename);
 		}
-		unordered_map<HivePartitionLookupKey, idx_t, HivePartitionLookupKeyHash> field_partition_key_map;
-		for (auto &partition_fields : partition_data->fields) {
-			field_partition_key_map[{partition_fields.field_id, partition_fields.transform.type}] =
-			    partition_fields.partition_key_index;
-		}
 		for (auto &hive_partition : file.hive_partition_values) {
-			auto partition_key =
-			    field_partition_key_map.find({hive_partition.field_index, hive_partition.transform_type});
-			if (partition_key == field_partition_key_map.end()) {
-				throw InternalException("Missing partition key index for hive partition");
-			}
 			result.partition_values.push_back(
-			    {partition_key->second, hive_partition.hive_value});
+			    {hive_partition.partition_key_index.GetIndex(), hive_partition.hive_value});
 		}
 		result.partition_id = partition_data->partition_id;
 	}

--- a/test/sql/add_files/add_file_partitioned.test
+++ b/test/sql/add_files/add_file_partitioned.test
@@ -141,6 +141,23 @@ COPY (SELECT 10 AS id, 'x' as value, '2024-02-10'::DATE as dt) TO '{DATA_PATH}/a
 statement ok
 CALL ducklake_add_data_files('ducklake', 'multi_partition_t', '{DATA_PATH}/add_file_partitioned/main/multi_partition_t/year=2024/month=2/day=10/full_match.parquet')
 
+statement ok
+SET VARIABLE full_match_data_file_id = (
+	SELECT data_file_id
+	FROM metadata.ducklake_data_file
+	WHERE path LIKE '%full_match.parquet'
+)
+
+query IT
+SELECT partition_key_index, partition_value
+FROM metadata.ducklake_file_partition_value
+WHERE data_file_id = getvariable('full_match_data_file_id')
+ORDER BY partition_key_index
+----
+0	2024
+1	2
+2	10
+
 query III
 FROM multi_partition_t WHERE id = 10;
 ----

--- a/test/sql/add_files/add_file_repeated_bucket.test
+++ b/test/sql/add_files/add_file_repeated_bucket.test
@@ -1,0 +1,54 @@
+# name: test/sql/add_files/add_file_repeated_bucket.test
+# description: ducklake_add_data_files maps repeated bucket transforms to the correct partition_key_index
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+	DATA_PATH '{DATA_PATH}/add_file_repeated_bucket/',
+	METADATA_CATALOG 'metadata'
+);
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE double_bucket_t (id INT, c INT);
+
+statement ok
+ALTER TABLE double_bucket_t SET PARTITIONED BY (bucket(4, c), bucket(8, c));
+
+statement ok
+COPY (SELECT 10 AS id, 42 AS c, 1 AS bucket, 5 AS bucket_c)
+TO '{DATA_PATH}/repeated_bucket_staged'
+(FORMAT parquet, PARTITION_BY (bucket, bucket_c));
+
+statement ok
+CALL ducklake_add_data_files(
+	'ducklake',
+	'double_bucket_t',
+	'{DATA_PATH}/repeated_bucket_staged/bucket=1/bucket_c=5/*.parquet'
+)
+
+statement ok
+SET VARIABLE bucket_file_id = (
+	SELECT data_file_id
+	FROM metadata.ducklake_data_file
+	WHERE path LIKE '%bucket_c=5%'
+)
+
+query IT
+SELECT partition_key_index, partition_value
+FROM metadata.ducklake_file_partition_value
+WHERE data_file_id = getvariable('bucket_file_id')
+ORDER BY partition_key_index
+----
+0	1
+1	5


### PR DESCRIPTION
## Summary
- Carry the exact ducklake_add_data_files partition_key_index through hive partition mapping instead of reconstructing it from source field and transform type.
- Validate parsed hive partition values against unique partition key indexes and the full partition transform before writing metadata.
- Add regression coverage for repeated bucket transforms over the same source column.