### PR TITLE
Ensure REWRITE_DELETES respects target_file_size

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -295,30 +295,13 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 
 		candidates[group].candidate_files.push_back(file_idx);
 	}
-	if (type == CompactionType::REWRITE_DELETES) {
-		// For REWRITE_DELETES, generate one compaction command per partition group
-		for (auto &entry : candidates) {
-			auto &candidate_list = entry.second.candidate_files;
-			if (candidate_list.empty()) {
-				continue;
-			}
-			vector<DuckLakeCompactionFileEntry> partition_files;
-			for (auto &candidate_idx : candidate_list) {
-				partition_files.push_back(std::move(files[candidate_idx]));
-			}
-			auto compaction_command = GenerateCompactionCommand(std::move(partition_files));
-			if (compaction_command) {
-				compactions.push_back(std::move(compaction_command));
-			}
-		}
-		return;
-	}
+
 	// we have gathered all the candidate files per compaction group
 	// iterate over them to generate actual compaction commands
 	uint64_t compacted_files = 0;
 	for (auto &entry : candidates) {
 		auto &candidate_list = entry.second.candidate_files;
-		if (candidate_list.size() <= 1) {
+		if (type == CompactionType::MERGE_ADJACENT_TABLES && candidate_list.size() <= 1) {
 			// we need at least 2 files to consider a merge
 			continue;
 		}
@@ -327,15 +310,17 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 			idx_t current_file_size = 0;
 			idx_t compaction_idx;
 			for (compaction_idx = start_idx; compaction_idx < candidate_list.size(); compaction_idx++) {
-				if (current_file_size >= target_file_size) {
-					// we hit the target size already - stop
-					break;
-				}
 				auto candidate_idx = candidate_list[compaction_idx];
 				auto &candidate = files[candidate_idx];
 				idx_t file_size = candidate.file.data.file_size_bytes;
-				if (file_size >= target_file_size) {
-					// don't consider merging if the file is larger than the target size
+				if (type == CompactionType::REWRITE_DELETES) {
+					// estimate size of remaining rows
+					file_size *= (1 - candidate.delete_ratio);
+				}
+				const int64_t current_size_diff = NumericCast<int64_t>(current_file_size) - target_file_size;
+				const int64_t merged_size_diff = NumericCast<int64_t>(current_file_size + file_size) - target_file_size;
+				if (current_file_size > 0 && std::abs(merged_size_diff) >= std::abs(current_size_diff)) {
+					// adding this file would move away from target_file_size - stop
 					break;
 				}
 				// this file can be compacted along with the neighbors
@@ -344,8 +329,8 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 
 			if (start_idx < compaction_idx) {
 				idx_t compaction_file_count = compaction_idx - start_idx;
-				if (compaction_file_count == 1) {
-					// If we only have one file to compact, we have nothing to compact
+				if (type == CompactionType::MERGE_ADJACENT_TABLES && compaction_file_count == 1) {
+					// If we only have one file to merge, we have nothing to compact
 					compacted_files++;
 					if (compacted_files >= options.max_files) {
 						break;
@@ -360,11 +345,11 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 				start_idx += compaction_file_count - 1;
 			}
 			compacted_files++;
-			if (compacted_files >= options.max_files) {
+			if (type == CompactionType::MERGE_ADJACENT_TABLES && compacted_files >= options.max_files) {
 				break;
 			}
 		}
-		if (compacted_files >= options.max_files) {
+		if (type == CompactionType::MERGE_ADJACENT_TABLES && compacted_files >= options.max_files) {
 			break;
 		}
 	}

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -462,6 +462,7 @@ struct DuckLakeCompactionFileEntry {
 	set<idx_t> inlined_file_deletions;
 	//! Whether this file has any inlined deletions (cheap flag; set for all compaction types).
 	bool has_inlined_deletions = false;
+	double delete_ratio = 0;
 };
 
 struct DuckLakeRewriteFileEntry {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2368,11 +2368,10 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 				active_delete_count = file.delete_files.back().row_count;
 			}
 			auto total_delete_count = active_delete_count + file.inlined_file_deletions.size();
-			double delete_ratio = 0;
 			if (file.file.row_count > 0) {
-				delete_ratio = static_cast<double>(total_delete_count) / static_cast<double>(file.file.row_count);
+				file.delete_ratio = static_cast<double>(total_delete_count) / static_cast<double>(file.file.row_count);
 			}
-			if (total_delete_count == 0 || delete_ratio < deletion_threshold) {
+			if (total_delete_count == 0 || file.delete_ratio < deletion_threshold) {
 				files.erase_at(file_idx);
 				file_idx--;
 			}

--- a/test/sql/compaction/merge_adjacent_partial_file_info.test
+++ b/test/sql/compaction/merge_adjacent_partial_file_info.test
@@ -22,7 +22,7 @@ CREATE TABLE t (id INTEGER, data VARCHAR);
 
 # Set small target file size to control merging behavior (VERSION 1)
 statement ok
-CALL ducklake_set_option('ducklake', 'target_file_size', '1KB');
+CALL ducklake_set_option('ducklake', 'target_file_size', '1.5KB');
 
 # Create small files A (VERSION 2)
 statement ok

--- a/test/sql/compaction/merge_adjacent_tiered.test_slow
+++ b/test/sql/compaction/merge_adjacent_tiered.test_slow
@@ -54,7 +54,7 @@ CALL ducklake_merge_adjacent_files('ducklake', 'tiered', min_file_size=>10000, m
 query I
 SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
 ----
-10
+12
 
 # Tier 2 → Tier 3: merge large files (100KB-500KB) into ~1MB files
 statement ok
@@ -66,7 +66,7 @@ CALL ducklake_merge_adjacent_files('ducklake', 'tiered', min_file_size=>100000, 
 query I
 SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
 ----
-3
+2
 
 # Full compaction: merge everything into final large files
 statement ok

--- a/test/sql/compaction/merge_rewrite_partial_file_info.test
+++ b/test/sql/compaction/merge_rewrite_partial_file_info.test
@@ -112,7 +112,7 @@ SET VARIABLE snap_E = (SELECT MAX(snapshot_id) FROM ducklake_snapshots('ducklake
 
 # Set small target file size so only D & E get merged
 statement ok
-CALL ducklake_set_option('ducklake', 'target_file_size', '1KB');
+CALL ducklake_set_option('ducklake', 'target_file_size', '1.5KB');
 
 # Capture expected partial_max for D+E merge: max begin_snapshot of files created after the first merge
 statement ok

--- a/test/sql/compaction/mix_large_small_insertions.test
+++ b/test/sql/compaction/mix_large_small_insertions.test
@@ -16,7 +16,7 @@ ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/duck
 
 # set target file size very small
 statement ok
-CALL ducklake.set_option('target_file_size', '2KB');
+CALL ducklake.set_option('target_file_size', '4KB');
 
 # snapshot 1
 statement ok
@@ -84,10 +84,10 @@ SELECT COUNT(*) FROM GLOB('{DATA_PATH}/ducklake_compaction_mix_files/**/*.parque
 7
 
 # now compact and cleanup
-query II
-SELECT table_name, files_created FROM ducklake_merge_adjacent_files('ducklake')
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake')
 ----
-tbl	1
+tbl	5	1
 
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);

--- a/test/sql/rewrite_data_files/test_rewrite_target_file_size.test
+++ b/test/sql/rewrite_data_files/test_rewrite_target_file_size.test
@@ -1,0 +1,99 @@
+# name: test/sql/rewrite_data_files/test_rewrite_target_file_size.test
+# description: Test that rewrite_data_files respects target_file_size
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/rewrite_target_file_size', METADATA_CATALOG 'ducklake_metadata')
+
+# set target file size very small
+statement ok
+CALL ducklake.set_option('target_file_size', '4KB');
+
+statement ok
+CREATE TABLE ducklake.tbl(id INTEGER, str VARCHAR);
+
+# create four data files
+statement ok
+INSERT INTO ducklake.tbl SELECT i, concat('thisisastring', i) FROM range(1000) t(i)
+
+statement ok
+INSERT INTO ducklake.tbl SELECT 1000 + i, concat('thisisalsoastring', i) FROM range(1000) t(i)
+
+statement ok
+INSERT INTO ducklake.tbl SELECT 2000 + i, concat('thisisastringtoo', i) FROM range(1000) t(i)
+
+statement ok
+INSERT INTO ducklake.tbl SELECT 3000 + i, concat('thisisafinalstring', i) FROM range(1000) t(i)
+
+# verify we have 4 data files
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+4
+
+# delete one row from each of the first three files (inlined deletes)
+statement ok
+DELETE FROM ducklake.tbl WHERE id % 1000 = 0 AND id < 3000
+
+# rewrite deletes (each file should be rewritten separately due to small target_file_size)
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0)
+----
+tbl	1	1
+tbl	1	1
+tbl	1	1
+
+# verify we still have 4 data files, and no delete files
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_data_file WHERE end_snapshot IS NULL
+----
+4
+
+query I
+SELECT count(*) FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+0
+
+# delete all but one row from the first three files (so that they are merged together)
+statement ok
+DELETE FROM ducklake.tbl WHERE id < 3000 AND id % 1000 != 1
+
+# also delete one row from the final file so that it is compacted (but not merged)
+statement ok
+DELETE FROM ducklake.tbl WHERE id = 3000
+
+# verify we now have at least 3 delete files
+query I
+SELECT count(*) >= 3 FROM ducklake_metadata.ducklake_delete_file WHERE end_snapshot IS NULL
+----
+true
+
+# rewrite deletes (first three files should be merged because estimated size < target_file_size)
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0) ORDER BY ALL
+----
+tbl	1	1
+tbl	3	1
+
+# verify data correctness
+query I
+SELECT count(*) FROM ducklake.tbl
+----
+1002
+
+query II
+SELECT * FROM ducklake.tbl ORDER BY ALL LIMIT 4
+----
+1	thisisastring1
+1001	thisisalsoastring1
+2001	thisisastringtoo1
+3001	thisisafinalstring1


### PR DESCRIPTION
Fixes #1241 

Changed `ducklake_rewrite_data_files` to process each input file individually, rather than merging them together. @pdet please let me know if this is the desired behavior.

The change simplifies the checks in `DuckLakeCompactor::GenerateCompactions`, because the paths for `REWRITE_DELETES` and `MERGE_ADJACENT_TABLES` are separated more clearly. One note: I left in the check for `end_snapshot.IsValid()`, but the query in `metadata_manager.GetFilesForCompaction` does also check for `end_snapshot IS NULL`. Do we want to leave the check in here as well (for clarity/robustness), or can it be removed?

I also updated the relevant tests that rewrite deletes and count the resulting files, manually verifying whether the changes made sense. CI completed successfully [on my fork](https://github.com/gijshendriksen/ducklake/pull/1/checks).