### PR TITLE
Update table stats when DELETEs drop whole files

### DIFF
--- a/src/include/storage/ducklake_server_side_commit.hpp
+++ b/src/include/storage/ducklake_server_side_commit.hpp
@@ -47,6 +47,8 @@ private:
 
 	//! Read commit metadata (author, message, snapshot ids).
 	void ReadCommitHeader();
+	//! Read staged dropped file rows once and cache them.
+	void ReadStagedDroppedFileEntries();
 	//! Load column types for every table touched in this commit.
 	void ReadColumnTypes();
 	//! Read staged data files and their per-file column stats.
@@ -107,6 +109,9 @@ private:
 	TransactionChangeInformation transaction_changes;
 	map<ColumnKey, LogicalType> column_types;
 	map<TableIndex, shared_ptr<DuckLakeTableStats>> existing_table_stats;
+	bool staged_dropped_files_read = false;
+	vector<pair<string, idx_t>> staged_dropped_files;
+	map<TableIndex, DroppedDataFileStats> staged_dropped_file_stats;
 
 	//! Per-table SQL literal tuples for inlined-data inserts.
 	map<TableIndex, vector<string>> staged_inlined_tuples;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -48,6 +48,11 @@ struct FlushedInlinedTableInfo {
 	idx_t flush_snapshot_id;
 };
 
+struct DroppedDataFileStats {
+	idx_t row_count = 0;
+	idx_t file_size_bytes = 0;
+};
+
 struct LocalTableDataChanges {
 	vector<DuckLakeDataFile> new_data_files;
 	unique_ptr<DuckLakeInlinedData> new_inlined_data;
@@ -246,7 +251,7 @@ public:
 	void DropView(DuckLakeViewEntry &view);
 	void DropScalarMacro(DuckLakeScalarMacroEntry &macro);
 	void DropTableMacro(DuckLakeTableMacroEntry &macro);
-	void DropFile(TableIndex table_id, DataFileIndex data_file_id, string path);
+	void DropFile(TableIndex table_id, DataFileIndex data_file_id, string path, idx_t row_count, idx_t file_size_bytes);
 
 	void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
 	void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -99,6 +99,9 @@ struct DuckLakeCommitContext {
 	std::function<void(idx_t)> set_catalog_version;
 	//! Records the committed snapshot id on the catalog.
 	std::function<void(idx_t)> set_committed_snapshot_id;
+	//! Invalidates the cached stats entry for a table after a stats-affecting file drop.
+	std::function<void(idx_t, TableIndex)> invalidate_table_stats_cache = [](idx_t, TableIndex) {
+	};
 	//! Author / message / extra info for the snapshot row.
 	DuckLakeSnapshotCommit commit_info;
 	//! When true, Commit() skips the post-commit DropEmptySupersededInlinedTables cleanup.
@@ -133,7 +136,8 @@ public:
 	                            const DuckLakeSnapshotCommit &commit_info) const;
 
 	string CommitChanges(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes,
-	                     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context);
+	                     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context,
+	                     map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 
 	vector<DuckLakeSchemaInfo> GetNewSchemas(DuckLakeCommitState &commit_state);
 	NewTableInfo GetNewTables(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
@@ -146,7 +150,16 @@ public:
 	NewMacroInfo GetNewMacros(DuckLakeCommitState &commit_state, TransactionChangeInformation &transaction_changes);
 	NewDataInfo GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
 	                            optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-	                            const DuckLakeCommitContext &context);
+	                            const DuckLakeCommitContext &context,
+	                            map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	//! Decrement table-level stats for files dropped this commit. Returns true when live rows remain in the table,
+	//! in which case the caller must delete the table column-stats rows (table-level min/max became unknowable
+	//! without a scan). When the table is emptied, the column stats are reset in place to NULL instead.
+	static bool ApplyDroppedFileStats(TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
+	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	string UpdateStatsForDroppedFiles(optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
+	                                  const DuckLakeCommitContext &context,
+	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 	CompactionInformation GetCompactionChanges(DuckLakeCommitState &commit_state, CompactionType type);
 	//! After a REWRITE_DELETES compaction, recompute EXACT global stats for `table_id` from the post-rewrite file set
 	//! (+ committed inlined data) and append the UpdateGlobalTableStats SQL to `batch_query`. No-op (leaving the
@@ -201,6 +214,7 @@ public:
 	set<TableIndex> renamed_views;
 	set<TableIndex> dropped_views;
 	unordered_map<string, DataFileIndex> dropped_files;
+	map<TableIndex, DroppedDataFileStats> dropped_file_stats;
 	set<TableIndex> tables_deleted_from;
 	unique_ptr<DuckLakeCatalogSet> new_schemas;
 	map<SchemaIndex, reference<DuckLakeSchemaEntry>> dropped_schemas;

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -152,9 +152,7 @@ public:
 	                            optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
 	                            const DuckLakeCommitContext &context,
 	                            map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
-	//! Decrement table-level stats for files dropped this commit. Returns true when live rows remain in the table,
-	//! in which case the caller must delete the table column-stats rows (table-level min/max became unknowable
-	//! without a scan). When the table is emptied, the column stats are reset in place to NULL instead.
+	//! Decrement table-level stats for files dropped this commit; returns true if live rows remain.
 	static bool ApplyDroppedFileStats(TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
 	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 	string UpdateStatsForDroppedFiles(optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,

--- a/src/storage/ducklake_delete.cpp
+++ b/src/storage/ducklake_delete.cpp
@@ -411,7 +411,8 @@ bool DuckLakeDelete::TryDropFullyDeletedFile(DuckLakeTransaction &transaction, c
 	}
 	// ALL rows in this file are deleted - drop the file
 	if (delete_file.data_file_id.IsValid()) {
-		transaction.DropFile(table.GetTableId(), delete_file.data_file_id, data_file_info.file.path);
+		transaction.DropFile(table.GetTableId(), delete_file.data_file_id, data_file_info.file.path,
+		                     data_file_info.row_count, data_file_info.file.file_size_bytes);
 	} else {
 		transaction.DropTransactionLocalFile(table.GetTableId(), data_file_info.file.path);
 	}
@@ -516,6 +517,11 @@ void DuckLakeDelete::FlushDelete(DuckLakeTransaction &transaction, ClientContext
 	delete_file.data_file_id = data_file_info.file_id;
 	// check if the file already has deletes
 	auto existing_delete_data = delete_map->GetDeleteData(filename);
+
+	if (!existing_delete_data &&
+	    TryDropFullyDeletedFile(transaction, delete_file, data_file_info, sorted_deletes.size())) {
+		return;
+	}
 
 	// check if we should use inlined file deletions instead of creating a delete file
 	if (data_file_info.file_id.IsValid()) {

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -47,6 +47,17 @@ struct EntryShell {
 	bool hive_partition;
 };
 
+static string JoinIds(const vector<idx_t> &ids) {
+	string result;
+	for (auto id : ids) {
+		if (!result.empty()) {
+			result += ",";
+		}
+		result += to_string(id);
+	}
+	return result;
+}
+
 unique_ptr<DuckLakeNameMapEntry> BuildNameMapEntry(idx_t id, const std::map<idx_t, const EntryShell *> &shell_by_id,
                                                    const std::map<idx_t, vector<idx_t>> &children_of) {
 	auto &shell = *shell_by_id.at(id);
@@ -212,6 +223,20 @@ void DuckLakeServerSideCommit::ReadColumnTypes() {
 	auto inlined = ScanStagedTable(DuckLakeStagedTableType::INLINED_DATA);
 	for (auto &row : *inlined) {
 		table_ids.insert(AsIdx(row, 0));
+	}
+	vector<idx_t> dropped_file_ids;
+	auto dropped_files = ScanStagedTable(DuckLakeStagedTableType::DROPPED_FILE);
+	for (auto &row : *dropped_files) {
+		dropped_file_ids.push_back(AsIdx(row, 1));
+	}
+	if (!dropped_file_ids.empty()) {
+		auto dropped_tables = RunQuery(
+		    StringUtil::Format("SELECT DISTINCT table_id FROM %s.ducklake_data_file WHERE data_file_id IN (%s)",
+		                       schema_id, JoinIds(dropped_file_ids)),
+		    "read dropped file table ids");
+		for (auto &row : *dropped_tables) {
+			table_ids.insert(AsIdx(row, 0));
+		}
 	}
 	if (table_ids.empty()) {
 		return;
@@ -445,8 +470,23 @@ void DuckLakeServerSideCommit::ReadStagedDeleteFiles() {
 
 void DuckLakeServerSideCommit::ReadStagedDroppedFiles() {
 	auto dropped = ScanStagedTable(DuckLakeStagedTableType::DROPPED_FILE);
+	vector<idx_t> dropped_file_ids;
 	for (auto &row : *dropped) {
-		state->dropped_files.emplace(row.GetValue<string>(0), DataFileIndex(AsIdx(row, 1)));
+		auto file_id = AsIdx(row, 1);
+		state->dropped_files.emplace(row.GetValue<string>(0), DataFileIndex(file_id));
+		dropped_file_ids.push_back(file_id);
+	}
+	if (!dropped_file_ids.empty()) {
+		auto dropped_stats = RunQuery(
+		    StringUtil::Format(
+		        "SELECT table_id, record_count, file_size_bytes FROM %s.ducklake_data_file WHERE data_file_id IN (%s)",
+		        schema_id, JoinIds(dropped_file_ids)),
+		    "read dropped file stats");
+		for (auto &row : *dropped_stats) {
+			auto &stats = state->dropped_file_stats[TableIndex(AsIdx(row, 0))];
+			stats.row_count += AsIdx(row, 1);
+			stats.file_size_bytes += AsIdx(row, 2);
+		}
 	}
 	auto tables = ScanStagedTable(DuckLakeStagedTableType::TABLES_DELETED_FROM);
 	for (auto &row : *tables) {

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -48,14 +48,7 @@ struct EntryShell {
 };
 
 static string JoinIds(const vector<idx_t> &ids) {
-	string result;
-	for (auto id : ids) {
-		if (!result.empty()) {
-			result += ",";
-		}
-		result += to_string(id);
-	}
-	return result;
+	return StringUtil::Join(ids, ids.size(), ",", [](const idx_t &id) { return to_string(id); });
 }
 
 unique_ptr<DuckLakeNameMapEntry> BuildNameMapEntry(idx_t id, const std::map<idx_t, const EntryShell *> &shell_by_id,
@@ -214,6 +207,32 @@ void DuckLakeServerSideCommit::ReadCommitHeader() {
 	}
 }
 
+void DuckLakeServerSideCommit::ReadStagedDroppedFileEntries() {
+	if (staged_dropped_files_read) {
+		return;
+	}
+	vector<idx_t> dropped_file_ids;
+	auto dropped_files = ScanStagedTable(DuckLakeStagedTableType::DROPPED_FILE);
+	for (auto &row : *dropped_files) {
+		auto file_id = AsIdx(row, 1);
+		staged_dropped_files.emplace_back(row.GetValue<string>(0), file_id);
+		dropped_file_ids.push_back(file_id);
+	}
+	if (!dropped_file_ids.empty()) {
+		auto dropped_stats = RunQuery(
+		    StringUtil::Format(
+		        "SELECT table_id, record_count, file_size_bytes FROM %s.ducklake_data_file WHERE data_file_id IN (%s)",
+		        schema_id, JoinIds(dropped_file_ids)),
+		    "read dropped file stats");
+		for (auto &row : *dropped_stats) {
+			auto &stats = staged_dropped_file_stats[TableIndex(AsIdx(row, 0))];
+			stats.row_count += AsIdx(row, 1);
+			stats.file_size_bytes += AsIdx(row, 2);
+		}
+	}
+	staged_dropped_files_read = true;
+}
+
 void DuckLakeServerSideCommit::ReadColumnTypes() {
 	unordered_set<idx_t> table_ids;
 	auto data_files = ScanStagedTable(DuckLakeStagedTableType::DATA_FILE);
@@ -224,19 +243,9 @@ void DuckLakeServerSideCommit::ReadColumnTypes() {
 	for (auto &row : *inlined) {
 		table_ids.insert(AsIdx(row, 0));
 	}
-	vector<idx_t> dropped_file_ids;
-	auto dropped_files = ScanStagedTable(DuckLakeStagedTableType::DROPPED_FILE);
-	for (auto &row : *dropped_files) {
-		dropped_file_ids.push_back(AsIdx(row, 1));
-	}
-	if (!dropped_file_ids.empty()) {
-		auto dropped_tables = RunQuery(
-		    StringUtil::Format("SELECT DISTINCT table_id FROM %s.ducklake_data_file WHERE data_file_id IN (%s)",
-		                       schema_id, JoinIds(dropped_file_ids)),
-		    "read dropped file table ids");
-		for (auto &row : *dropped_tables) {
-			table_ids.insert(AsIdx(row, 0));
-		}
+	ReadStagedDroppedFileEntries();
+	for (auto &entry : staged_dropped_file_stats) {
+		table_ids.insert(entry.first.index);
 	}
 	if (table_ids.empty()) {
 		return;
@@ -469,24 +478,13 @@ void DuckLakeServerSideCommit::ReadStagedDeleteFiles() {
 }
 
 void DuckLakeServerSideCommit::ReadStagedDroppedFiles() {
-	auto dropped = ScanStagedTable(DuckLakeStagedTableType::DROPPED_FILE);
-	vector<idx_t> dropped_file_ids;
-	for (auto &row : *dropped) {
-		auto file_id = AsIdx(row, 1);
-		state->dropped_files.emplace(row.GetValue<string>(0), DataFileIndex(file_id));
-		dropped_file_ids.push_back(file_id);
+	ReadStagedDroppedFileEntries();
+	for (auto &entry : staged_dropped_files) {
+		auto file_id = entry.second;
+		state->dropped_files.emplace(entry.first, DataFileIndex(file_id));
 	}
-	if (!dropped_file_ids.empty()) {
-		auto dropped_stats = RunQuery(
-		    StringUtil::Format(
-		        "SELECT table_id, record_count, file_size_bytes FROM %s.ducklake_data_file WHERE data_file_id IN (%s)",
-		        schema_id, JoinIds(dropped_file_ids)),
-		    "read dropped file stats");
-		for (auto &row : *dropped_stats) {
-			auto &stats = state->dropped_file_stats[TableIndex(AsIdx(row, 0))];
-			stats.row_count += AsIdx(row, 1);
-			stats.file_size_bytes += AsIdx(row, 2);
-		}
+	for (auto &entry : staged_dropped_file_stats) {
+		state->dropped_file_stats[entry.first] = entry.second;
 	}
 	auto tables = ScanStagedTable(DuckLakeStagedTableType::TABLES_DELETED_FROM);
 	for (auto &row : *tables) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1336,6 +1336,11 @@ void DuckLakeTransaction::FlushChanges() {
 }
 
 void DuckLakeTransaction::ApplyServerSideCommit(idx_t schema_version) {
+	if (snapshot) {
+		for (auto &entry : state->dropped_file_stats) {
+			ducklake_catalog.InvalidateTableStatsCache(snapshot->next_file_id, entry.first);
+		}
+	}
 	catalog_version = schema_version;
 	if (connection) {
 		connection->Commit();
@@ -1473,6 +1478,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.set_committed_snapshot_id = [&](idx_t snapshot_id) {
 		ducklake_catalog.SetCommittedSnapshotId(snapshot_id);
+	};
+	context.invalidate_table_stats_cache = [&](idx_t next_file_id, TableIndex table_id) {
+		ducklake_catalog.InvalidateTableStatsCache(next_file_id, table_id);
 	};
 	context.commit_info = state->commit_info;
 	context.write_row_group_count = ducklake_catalog.SupportsRowGroupCount();
@@ -1788,9 +1796,16 @@ void DuckLakeTransaction::DropTableMacro(DuckLakeTableMacroEntry &macro) {
 	state->dropped_table_macros.insert(macro.GetIndex());
 }
 
-void DuckLakeTransaction::DropFile(TableIndex table_id, DataFileIndex data_file_id, string path) {
+void DuckLakeTransaction::DropFile(TableIndex table_id, DataFileIndex data_file_id, string path, idx_t row_count,
+                                   idx_t file_size_bytes) {
 	state->tables_deleted_from.insert(table_id);
-	state->dropped_files.emplace(std::move(path), data_file_id);
+	auto inserted = state->dropped_files.emplace(std::move(path), data_file_id);
+	if (!inserted.second) {
+		return;
+	}
+	auto &stats = state->dropped_file_stats[table_id];
+	stats.row_count += row_count;
+	stats.file_size_bytes += file_size_bytes;
 }
 
 bool DuckLakeTransaction::HasDroppedFiles() const {

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -934,9 +934,97 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
 }
 
+static idx_t SaturatingSubtract(idx_t value, idx_t decrement) {
+	return decrement > value ? 0 : value - decrement;
+}
+
+static string DeleteTableColumnStatsSql(TableIndex table_id) {
+	return StringUtil::Format("DELETE FROM {METADATA_CATALOG}.ducklake_table_column_stats WHERE table_id=%d;",
+	                          table_id.index);
+}
+
+bool DuckLakeTransactionState::ApplyDroppedFileStats(
+    TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
+    map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+	auto entry = attempt_dropped_file_stats.find(table_id);
+	if (entry == attempt_dropped_file_stats.end()) {
+		return false;
+	}
+	auto &stats = new_stats.stats;
+	stats.record_count = SaturatingSubtract(stats.record_count, entry->second.row_count);
+	stats.table_size_bytes = SaturatingSubtract(stats.table_size_bytes, entry->second.file_size_bytes);
+	attempt_dropped_file_stats.erase(entry);
+	// File drops can make table-level min/max stale. If live rows remain in files we did not drop, the caller
+	// deletes the column-stats rows so later inserts do not rebuild stats from only the newly inserted files.
+	// If the table is now empty, there are no surviving rows, so reset the column stats to NULL in place instead.
+	bool live_rows_remain = stats.record_count > 0;
+	if (!live_rows_remain) {
+		for (auto &column_stats : stats.column_stats) {
+			column_stats.second = DuckLakeColumnStats(column_stats.second.type);
+		}
+	}
+	return live_rows_remain;
+}
+
+string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
+    optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context,
+    map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+	if (attempt_dropped_file_stats.empty()) {
+		return string();
+	}
+
+	string result;
+	unique_ptr<DuckLakeStats> dl_stats;
+	if (stats) {
+		dl_stats = context.build_stats_map(*stats);
+	}
+
+	vector<TableIndex> table_ids;
+	for (auto &entry : attempt_dropped_file_stats) {
+		table_ids.push_back(entry.first);
+	}
+	for (auto &table_id : table_ids) {
+		if (attempt_dropped_file_stats.find(table_id) == attempt_dropped_file_stats.end()) {
+			continue;
+		}
+
+		optional_ptr<DuckLakeTableStats> current_stats;
+		shared_ptr<DuckLakeTableStats> current_stats_pin;
+		if (dl_stats) {
+			auto dl_stats_entry = dl_stats->table_stats.find(table_id);
+			if (dl_stats_entry != dl_stats->table_stats.end()) {
+				current_stats = dl_stats_entry->second.get();
+			}
+		} else {
+			current_stats_pin = context.get_table_stats(table_id);
+			current_stats = current_stats_pin.get();
+		}
+		if (!current_stats) {
+			continue;
+		}
+
+		DuckLakeNewGlobalStats new_globals;
+		new_globals.stats = *current_stats;
+		new_globals.initialized = true;
+		bool delete_column_stats = ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
+		if (delete_column_stats) {
+			// the rows are deleted below - drop them from the update so we do not write values we then delete
+			new_globals.stats.column_stats.clear();
+		}
+		result += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
+		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+		if (delete_column_stats) {
+			result += DeleteTableColumnStatsSql(table_id);
+		}
+	}
+	return result;
+}
+
 NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
                                                       optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                                      const DuckLakeCommitContext &context) {
+                                                      const DuckLakeCommitContext &context,
+                                                      map<TableIndex, DroppedDataFileStats>
+                                                          &attempt_dropped_file_stats) {
 	NewDataInfo result;
 	// get the global table stats
 	DuckLakeNewGlobalStats new_globals;
@@ -972,6 +1060,7 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckL
 			new_globals.stats = *current_stats;
 			new_globals.initialized = true;
 		}
+		bool clear_column_stats = ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
@@ -1030,9 +1119,16 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckL
 				commit_state.commit_snapshot.next_file_id++;
 			}
 		}
+		if (clear_column_stats) {
+			// the rows are deleted below - drop them from the update so we do not write values we then delete
+			new_stats.column_stats.clear();
+		}
 		// update the global stats for this table based on the newly written data
 		batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
 		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+		if (clear_column_stats) {
+			batch_query += DeleteTableColumnStatsSql(table_id);
+		}
 	}
 	return result;
 }
@@ -1383,7 +1479,8 @@ vector<DuckLakeSchemaInfo> DuckLakeTransactionState::GetNewSchemas(DuckLakeCommi
 string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state,
                                                TransactionChangeInformation &transaction_changes,
                                                optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                               const DuckLakeCommitContext &context) {
+                                               const DuckLakeCommitContext &context,
+                                               map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
 	auto &commit_snapshot = commit_state.commit_snapshot;
 
 	EnsureCommitInfoProvided(commit_info);
@@ -1493,7 +1590,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 	// write new data / data files
 	bool has_table_data_changes = local_changes.HasChanges();
 	if (has_table_data_changes) {
-		auto result = GetNewDataFiles(batch_queries, commit_state, stats, context);
+		auto result = GetNewDataFiles(batch_queries, commit_state, stats, context, attempt_dropped_file_stats);
 		batch_queries += write_data_files_sql(result.new_files);
 		batch_queries += context.write_inlined_data(commit_snapshot, result.new_inlined_data, new_tables_result,
 		                                            new_inlined_data_tables_result);
@@ -1511,6 +1608,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			dropped_indexes.insert(entry.second);
 		}
 		batch_queries += DuckLakeMetadataManager::DropDataFiles(dropped_indexes);
+		batch_queries += UpdateStatsForDroppedFiles(stats, context, attempt_dropped_file_stats);
 	}
 
 	if (has_table_data_changes) {
@@ -1708,6 +1806,7 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 	for (idx_t i = 0; i < retry_config.max_retry_count + 1; i++) {
 		bool can_retry;
 		auto attempt_changes = transaction_changes;
+		auto attempt_dropped_file_stats = dropped_file_stats;
 		try {
 			can_retry = false;
 			if (i > 0) {
@@ -1728,7 +1827,7 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			DuckLakeCommitState commit_state(commit_snapshot);
 			// write the new snapshot
 			string batch_queries = DuckLakeMetadataManager::InsertSnapshotSql();
-			batch_queries += CommitChanges(commit_state, attempt_changes, stats, context);
+			batch_queries += CommitChanges(commit_state, attempt_changes, stats, context, attempt_dropped_file_stats);
 			batch_queries += WriteSnapshotChanges(commit_state, attempt_changes, context.commit_info);
 			auto res = context.execute_commit_batch(commit_snapshot, batch_queries);
 			if (res->HasError()) {
@@ -1737,6 +1836,9 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			bool flushed_inlined = !flushed_inlined_tables.empty();
 			context.flush_cache_if_pending();
 			context.commit_connection();
+			for (auto &entry : dropped_file_stats) {
+				context.invalidate_table_stats_cache(commit_snapshot.next_file_id, entry.first);
+			}
 			if (flushed_inlined && !context.skip_drop_empty_inlined) {
 				DropEmptySupersededInlinedTables(context);
 			}

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -934,8 +934,11 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
 }
 
-static idx_t SaturatingSubtract(idx_t value, idx_t decrement) {
-	return decrement > value ? 0 : value - decrement;
+static idx_t SubtractDroppedFileStat(idx_t value, idx_t decrement) {
+	if (decrement > value) {
+		throw InternalException("Dropped DuckLake file stats exceed current table stats");
+	}
+	return value - decrement;
 }
 
 static string DeleteTableColumnStatsSql(TableIndex table_id) {
@@ -951,18 +954,18 @@ bool DuckLakeTransactionState::ApplyDroppedFileStats(
 		return false;
 	}
 	auto &stats = new_stats.stats;
-	stats.record_count = SaturatingSubtract(stats.record_count, entry->second.row_count);
-	stats.table_size_bytes = SaturatingSubtract(stats.table_size_bytes, entry->second.file_size_bytes);
-	attempt_dropped_file_stats.erase(entry);
-	// File drops can make table-level min/max stale. If live rows remain in files we did not drop, the caller
-	// deletes the column-stats rows so later inserts do not rebuild stats from only the newly inserted files.
-	// If the table is now empty, there are no surviving rows, so reset the column stats to NULL in place instead.
+	auto dropped_stats = entry->second;
+	stats.record_count = SubtractDroppedFileStat(stats.record_count, dropped_stats.row_count);
 	bool live_rows_remain = stats.record_count > 0;
-	if (!live_rows_remain) {
+	if (live_rows_remain) {
+		stats.table_size_bytes = SubtractDroppedFileStat(stats.table_size_bytes, dropped_stats.file_size_bytes);
+	} else {
+		stats.table_size_bytes = 0;
 		for (auto &column_stats : stats.column_stats) {
 			column_stats.second = DuckLakeColumnStats(column_stats.second.type);
 		}
 	}
+	attempt_dropped_file_stats.erase(entry);
 	return live_rows_remain;
 }
 
@@ -1000,7 +1003,7 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 			current_stats = current_stats_pin.get();
 		}
 		if (!current_stats) {
-			continue;
+			throw InternalException("Missing DuckLake table stats for table with dropped data files");
 		}
 
 		DuckLakeNewGlobalStats new_globals;

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -962,7 +962,10 @@ bool DuckLakeTransactionState::ApplyDroppedFileStats(
 	} else {
 		stats.table_size_bytes = 0;
 		for (auto &column_stats : stats.column_stats) {
-			column_stats.second = DuckLakeColumnStats(column_stats.second.type);
+			auto reset = DuckLakeColumnStats(column_stats.second.type);
+			// Let same-commit inserts seed min/max after the table was emptied.
+			reset.any_valid = false;
+			column_stats.second = std::move(reset);
 		}
 	}
 	attempt_dropped_file_stats.erase(entry);

--- a/test/sql/delete/full_file_delete_stats.test
+++ b/test/sql/delete/full_file_delete_stats.test
@@ -110,3 +110,64 @@ query TT
 SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id = getvariable('t_id')
 ----
 100	109
+
+statement ok
+CREATE TABLE ducklake.merge_then_drop AS SELECT range::INT id FROM range(50)
+
+statement ok
+INSERT INTO ducklake.merge_then_drop SELECT range::INT id FROM range(50, 100)
+
+statement ok
+INSERT INTO ducklake.merge_then_drop SELECT range::INT id FROM range(100, 150)
+
+statement ok
+INSERT INTO ducklake.merge_then_drop SELECT range::INT id FROM range(150, 200)
+
+statement ok
+SET VARIABLE merge_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'merge_then_drop')
+
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake', 'merge_then_drop')
+
+query I
+DELETE FROM ducklake.merge_then_drop
+----
+200
+
+query III
+SELECT record_count, next_row_id, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('merge_id')
+----
+0	200	0
+
+statement ok
+CREATE TABLE ducklake.rewrite_then_drop AS SELECT range::INT id FROM range(50)
+
+statement ok
+INSERT INTO ducklake.rewrite_then_drop SELECT range::INT id FROM range(50, 100)
+
+statement ok
+INSERT INTO ducklake.rewrite_then_drop SELECT range::INT id FROM range(100, 150)
+
+statement ok
+INSERT INTO ducklake.rewrite_then_drop SELECT range::INT id FROM range(150, 200)
+
+statement ok
+SET VARIABLE rewrite_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'rewrite_then_drop')
+
+query I
+DELETE FROM ducklake.rewrite_then_drop WHERE id % 2 = 0
+----
+100
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'rewrite_then_drop', delete_threshold => 0)
+
+query I
+DELETE FROM ducklake.rewrite_then_drop
+----
+100
+
+query III
+SELECT record_count, next_row_id, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('rewrite_id')
+----
+0	200	0

--- a/test/sql/delete/full_file_delete_stats.test
+++ b/test/sql/delete/full_file_delete_stats.test
@@ -1,0 +1,112 @@
+# name: test/sql/delete/full_file_delete_stats.test
+# description: Deletes that drop a whole data file decrement table stats
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/full_file_delete_stats', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t AS SELECT range::INT id FROM range(100)
+
+# Materialize ids/sizes one scan at a time so this also works against
+# metadata catalogs that cannot run multiple streaming scans per query.
+statement ok
+SET VARIABLE t_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 't')
+
+statement ok
+SET VARIABLE initial_size = (SELECT file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id'))
+
+# A partial delete writes a delete file and leaves the data file active, so table stats are unchanged.
+query I
+DELETE FROM ducklake.t WHERE id < 30
+----
+30
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_delete_file WHERE table_id = getvariable('t_id') AND end_snapshot IS NULL
+----
+1
+
+query III
+SELECT record_count, next_row_id, file_size_bytes = getvariable('initial_size') FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+100	100	true
+
+# Deleting the remaining rows fully deletes the file: it is dropped, the stats are decremented to
+# zero, and next_row_id stays monotonic.
+query I
+DELETE FROM ducklake.t WHERE id >= 30
+----
+70
+
+query I
+SELECT COUNT(*) FROM ducklake.t
+----
+0
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('t_id') AND end_snapshot IS NULL
+----
+0
+
+query III
+SELECT record_count, next_row_id, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+0	100	0
+
+query II
+SELECT (min_value IS NULL)::INT, (max_value IS NULL)::INT FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id = getvariable('t_id')
+----
+1	1
+
+statement ok
+CREATE TABLE ducklake.partial AS SELECT range::INT id FROM range(200)
+
+statement ok
+SET VARIABLE partial_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'partial')
+
+statement ok
+INSERT INTO ducklake.partial SELECT range::INT id FROM range(1000, 1200)
+
+query I
+DELETE FROM ducklake.partial WHERE id < 200
+----
+200
+
+query II
+SELECT record_count, next_row_id FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('partial_id')
+----
+200	400
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id = getvariable('partial_id')
+----
+0
+
+# Re-insert after the drop in the same connection: the stats cache was invalidated, so the insert
+# starts from the decremented base (record_count 0), not the stale pre-delete value.
+statement ok
+INSERT INTO ducklake.t SELECT range::INT id FROM range(100, 110)
+
+query III
+SELECT COUNT(*), MIN(id), MAX(id) FROM ducklake.t
+----
+10	100	109
+
+query II
+SELECT record_count, next_row_id FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+10	110
+
+query TT
+SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id = getvariable('t_id')
+----
+100	109

--- a/test/sql/delete/full_file_delete_stats_default_inlining.test
+++ b/test/sql/delete/full_file_delete_stats_default_inlining.test
@@ -1,0 +1,113 @@
+# name: test/sql/delete/full_file_delete_stats_default_inlining.test
+# description: Whole-file-drop stats accounting under the default data inlining row limit
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+# No DATA_INLINING_ROW_LIMIT override: the catalog uses the default (10), so inlined file deletes are active.
+# This is the path the shipped full_file_delete_stats.test cannot reach because it disables inlining.
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/full_file_delete_stats_default_inlining')
+
+# A whole-file delete at or below the inline limit still drops the data file before considering an
+# inlined delete, and decrements table stats to zero.
+statement ok
+CREATE TABLE ducklake.small_dropped AS SELECT range::INT id FROM range(5)
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+SET VARIABLE small_dropped_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'small_dropped')
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('small_dropped_id') AND end_snapshot IS NULL
+----
+1
+
+query I
+DELETE FROM ducklake.small_dropped
+----
+5
+
+query I
+SELECT COUNT(*) FROM ducklake.small_dropped
+----
+0
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('small_dropped_id') AND end_snapshot IS NULL
+----
+0
+
+query II
+SELECT record_count, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('small_dropped_id')
+----
+0	0
+
+# A delete larger than the inline limit fully empties the file: it is dropped (not inlined) and table stats
+# are decremented to zero - the stats fix works under default inlining, not only with inlining disabled.
+statement ok
+CREATE TABLE ducklake.dropped AS SELECT range::INT id FROM range(100)
+
+statement ok
+SET VARIABLE dropped_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'dropped')
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('dropped_id') AND end_snapshot IS NULL
+----
+1
+
+query I
+DELETE FROM ducklake.dropped
+----
+100
+
+query I
+SELECT COUNT(*) FROM ducklake.dropped
+----
+0
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('dropped_id') AND end_snapshot IS NULL
+----
+0
+
+query II
+SELECT record_count, file_size_bytes FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('dropped_id')
+----
+0	0
+
+# A delete within the inline limit is inlined as file deletes: the data file stays active and table stats are
+# unchanged. This guards the default inlined-delete behavior - the stats accounting does not drop the file early.
+statement ok
+CREATE TABLE ducklake.inlined AS SELECT range::INT id FROM range(100)
+
+statement ok
+SET VARIABLE inlined_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 'inlined')
+
+query I
+DELETE FROM ducklake.inlined WHERE id < 5
+----
+5
+
+query I
+SELECT COUNT(*) FROM ducklake.inlined
+----
+95
+
+query I
+SELECT COUNT(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE table_id = getvariable('inlined_id') AND end_snapshot IS NULL
+----
+1
+
+query I
+SELECT record_count FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('inlined_id')
+----
+100

--- a/test/sql/delete/full_file_delete_stats_reinsert.test
+++ b/test/sql/delete/full_file_delete_stats_reinsert.test
@@ -1,0 +1,64 @@
+# name: test/sql/delete/full_file_delete_stats_reinsert.test
+# description: Dropping every file then re-inserting in the same transaction keeps column stats accurate
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/full_file_delete_stats_reinsert', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t AS SELECT range::INT id FROM range(100)
+
+statement ok
+SET VARIABLE t_id = (SELECT table_id FROM __ducklake_metadata_ducklake.ducklake_table WHERE table_name = 't')
+
+# Same transaction: drop the whole file (empties the table) then insert a disjoint range 200..209.
+statement ok
+BEGIN
+
+statement ok
+DELETE FROM ducklake.t
+
+statement ok
+INSERT INTO ducklake.t SELECT range::INT id FROM range(200, 210)
+
+statement ok
+COMMIT
+
+query I
+SELECT record_count FROM __ducklake_metadata_ducklake.ducklake_table_stats WHERE table_id = getvariable('t_id')
+----
+10
+
+# The column stats reflect the re-inserted rows, not NULL: the dropped file's min/max must not erase them.
+query TT
+SELECT min_value, max_value FROM __ducklake_metadata_ducklake.ducklake_table_column_stats WHERE table_id = getvariable('t_id')
+----
+200	209
+
+# A narrower insert in a separate transaction widens the min but keeps the max. Table holds {50..59, 200..209}.
+statement ok
+INSERT INTO ducklake.t SELECT range::INT id FROM range(50, 60)
+
+# Point lookup that relies on min/max pruning: row 205 exists and must not be pruned away.
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE id = 205
+----
+1
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE id > 100
+----
+10
+
+query I
+SELECT COUNT(*) FROM ducklake.t
+----
+20


### PR DESCRIPTION
When a `DELETE` removes every row of a data file, the file is dropped from the active set, but the table stats were left untouched. `record_count` and `file_size_bytes` kept counting rows and bytes that no longer exist, so repeated delete/reinsert cycles inflated cardinality estimates and the size reported by `duckdb_tables`.

This subtracts the dropped files' stats at commit time:
  - track row count and file size for each dropped committed data file.
  - subtract those amounts from the table stats during commit, including the server-side commit path.
  - clear the table column stats when a drop leaves the recorded min/max stale. Exact min/max cannot be recomputed without rescanning the surviving files, so they are reset to unknown and rebuilt on the next write.
  - `next_row_id` stays monotonic. The stats cache is invalidated after delete-only commits, since those commits do not advance `next_file_id`.

### Whole-file deletes under inlining

A fully-deleted file is now dropped before a small delete would be routed into inlined file deletes. Before this change, with the default inline limit, deleting every row of a small file inlined the deletes and left the dead file in place with stale stats. Dropping it is cheaper and keeps the stats correct. Only the case with no existing delete file takes this path; deletes that merge with an existing delete file are unchanged.