### PR TITLE
Implement inlining for the MERGE INTO ... INSERT case (fixes #1186)

### DIFF
--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -155,6 +155,24 @@ static void SinkInlineOrCopy(ExecutionContext &context, DataChunk &execute_input
 	}
 }
 
+static void DrainInlineData(optional_ptr<DuckLakeInlineData> inline_data_op, ExecutionContext &context, OperatorSinkCombineInput &input, PhysicalOperator &physical_copy, DuckLakeMergeSinkGlobalState &gstate, DuckLakeMergeSinkLocalState &lstate) {
+	auto &inline_output = lstate.inline_output;
+	while (true) {
+		lstate.inline_output.Reset();
+		auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
+		                                            *lstate.inline_data_lstate);
+		if (inline_output.size() > 0) {
+			ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
+			                      lstate.projected_chunk, lstate.cast_chunk);
+			OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+			physical_copy.Sink(context, lstate.cast_chunk, copy_input);
+		}
+		if (fresult == OperatorFinalizeResultType::FINISHED) {
+			break;
+		}
+	}
+}
+
 SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<DuckLakeMergeSinkGlobalState>();
 	auto &lstate = input.local_state.Cast<DuckLakeMergeSinkLocalState>();
@@ -169,21 +187,7 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 
 	// drain inline data
 	if (inline_data_op) {
-		auto &inline_output = lstate.inline_output;
-		while (true) {
-			lstate.inline_output.Reset();
-			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
-			                                            *lstate.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-				                      lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-			}
-			if (fresult == OperatorFinalizeResultType::FINISHED) {
-				break;
-			}
-		}
+		DrainInlineData(inline_data_op, context, input, physical_copy, gstate, lstate);
 	}
 
 	OperatorSinkCombineInput combine_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
@@ -432,23 +436,8 @@ SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, Op
 	auto &gstate = input.global_state.Cast<DuckLakeMergeUpdateGlobalState>();
 	auto &lstate = input.local_state.Cast<DuckLakeMergeUpdateLocalState>();
 
-	// drain inline data
 	if (inline_data_op) {
-		auto &inline_output = lstate.inline_output;
-		while (true) {
-			lstate.inline_output.Reset();
-			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
-			                                            *lstate.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-				                      lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-			}
-			if (fresult == OperatorFinalizeResultType::FINISHED) {
-				break;
-			}
-		}
+		DrainInlineData(inline_data_op, context, input, physical_copy, gstate, lstate);
 	}
 
 	DataChunk dummy;

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -578,8 +578,7 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		optional_ptr<DuckLakeInlineData> inline_data_op;
 		idx_t data_inlining_row_limit = catalog.GetInliningLimit(context, ducklake_table);
 		if (data_inlining_row_limit > 0) {
-			// the inlined chunks hold only the table's physical columns - the generated partition columns are
-			// only projected (through the extra projections) for data that is passed through to the copy
+			// slice to just the physical columns, because the inlined data does not have the partition columns
 			auto &expected_types = physical_copy.Cast<PhysicalCopyToFile>().expected_types;
 			vector<LogicalType> inline_types(expected_types.begin(),
 			                                 expected_types.begin() +

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -25,13 +25,13 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 class DuckLakeMergeInsert : public PhysicalOperator {
 public:
-	DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, PhysicalOperator &insert,
-	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &copy);
+	DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, PhysicalOperator &catalog_insert,
+	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &physical_copy);
 
 	//! The copy operator that writes to the file
-	PhysicalOperator &copy;
+	PhysicalOperator &physical_copy;
 	//! The final insert operator
-	PhysicalOperator &insert;
+	PhysicalOperator &catalog_insert;
 	//! The inline data operator (if data inlining is enabled)
 	optional_ptr<DuckLakeInlineData> inline_data_op;
 	//! Extra Projections
@@ -65,9 +65,9 @@ public:
 };
 
 DuckLakeMergeInsert::DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
-                                         PhysicalOperator &insert, optional_ptr<DuckLakeInlineData> inline_data_op,
-                                         PhysicalOperator &copy)
-    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), copy(copy), insert(insert),
+                                         PhysicalOperator &catalog_insert, optional_ptr<DuckLakeInlineData> inline_data_op,
+                                         PhysicalOperator &physical_copy)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), physical_copy(physical_copy), catalog_insert(catalog_insert),
       inline_data_op(inline_data_op) {
 }
 
@@ -116,43 +116,43 @@ public:
 	DataChunk inline_output;
 	//! Used if we have extra projections
 	DataChunk cast_chunk;
-	DataChunk chunk;
+	DataChunk projected_chunk;
 	unique_ptr<ExpressionExecutor> expression_executor;
 };
 
 SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
-	auto &local_state = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
 
-	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
-	// through to the CopyToFile sink
+	DataChunk &execute_input = chunk;
+	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it through to the CopyToFile sink
 	if (inline_data_op) {
-		auto &inline_output = local_state.inline_output;
+		auto &inline_output = lstate.inline_output;
 		inline_output.Reset();
-		auto result = inline_data_op->Execute(context, chunk, inline_output, *gstate.inline_data_gstate,
-		                                      *local_state.inline_data_lstate);
+		auto result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
+		                                      *lstate.inline_data_lstate);
 		if (inline_output.size() > 0) {
-			ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
-			                      local_state.chunk, local_state.cast_chunk);
-			OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-			copy.Sink(context, local_state.cast_chunk, copy_input);
+			ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
+			                      lstate.projected_chunk, lstate.cast_chunk);
+			OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+			physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 		}
 		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
 			inline_output.Reset();
-			result = inline_data_op->Execute(context, chunk, inline_output, *gstate.inline_data_gstate,
-			                                 *local_state.inline_data_lstate);
+			result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
+			                                 *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
-				                      local_state.chunk, local_state.cast_chunk);
-				OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-				copy.Sink(context, local_state.cast_chunk, copy_input);
+				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
+                              lstate.projected_chunk, lstate.cast_chunk);
+				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 			}
 		}
 	} else {
-		ProjectAndCastForCopy(context.client, chunk, copy, local_state.expression_executor.get(), local_state.chunk,
-													local_state.cast_chunk);
-		OperatorSinkInput sink_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-		return copy.Sink(context, local_state.cast_chunk, sink_input);
+		ProjectAndCastForCopy(context.client, execute_input, physical_copy, lstate.expression_executor.get(),
+		                      lstate.projected_chunk, lstate.cast_chunk);
+		OperatorSinkInput sink_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+		physical_copy.Sink(context, lstate.cast_chunk, sink_input);
 	}
 	return SinkResultType::NEED_MORE_INPUT;
 }
@@ -169,10 +169,10 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
 			                                            *local_state.inline_data_lstate);
 			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
-				                      local_state.chunk, local_state.cast_chunk);
-				OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-				copy.Sink(context, local_state.cast_chunk, copy_input);
+				ProjectAndCastForCopy(context.client, inline_output, physical_copy, local_state.expression_executor.get(),
+				                      local_state.projected_chunk, local_state.cast_chunk);
+				OperatorSinkInput copy_input {*physical_copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+				physical_copy.Sink(context, local_state.cast_chunk, copy_input);
 			}
 			if (fresult == OperatorFinalizeResultType::FINISHED) {
 				break;
@@ -180,8 +180,8 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 		}
 	}
 
-	OperatorSinkCombineInput combine_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-	return copy.Combine(context, combine_input);
+	OperatorSinkCombineInput combine_input {*physical_copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+	return physical_copy.Combine(context, combine_input);
 }
 
 
@@ -287,7 +287,7 @@ SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event,
 		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize);
 	}
 
-	return FinalizeCopyToInsert(pipeline, event, context, copy, insert, input.interrupt_state);
+	return FinalizeCopyToInsert(pipeline, event, context, physical_copy, catalog_insert, input.interrupt_state);
 }
 
 unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContext &context) const {
@@ -295,13 +295,13 @@ unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContex
 	if (inline_data_op) {
 		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
 	}
-	copy.sink_state = copy.GetGlobalSinkState(context);
+	physical_copy.sink_state = physical_copy.GetGlobalSinkState(context);
 	return std::move(result);
 }
 
 unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionContext &context) const {
 	auto result = make_uniq<DuckLakeMergeIntoLocalState>();
-	result->copy_sink_state = copy.GetLocalSinkState(context);
+	result->copy_sink_state = physical_copy.GetLocalSinkState(context);
 	if (inline_data_op) {
 		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
 		result->inline_output.Initialize(context.client, inline_data_op->types);
@@ -312,9 +312,9 @@ unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionConte
 		for (auto &expr : result->expression_executor->expressions) {
 			insert_types.push_back(expr->GetReturnType());
 		}
-		result->chunk.Initialize(context.client, insert_types);
+		result->projected_chunk.Initialize(context.client, insert_types);
 	}
-	result->cast_chunk.Initialize(context.client, copy.Cast<PhysicalCopyToFile>().expected_types);
+	result->cast_chunk.Initialize(context.client, physical_copy.Cast<PhysicalCopyToFile>().expected_types);
 
 	return std::move(result);
 }
@@ -325,16 +325,16 @@ unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionConte
 class DuckLakeMergeUpdate : public PhysicalOperator {
 public:
 	DuckLakeMergeUpdate(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeUpdate &update_op,
-	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &copy_op,
-	                    PhysicalOperator &insert_op)
+	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &physical_copy,
+	                    PhysicalOperator &catalog_insert)
 	    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), update_op(update_op),
-	      inline_data_op(inline_data_op), copy_op(copy_op), insert_op(insert_op) {
+	      inline_data_op(inline_data_op), physical_copy(physical_copy), catalog_insert(catalog_insert) {
 	}
 
 	DuckLakeUpdate &update_op;
 	optional_ptr<DuckLakeInlineData> inline_data_op;
-	PhysicalOperator &copy_op;
-	PhysicalOperator &insert_op;
+	PhysicalOperator &physical_copy;
+	PhysicalOperator &catalog_insert;
 	//! Extra projections for partition columns
 	vector<unique_ptr<Expression>> extra_projections;
 
@@ -374,7 +374,7 @@ class DuckLakeMergeUpdateLocalState : public LocalSinkState {
 public:
 	unique_ptr<OperatorState> update_lstate;
 	unique_ptr<OperatorState> inline_data_lstate;
-	unique_ptr<LocalSinkState> copy_lstate;
+	unique_ptr<LocalSinkState> copy_sink_state;
 	DataChunk update_output;
 	DataChunk inline_output;
 	//! Projection and cast chunks for partition columns (same pattern as DuckLakeMergeInsert)
@@ -389,7 +389,7 @@ unique_ptr<GlobalSinkState> DuckLakeMergeUpdate::GetGlobalSinkState(ClientContex
 	if (inline_data_op) {
 		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
 	}
-	copy_op.sink_state = copy_op.GetGlobalSinkState(context);
+	physical_copy.sink_state = physical_copy.GetGlobalSinkState(context);
 	return std::move(result);
 }
 
@@ -400,7 +400,7 @@ unique_ptr<LocalSinkState> DuckLakeMergeUpdate::GetLocalSinkState(ExecutionConte
 		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
 		result->inline_output.Initialize(context.client, inline_data_op->types);
 	}
-	result->copy_lstate = copy_op.GetLocalSinkState(context);
+	result->copy_sink_state = physical_copy.GetLocalSinkState(context);
 	result->update_output.Initialize(context.client, update_op.types);
 	if (!extra_projections.empty()) {
 		result->expression_executor = make_uniq<ExpressionExecutor>(context.client, extra_projections);
@@ -410,7 +410,7 @@ unique_ptr<LocalSinkState> DuckLakeMergeUpdate::GetLocalSinkState(ExecutionConte
 		}
 		result->projected_chunk.Initialize(context.client, projected_types);
 	}
-	result->cast_chunk.Initialize(context.client, copy_op.Cast<PhysicalCopyToFile>().expected_types);
+	result->cast_chunk.Initialize(context.client, physical_copy.Cast<PhysicalCopyToFile>().expected_types);
 	return std::move(result);
 }
 
@@ -425,35 +425,36 @@ SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &c
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
+	DataChunk &execute_input = lstate.update_output;
 	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
 	// through to the CopyToFile sink
 	if (inline_data_op) {
 		auto &inline_output = lstate.inline_output;
 		inline_output.Reset();
-		auto result = inline_data_op->Execute(context, lstate.update_output, inline_output, *gstate.inline_data_gstate,
+		auto result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
 		                                      *lstate.inline_data_lstate);
 		if (inline_output.size() > 0) {
-			ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
+			ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
 			                      lstate.projected_chunk, lstate.cast_chunk);
-			OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-			copy_op.Sink(context, lstate.cast_chunk, copy_input);
+			OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+			physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 		}
 		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
 			inline_output.Reset();
-			result = inline_data_op->Execute(context, lstate.update_output, inline_output, *gstate.inline_data_gstate,
+			result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
 			                                 *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
-				                      lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-				copy_op.Sink(context, lstate.cast_chunk, copy_input);
+				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
+                              lstate.projected_chunk, lstate.cast_chunk);
+				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 			}
 		}
 	} else {
-		ProjectAndCastForCopy(context.client, lstate.update_output, copy_op, lstate.expression_executor.get(),
-		                      lstate.projected_chunk, lstate.cast_chunk);
-		OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-		copy_op.Sink(context, lstate.cast_chunk, copy_input);
+		ProjectAndCastForCopy(context.client, execute_input, physical_copy, lstate.expression_executor.get(),
+				                  lstate.projected_chunk, lstate.cast_chunk);
+		OperatorSinkInput sink_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+		physical_copy.Sink(context, lstate.cast_chunk, sink_input);
 	}
 	return SinkResultType::NEED_MORE_INPUT;
 }
@@ -470,10 +471,10 @@ SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, Op
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
 			                                            *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, copy_op, lstate.expression_executor.get(),
+				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
 				                      lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-				copy_op.Sink(context, lstate.cast_chunk, copy_input);
+				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 			}
 			if (fresult == OperatorFinalizeResultType::FINISHED) {
 				break;
@@ -484,8 +485,8 @@ SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, Op
 	DataChunk dummy;
 	update_op.FinalExecute(context, dummy, *gstate.update_gstate, *lstate.update_lstate);
 
-	OperatorSinkCombineInput copy_combine {*copy_op.sink_state, *lstate.copy_lstate, input.interrupt_state};
-	copy_op.Combine(context, copy_combine);
+	OperatorSinkCombineInput copy_combine {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+	physical_copy.Combine(context, copy_combine);
 	return SinkCombineResultType::FINISHED;
 }
 
@@ -501,7 +502,7 @@ SinkFinalizeType DuckLakeMergeUpdate::Finalize(Pipeline &pipeline, Event &event,
 		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize);
 	}
 
-	return FinalizeCopyToInsert(pipeline, event, context, copy_op, insert_op, input.interrupt_state);
+	return FinalizeCopyToInsert(pipeline, event, context, physical_copy, catalog_insert, input.interrupt_state);
 }
 
 //===--------------------------------------------------------------------===//
@@ -542,28 +543,28 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		update_op.row_id_index = child_plan.types.size() - DuckLakeUpdate::DELETION_INFO_SIZE - 1;
 
 		// maybe wrap with InlineData if we hit the row limit
-		optional_ptr<DuckLakeInlineData> inline_data;
+		optional_ptr<DuckLakeInlineData> inline_data_op;
 		idx_t data_inlining_row_limit = catalog.GetInliningLimit(context, ducklake_table);
 		if (data_inlining_row_limit > 0) {
 			auto &inline_op =
 			    planner.Make<DuckLakeInlineData>(update_op, data_inlining_row_limit).Cast<DuckLakeInlineData>();
-			inline_data = &inline_op;
+			inline_data_op = &inline_op;
 		}
 
 		// plan copy and insert
 		auto copy_options = DuckLakeInsert::GetCopyOptions(context, copy_input);
-		auto &copy_op = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, nullptr);
-		auto &copy_dummy = planner.Make<PhysicalDummyScan>(copy_op.Cast<PhysicalCopyToFile>().expected_types, 1);
-		copy_op.children.push_back(copy_dummy);
-		auto &insert_op =
+		auto &physical_copy = DuckLakeInsert::PlanCopyForInsert(context, planner, copy_input, nullptr);
+		auto &copy_dummy = planner.Make<PhysicalDummyScan>(physical_copy.Cast<PhysicalCopyToFile>().expected_types, 1);
+		physical_copy.children.push_back(copy_dummy);
+		auto &catalog_insert =
 		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
-		if (inline_data) {
-			inline_data->insert = insert_op.Cast<DuckLakeInsert>();
+		if (inline_data_op) {
+			inline_data_op->insert = catalog_insert.Cast<DuckLakeInsert>();
 		}
-		insert_op.children.push_back(copy_op);
+		catalog_insert.children.push_back(physical_copy);
 
 		// wrap in DuckLakeMergeUpdate
-		auto &merge_update = planner.Make<DuckLakeMergeUpdate>(return_types, update_op, inline_data, copy_op, insert_op)
+		auto &merge_update = planner.Make<DuckLakeMergeUpdate>(return_types, update_op, inline_data_op, physical_copy, catalog_insert)
 		                         .Cast<DuckLakeMergeUpdate>();
 		merge_update.extra_projections = std::move(copy_options.projection_list);
 		result->op = merge_update;
@@ -616,7 +617,7 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		physical_copy.children.push_back(copy_dummy);
 
 		// maybe wrap with InlineData if we hit the row limit
-		optional_ptr<DuckLakeInlineData> inline_data;
+		optional_ptr<DuckLakeInlineData> inline_data_op;
 		idx_t data_inlining_row_limit = catalog.GetInliningLimit(context, ducklake_table);
 		if (data_inlining_row_limit > 0) {
 			// the inlined chunks hold only the table's physical columns - the generated partition columns are
@@ -628,17 +629,17 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 			auto &inline_dummy = planner.Make<PhysicalDummyScan>(std::move(inline_types), 1);
 			auto &inline_op =
 			    planner.Make<DuckLakeInlineData>(inline_dummy, data_inlining_row_limit).Cast<DuckLakeInlineData>();
-			inline_data = &inline_op;
+			inline_data_op = &inline_op;
 		}
 
-		auto &insert =
+		auto &catalog_insert =
 		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
-		if (inline_data) {
-			inline_data->insert = insert.Cast<DuckLakeInsert>();
+		if (inline_data_op) {
+			inline_data_op->insert = catalog_insert.Cast<DuckLakeInsert>();
 		}
-		insert.children.push_back(physical_copy);
+		catalog_insert.children.push_back(physical_copy);
 
-		auto &merge_insert = planner.Make<DuckLakeMergeInsert>(insert.types, insert, inline_data, physical_copy)
+		auto &merge_insert = planner.Make<DuckLakeMergeInsert>(return_types, catalog_insert, inline_data_op, physical_copy)
 		                         .Cast<DuckLakeMergeInsert>();
 		merge_insert.extra_projections = std::move(copy_options.projection_list);
 		result->op = merge_insert;

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -101,6 +101,41 @@ static void ProjectAndCastForCopy(ClientContext &context, DataChunk &input_chunk
 	cast_chunk.SetChildCardinality(chunk_ref.get().size());
 }
 
+// Run a chunk through the optional inline-data operator or send it straight to the copy sink.
+static void SinkInlineOrCopy(ExecutionContext &context, DataChunk &execute_input,
+                             optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &physical_copy,
+                             optional_ptr<GlobalOperatorState> inline_data_gstate,
+                             optional_ptr<OperatorState> inline_data_lstate, DataChunk &inline_output,
+                             ExpressionExecutor *expression_executor, DataChunk &projected_chunk, DataChunk &cast_chunk,
+                             LocalSinkState &copy_sink_state, InterruptState &interrupt_state) {
+	
+	auto sink_to_copy = [&](DataChunk &chunk) {
+		ProjectAndCastForCopy(context.client, chunk, physical_copy, expression_executor, projected_chunk, cast_chunk);
+		OperatorSinkInput copy_input {*physical_copy.sink_state, copy_sink_state, interrupt_state};
+		physical_copy.Sink(context, cast_chunk, copy_input);
+	};
+
+	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it through to the CopyToFile sink
+	if (inline_data_op) {
+		inline_output.Reset();
+		auto result = 
+			  inline_data_op->Execute(context, execute_input, inline_output, *inline_data_gstate, *inline_data_lstate);
+		if (inline_output.size() > 0) {
+			sink_to_copy(inline_output);
+		}
+		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+			inline_output.Reset();
+			result = 
+					inline_data_op->Execute(context, execute_input, inline_output, *inline_data_gstate, *inline_data_lstate);
+			if (inline_output.size() > 0) {
+				sink_to_copy(inline_output);
+			}
+		}
+	} else {
+		sink_to_copy(execute_input);
+	}
+}
+
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
@@ -125,54 +160,28 @@ SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &c
 	auto &lstate = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
 
 	DataChunk &execute_input = chunk;
-	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it through to the CopyToFile sink
-	if (inline_data_op) {
-		auto &inline_output = lstate.inline_output;
-		inline_output.Reset();
-		auto result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
-		                                      *lstate.inline_data_lstate);
-		if (inline_output.size() > 0) {
-			ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-			                      lstate.projected_chunk, lstate.cast_chunk);
-			OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-			physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-		}
-		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
-			inline_output.Reset();
-			result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
-			                                 *lstate.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-                              lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-			}
-		}
-	} else {
-		ProjectAndCastForCopy(context.client, execute_input, physical_copy, lstate.expression_executor.get(),
-		                      lstate.projected_chunk, lstate.cast_chunk);
-		OperatorSinkInput sink_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-		physical_copy.Sink(context, lstate.cast_chunk, sink_input);
-	}
+	SinkInlineOrCopy(context, execute_input, inline_data_op, physical_copy, gstate.inline_data_gstate.get(),
+	                 lstate.inline_data_lstate.get(), lstate.inline_output, lstate.expression_executor.get(),
+	                 lstate.projected_chunk, lstate.cast_chunk, *lstate.copy_sink_state, input.interrupt_state);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
 SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
 	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
-	auto &local_state = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
 
 	// drain inline data
 	if (inline_data_op) {
-		auto &inline_output = local_state.inline_output;
+		auto &inline_output = lstate.inline_output;
 		while (true) {
 			inline_output.Reset();
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
-			                                            *local_state.inline_data_lstate);
+			                                            *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, physical_copy, local_state.expression_executor.get(),
-				                      local_state.projected_chunk, local_state.cast_chunk);
-				OperatorSinkInput copy_input {*physical_copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-				physical_copy.Sink(context, local_state.cast_chunk, copy_input);
+				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
+				                      lstate.projected_chunk, lstate.cast_chunk);
+				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
 			}
 			if (fresult == OperatorFinalizeResultType::FINISHED) {
 				break;
@@ -180,8 +189,9 @@ SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, Op
 		}
 	}
 
-	OperatorSinkCombineInput combine_input {*physical_copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-	return physical_copy.Combine(context, combine_input);
+	OperatorSinkCombineInput combine_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
+	physical_copy.Combine(context, combine_input);
+	return SinkCombineResultType::FINISHED;
 }
 
 
@@ -426,36 +436,9 @@ SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &c
 	}
 
 	DataChunk &execute_input = lstate.update_output;
-	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
-	// through to the CopyToFile sink
-	if (inline_data_op) {
-		auto &inline_output = lstate.inline_output;
-		inline_output.Reset();
-		auto result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
-		                                      *lstate.inline_data_lstate);
-		if (inline_output.size() > 0) {
-			ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-			                      lstate.projected_chunk, lstate.cast_chunk);
-			OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-			physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-		}
-		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
-			inline_output.Reset();
-			result = inline_data_op->Execute(context, execute_input, inline_output, *gstate.inline_data_gstate,
-			                                 *lstate.inline_data_lstate);
-			if (inline_output.size() > 0) {
-				ProjectAndCastForCopy(context.client, inline_output, physical_copy, lstate.expression_executor.get(),
-                              lstate.projected_chunk, lstate.cast_chunk);
-				OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-				physical_copy.Sink(context, lstate.cast_chunk, copy_input);
-			}
-		}
-	} else {
-		ProjectAndCastForCopy(context.client, execute_input, physical_copy, lstate.expression_executor.get(),
-				                  lstate.projected_chunk, lstate.cast_chunk);
-		OperatorSinkInput sink_input {*physical_copy.sink_state, *lstate.copy_sink_state, input.interrupt_state};
-		physical_copy.Sink(context, lstate.cast_chunk, sink_input);
-	}
+	SinkInlineOrCopy(context, execute_input, inline_data_op, physical_copy, gstate.inline_data_gstate.get(),
+	                 lstate.inline_data_lstate.get(), lstate.inline_output, lstate.expression_executor.get(),
+	                 lstate.projected_chunk, lstate.cast_chunk, *lstate.copy_sink_state, input.interrupt_state);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -101,50 +101,16 @@ static void ProjectAndCastForCopy(ClientContext &context, DataChunk &input_chunk
 	cast_chunk.SetChildCardinality(chunk_ref.get().size());
 }
 
-// Run a chunk through the optional inline-data operator or send it straight to the copy sink.
-static void SinkInlineOrCopy(ExecutionContext &context, DataChunk &execute_input,
-                             optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &physical_copy,
-                             optional_ptr<GlobalOperatorState> inline_data_gstate,
-                             optional_ptr<OperatorState> inline_data_lstate, DataChunk &inline_output,
-                             ExpressionExecutor *expression_executor, DataChunk &projected_chunk, DataChunk &cast_chunk,
-                             LocalSinkState &copy_sink_state, InterruptState &interrupt_state) {
-	
-	auto sink_to_copy = [&](DataChunk &chunk) {
-		ProjectAndCastForCopy(context.client, chunk, physical_copy, expression_executor, projected_chunk, cast_chunk);
-		OperatorSinkInput copy_input {*physical_copy.sink_state, copy_sink_state, interrupt_state};
-		physical_copy.Sink(context, cast_chunk, copy_input);
-	};
-
-	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it through to the CopyToFile sink
-	if (inline_data_op) {
-		inline_output.Reset();
-		auto result = 
-			  inline_data_op->Execute(context, execute_input, inline_output, *inline_data_gstate, *inline_data_lstate);
-		if (inline_output.size() > 0) {
-			sink_to_copy(inline_output);
-		}
-		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
-			inline_output.Reset();
-			result = 
-					inline_data_op->Execute(context, execute_input, inline_output, *inline_data_gstate, *inline_data_lstate);
-			if (inline_output.size() > 0) {
-				sink_to_copy(inline_output);
-			}
-		}
-	} else {
-		sink_to_copy(execute_input);
-	}
-}
-
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
-class DuckLakeMergeIntoGlobalState : public GlobalSinkState {
+// Shared sink state for the merge operators that copy/inline rows (DuckLakeMergeInsert and DuckLakeMergeUpdate).
+class DuckLakeMergeSinkGlobalState : public GlobalSinkState {
 public:
 	unique_ptr<GlobalOperatorState> inline_data_gstate;
 };
 
-class DuckLakeMergeIntoLocalState : public LocalSinkState {
+class DuckLakeMergeSinkLocalState : public LocalSinkState {
 public:
 	unique_ptr<LocalSinkState> copy_sink_state;
 	unique_ptr<OperatorState> inline_data_lstate;
@@ -155,26 +121,57 @@ public:
 	unique_ptr<ExpressionExecutor> expression_executor;
 };
 
-SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
-	auto &lstate = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+// Run a chunk through the optional inline-data operator or send it straight to the copy sink.
+static void SinkInlineOrCopy(ExecutionContext &context, DataChunk &execute_input,
+                             optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &physical_copy,
+                             DuckLakeMergeSinkGlobalState &gstate, DuckLakeMergeSinkLocalState &lstate,
+                             InterruptState &interrupt_state) {
+	auto sink_to_copy = [&](DataChunk &chunk) {
+		ProjectAndCastForCopy(context.client, chunk, physical_copy, lstate.expression_executor.get(),
+		                      lstate.projected_chunk, lstate.cast_chunk);
+		OperatorSinkInput copy_input {*physical_copy.sink_state, *lstate.copy_sink_state, interrupt_state};
+		physical_copy.Sink(context, lstate.cast_chunk, copy_input);
+	};
 
-	DataChunk &execute_input = chunk;
-	SinkInlineOrCopy(context, execute_input, inline_data_op, physical_copy, gstate.inline_data_gstate.get(),
-	                 lstate.inline_data_lstate.get(), lstate.inline_output, lstate.expression_executor.get(),
-	                 lstate.projected_chunk, lstate.cast_chunk, *lstate.copy_sink_state, input.interrupt_state);
+	// run the chunk through the inline data operator - it inlines what fits and passes the rest to the copy sink
+	if (inline_data_op) {
+		lstate.inline_output.Reset();
+		auto result = inline_data_op->Execute(context, execute_input, lstate.inline_output, *gstate.inline_data_gstate,
+																					*lstate.inline_data_lstate);
+		if (lstate.inline_output.size() > 0) {
+			sink_to_copy(lstate.inline_output);
+		}
+		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+			lstate.inline_output.Reset();
+			result = inline_data_op->Execute(context, execute_input, lstate.inline_output, *gstate.inline_data_gstate,
+																			 *lstate.inline_data_lstate);
+			if (lstate.inline_output.size() > 0) {
+				sink_to_copy(lstate.inline_output);
+			}
+		}
+	} else {
+		sink_to_copy(execute_input);
+		return;
+	}
+}
+
+SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeSinkGlobalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeSinkLocalState>();
+
+	SinkInlineOrCopy(context, chunk, inline_data_op, physical_copy, gstate, lstate, input.interrupt_state);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
 SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
-	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
-	auto &lstate = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+	auto &gstate = input.global_state.Cast<DuckLakeMergeSinkGlobalState>();
+	auto &lstate = input.local_state.Cast<DuckLakeMergeSinkLocalState>();
 
 	// drain inline data
 	if (inline_data_op) {
 		auto &inline_output = lstate.inline_output;
 		while (true) {
-			inline_output.Reset();
+			lstate.inline_output.Reset();
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
 			                                            *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {
@@ -292,7 +289,7 @@ static SinkFinalizeType FinalizeCopyToInsert(Pipeline &pipeline, Event &event, C
 SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                                OperatorSinkFinalizeInput &input) const {
 	if (inline_data_op) {
-		auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
+		auto &gstate = input.global_state.Cast<DuckLakeMergeSinkGlobalState>();
 		OperatorFinalizeInput inline_finalize {*gstate.inline_data_gstate, input.interrupt_state};
 		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize);
 	}
@@ -301,7 +298,7 @@ SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event,
 }
 
 unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContext &context) const {
-	auto result = make_uniq<DuckLakeMergeIntoGlobalState>();
+	auto result = make_uniq<DuckLakeMergeSinkGlobalState>();
 	if (inline_data_op) {
 		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
 	}
@@ -310,7 +307,7 @@ unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContex
 }
 
 unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionContext &context) const {
-	auto result = make_uniq<DuckLakeMergeIntoLocalState>();
+	auto result = make_uniq<DuckLakeMergeSinkLocalState>();
 	result->copy_sink_state = physical_copy.GetLocalSinkState(context);
 	if (inline_data_op) {
 		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
@@ -374,23 +371,15 @@ public:
 	                          OperatorSinkFinalizeInput &input) const override;
 };
 
-class DuckLakeMergeUpdateGlobalState : public GlobalSinkState {
+class DuckLakeMergeUpdateGlobalState : public DuckLakeMergeSinkGlobalState {
 public:
 	unique_ptr<GlobalOperatorState> update_gstate;
-	unique_ptr<GlobalOperatorState> inline_data_gstate;
 };
 
-class DuckLakeMergeUpdateLocalState : public LocalSinkState {
+class DuckLakeMergeUpdateLocalState : public DuckLakeMergeSinkLocalState {
 public:
 	unique_ptr<OperatorState> update_lstate;
-	unique_ptr<OperatorState> inline_data_lstate;
-	unique_ptr<LocalSinkState> copy_sink_state;
 	DataChunk update_output;
-	DataChunk inline_output;
-	//! Projection and cast chunks for partition columns (same pattern as DuckLakeMergeInsert)
-	unique_ptr<ExpressionExecutor> expression_executor;
-	DataChunk projected_chunk;
-	DataChunk cast_chunk;
 };
 
 unique_ptr<GlobalSinkState> DuckLakeMergeUpdate::GetGlobalSinkState(ClientContext &context) const {
@@ -435,10 +424,7 @@ SinkResultType DuckLakeMergeUpdate::Sink(ExecutionContext &context, DataChunk &c
 		return SinkResultType::NEED_MORE_INPUT;
 	}
 
-	DataChunk &execute_input = lstate.update_output;
-	SinkInlineOrCopy(context, execute_input, inline_data_op, physical_copy, gstate.inline_data_gstate.get(),
-	                 lstate.inline_data_lstate.get(), lstate.inline_output, lstate.expression_executor.get(),
-	                 lstate.projected_chunk, lstate.cast_chunk, *lstate.copy_sink_state, input.interrupt_state);
+	SinkInlineOrCopy(context, lstate.update_output, inline_data_op, physical_copy, gstate, lstate, input.interrupt_state);
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
@@ -450,7 +436,7 @@ SinkCombineResultType DuckLakeMergeUpdate::Combine(ExecutionContext &context, Op
 	if (inline_data_op) {
 		auto &inline_output = lstate.inline_output;
 		while (true) {
-			inline_output.Reset();
+			lstate.inline_output.Reset();
 			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
 			                                            *lstate.inline_data_lstate);
 			if (inline_output.size() > 0) {

--- a/src/storage/ducklake_merge_into.cpp
+++ b/src/storage/ducklake_merge_into.cpp
@@ -26,12 +26,14 @@ namespace duckdb {
 class DuckLakeMergeInsert : public PhysicalOperator {
 public:
 	DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, PhysicalOperator &insert,
-	                    PhysicalOperator &copy);
+	                    optional_ptr<DuckLakeInlineData> inline_data_op, PhysicalOperator &copy);
 
 	//! The copy operator that writes to the file
 	PhysicalOperator &copy;
 	//! The final insert operator
 	PhysicalOperator &insert;
+	//! The inline data operator (if data inlining is enabled)
+	optional_ptr<DuckLakeInlineData> inline_data_op;
 	//! Extra Projections
 	vector<unique_ptr<Expression>> extra_projections;
 
@@ -63,8 +65,10 @@ public:
 };
 
 DuckLakeMergeInsert::DuckLakeMergeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types,
-                                         PhysicalOperator &insert, PhysicalOperator &copy)
-    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), copy(copy), insert(insert) {
+                                         PhysicalOperator &insert, optional_ptr<DuckLakeInlineData> inline_data_op,
+                                         PhysicalOperator &copy)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), copy(copy), insert(insert),
+      inline_data_op(inline_data_op) {
 }
 
 SourceResultType DuckLakeMergeInsert::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
@@ -100,9 +104,16 @@ static void ProjectAndCastForCopy(ClientContext &context, DataChunk &input_chunk
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
+class DuckLakeMergeIntoGlobalState : public GlobalSinkState {
+public:
+	unique_ptr<GlobalOperatorState> inline_data_gstate;
+};
+
 class DuckLakeMergeIntoLocalState : public LocalSinkState {
 public:
 	unique_ptr<LocalSinkState> copy_sink_state;
+	unique_ptr<OperatorState> inline_data_lstate;
+	DataChunk inline_output;
 	//! Used if we have extra projections
 	DataChunk cast_chunk;
 	DataChunk chunk;
@@ -110,15 +121,65 @@ public:
 };
 
 SinkResultType DuckLakeMergeInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
 	auto &local_state = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
-	ProjectAndCastForCopy(context.client, chunk, copy, local_state.expression_executor.get(), local_state.chunk,
-	                      local_state.cast_chunk);
-	OperatorSinkInput sink_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
-	return copy.Sink(context, local_state.cast_chunk, sink_input);
+
+	// if we have an inline data operator, we need to execute through it, it will either inline it or pass it
+	// through to the CopyToFile sink
+	if (inline_data_op) {
+		auto &inline_output = local_state.inline_output;
+		inline_output.Reset();
+		auto result = inline_data_op->Execute(context, chunk, inline_output, *gstate.inline_data_gstate,
+		                                      *local_state.inline_data_lstate);
+		if (inline_output.size() > 0) {
+			ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
+			                      local_state.chunk, local_state.cast_chunk);
+			OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+			copy.Sink(context, local_state.cast_chunk, copy_input);
+		}
+		while (result == OperatorResultType::HAVE_MORE_OUTPUT) {
+			inline_output.Reset();
+			result = inline_data_op->Execute(context, chunk, inline_output, *gstate.inline_data_gstate,
+			                                 *local_state.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
+				                      local_state.chunk, local_state.cast_chunk);
+				OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+				copy.Sink(context, local_state.cast_chunk, copy_input);
+			}
+		}
+	} else {
+		ProjectAndCastForCopy(context.client, chunk, copy, local_state.expression_executor.get(), local_state.chunk,
+													local_state.cast_chunk);
+		OperatorSinkInput sink_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+		return copy.Sink(context, local_state.cast_chunk, sink_input);
+	}
+	return SinkResultType::NEED_MORE_INPUT;
 }
 
 SinkCombineResultType DuckLakeMergeInsert::Combine(ExecutionContext &context, OperatorSinkCombineInput &input) const {
+	auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
 	auto &local_state = input.local_state.Cast<DuckLakeMergeIntoLocalState>();
+
+	// drain inline data
+	if (inline_data_op) {
+		auto &inline_output = local_state.inline_output;
+		while (true) {
+			inline_output.Reset();
+			auto fresult = inline_data_op->FinalExecute(context, inline_output, *gstate.inline_data_gstate,
+			                                            *local_state.inline_data_lstate);
+			if (inline_output.size() > 0) {
+				ProjectAndCastForCopy(context.client, inline_output, copy, local_state.expression_executor.get(),
+				                      local_state.chunk, local_state.cast_chunk);
+				OperatorSinkInput copy_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
+				copy.Sink(context, local_state.cast_chunk, copy_input);
+			}
+			if (fresult == OperatorFinalizeResultType::FINISHED) {
+				break;
+			}
+		}
+	}
+
 	OperatorSinkCombineInput combine_input {*copy.sink_state, *local_state.copy_sink_state, input.interrupt_state};
 	return copy.Combine(context, combine_input);
 }
@@ -220,17 +281,31 @@ static SinkFinalizeType FinalizeCopyToInsert(Pipeline &pipeline, Event &event, C
 
 SinkFinalizeType DuckLakeMergeInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
                                                OperatorSinkFinalizeInput &input) const {
+	if (inline_data_op) {
+		auto &gstate = input.global_state.Cast<DuckLakeMergeIntoGlobalState>();
+		OperatorFinalizeInput inline_finalize {*gstate.inline_data_gstate, input.interrupt_state};
+		inline_data_op->OperatorFinalize(pipeline, event, context, inline_finalize);
+	}
+
 	return FinalizeCopyToInsert(pipeline, event, context, copy, insert, input.interrupt_state);
 }
 
 unique_ptr<GlobalSinkState> DuckLakeMergeInsert::GetGlobalSinkState(ClientContext &context) const {
+	auto result = make_uniq<DuckLakeMergeIntoGlobalState>();
+	if (inline_data_op) {
+		result->inline_data_gstate = inline_data_op->GetGlobalOperatorState(context);
+	}
 	copy.sink_state = copy.GetGlobalSinkState(context);
-	return make_uniq<GlobalSinkState>();
+	return std::move(result);
 }
 
 unique_ptr<LocalSinkState> DuckLakeMergeInsert::GetLocalSinkState(ExecutionContext &context) const {
 	auto result = make_uniq<DuckLakeMergeIntoLocalState>();
 	result->copy_sink_state = copy.GetLocalSinkState(context);
+	if (inline_data_op) {
+		result->inline_data_lstate = inline_data_op->GetOperatorState(context);
+		result->inline_output.Initialize(context.client, inline_data_op->types);
+	}
 	if (!extra_projections.empty()) {
 		result->expression_executor = make_uniq<ExpressionExecutor>(context.client, extra_projections);
 		vector<LogicalType> insert_types;
@@ -539,12 +614,32 @@ static unique_ptr<MergeIntoOperator> DuckLakePlanMergeIntoAction(DuckLakeCatalog
 		auto &copy_dummy =
 		    planner.Make<PhysicalDummyScan>(physical_copy.Cast<PhysicalCopyToFile>().expected_types, 1);
 		physical_copy.children.push_back(copy_dummy);
+
+		// maybe wrap with InlineData if we hit the row limit
+		optional_ptr<DuckLakeInlineData> inline_data;
+		idx_t data_inlining_row_limit = catalog.GetInliningLimit(context, ducklake_table);
+		if (data_inlining_row_limit > 0) {
+			// the inlined chunks hold only the table's physical columns - the generated partition columns are
+			// only projected (through the extra projections) for data that is passed through to the copy
+			auto &expected_types = physical_copy.Cast<PhysicalCopyToFile>().expected_types;
+			vector<LogicalType> inline_types(expected_types.begin(),
+			                                 expected_types.begin() +
+			                                     ducklake_table.GetColumns().PhysicalColumnCount());
+			auto &inline_dummy = planner.Make<PhysicalDummyScan>(std::move(inline_types), 1);
+			auto &inline_op =
+			    planner.Make<DuckLakeInlineData>(inline_dummy, data_inlining_row_limit).Cast<DuckLakeInlineData>();
+			inline_data = &inline_op;
+		}
+
 		auto &insert =
 		    DuckLakeInsert::PlanInsert(context, planner, ducklake_table, std::move(copy_input.encryption_key));
+		if (inline_data) {
+			inline_data->insert = insert.Cast<DuckLakeInsert>();
+		}
 		insert.children.push_back(physical_copy);
 
-		auto &merge_insert =
-		    planner.Make<DuckLakeMergeInsert>(insert.types, insert, physical_copy).Cast<DuckLakeMergeInsert>();
+		auto &merge_insert = planner.Make<DuckLakeMergeInsert>(insert.types, insert, inline_data, physical_copy)
+		                         .Cast<DuckLakeMergeInsert>();
 		merge_insert.extra_projections = std::move(copy_options.projection_list);
 		result->op = merge_insert;
 		break;

--- a/test/sql/data_inlining/data_inlining_merge_insert_only.test
+++ b/test/sql/data_inlining/data_inlining_merge_insert_only.test
@@ -1,0 +1,44 @@
+# name: test/sql/data_inlining/data_inlining_merge_insert_only.test
+# description: data inlining applies to MERGE INTO's INSERTs
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/merge_insert_only_inlining', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE t (id INT, val VARCHAR);
+
+# MERGE with only WHEN NOT MATCHED THEN INSERT (no MATCHED branch)
+# The single new row is below the inlining limit - it should be inlined, not written to parquet
+statement ok
+MERGE INTO t AS tgt
+USING (VALUES (2, 'merge-insert')) AS src(id, val)
+    ON tgt.id = src.id
+WHEN NOT MATCHED THEN INSERT (id, val) VALUES (src.id, src.val);
+
+query II
+SELECT * FROM t ORDER BY id
+----
+2	merge-insert
+
+# no parquet files should exist - both rows should be inlined
+query I
+SELECT COUNT(*) FROM GLOB('{DATA_PATH}/merge_insert_only_inlining/**')
+----
+0
+
+query I
+SELECT DISTINCT filename LIKE 'ducklake_inlined_data%' FROM t
+----
+true

--- a/test/sql/merge/merge_multi_partition_timestamp.test
+++ b/test/sql/merge/merge_multi_partition_timestamp.test
@@ -10,8 +10,9 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
+# this test verifies the partition values of written files - disable inlining so the MERGE writes a file
 statement ok
-ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/merge_partition_bug', METADATA_CATALOG 'meta')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/merge_partition_bug', METADATA_CATALOG 'meta', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake

--- a/test/sql/rewrite_data_files/test_rewrite_partitioning.test
+++ b/test/sql/rewrite_data_files/test_rewrite_partitioning.test
@@ -10,9 +10,8 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
 test-env DATA_PATH {TEST_DIR}
 
-
 statement ok
-ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/rewrite_partitioned', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/rewrite_partitioned', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -24,20 +23,12 @@ CREATE TABLE partitioned(part_key INTEGER, id INTEGER, value INTEGER);
 statement ok
 ALTER TABLE partitioned SET PARTITIONED BY (part_key);
 
-# Initial data load into multiple partitions
+# Initial data load into multiple partitions (inlining disabled so it creates a file)
 statement ok
 INSERT INTO partitioned VALUES (1, 1, 10), (1, 2, 20);
 
-# flush to create file
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
-
 statement ok
 INSERT INTO partitioned VALUES (2, 1, 100), (2, 2, 200);
-
-# flush to create file
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 # We should have 2 data files (one per insert, but inserts had multiple rows)
 query I
@@ -57,10 +48,6 @@ USING _merge_source AS source
 ON (target.part_key = source.part_key AND target.id = source.id)
 WHEN MATCHED THEN UPDATE SET value = source.value
 WHEN NOT MATCHED THEN INSERT *;
-
-# flush to create delete files from inlined deletions
-statement ok
-CALL ducklake_flush_inlined_data('ducklake')
 
 # Verify delete files were created by MERGE
 query I
@@ -105,12 +92,11 @@ SELECT * FROM partitioned ORDER BY part_key, id
 2	3	300
 
 # Merge adjacent files to consolidate (rewrite doesn't merge, just applies deletes)
-# each partition has 2 files: the flushed inlined MERGE rows and the rewritten initial file
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'partitioned') ORDER BY ALL
 ----
-partitioned	2	1
-partitioned	2	1
+partitioned	3	1
+partitioned	3	1
 
 # Cleanup old files
 statement ok

--- a/test/sql/rewrite_data_files/test_rewrite_partitioning.test
+++ b/test/sql/rewrite_data_files/test_rewrite_partitioning.test
@@ -105,11 +105,12 @@ SELECT * FROM partitioned ORDER BY part_key, id
 2	3	300
 
 # Merge adjacent files to consolidate (rewrite doesn't merge, just applies deletes)
+# each partition has 2 files: the flushed inlined MERGE rows and the rewritten initial file
 query III
 SELECT table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'partitioned') ORDER BY ALL
 ----
-partitioned	3	1
-partitioned	3	1
+partitioned	2	1
+partitioned	2	1
 
 # Cleanup old files
 statement ok


### PR DESCRIPTION
Commit https://github.com/duckdb/ducklake/commit/c89438ff added the update implementation for MERGE INTO with support for inlining, but the INSERT case never had it. I think it was simply forgotten or deferred. So I added the insert handling analogous to what is already happening.

This is my first PR for anything duckdb related and it took me quite some time to grok the duckdb/ducklake codebase but the end result seemed so obvious given the UPDATE branch paths that I think it should be correct.

I didn't see a HACKING.md but feel free to let me know if there are things I should take into account.