### PR TITLE
Invalidate stale schema entries

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -71,6 +71,8 @@ class DuckLakeSchemaPinState : public ClientContextState {
 public:
 	void QueryEnd(ClientContext &context) override;
 	void Pin(shared_ptr<DuckLakeSchemaCacheEntry> entry);
+	//! Clear all pinned schema cache entries for this pin state.
+	void Clear();
 
 private:
 	mutex lock;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -39,6 +39,7 @@ struct NewNameMapInfo;
 struct CompactionInformation;
 struct DuckLakePath;
 struct DuckLakeCommitState;
+struct DuckLakeSchemaCacheEntry;
 class DuckLakeFieldId;
 class LocalTableChangeIterationHelper;
 class DuckLakeTransactionState;
@@ -197,6 +198,7 @@ public:
 	DuckLakeSnapshot GetSnapshot();
 	DuckLakeSnapshot GetSnapshot(optional_ptr<BoundAtClause> at_clause,
 	                             SnapshotBound bound = SnapshotBound::UPPER_BOUND);
+	void PinSchemaCacheEntry(shared_ptr<DuckLakeSchemaCacheEntry> entry);
 
 	static DuckLakeTransaction &Get(ClientContext &context, Catalog &catalog);
 
@@ -336,6 +338,9 @@ private:
 	void AlterEntryInternal(DuckLakeViewEntry &old_entry, unique_ptr<CatalogEntry> new_entry);
 	case_insensitive_map_t<unique_ptr<DuckLakeCatalogSet>> &GetNewMacroMap(CatalogType type);
 
+	// Invoked at transaction completion, invalidates all schema cache entries referenced by this transaction.
+	void ClearSchemaCachePins();
+
 private:
 	DuckLakeCatalog &ducklake_catalog;
 	DatabaseInstance &db;
@@ -348,6 +353,11 @@ private:
 	idx_t local_catalog_id;
 	//! Set when this transaction inlines into a table that does not yet have an inlined-data table
 	atomic<bool> requires_new_inlined_table {false};
+	//! Schema cache entries referenced by this transaction's catalog entries. These pins keep transaction-local
+	//! parent references valid even if another transaction invalidates the global object-cache entry.
+	//! Maps from cache entry pointer to the shared pointer to the cache entry.
+	mutex schema_pin_lock;
+	unordered_map<DuckLakeSchemaCacheEntry *, shared_ptr<DuckLakeSchemaCacheEntry>> schema_pins;
 	//! Per-transaction mutable change state (new/dropped/renamed entries, local file changes, flushed
 	//! inlined tables) and the Commit loop. Owns the data formerly held directly on the transaction.
 	unique_ptr<DuckLakeTransactionState> state;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -40,6 +40,7 @@ struct CompactionInformation;
 struct DuckLakePath;
 struct DuckLakeCommitState;
 struct DuckLakeSchemaCacheEntry;
+class DuckLakeSchemaPinState;
 class DuckLakeFieldId;
 class LocalTableChangeIterationHelper;
 class DuckLakeTransactionState;
@@ -355,9 +356,7 @@ private:
 	atomic<bool> requires_new_inlined_table {false};
 	//! Schema cache entries referenced by this transaction's catalog entries. These pins keep transaction-local
 	//! parent references valid even if another transaction invalidates the global object-cache entry.
-	//! Maps from cache entry pointer to the shared pointer to the cache entry.
-	mutex schema_pin_lock;
-	unordered_map<DuckLakeSchemaCacheEntry *, shared_ptr<DuckLakeSchemaCacheEntry>> schema_pins;
+	unique_ptr<DuckLakeSchemaPinState> schema_pins;
 	//! Per-transaction mutable change state (new/dropped/renamed entries, local file changes, flushed
 	//! inlined tables) and the Commit loop. Owns the data formerly held directly on the transaction.
 	unique_ptr<DuckLakeTransactionState> state;

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -362,6 +362,7 @@ shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaCacheEntry(DuckLa
 
 DuckLakeCatalogSet &DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot) {
 	auto entry = GetSchemaCacheEntry(transaction, snapshot);
+	transaction.PinSchemaCacheEntry(entry);
 	PinSchemaForQuery(transaction, entry);
 	return entry->catalog_set;
 }

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -164,6 +164,10 @@ optional_idx DuckLakeSchemaCacheEntry::GetEstimatedCacheMemory() const {
 }
 
 void DuckLakeSchemaPinState::QueryEnd(ClientContext &context) {
+	Clear();
+}
+
+void DuckLakeSchemaPinState::Clear() {
 	lock_guard<mutex> guard(lock);
 	pins.clear();
 }

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -703,6 +703,7 @@ DuckLakeTransaction::DuckLakeTransaction(DuckLakeCatalog &ducklake_catalog, Tran
     : Transaction(manager, context), ducklake_catalog(ducklake_catalog), db(*context.db),
       local_catalog_id(DuckLakeConstants::TRANSACTION_LOCAL_ID_START), catalog_version(0) {
 	metadata_manager = DuckLakeMetadataManager::Create(*this);
+	schema_pins = make_uniq<DuckLakeSchemaPinState>();
 	state = make_uniq<DuckLakeTransactionState>(db, ducklake_catalog.IsCommitInfoRequired(), new_name_maps,
 	                                            ducklake_catalog.DataPath(), ducklake_catalog.Separator());
 }
@@ -714,14 +715,11 @@ void DuckLakeTransaction::PinSchemaCacheEntry(shared_ptr<DuckLakeSchemaCacheEntr
 	if (!entry) {
 		return;
 	}
-	lock_guard<mutex> guard(schema_pin_lock);
-	auto *raw = entry.get();
-	schema_pins.emplace(raw, std::move(entry));
+	schema_pins->Pin(std::move(entry));
 }
 
 void DuckLakeTransaction::ClearSchemaCachePins() {
-	lock_guard<mutex> guard(schema_pin_lock);
-	schema_pins.clear();
+	schema_pins->Clear();
 }
 
 const LocalTableChanges &DuckLakeTransaction::GetLocalChanges() const {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -710,6 +710,20 @@ DuckLakeTransaction::DuckLakeTransaction(DuckLakeCatalog &ducklake_catalog, Tran
 DuckLakeTransaction::~DuckLakeTransaction() {
 }
 
+void DuckLakeTransaction::PinSchemaCacheEntry(shared_ptr<DuckLakeSchemaCacheEntry> entry) {
+	if (!entry) {
+		return;
+	}
+	lock_guard<mutex> guard(schema_pin_lock);
+	auto *raw = entry.get();
+	schema_pins.emplace(raw, std::move(entry));
+}
+
+void DuckLakeTransaction::ClearSchemaCachePins() {
+	lock_guard<mutex> guard(schema_pin_lock);
+	schema_pins.clear();
+}
+
 const LocalTableChanges &DuckLakeTransaction::GetLocalChanges() const {
 	return state->local_changes;
 }
@@ -744,6 +758,7 @@ void DuckLakeTransaction::Commit() {
 	connection.reset();
 	state->local_changes.Clear();
 	SetRequiresNewInlinedTable(false);
+	ClearSchemaCachePins();
 }
 
 void DuckLakeTransaction::Rollback() {
@@ -755,6 +770,7 @@ void DuckLakeTransaction::Rollback() {
 	state->CleanupFiles();
 	state->local_changes.Clear();
 	SetRequiresNewInlinedTable(false);
+	ClearSchemaCachePins();
 }
 
 Connection &DuckLakeTransaction::GetConnection() {

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1741,6 +1741,10 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 				DropEmptySupersededInlinedTables(context);
 			}
 			context.set_catalog_version(commit_snapshot.schema_version);
+			if (SchemaChangesMade()) {
+				// No-op if the previous schema version doesn't exist in cache.
+				context.invalidate_schema_cache(commit_snapshot.schema_version - 1);
+			}
 
 			// finished writing
 			break;

--- a/test/sql/issues/issue_852_schema_cache_growth.test
+++ b/test/sql/issues/issue_852_schema_cache_growth.test
@@ -1,5 +1,5 @@
 # name: test/sql/issues/issue_852_schema_cache_growth.test
-# description: https://github.com/duckdb/ducklake/issues/852 - DuckLakeCatalog::GetSchemaCacheEntry inserts into the ObjectCache keyed by schema_version. On a long-lived connection, repeated DDL grows the cache, and ducklake_expire_snapshots should release entries for expired schema versions.
+# description: https://github.com/duckdb/ducklake/issues/852 - DuckLakeCatalog::GetSchemaCacheEntry inserts into the ObjectCache keyed by schema_version. Schema cache entries for stale versions are invalidated on every DDL commit, so repeated DDL does not grow the cache. ducklake_expire_snapshots prunes the snapshot table.
 # group: [issues]
 
 require ducklake
@@ -42,38 +42,24 @@ SELECT * FROM ducklake.anchor LIMIT 0
 
 endloop
 
-# Schema churn grows ObjectCache memory.
+# Schema cache entries are invalidated on every DDL commit, so repeated schema
+# churn does NOT grow ObjectCache memory unboundedly. At most one entry (the
+# current schema version) is live at any point, keeping memory near baseline.
 query I
-SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') > (SELECT bytes FROM baseline)
+SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') <= (SELECT bytes * 2 FROM baseline)
 ----
 true
-
-# Snapshot the post-churn cache memory so we can compare dry-run and real expiration.
-statement ok
-CREATE TEMP TABLE post_churn AS SELECT memory_usage_bytes AS bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE'
 
 # Dry-run expiration must not evict cache entries.
 statement ok
 CALL ducklake_expire_snapshots('ducklake', dry_run => true, older_than => now())
 
-query I
-SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') >= (SELECT bytes FROM post_churn)
-----
-true
-
-# Maintenance: CHECKPOINT does not evict ObjectCache entries, but real snapshot
-# expiration should invalidate schema cache entries for the expired versions.
+# Maintenance: CHECKPOINT followed by real snapshot expiration prunes old snapshots.
 statement ok
 CHECKPOINT
 
 statement ok
 CALL ducklake_expire_snapshots('ducklake', older_than => now())
-
-# expire_snapshots releases schema cache entries.
-query I
-SELECT (SELECT memory_usage_bytes FROM duckdb_memory() WHERE tag = 'OBJECT_CACHE') < (SELECT bytes FROM post_churn)
-----
-true
 
 # Sanity-check: snapshot table itself was pruned.
 query I


### PR DESCRIPTION
Hi team, IIRC, schema cache entries are only invalidated on (1) snapshot expiration; or (2) inline table superseded.
On DDL, new version of schema is loaded into cache, but stale ones are never cleaned and used.
