### PR TITLE
Fixed D_ASSERT tripped by missing SetVectorType

### DIFF
--- a/src/functions/ducklake_murmur3.cpp
+++ b/src/functions/ducklake_murmur3.cpp
@@ -94,6 +94,10 @@ static void Murmur3ScalarFunction(DataChunk &args, ExpressionState &state, Vecto
 		}
 		}
 	}
+
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
 }
 
 ScalarFunction DuckLakeMurmur3Function() {


### PR DESCRIPTION
Set vector to const if all inputs are const.

Fixes https://github.com/duckdblabs/motherduck/issues/550