### PR TITLE
Preserve externally added transaction-local files

### DIFF
--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -150,13 +150,16 @@ void LocalTableChanges::DropTransactionLocalFile(ClientContext &context, TableIn
 	for (idx_t i = 0; i < table_files.size(); i++) {
 		auto &file = table_files[i];
 		if (file.file_name == path) {
+			auto created_by_ducklake = file.created_by_ducklake;
 			for (auto &del_file : file.delete_files) {
 				fs.RemoveFile(del_file.file_name);
 			}
 			file.delete_files.clear();
-			// found the file - delete it from the table list and from disk
+			// found the file - delete it from the table list and from disk if DuckLake owns it
 			table_files.erase_at(i);
-			fs.RemoveFile(path);
+			if (created_by_ducklake) {
+				fs.RemoveFile(path);
+			}
 			if (table_changes.IsEmpty()) {
 				// no more files remaining
 				changes.erase(entry);
@@ -597,7 +600,9 @@ void LocalTableChanges::CleanupFiles(ClientContext &context, TableIndex table_id
 		auto &table_changes = table_entry->second;
 		auto &fs = FileSystem::GetFileSystem(context);
 		for (auto &file : table_changes.new_data_files) {
-			fs.RemoveFile(file.file_name);
+			if (file.created_by_ducklake) {
+				fs.RemoveFile(file.file_name);
+			}
 			for (auto &del_file : file.delete_files) {
 				fs.TryRemoveFile(del_file.file_name);
 			}

--- a/test/sql/delete/preserve_external_transaction_local_files.test
+++ b/test/sql/delete/preserve_external_transaction_local_files.test
@@ -1,0 +1,97 @@
+# name: test/sql/delete/preserve_external_transaction_local_files.test
+# description: Transaction-local drops of externally registered files preserve the files on disk
+# group: [delete]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/preserve_external_transaction_local_files', METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+CREATE TABLE ducklake.delete_t(id INTEGER, payload VARCHAR)
+
+statement ok
+COPY (
+    SELECT 1 AS id, 'a' AS payload
+    UNION ALL
+    SELECT 2 AS id, 'b' AS payload
+    UNION ALL
+    SELECT 3 AS id, 'c' AS payload
+) TO '{DATA_PATH}/preserve_external_delete.parquet'
+
+statement ok
+BEGIN
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'delete_t', '{DATA_PATH}/preserve_external_delete.parquet')
+
+query I
+SELECT COUNT(*) FROM ducklake.delete_t
+----
+3
+
+query I
+DELETE FROM ducklake.delete_t
+----
+3
+
+statement ok
+COMMIT
+
+query I
+SELECT COUNT(*) FROM ducklake.delete_t
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_parquet('{DATA_PATH}/preserve_external_delete.parquet')
+----
+3
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_data_file WHERE path LIKE '%preserve_external_delete.parquet'
+----
+0
+
+statement ok
+COPY (
+    SELECT 10 AS id, 'x' AS payload
+    UNION ALL
+    SELECT 20 AS id, 'y' AS payload
+) TO '{DATA_PATH}/preserve_external_drop_table.parquet'
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE ducklake.drop_t(id INTEGER, payload VARCHAR)
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'drop_t', '{DATA_PATH}/preserve_external_drop_table.parquet')
+
+query I
+SELECT COUNT(*) FROM ducklake.drop_t
+----
+2
+
+statement ok
+DROP TABLE ducklake.drop_t
+
+query I
+SELECT COUNT(*) FROM read_parquet('{DATA_PATH}/preserve_external_drop_table.parquet')
+----
+2
+
+statement ok
+ROLLBACK
+
+query I
+SELECT COUNT(*) FROM read_parquet('{DATA_PATH}/preserve_external_drop_table.parquet')
+----
+2


### PR DESCRIPTION
## Summary
- preserve externally registered transaction-local data files on disk when DuckLake drops them from metadata
- keep deleting DuckLake-created files and delete files during cleanup
- add coverage for delete-to-empty and transaction-local drop-table paths

The `created_by_ducklake flag` is already present on main; this PR applies the remaining guards at the transaction-local physical removal sites exercised by externally added files.
