### PR TITLE
[codex] Avoid view snapshots for identical replacement

### DIFF
--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -145,6 +145,20 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateIndex(CatalogTransaction t
 }
 
 optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
+	// Replace our catalog name with a generic {DUCKLAKE_CATALOG}.
+	auto query_sql = info.query->ToString();
+	auto &catalog_name = ParentCatalog().GetName();
+	query_sql = DuckLakeUtil::ReplaceSkippingQuotes(query_sql, catalog_name + ".", "{DUCKLAKE_CATALOG}.");
+
+	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		auto existing_entry = GetEntry(transaction, CatalogType::VIEW_ENTRY, info.view_name);
+		if (existing_entry && existing_entry->type == CatalogType::VIEW_ENTRY) {
+			auto &existing_view = existing_entry->Cast<DuckLakeViewEntry>();
+			if (existing_view.GetQuerySQL() == query_sql && existing_view.aliases == info.aliases) {
+				return existing_entry;
+			}
+		}
+	}
 	// check if we have an existing entry with this name
 	if (!HandleCreateConflict(transaction, CatalogType::VIEW_ENTRY, info.view_name.GetIdentifierName(),
 	                          info.on_conflict)) {
@@ -154,11 +168,6 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateView(CatalogTransaction tr
 	// get a local view-id
 	auto view_id = TableIndex(duck_transaction.GetLocalCatalogId());
 	auto view_uuid = UUID::ToString(UUID::GenerateRandomUUID());
-
-	// replace our catalog name with a generic {DUCKLAKE_CATALOG}.
-	auto query_sql = info.query->ToString();
-	auto &catalog_name = ParentCatalog().GetName();
-	query_sql = DuckLakeUtil::ReplaceSkippingQuotes(query_sql, catalog_name + ".", "{DUCKLAKE_CATALOG}.");
 
 	auto view_entry = make_uniq<DuckLakeViewEntry>(ParentCatalog(), *this, info, view_id, std::move(view_uuid),
 	                                               query_sql, LocalChangeType::CREATED);

--- a/test/sql/view/ducklake_view_replace_noop.test
+++ b/test/sql/view/ducklake_view_replace_noop.test
@@ -1,0 +1,68 @@
+# name: test/sql/view/ducklake_view_replace_noop.test
+# description: Verify replacing a view with an identical definition does not create a snapshot
+# group: [view]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_view_replace_noop')
+
+statement ok
+CREATE VIEW ducklake.v AS SELECT 42
+
+query I
+FROM ducklake_current_snapshot('ducklake')
+----
+1
+
+# An identical replacement is a no-op.
+statement ok
+CREATE OR REPLACE VIEW ducklake.v AS SELECT 42
+
+query I
+FROM ducklake_current_snapshot('ducklake')
+----
+1
+
+# Changing the aliases replaces the view.
+statement ok
+CREATE OR REPLACE VIEW ducklake.v(answer) AS SELECT 42
+
+query I
+FROM ducklake_current_snapshot('ducklake')
+----
+2
+
+query I
+SELECT answer FROM ducklake.v
+----
+42
+
+# Repeating the aliased definition is also a no-op.
+statement ok
+CREATE OR REPLACE VIEW ducklake.v(answer) AS SELECT 42
+
+query I
+FROM ducklake_current_snapshot('ducklake')
+----
+2
+
+# Changing the query replaces the view.
+statement ok
+CREATE OR REPLACE VIEW ducklake.v(answer) AS SELECT 84
+
+query I
+FROM ducklake_current_snapshot('ducklake')
+----
+3
+
+query I
+SELECT answer FROM ducklake.v
+----
+84


### PR DESCRIPTION
## Summary
- skip CREATE OR REPLACE VIEW when the existing view has the same stored SQL and aliases
- preserve normal replacement behavior when the query or aliases change
- add a sqllogictest that checks snapshot ids for no-op and real replacements

## Testing
- VCPKG_TOOLCHAIN_PATH=/home/ubuntu/vcpkg/scripts/buildsystems/vcpkg.cmake GEN=ninja make release
- python3 duckdb/scripts/ci/run_tests.py build/release/test/unittest test/sql/view/ducklake_view_replace_noop.test
- python3 duckdb/scripts/ci/run_tests.py build/release/test/unittest test/sql/view/ducklake_view.test

Note: an initial debug build attempt compiled the changed objects but failed during final link because the filesystem ran out of space; the release build completed successfully.