### PR TITLE
Fix floating non-equal

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1282,7 +1282,6 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 		referenced_stats.insert("contains_nan");
 		return filter + " OR contains_nan";
 	}
-	case ExpressionType::COMPARE_NOTEQUAL:
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 	case ExpressionType::COMPARE_LESSTHAN:
 		if (constant_is_nan) {
@@ -1291,6 +1290,23 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 		}
 		// these are equivalent to the numeric filter
 		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+	case ExpressionType::COMPARE_NOTEQUAL: {
+		// x <> constant
+		if (constant_is_nan) {
+			// x <> NaN is true for every non-NaN value and false only for NaN.
+			// proving a file can be pruned would require knowing all its values are NaN, which min/max
+			// cannot express - so never prune.
+			return string();
+		}
+		// generate the numeric filter
+		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		if (filter.empty()) {
+			return string();
+		}
+		// NaN <> constant is always true, so we must also keep files that contain NaN
+		referenced_stats.insert("contains_nan");
+		return filter + " OR contains_nan";
+	}
 	default:
 		// unsupported
 		return string();

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1027,11 +1027,9 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 	return result;
 }
 
-NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
-                                                      optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                                      const DuckLakeCommitContext &context,
-                                                      map<TableIndex, DroppedDataFileStats>
-                                                          &attempt_dropped_file_stats) {
+NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
+    string &batch_query, DuckLakeCommitState &commit_state, optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
+    const DuckLakeCommitContext &context, map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
 	NewDataInfo result;
 	// get the global table stats
 	DuckLakeNewGlobalStats new_globals;

--- a/test/sql/stats/filter_pushdown_float_nan.test
+++ b/test/sql/stats/filter_pushdown_float_nan.test
@@ -1,0 +1,27 @@
+# name: test/sql/stats/filter_pushdown_float_nan.test
+# description: Regression: float/double <> must not prune NaN-containing files
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_float_nan_files', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.dbl(x DOUBLE);
+
+# single file with stats min_value = max_value = 1.0, contains_nan
+statement ok
+INSERT INTO ducklake.dbl VALUES (1.0), ('NaN');
+
+# bug: previously returned 0 (file pruned away, dropping the NaN row)
+query I
+SELECT COUNT(*) FROM ducklake.dbl WHERE x <> 1.0;
+----
+1


### PR DESCRIPTION
For the current implementation, a `WHERE x <> c` filter on a floating column could silently return too few rows because file-level stats pruning incorrectly discards data files which contains nan.

The key idea is: a file containing NaN values can never be pruned by a <> filter on a numeric constant, because those NaN rows will always satisfy the predicate.