### PR TITLE
Fix test warning

### DIFF
--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1027,11 +1027,9 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 	return result;
 }
 
-NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
-                                                      optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-                                                      const DuckLakeCommitContext &context,
-                                                      map<TableIndex, DroppedDataFileStats>
-                                                          &attempt_dropped_file_stats) {
+NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
+    string &batch_query, DuckLakeCommitState &commit_state, optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
+    const DuckLakeCommitContext &context, map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
 	NewDataInfo result;
 	// get the global table stats
 	DuckLakeNewGlobalStats new_globals;

--- a/test/sql/compaction/merge_adjacent_external_hive_paths.test
+++ b/test/sql/compaction/merge_adjacent_external_hive_paths.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/canonical_files', METADATA_CATALOG 'metadata')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/canonical_files', METADATA_CATALOG 'metadata')
 
 statement ok
 CREATE TABLE ducklake.t(id INTEGER, source VARCHAR);
@@ -23,14 +23,14 @@ ALTER TABLE ducklake.t SET PARTITIONED BY (source);
 
 statement ok
 COPY (SELECT 1 AS id, 'audio' AS source)
-TO '${DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source));
+TO '{DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source));
 
 statement ok
 COPY (SELECT 2 AS id, 'audio' AS source)
-TO '${DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source), APPEND);
+TO '{DATA_PATH}/external_source' (FORMAT parquet, PARTITION_BY (source), APPEND);
 
 statement ok
-CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/external_source/source=audio/*.parquet');
+CALL ducklake_add_data_files('ducklake', 't', '{DATA_PATH}/external_source/source=audio/*.parquet');
 
 query II
 SELECT id, source FROM ducklake.t ORDER BY ALL
@@ -52,12 +52,12 @@ ORDER BY ALL
 <REGEX>:source=audio/ducklake-.*\.parquet
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/t/source=audio/*.parquet')
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/main/t/source=audio/*.parquet')
 ----
 1
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_source%'
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_source%'
 ----
 0
 
@@ -65,14 +65,14 @@ SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/**/*.parquet') WHERE fil
 
 statement ok
 COPY (SELECT 3 AS id, NULL::VARCHAR AS source)
-TO '${DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source));
+TO '{DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source));
 
 statement ok
 COPY (SELECT 4 AS id, NULL::VARCHAR AS source)
-TO '${DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source), APPEND);
+TO '{DATA_PATH}/external_null' (FORMAT parquet, PARTITION_BY (source), APPEND);
 
 statement ok
-CALL ducklake_add_data_files('ducklake', 't', '${DATA_PATH}/external_null/source=__HIVE_DEFAULT_PARTITION__/*.parquet');
+CALL ducklake_add_data_files('ducklake', 't', '{DATA_PATH}/external_null/source=__HIVE_DEFAULT_PARTITION__/*.parquet');
 
 query II
 SELECT id, source FROM ducklake.t ORDER BY ALL
@@ -101,12 +101,12 @@ SELECT COUNT(*) FROM metadata.ducklake_file_partition_value WHERE partition_valu
 1
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/t/source=__HIVE_DEFAULT_PARTITION__/*.parquet')
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/main/t/source=__HIVE_DEFAULT_PARTITION__/*.parquet')
 ----
 1
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_null%'
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/**/*.parquet') WHERE file LIKE '%external_null%'
 ----
 0
 
@@ -122,16 +122,16 @@ statement ok
 COPY (
 	SELECT 10 AS id, TIMESTAMP '2024-05-01 00:00:00' AS ts, 2024 AS year, 5 AS month
 )
-TO '${DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month));
+TO '{DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month));
 
 statement ok
 COPY (
 	SELECT 11 AS id, TIMESTAMP '2024-05-02 00:00:00' AS ts, 2024 AS year, 5 AS month
 )
-TO '${DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month), APPEND);
+TO '{DATA_PATH}/external_transform' (FORMAT parquet, PARTITION_BY (year, month), APPEND);
 
 statement ok
-CALL ducklake_add_data_files('ducklake', 'transformed_t', '${DATA_PATH}/external_transform/year=2024/month=5/*.parquet');
+CALL ducklake_add_data_files('ducklake', 'transformed_t', '{DATA_PATH}/external_transform/year=2024/month=5/*.parquet');
 
 query II
 SELECT id, ts::DATE FROM ducklake.transformed_t ORDER BY ALL
@@ -153,7 +153,7 @@ ORDER BY ALL
 <REGEX>:.*year=2024/month=5/ducklake-.*\.parquet
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/transformed_t/year=2024/month=5/*.parquet')
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/main/transformed_t/year=2024/month=5/*.parquet')
 ----
 1
 
@@ -167,14 +167,14 @@ ALTER TABLE ducklake.weird_t SET PARTITIONED BY (weird);
 
 statement ok
 COPY (SELECT 20 AS id, 'a/b=c% d' AS weird)
-TO '${DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird));
+TO '{DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird));
 
 statement ok
 COPY (SELECT 21 AS id, 'a/b=c% d' AS weird)
-TO '${DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird), APPEND);
+TO '{DATA_PATH}/external_weird' (FORMAT parquet, PARTITION_BY (weird), APPEND);
 
 statement ok
-CALL ducklake_add_data_files('ducklake', 'weird_t', '${DATA_PATH}/external_weird/weird=*/*.parquet');
+CALL ducklake_add_data_files('ducklake', 'weird_t', '{DATA_PATH}/external_weird/weird=*/*.parquet');
 
 query II
 SELECT id, weird FROM ducklake.weird_t ORDER BY ALL
@@ -191,7 +191,7 @@ query I
 SELECT COUNT(*)
 FROM (
 	SELECT regexp_extract(file, '(weird=[^/\\]*)[/\\]', 1) AS partition_segment
-	FROM glob('${DATA_PATH}/external_weird/weird=*/*.parquet')
+	FROM glob('{DATA_PATH}/external_weird/weird=*/*.parquet')
 	INTERSECT
 	SELECT regexp_extract(path, '(weird=[^/\\]*)[/\\]', 1) AS partition_segment
 	FROM metadata.ducklake_data_file
@@ -201,6 +201,6 @@ FROM (
 1
 
 query I
-SELECT COUNT(*) FROM glob('${DATA_PATH}/canonical_files/main/weird_t/weird=*/*.parquet')
+SELECT COUNT(*) FROM glob('{DATA_PATH}/canonical_files/main/weird_t/weird=*/*.parquet')
 ----
 1

--- a/test/sql/data_inlining/inlining_reserved_column_names.test
+++ b/test/sql/data_inlining/inlining_reserved_column_names.test
@@ -183,7 +183,7 @@ DETACH ducklake
 
 # Check Alter
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/ducklake_reserved_cols3.db' AS ducklake (DATA_PATH '__TEST_DIR__/ducklake_reserved_cols3_files')
+ATTACH 'ducklake:{TEST_DIR}/ducklake_reserved_cols3.db' AS ducklake (DATA_PATH '{TEST_DIR}/ducklake_reserved_cols3_files')
 
 statement ok
 SET ducklake_default_data_inlining_row_limit = 0;

--- a/test/sql/metadata/hide_metadata_catalog.test
+++ b/test/sql/metadata/hide_metadata_catalog.test
@@ -6,13 +6,13 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 # no explicit METADATA_CATALOG, we hide catalog by default
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '${DATA_PATH}/hide_metadata_default_files')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '{DATA_PATH}/hide_metadata_default_files')
 
 statement ok
 CREATE TABLE lake.test(i INTEGER);
@@ -61,7 +61,7 @@ DETACH lake
 
 # explicit METADATA_CATALOG, the metadata catalog is visible
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '${DATA_PATH}/hide_metadata_default_files', METADATA_CATALOG 'ducklake_meta')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '{DATA_PATH}/hide_metadata_default_files', METADATA_CATALOG 'ducklake_meta')
 
 query I
 SELECT count(*) FROM duckdb_databases() WHERE database_name = 'ducklake_meta';

--- a/test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test
+++ b/test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test
@@ -8,12 +8,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/concurrent_insert_orphan_cleanup', DATA_INLINING_ROW_LIMIT 0)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/concurrent_insert_orphan_cleanup', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 CREATE TABLE ducklake.tbl(id INTEGER);
@@ -23,7 +23,7 @@ INSERT INTO ducklake.tbl SELECT i FROM range(10) t(i);
 
 # Add a known orphan before the concurrent workload starts.
 statement ok
-COPY ducklake.tbl TO '${DATA_PATH}/concurrent_insert_orphan_cleanup/main/tbl/orphan.parquet';
+COPY ducklake.tbl TO '{DATA_PATH}/concurrent_insert_orphan_cleanup/main/tbl/orphan.parquet';
 
 query I
 SELECT count(*) FROM ducklake_delete_orphaned_files('ducklake', cleanup_all => true, dry_run => true);
@@ -38,7 +38,7 @@ concurrentloop threadid 0 10
 loop j 0 5
 
 statement maybe
-INSERT INTO ducklake.tbl VALUES (1000 + ${threadid} * 100 + ${j});
+INSERT INTO ducklake.tbl VALUES (1000 + {threadid} * 100 + {j});
 ----
 
 statement maybe

--- a/test/sql/sorted_table/insert_sorted_default_direction.test
+++ b/test/sql/sorted_table/insert_sorted_default_direction.test
@@ -11,9 +11,6 @@ test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 test-env DATA_PATH {TEST_DIR}
 
 statement ok
-PRAGMA enable_verification
-
-statement ok
 COPY (
     SELECT (DATE '2011-01-03' + (i::INTEGER))::DATE AS date, 0.0::FLOAT AS value FROM range(0, 20) t(i)
     UNION ALL

--- a/test/sql/stats/min_max_nested_leaf_rewrite_corruption.test
+++ b/test/sql/stats/min_max_nested_leaf_rewrite_corruption.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/nested_rewrite', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 100);
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/nested_rewrite', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 100);
 
 statement ok
 CREATE TABLE ducklake.t(i INTEGER, s STRUCT(a INTEGER), l INTEGER[], m MAP(INTEGER, INTEGER));

--- a/test/sql/stats/min_max_optimization_basic.test
+++ b/test/sql/stats/min_max_optimization_basic.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_optimization')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/min_max_optimization')
 
 # ============================================
 # 1. MIN/MAX answered from catalog metadata

--- a/test/sql/stats/min_max_optimization_compaction.test
+++ b/test/sql/stats/min_max_optimization_compaction.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_compaction', DATA_INLINING_ROW_LIMIT 100)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/min_max_compaction', DATA_INLINING_ROW_LIMIT 100)
 
 # ============================================
 # 1. After rewriting deletes away, MIN/MAX fold again

--- a/test/sql/stats/min_max_optimization_deletes.test
+++ b/test/sql/stats/min_max_optimization_deletes.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_deletes', DATA_INLINING_ROW_LIMIT 100)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/min_max_deletes', DATA_INLINING_ROW_LIMIT 100)
 
 # ============================================
 # 1. Data-file deletes

--- a/test/sql/stats/min_max_optimization_inlined.test
+++ b/test/sql/stats/min_max_optimization_inlined.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_inlined', DATA_INLINING_ROW_LIMIT 100)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/min_max_inlined', DATA_INLINING_ROW_LIMIT 100)
 
 # data small enough to be inlined (never flushed to parquet)
 statement ok

--- a/test/sql/stats/min_max_optimization_time_travel.test
+++ b/test/sql/stats/min_max_optimization_time_travel.test
@@ -6,12 +6,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/min_max_time_travel')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/min_max_time_travel')
 
 statement ok
 CREATE TABLE ducklake.tt(i INTEGER);


### PR DESCRIPTION
I get a ton of warning messages like below
```sh
Replacing deprecated loop iterator ${threadid} in test "test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test" - please use the new loop iterator {threadid}
Replacing deprecated loop iterator ${j} in test "test/sql/remove_orphans/concurrent_insert_orphan_cleanup.test" - please use the new loop iterator {j}
```