### PR TITLE
Add max_compacted_files option to ducklake_rewrite_data_files

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -192,15 +192,16 @@ string DuckLakeCompaction::GetName() const {
 }
 
 DuckLakeCompactor::DuckLakeCompactor(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
-                                     Binder &binder, TableIndex table_id, DuckLakeMergeAdjacentOptions options)
+                                     Binder &binder, TableIndex table_id, uint64_t max_files,
+                                     DuckLakeMergeAdjacentOptions options)
     : context(context), catalog(catalog), transaction(transaction), binder(binder), table_id(table_id),
-      options(options), type(CompactionType::MERGE_ADJACENT_TABLES) {
+      max_files(max_files), options(options), type(CompactionType::MERGE_ADJACENT_TABLES) {
 }
 
 DuckLakeCompactor::DuckLakeCompactor(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
-                                     Binder &binder, TableIndex table_id, double delete_threshold_p)
+                                     Binder &binder, TableIndex table_id, uint64_t max_files, double delete_threshold_p)
     : context(context), catalog(catalog), transaction(transaction), binder(binder), table_id(table_id),
-      delete_threshold(delete_threshold_p), type(CompactionType::REWRITE_DELETES) {
+      max_files(max_files), delete_threshold(delete_threshold_p), type(CompactionType::REWRITE_DELETES) {
 }
 
 struct DuckLakeCompactionCandidates {
@@ -393,7 +394,7 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 				if (type == CompactionType::MERGE_ADJACENT_TABLES && compaction_file_count == 1) {
 					// If we only have one file to merge, we have nothing to compact
 					compacted_files++;
-					if (compacted_files >= options.max_files) {
+					if (compacted_files >= max_files) {
 						break;
 					}
 					continue;
@@ -406,11 +407,11 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 				start_idx += compaction_file_count - 1;
 			}
 			compacted_files++;
-			if (type == CompactionType::MERGE_ADJACENT_TABLES && compacted_files >= options.max_files) {
+			if (compacted_files >= max_files) {
 				break;
 			}
 		}
-		if (type == CompactionType::MERGE_ADJACENT_TABLES && compacted_files >= options.max_files) {
+		if (compacted_files >= max_files) {
 			break;
 		}
 	}
@@ -743,17 +744,16 @@ static void GenerateCompaction(ClientContext &context, DuckLakeTransaction &tran
 	switch (type) {
 	case CompactionType::MERGE_ADJACENT_TABLES: {
 		DuckLakeMergeAdjacentOptions options;
-		options.max_files = max_files;
 		options.min_file_size = min_file_size;
 		options.max_file_size = max_file_size;
 		DuckLakeCompactor compactor(context, ducklake_catalog, transaction, *input.binder, cur_table.GetTableId(),
-		                            options);
+		                            max_files, options);
 		compactor.GenerateCompactions(cur_table, compactions);
 		break;
 	}
 	case CompactionType::REWRITE_DELETES: {
 		DuckLakeCompactor compactor(context, ducklake_catalog, transaction, *input.binder, cur_table.GetTableId(),
-		                            delete_threshold);
+		                            max_files, delete_threshold);
 		compactor.GenerateCompactions(cur_table, compactions);
 		break;
 	}
@@ -922,6 +922,7 @@ TableFunctionSet DuckLakeRewriteDataFilesFunction::GetFunctions() {
 		TableFunction function("ducklake_rewrite_data_files", type, nullptr, nullptr, nullptr);
 		function.bind_operator = RewriteFilesBind;
 		function.named_parameters["delete_threshold"] = LogicalType::DOUBLE;
+		function.named_parameters["max_compacted_files"] = LogicalType::UBIGINT;
 		if (type.size() == 2) {
 			function.named_parameters["schema"] = LogicalType::VARCHAR;
 		}

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -83,9 +83,9 @@ public:
 class DuckLakeCompactor {
 public:
 	DuckLakeCompactor(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
-	                  Binder &binder, TableIndex table_id, DuckLakeMergeAdjacentOptions options);
+	                  Binder &binder, TableIndex table_id, uint64_t max_files, DuckLakeMergeAdjacentOptions options);
 	DuckLakeCompactor(ClientContext &context, DuckLakeCatalog &catalog, DuckLakeTransaction &transaction,
-	                  Binder &binder, TableIndex table_id, double delete_threshold);
+	                  Binder &binder, TableIndex table_id, uint64_t max_files, double delete_threshold);
 	void GenerateCompactions(DuckLakeTableEntry &table, vector<unique_ptr<LogicalOperator>> &compactions);
 	unique_ptr<LogicalOperator> GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files,
 	                                                      bool bind_to_latest_schema = false);
@@ -102,6 +102,7 @@ private:
 	DuckLakeTransaction &transaction;
 	Binder &binder;
 	TableIndex table_id;
+	uint64_t max_files;
 	double delete_threshold = 0.95;
 	DuckLakeMergeAdjacentOptions options;
 

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -494,7 +494,6 @@ struct DuckLakeCompactedFileInfo {
 };
 
 struct DuckLakeMergeAdjacentOptions {
-	uint64_t max_files;
 	optional_idx min_file_size;
 	optional_idx max_file_size;
 };

--- a/test/sql/rewrite_data_files/test_rewrite_max_files.test
+++ b/test/sql/rewrite_data_files/test_rewrite_max_files.test
@@ -1,0 +1,117 @@
+# name: test/sql/rewrite_data_files/test_rewrite_max_files.test
+# description: test ducklake rewrite data files files max_compacted_files option
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+# DATA_INLINING_ROW_LIMIT 1 implies our insertions will not be inlined, but deletions will be
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/rewrite_max_files', DATA_INLINING_ROW_LIMIT 1)
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE example (key integer);
+
+# Generate 6 files
+loop i 0 6
+
+statement ok
+INSERT INTO example SELECT 10 * {i} + range FROM range(10);
+
+endloop
+
+# Ensure files each delete file is processed individually (adjacent files are not merged)
+statement ok
+CALL ducklake.set_option('target_file_size', '1B');
+
+statement ok
+DELETE FROM example WHERE key % 10 = 0;
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0, max_compacted_files => 1)
+----
+example	1	1
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0, max_compacted_files => 2)
+----
+example	1	1
+example	1	1
+
+query III
+SELECT count(*), bool_and(files_processed = 1), bool_and(files_created = 1) FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0)
+----
+3	true	true
+
+# Allow merging of adjacent files
+statement ok
+CALL ducklake.set_option('target_file_size', '512MB');
+
+statement ok
+DELETE FROM example WHERE key % 10 = 1;
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0, max_compacted_files => 2)
+----
+example	6	1
+
+# max_compacted_files should work per table
+statement ok
+CREATE TABLE example2(key integer);
+
+statement ok
+INSERT INTO example2 FROM range(10);
+
+statement ok
+INSERT INTO example2 SELECT range + 10 FROM range(10);
+
+statement ok
+CALL ducklake.set_option('target_file_size', '1B');
+
+statement ok
+DELETE FROM example WHERE key % 10 = 2;
+
+statement ok
+DELETE FROM example2 WHERE key % 10 = 2;
+
+query III
+SELECT table_name, files_processed, files_created FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0, max_compacted_files => 1) ORDER BY ALL
+----
+example	1	1
+example2	1	1
+
+# Ensure data correctness
+query I
+SELECT count(*) FROM example
+----
+42
+
+query I
+SELECT count(*) FROM example2
+----
+18
+
+
+# Input validation
+statement error
+CALL ducklake_rewrite_data_files('ducklake', max_compacted_files=>-1);
+----
+Type INT32 with value -1 can't be cast
+
+statement error
+CALL ducklake_rewrite_data_files('ducklake', max_compacted_files=>NULL);
+----
+The max_compacted_files option must be a non-null integer
+
+statement error
+CALL ducklake_rewrite_data_files('ducklake', max_compacted_files=>0);
+----
+The max_compacted_files option must be greater than zero.


### PR DESCRIPTION
Like `ducklake_merge_adjacent_files`, `ducklake_rewrite_data_files` can be expensive to run if there are many files that need to be rewritten -- especially if files are also merged, rows are sorted, etc. For `ducklake_merge_adjacent_files`, the `max_compacted_files` option can be used to limit the number of compacted files (and thus, memory usage). This PR extends support for this option to `ducklake_rewrite_data_files`, so users can choose to control the compaction scale there as well.