### PR TITLE
Resolve path-like DuckLake secret names before metadata paths

### DIFF
--- a/src/storage/ducklake_secret.cpp
+++ b/src/storage/ducklake_secret.cpp
@@ -53,6 +53,10 @@ unique_ptr<SecretEntry> DuckLakeSecret::GetSecret(ClientContext &context, const 
 	auto &secret_manager = SecretManager::Get(context);
 	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
 	// omitting the storage searches all registered secret storages, including extension-registered ones
-	return secret_manager.GetSecretByName(transaction, secret_name);
+	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
+	if (secret_entry && secret_entry->secret->GetType() == "ducklake") {
+		return secret_entry;
+	}
+	return nullptr;
 }
 } // namespace duckdb

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -79,17 +79,19 @@ static unique_ptr<Catalog> DuckLakeAttach(optional_ptr<StorageExtensionInfo> sto
 			throw InvalidInputException(
 			    "Default secret was not found - either specify a path to attach to directly, or create the secret");
 		}
-	} else if (DuckLakeSecret::PathIsSecret(info.path)) {
-		// if the path is a plain name - load the secret name
+	} else {
+		// Secret names can be quoted identifiers, so first try an exact lookup before treating path-like names as
+		// paths.
 		secret = DuckLakeSecret::GetSecret(context, info.path);
 		if (!secret) {
-			throw InvalidInputException(
-			    "Secret \"%s\" was not found - if this was meant to be a path to a DuckDB file, use duckdb:%s instead",
-			    info.path, info.path);
+			if (DuckLakeSecret::PathIsSecret(info.path)) {
+				throw InvalidInputException("Secret \"%s\" was not found - if this was meant to be a path to a DuckDB "
+				                            "file, use duckdb:%s instead",
+				                            info.path, info.path);
+			}
+			// otherwise set the remainder of the path as the metadata path
+			options.metadata_path = info.path;
 		}
-	} else {
-		// otherwise set the remainder of the path as the metadata path
-		options.metadata_path = info.path;
 	}
 	if (secret) {
 		// if we have a secret - handle the options

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -82,17 +82,19 @@ static unique_ptr<Catalog> DuckLakeAttach(optional_ptr<StorageExtensionInfo> sto
 			throw InvalidInputException(
 			    "Default secret was not found - either specify a path to attach to directly, or create the secret");
 		}
-	} else if (DuckLakeSecret::PathIsSecret(info.path)) {
-		// if the path is a plain name - load the secret name
+	} else {
+		// Secret names can be quoted identifiers, so first try an exact lookup before treating path-like names as
+		// paths.
 		secret = DuckLakeSecret::GetSecret(context, info.path);
 		if (!secret) {
-			throw InvalidInputException(
-			    "Secret \"%s\" was not found - if this was meant to be a path to a DuckDB file, use duckdb:%s instead",
-			    info.path, info.path);
+			if (DuckLakeSecret::PathIsSecret(info.path)) {
+				throw InvalidInputException("Secret \"%s\" was not found - if this was meant to be a path to a DuckDB "
+				                            "file, use duckdb:%s instead",
+				                            info.path, info.path);
+			}
+			// otherwise set the remainder of the path as the metadata path
+			options.metadata_path = info.path;
 		}
-	} else {
-		// otherwise set the remainder of the path as the metadata path
-		options.metadata_path = info.path;
 	}
 	if (secret) {
 		// if we have a secret - handle the options

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -98,6 +98,36 @@ FROM ducklake.test
 statement ok
 DETACH ducklake
 
+# named secrets with path-like names
+statement ok
+CREATE SECRET "tenant/ducklake" (
+	TYPE DUCKLAKE,
+	METADATA_PATH '{TEST_DIR}/metadata_named_slash.db',
+	DATA_PATH '{TEST_DIR}/my_data_path_named_slash'
+);
+
+statement ok
+ATTACH 'ducklake:tenant/ducklake' AS ducklake
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1), (2), (3);
+
+# flush inlined data to create files
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+# verify a path-like secret name resolves the secret instead of becoming a metadata path
+query I
+SELECT COUNT(*) FROM glob('{TEST_DIR}/my_data_path_named_slash/**/*.parquet')
+----
+1
+
+statement ok
+DETACH ducklake
+
 # metadata parameters
 statement ok
 CREATE SECRET metadata_parameters123 (

--- a/test/sql/secrets/ducklake_secrets.test
+++ b/test/sql/secrets/ducklake_secrets.test
@@ -128,6 +128,18 @@ SELECT COUNT(*) FROM glob('{TEST_DIR}/my_data_path_named_slash/**/*.parquet')
 statement ok
 DETACH ducklake
 
+# a secret with the same name but a different type must not be loaded as a DuckLake secret
+statement ok
+CREATE SECRET wrong_type_ducklake (
+	TYPE HTTP,
+	BEARER_TOKEN 'token'
+);
+
+statement error
+ATTACH 'ducklake:wrong_type_ducklake' AS wrong_type_ducklake
+----
+Secret "wrong_type_ducklake" was not found
+
 # metadata parameters
 statement ok
 CREATE SECRET metadata_parameters123 (


### PR DESCRIPTION
## Summary

`ATTACH ducklake:<name>` now tries an exact DuckLake secret lookup before treating path-like names as metadata paths. This lets quoted secret identifiers such as `tenant/ducklake` resolve correctly instead of being interpreted as filesystem paths.

Fixes #1270.

## Tests

- `PATH="$HOME/Library/Python/3.9/bin:$PATH" python3 duckdb/scripts/format.py --all --check --directories src test`
- `./build/release/test/unittest test/sql/secrets/ducklake_secrets.test`
