### PR TITLE
Fix delete positions when flushing partitioned inlined data

### DIFF
--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -20,6 +20,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -389,6 +390,14 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	copy->write_partition_columns = copy_options.write_partition_columns;
 	copy->write_empty_file = copy_options.write_empty_file;
 	copy->partition_columns = std::move(copy_options.partition_columns);
+	if (copy->partition_output && sort_order_sql.empty()) {
+		auto row_id_idx = columns.PhysicalColumnCount();
+		auto snapshot_id_idx = row_id_idx + 1;
+		copy->order_columns.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                                 make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, row_id_idx));
+		copy->order_columns.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                                 make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, snapshot_id_idx));
+	}
 	copy->names = StringsToIdentifiers(copy_options.names);
 	copy->expected_types = std::move(copy_options.expected_types);
 

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -26,6 +26,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -401,6 +402,14 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	copy->write_partition_columns = copy_options.write_partition_columns;
 	copy->write_empty_file = copy_options.write_empty_file;
 	copy->partition_columns = std::move(copy_options.partition_columns);
+	if (copy->partition_output && sort_order_sql.empty()) {
+		auto row_id_idx = columns.PhysicalColumnCount();
+		auto snapshot_id_idx = row_id_idx + 1;
+		copy->order_columns.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                                 make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, row_id_idx));
+		copy->order_columns.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                                 make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, snapshot_id_idx));
+	}
 	copy->names = copy_options.names;
 	copy->expected_types = std::move(copy_options.expected_types);
 

--- a/test/sql/issues/issue_1266.test
+++ b/test/sql/issues/issue_1266.test
@@ -1,0 +1,42 @@
+# name: test/sql/issues/issue_1266.test
+# description: Flushing inlined deletes for a partitioned table must preserve visible rows
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_1266', DATA_INLINING_ROW_LIMIT 1000000);
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE t(part INT, i INT);
+
+statement ok
+ALTER TABLE t SET PARTITIONED BY (part);
+
+statement ok
+INSERT INTO t SELECT i % 4, i FROM range(0, 400) tbl(i);
+
+statement ok
+DELETE FROM t WHERE i % 5 = 0;
+
+query II
+SELECT count(), sum(i) FROM t;
+----
+320	64000
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake');
+
+query II
+SELECT count(), sum(i) FROM t;
+----
+320	64000


### PR DESCRIPTION
Fixes #1266.

When flushing inlined data for a partitioned table, DuckLake writes data files and then creates delete files for rows that were already deleted while the data was still inlined. The delete-position query assumes the flushed file order is `row_id, begin_snapshot`, but partitioned COPY output can write a partition file in a different internal order. That can make the delete file point at the wrong positions and produce an incorrect result after `ducklake_flush_inlined_data`.

This sets COPY `order_columns` for the partitioned flush path, when no table `SORTED BY` order is active, so each partition file is ordered by the embedded row id and snapshot id. That keeps the file order aligned with the existing delete-position calculation.

Added a regression test that reproduces the wrong result with a partitioned table: before flush the visible result is `count=320, sum=64000`; after the fix the result stays the same after flushing.

Local checks:
- `GEN=ninja CMAKE_PREFIX_PATH=/opt/homebrew/opt/croaring make release`
- `PATH="$HOME/Library/Python/3.9/bin:$PATH" python3 duckdb/scripts/format.py --all --check --directories src test`
- `./build/release/test/unittest test/sql/issues/issue_1266.test`
- `./build/release/test/unittest test/sql/deletion_inlining/test_deletion_inlining_partitions.test`
- `./build/release/test/unittest test/sql/delete/deletion_vector_inlined_flush.test`
- `./build/release/test/unittest test/sql/data_inlining/data_inlining_flush_sequential_updates.test`
- selected deletion/partition/compaction/sorted flush regression files