### PR TITLE
Fix empty files from inlined per-thread inserts

### DIFF
--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -34,6 +34,19 @@
 
 namespace duckdb {
 
+static bool PerThreadOutputEnabled(DuckLakeCatalog &catalog, DuckLakeTableEntry &table) {
+	string per_thread_output_str;
+	return catalog.TryGetConfigOption("per_thread_output", per_thread_output_str, table) &&
+	       per_thread_output_str == "true";
+}
+
+static bool IsSchemaOnlyInlinedInsertOutput(const DuckLakeInsertGlobalState &global_state,
+                                            const DuckLakeDataFile &file) {
+	// DuckLakeInlineData has already absorbed rows into inlined storage, so a zero-row
+	// file reported here is the schema-only COPY output produced by per_thread_output.
+	return global_state.total_insert_count > 0 && file.row_count == 0;
+}
+
 DuckLakeInsert::DuckLakeInsert(PhysicalPlan &physical_plan, const vector<LogicalType> &types, DuckLakeTableEntry &table,
                                optional_idx partition_id, string encryption_key_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, types, 1), table(&table), schema(nullptr),
@@ -253,6 +266,17 @@ SinkFinalizeType DuckLakeInsert::Finalize(Pipeline &pipeline, Event &event, Clie
                                           OperatorSinkFinalizeInput &input) const {
 	auto &global_state = input.global_state.Cast<DuckLakeInsertGlobalState>();
 
+	auto &catalog = global_state.table.catalog.Cast<DuckLakeCatalog>();
+	if (PerThreadOutputEnabled(catalog, global_state.table)) {
+		// Do not register schema-only COPY output as a live data file after inlining.
+		// Zero-row files from non-inlined inserts are still preserved for merge_adjacent_files.
+		global_state.written_files.erase(std::remove_if(global_state.written_files.begin(),
+		                                                global_state.written_files.end(),
+		                                                [&](const DuckLakeDataFile &file) {
+			                                                return IsSchemaOnlyInlinedInsertOutput(global_state, file);
+		                                                }),
+		                                 global_state.written_files.end());
+	}
 	for (auto &data_file : global_state.written_files) {
 		global_state.total_insert_count += data_file.row_count;
 	}

--- a/test/sql/data_inlining/per_thread_output_inline_insert.test
+++ b/test/sql/data_inlining/per_thread_output_inline_insert.test
@@ -1,0 +1,59 @@
+# name: test/sql/data_inlining/per_thread_output_inline_insert.test
+# description: test inlined inserts with per_thread_output enabled
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/per_thread_output_inline_insert', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+USE ducklake
+
+statement ok
+CALL ducklake.set_option('per_thread_output', 'true')
+
+statement ok
+CREATE TABLE t AS SELECT i AS part_id, i * 10 AS v FROM range(4) tt(i)
+
+query I
+INSERT INTO t BY NAME SELECT 1 AS part_id, 99 AS v
+----
+1
+
+query II
+SELECT count(*), COALESCE(sum(record_count), 0)
+FROM __ducklake_metadata_ducklake.ducklake_data_file
+WHERE end_snapshot IS NULL
+----
+0	0
+
+query I
+SELECT count(*) FROM t
+----
+5
+
+query I
+SELECT count(*) FROM t WHERE part_id = 1
+----
+2
+
+query I
+SELECT count(*) FROM t WHERE part_id = 0
+----
+1
+
+query II
+SELECT part_id, v FROM t ORDER BY part_id, v
+----
+0	0
+1	10
+1	99
+2	20
+3	30


### PR DESCRIPTION
This fixes #1251.

When a small INSERT is fully absorbed by data inlining, the downstream COPY can still report a zero-row schema-only file when per_thread_output is enabled. The INSERT path then registered that empty file in the catalog, which could overlap the inlined rows and make filter pruning return incorrect results.

The fix keeps zero-row file metadata for normal INSERT/compaction paths, but filters schema-only zero-row COPY output in DuckLakeInsert::Finalize when DuckLakeInlineData has already absorbed rows into inlined storage. This preserves merge-adjacent/compaction behavior while avoiding bogus live data-file metadata for inlined inserts.

Verification:
- added test/sql/data_inlining/per_thread_output_inline_insert.test
- watched the new test fail before the fix: part_id = 1 returned 5 rows instead of 2
- added a metadata assertion that active ducklake_data_file count stays 0 after the inlined per-thread insert
- ./build/release/test/unittest "test/sql/data_inlining/per_thread_output_inline_insert.test"
- ./build/release/test/unittest "test/sql/compaction/repro_merge_adjacent_zero_output.test"
- ./build/release/test/unittest "test/sql/compaction/compaction_per_thread_output.test"
- ./build/release/test/unittest "test/sql/data_inlining/inlining_issue_on_empty_inline.test"
- ./build/release/test/unittest "test/sql/data_inlining/basic_data_inlining.test"
- ./build/release/test/unittest "test/sql/data_inlining/data_inlining_filter.test"
- ./build/release/test/unittest "test/sql/data_inlining/data_inlining_flush.test"
- PATH=$HOME/Library/Python/3.9/bin:$PATH python3 duckdb/scripts/format.py --all --check --directories src test
- git diff --check

Current GitHub workflow runs on the latest fork head are action_required and need maintainer approval before they can execute.