### PR TITLE
fix: postgres isolation level to see concurrent commits

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -39,6 +39,7 @@ public:
 
 protected:
 	string GetLatestSnapshotQuery() const override;
+	string GetSnapshotAndStatsAndChangesQuery() override;
 	string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) override;
 
 private:

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -348,8 +348,13 @@ public:
 	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats);
 	static SnapshotChangeInfo
 	GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
-	                              const std::function<unique_ptr<QueryResult>(string)> &executor);
-	static string GetSnapshotAndStatsAndChangesQuery();
+	                              const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                              const std::function<string()> &query_builder);
+	//! Plain, backend-agnostic query text. Postgres overrides GetSnapshotAndStatsAndChangesQuery() to wrap
+	//! this in postgres_query(...) so both UNION ALL branches read a single Postgres statement/snapshot
+	//! instead of two separate remote scans.
+	static string BaseSnapshotAndStatsAndChangesQuery();
+	virtual string GetSnapshotAndStatsAndChangesQuery();
 	static SnapshotChangeInfo ParseSnapshotAndStatsAndChanges(QueryResult &result, SnapshotAndStats &current_snapshot);
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot();
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot(BoundAtClause &at_clause, SnapshotBound bound);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -26,6 +26,8 @@ struct DuckLakeColumnSchemaEntry {
 struct DuckLakeCommitContext {
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
+	//! Builds the query text for GetSnapshotAndStatsAndChanges.
+	std::function<string()> snapshot_and_stats_query;
 	//! Returns the latest snapshot for the first commit attempt.
 	std::function<DuckLakeSnapshot()> get_snapshot;
 	//! Executes the batched snapshot/changes SQL against the metadata DB.
@@ -123,7 +125,8 @@ public:
 
 	SnapshotAndStats CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
 	                                   const TransactionChangeInformation &changes,
-	                                   const std::function<unique_ptr<QueryResult>(string)> &executor);
+	                                   const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                                   const std::function<string()> &snapshot_and_stats_query);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
 	                       DuckLakeSnapshot transaction_snapshot,
 	                       const std::function<unique_ptr<QueryResult>(string)> &executor) const;

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -131,6 +131,13 @@ string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 	)";
 }
 
+string PostgresMetadataManager::GetSnapshotAndStatsAndChangesQuery() {
+	auto inner_query = StringUtil::Replace(DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery(),
+	                                       "{METADATA_CATALOG}", "{METADATA_SCHEMA_ESCAPED}");
+	inner_query = StringUtil::Replace(inner_query, "'", "''");
+	return "SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, '" + inner_query + "')";
+}
+
 string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) {
 	string select_list = "data_file_id";
 	for (const auto &stat : req.referenced_stats) {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -37,13 +37,20 @@ string DuckLakeInitializer::GetAttachOptions() {
 			throw InternalException("Unsupported access mode in DuckLake attach");
 		}
 	}
+	bool has_isolation_level_override = false;
 	for (auto &option : options.metadata_parameters) {
+		if (StringUtil::CIEquals(option.first, "isolation_level")) {
+			has_isolation_level_override = true;
+		}
 		attach_options.push_back(option.first + " " + option.second.ToSQLString());
 	}
 	const string metadata_type = catalog.MetadataType();
 	if (metadata_type.empty() || metadata_type == "duckdb") {
 		// this is duckdb, we always do latest storage
 		attach_options.push_back(StringUtil::Format("STORAGE_VERSION '%s'", "latest"));
+	}
+	if ((metadata_type == "postgres" || metadata_type == "postgres_scanner") && !has_isolation_level_override) {
+		attach_options.push_back("isolation_level 'read committed'");
 	}
 	if (options.hide_metadata_catalog) {
 		attach_options.push_back("HIDDEN true");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4192,6 +4192,10 @@ string DuckLakeMetadataManager::WriteSnapshotChangesSql(const SnapshotChangeInfo
 }
 
 string DuckLakeMetadataManager::GetSnapshotAndStatsAndChangesQuery() {
+	return BaseSnapshotAndStatsAndChangesQuery();
+}
+
+string DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery() {
 	return R"(
 SELECT
     snapshot_id,
@@ -4264,8 +4268,9 @@ SnapshotChangeInfo DuckLakeMetadataManager::ParseSnapshotAndStatsAndChanges(Quer
 
 SnapshotChangeInfo
 DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
-                                                       const std::function<unique_ptr<QueryResult>(string)> &executor) {
-	auto result = executor(GetSnapshotAndStatsAndChangesQuery());
+                                                       const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                                       const std::function<string()> &query_builder) {
+	auto result = executor(query_builder());
 	return ParseSnapshotAndStatsAndChanges(*result, current_snapshot);
 }
 

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -733,6 +733,9 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		auto sql = SubstitutePlaceholders(std::move(q), transaction_snapshot);
 		return unique_ptr_cast<MaterializedQueryResult, QueryResult>(fresh_conn.Query(sql));
 	};
+	ctx.snapshot_and_stats_query = []() {
+		return DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery();
+	};
 	ctx.get_snapshot = [this]() {
 		return transaction_snapshot;
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1299,6 +1299,11 @@ bool DuckLakeTransaction::RetryOnError(const string &original_message) {
 	if (StringUtil::Contains(message, "concurrent")) {
 		return true;
 	}
+	// retry on stale dropped-file stats (another transaction already committed the same drop;
+	// CheckForConflicts on retry reports this properly as a conflict)
+	if (StringUtil::Contains(message, "dropped ducklake file stats exceed current table stats")) {
+		return true;
+	}
 	return false;
 }
 
@@ -1375,6 +1380,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 			                               "snapshot changes for conflict resolution:");
 		}
 		return result;
+	};
+	context.snapshot_and_stats_query = [&]() {
+		return metadata_manager->GetSnapshotAndStatsAndChangesQuery();
 	};
 	context.get_snapshot = [&]() {
 		return GetSnapshot();

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1788,10 +1788,12 @@ WHERE idt.schema_version < (
 SnapshotAndStats
 DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
                                             const TransactionChangeInformation &changes,
-                                            const std::function<unique_ptr<QueryResult>(string)> &executor) {
+                                            const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                            const std::function<string()> &snapshot_and_stats_query) {
 	SnapshotAndStats snapshot_and_stats;
 	// get all changes made to the system after the current snapshot was started
-	auto changes_made = DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor);
+	auto changes_made =
+	    DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor, snapshot_and_stats_query);
 	// parse changes made by other transactions
 	auto other_changes = SnapshotChangeInformation::ParseChangesMade(changes_made.changes_made);
 
@@ -1817,7 +1819,8 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 				// we failed our first commit due to another transaction committing
 				// retry - but first check for conflicts
 				commit_stats_snapshot =
-				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
+				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor,
+				                      context.snapshot_and_stats_query);
 				stats = &commit_stats_snapshot.stats;
 			} else {
 				commit_stats_snapshot.snapshot = context.get_snapshot();

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -102,7 +102,8 @@
         "test/sql/autoloading/autoload_data_path.test",
         "test/sql/data_inlining/postgres_identifier_limit.test",
         "test/sql/issues/issue_sqlite_snapshot_time.test",
-        "test/sql/metadata/ducklake_settings_minio.test"
+        "test/sql/metadata/ducklake_settings_minio.test",
+        "test/sql/concurrent/postgres_isolation_level.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -99,7 +99,8 @@
       "reason": "Test only for Postgres as catalog",
       "paths": [
         "test/sql/metadata/ducklake_settings_postgres.test",
-        "test/sql/data_inlining/postgres_identifier_limit.test"
+        "test/sql/data_inlining/postgres_identifier_limit.test",
+        "test/sql/concurrent/postgres_isolation_level.test"
       ]
     },
     {

--- a/test/sql/concurrent/postgres_isolation_level.test
+++ b/test/sql/concurrent/postgres_isolation_level.test
@@ -1,0 +1,57 @@
+# name: test/sql/concurrent/postgres_isolation_level.test
+# description: DuckLake defaults postgres metadata connections to READ COMMITTED so commit-time conflict checks observe concurrent committers
+# group: [concurrent]
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+#FIXME: ADD THIS TO PG CI WHEN IT GETS BACK
+require-env DUCKLAKE_CI
+
+test-env DATA_PATH {TEST_DIR}
+
+# Scenario: no user override -> read committed applied
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl (DATA_PATH '{DATA_PATH}/iso_default', METADATA_SCHEMA 'iso_default')
+
+statement ok
+USE dl
+
+# create a table so the metadata connection has committed state to read back
+statement ok
+CREATE TABLE dl.t AS SELECT 1 AS x
+
+query I
+SELECT setting FROM postgres_query('__ducklake_metadata_dl', 'SELECT current_setting(''transaction_isolation'')') t(setting)
+----
+read committed
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl
+
+# Scenario: user override -> respected as-is (repeatable read, not read committed)
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl_override (DATA_PATH '{DATA_PATH}/iso_override', METADATA_SCHEMA 'iso_override', METADATA_PARAMETERS MAP {'isolation_level': 'repeatable read'})
+
+statement ok
+USE dl_override
+
+statement ok
+CREATE TABLE dl_override.t AS SELECT 1 AS x
+
+query I
+SELECT setting FROM postgres_query('__ducklake_metadata_dl_override', 'SELECT current_setting(''transaction_isolation'')') t(setting)
+----
+repeatable read
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl_override


### PR DESCRIPTION
> [!NOTE]
> This PR is one of four aimed at resolving issues that arise during high concurrency scenarios; i.e., cdc (see https://github.com/duckdb/ducklake/issues/1094 for more info). While related, none of them are logically dependent on one-another, but they do overlap some within source.

> [!IMPORTANT]
> While testing I stumbled upon two issues in `duckdb-postgres` that led to crashes at high concurrent pressure. A [use-after-free](https://github.com/duckdb/duckdb-postgres/pull/501) and a [race condition](https://github.com/duckdb/duckdb-postgres/pull/499). The code is self-contained, only the test's CI is gated.

## Problem

IDs are allocated client-side by reading the current value, applying a post-increment ++, then writing the value back. Postgres can have multiple connections read the same current value before either commits, creating a collision. At the moment, that's handled via a primary key violation and a retry. This relies on the default isolation mode, `REPEATABLE READ` creating a delicate aliance between unrelated mechanisms to provide conflict correctness where it can. Other situations; i.e., concurrent `ALTER`s, aren't so lucky and go undetected.

## Solution

Move ID allocation behind a hook. The post-increment behavior is preserved for non-postgres catalogs. Postgres will override the hooks to pull from sequences. This provides race-free concurrency with no primary collision reliance for ID assignment. Also, force isolation level to be `READ COMMITTED` to make conflict detection actually see the prior commits at the right time.


