### PR TITLE
fix: prevent concurrent inlined and parquet deletes of the same row from both committing (#1215)

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -37,6 +37,8 @@ public:
 
 	unique_ptr<QueryResult> Query(DuckLakeSnapshot snapshot, string &query) override;
 
+	string InlinedDeleteTableExistsQuery(const string &table_name) const override;
+
 protected:
 	string GetLatestSnapshotQuery() const override;
 	string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) override;

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -175,6 +175,11 @@ public:
 
 	virtual string MetadataExistsQuery() const;
 
+	//! Query that returns >=1 row iff a lazily-created inlined-file-delete table exists (cross-store conflict check).
+	//! Overridden per backend so the check reads live catalog state even when DuckDB's view of an attached
+	//! catalog is stale for cross-transaction DDL.
+	virtual string InlinedDeleteTableExistsQuery(const string &table_name) const;
+
 	//! Initialize a new DuckLake
 	virtual void InitializeDuckLake(bool has_explicit_schema, DuckLakeEncryption encryption);
 	//! Get the CREATE TABLE statements for all metadata tables

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -176,6 +176,8 @@ public:
 
 	virtual string MetadataExistsQuery() const;
 
+	virtual string InlinedDeleteTableExistsQuery(const string &table_name) const;
+
 	//! Initialize a new DuckLake
 	virtual void InitializeDuckLake(bool has_explicit_schema, DuckLakeEncryption encryption);
 	//! Get the CREATE TABLE statements for all metadata tables

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -26,6 +26,9 @@ struct DuckLakeColumnSchemaEntry {
 struct DuckLakeCommitContext {
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
+	//! Backend-specific query returning >=1 row iff the named inlined-file-delete table exists (see
+	//! DuckLakeMetadataManager::InlinedDeleteTableExistsQuery). Used by the cross-store conflict check.
+	std::function<string(const string &table_name)> inlined_delete_exists_query;
 	//! Returns the latest snapshot for the first commit attempt.
 	std::function<DuckLakeSnapshot()> get_snapshot;
 	//! Executes the batched snapshot/changes SQL against the metadata DB.
@@ -123,10 +126,12 @@ public:
 
 	SnapshotAndStats CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
 	                                   const TransactionChangeInformation &changes,
-	                                   const std::function<unique_ptr<QueryResult>(string)> &executor);
+	                                   const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                                   const std::function<string(const string &)> &inlined_delete_exists_query);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
 	                       DuckLakeSnapshot transaction_snapshot,
-	                       const std::function<unique_ptr<QueryResult>(string)> &executor) const;
+	                       const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                       const std::function<string(const string &)> &inlined_delete_exists_query) const;
 
 	static SnapshotDeletedFromFiles
 	GetFilesDeletedOrDroppedAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -26,6 +26,8 @@ struct DuckLakeColumnSchemaEntry {
 struct DuckLakeCommitContext {
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
+	//! Backend-specific existence check for the inlined-file-delete table.
+	std::function<string(const string &table_name)> inlined_delete_exists_query;
 	//! Returns the latest snapshot for the first commit attempt.
 	std::function<DuckLakeSnapshot()> get_snapshot;
 	//! Executes the batched snapshot/changes SQL against the metadata DB.
@@ -123,10 +125,12 @@ public:
 
 	SnapshotAndStats CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
 	                                   const TransactionChangeInformation &changes,
-	                                   const std::function<unique_ptr<QueryResult>(string)> &executor);
+	                                   const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                                   const std::function<string(const string &)> &inlined_delete_exists_query);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
 	                       DuckLakeSnapshot transaction_snapshot,
-	                       const std::function<unique_ptr<QueryResult>(string)> &executor) const;
+	                       const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                       const std::function<string(const string &)> &inlined_delete_exists_query) const;
 
 	static SnapshotDeletedFromFiles
 	GetFilesDeletedOrDroppedAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor);

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -121,6 +121,23 @@ unique_ptr<QueryResult> PostgresMetadataManager::Query(DuckLakeSnapshot snapshot
 	return DuckLakeMetadataManager::Query(snapshot, query);
 }
 
+string PostgresMetadataManager::InlinedDeleteTableExistsQuery(const string &table_name) const {
+	// read the live Postgres catalog via postgres_query. DuckDB's cached view of the attached catalog can be
+	// stale for a table another transaction just created, which would spuriously drop a cross-store delete
+	// conflict. Filter by schema as well, since multiple DuckLake catalogs can share one Postgres database.
+	// The comparison values sit two quoting layers deep: DuckDB parses the outer postgres_query('...') argument
+	// first, then Postgres parses the 'literal' inside it. So we escape twice -- SQLLiteralToString() produces the
+	// inner Postgres literal, then a second '->'' pass lets it survive the outer DuckDB literal. This mirrors how
+	// the {METADATA_SCHEMA_ESCAPED} placeholder is built for identifiers (SQLIdentifierToString + one more '->'').
+	auto &ducklake_catalog = transaction.GetCatalog();
+	auto schema_literal =
+	    StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataSchemaName()), "'", "''");
+	auto table_literal = StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(table_name), "'", "''");
+	return StringUtil::Format("SELECT 1 FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, "
+	                          "'SELECT 1 FROM information_schema.tables WHERE table_schema = %s AND table_name = %s')",
+	                          schema_literal, table_literal);
+}
+
 string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 	return R"(
 	SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL},

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -121,6 +121,19 @@ unique_ptr<QueryResult> PostgresMetadataManager::Query(DuckLakeSnapshot snapshot
 	return DuckLakeMetadataManager::Query(snapshot, query);
 }
 
+string PostgresMetadataManager::InlinedDeleteTableExistsQuery(const string &table_name) const {
+	// DuckDB's cached view of the attached catalog can be stale for a table another transaction created.
+	// Multiple DuckLake catalogs can share one Postgres database, hence the schema filter.
+	// Both values cross two parsers, DuckDB's then Postgres', so they escape twice.
+	auto &ducklake_catalog = transaction.GetCatalog();
+	auto schema_literal =
+	    StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataSchemaName()), "'", "''");
+	auto table_literal = StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(table_name), "'", "''");
+	return StringUtil::Format("SELECT 1 FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, "
+	                          "'SELECT 1 FROM information_schema.tables WHERE table_schema = %s AND table_name = %s')",
+	                          schema_literal, table_literal);
+}
+
 string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 	return R"(
 	SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL},

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -126,8 +126,8 @@ string PostgresMetadataManager::InlinedDeleteTableExistsQuery(const string &tabl
 	// Multiple DuckLake catalogs can share one Postgres database, hence the schema filter.
 	// Both values cross two parsers, DuckDB's then Postgres', so they escape twice.
 	auto &ducklake_catalog = transaction.GetCatalog();
-	auto schema_literal =
-	    StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataSchemaName()), "'", "''");
+	auto schema_literal = StringUtil::Replace(
+	    DuckLakeUtil::SQLLiteralToString(ducklake_catalog.MetadataSchemaName().GetIdentifierName()), "'", "''");
 	auto table_literal = StringUtil::Replace(DuckLakeUtil::SQLLiteralToString(table_name), "'", "''");
 	return StringUtil::Format("SELECT 1 FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, "
 	                          "'SELECT 1 FROM information_schema.tables WHERE table_schema = %s AND table_name = %s')",

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -169,6 +169,13 @@ string DuckLakeMetadataManager::MetadataExistsQuery() const {
 	return "SELECT NULL FROM {METADATA_CATALOG}.ducklake_metadata LIMIT 1";
 }
 
+string DuckLakeMetadataManager::InlinedDeleteTableExistsQuery(const string &table_name) const {
+	// the metadata catalog is a local DuckDB database, so its information_schema reflects the current state
+	return StringUtil::Format("SELECT 1 FROM information_schema.tables WHERE table_schema = "
+	                          "{METADATA_SCHEMA_NAME_LITERAL} AND table_name = %s",
+	                          DuckLakeUtil::SQLLiteralToString(table_name));
+}
+
 bool DuckLakeMetadataManager::MetadataExists() {
 	auto query = MetadataExistsQuery();
 	auto result = Query(query);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -168,6 +168,13 @@ string DuckLakeMetadataManager::MetadataExistsQuery() const {
 	return "SELECT NULL FROM {METADATA_CATALOG}.ducklake_metadata LIMIT 1";
 }
 
+string DuckLakeMetadataManager::InlinedDeleteTableExistsQuery(const string &table_name) const {
+	// the metadata catalog is a local DuckDB database, so its information_schema reflects the current state
+	return StringUtil::Format("SELECT 1 FROM information_schema.tables WHERE table_schema = "
+	                          "{METADATA_SCHEMA_NAME_LITERAL} AND table_name = %s",
+	                          DuckLakeUtil::SQLLiteralToString(table_name));
+}
+
 bool DuckLakeMetadataManager::MetadataExists() {
 	auto query = MetadataExistsQuery();
 	auto result = Query(query);

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -732,6 +732,13 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		auto sql = SubstitutePlaceholders(std::move(q), transaction_snapshot);
 		return unique_ptr_cast<MaterializedQueryResult, QueryResult>(fresh_conn.Query(sql));
 	};
+	ctx.inlined_delete_exists_query = [](const string &table_name) {
+		// No metadata-manager instance here, so the virtual is unreachable. The other transaction's
+		// metadata SQL runs against this same server catalog, so its new table is visible.
+		return StringUtil::Format("SELECT 1 FROM duckdb_tables() WHERE database_name = current_database() AND "
+		                          "schema_name = {METADATA_SCHEMA_NAME_LITERAL} AND table_name = %s",
+		                          DuckLakeUtil::SQLLiteralToString(table_name));
+	};
 	ctx.get_snapshot = [this]() {
 		return transaction_snapshot;
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1414,6 +1414,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 		}
 		return result;
 	};
+	context.inlined_delete_exists_query = [&](const string &table_name) {
+		return metadata_manager->InlinedDeleteTableExistsQuery(table_name);
+	};
 	context.get_snapshot = [&]() {
 		return GetSnapshot();
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1439,6 +1439,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 		}
 		return result;
 	};
+	context.inlined_delete_exists_query = [&](const string &table_name) {
+		return metadata_manager->InlinedDeleteTableExistsQuery(table_name);
+	};
 	context.get_snapshot = [&]() {
 		return GetSnapshot();
 	};

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -153,6 +153,21 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 		file_id_list += to_string(file_id);
 	}
 	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
+	// the inlined-file-deletion table is created lazily, so it is absent when the other transaction only
+	// deleted inlined data; treat a missing table as "no inlined-file deletes" instead of erroring the commit
+	auto exists_sql = StringUtil::Format(
+	    "SELECT 1 FROM information_schema.tables WHERE table_schema = {METADATA_SCHEMA_NAME_LITERAL} "
+	    "AND table_name = %s",
+	    DuckLakeUtil::SQLLiteralToString(table_name));
+	auto exists_result = executor(exists_sql);
+	bool table_exists = false;
+	for (auto &row : *exists_result) {
+		table_exists = true;
+		break;
+	}
+	if (!table_exists) {
+		return result;
+	}
 	auto sql = StringUtil::Format("SELECT DISTINCT file_id FROM {METADATA_CATALOG}.%s "
 	                              "WHERE file_id IN (%s) AND begin_snapshot > {SNAPSHOT_ID}",
 	                              table_name, file_id_list);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -137,6 +137,36 @@ void ConflictCheck(const case_insensitive_map_t<reference_set_t<CatalogEntry>> &
 	}
 }
 
+//! Returns which of `file_ids` (in table `table_id`) another transaction tombstoned via an inlined delete
+//! committed after this transaction's snapshot, for cross-store delete conflict detection (#1215).
+set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                                      TableIndex table_id, const vector<idx_t> &file_ids) {
+	set<DataFileIndex> result;
+	if (file_ids.empty()) {
+		return result;
+	}
+	string file_id_list;
+	for (auto &file_id : file_ids) {
+		if (!file_id_list.empty()) {
+			file_id_list += ", ";
+		}
+		file_id_list += to_string(file_id);
+	}
+	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
+	auto sql = StringUtil::Format("SELECT DISTINCT file_id FROM {METADATA_CATALOG}.%s "
+	                              "WHERE file_id IN (%s) AND begin_snapshot > {SNAPSHOT_ID}",
+	                              table_name, file_id_list);
+	auto query_result = executor(sql);
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw(
+		    "Failed to commit DuckLake transaction - failed to check for inlined delete conflicts:");
+	}
+	for (auto &row : *query_result) {
+		result.insert(DataFileIndex(row.GetValue<idx_t>(0)));
+	}
+	return result;
+}
+
 } // namespace
 
 void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformation &changes,
@@ -225,23 +255,49 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 		ConflictCheck(table_id, other_changes.inserted_tables, "delete from table", "inserted into it");
 		ConflictCheck(table_id, other_changes.tables_inserted_inlined, "delete from table", "inserted into it");
 	}
-	if (!changes.tables_deleted_from.empty()) {
+	// file-level cross-store delete conflict check: same data file conflicts, whether parquet or inlined (#1215)
+	bool self_deletes = !changes.tables_deleted_from.empty() || !changes.tables_deleted_inlined.empty();
+	bool other_deletes = !other_changes.tables_deleted_from.empty() || !other_changes.tables_deleted_inlined.empty();
+	if (self_deletes && other_deletes) {
+		// iterate the deleted-table id sets (not local file changes) so full-table file drops are included
 		bool check_for_matches = false;
-		for (auto &table_id : changes.tables_deleted_from) {
-			if (other_changes.tables_deleted_from.find(table_id) != other_changes.tables_deleted_from.end()) {
-				check_for_matches = true;
+		for (auto &deleted_set : {&changes.tables_deleted_from, &changes.tables_deleted_inlined}) {
+			for (auto &table_id : *deleted_set) {
+				if (other_changes.tables_deleted_from.find(table_id) != other_changes.tables_deleted_from.end() ||
+				    other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
+					check_for_matches = true;
+					break;
+				}
+			}
+			if (check_for_matches) {
 				break;
 			}
 		}
 		if (check_for_matches) {
-			// If we have deletes on the tables, check for files being deleted
 			const auto deleted_files = GetFilesDeletedOrDroppedAfterSnapshot(executor);
 			for (auto &entry : local_changes.Changes()) {
+				auto table_id = entry.GetTableIndex();
 				auto &table_changes = entry.GetTableChanges();
+				vector<idx_t> deleted_file_ids;
 				for (auto &file_entry : table_changes.new_delete_files) {
 					for (auto &file : file_entry.second) {
 						ConflictCheck(file.data_file_id, deleted_files.deleted_from_files, "delete from file",
 						              "deleted from it");
+						deleted_file_ids.push_back(file.data_file_id.index);
+					}
+				}
+				if (table_changes.new_inlined_file_deletes) {
+					for (auto &file_entry : table_changes.new_inlined_file_deletes->file_deletes) {
+						ConflictCheck(DataFileIndex(file_entry.first), deleted_files.deleted_from_files,
+						              "delete from file", "deleted from it");
+						deleted_file_ids.push_back(file_entry.first);
+					}
+				}
+				// also check our files against the other transaction's inlined deletes
+				if (other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
+					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, table_id, deleted_file_ids);
+					for (auto &file_id : deleted_file_ids) {
+						ConflictCheck(DataFileIndex(file_id), inlined_deleted, "delete from file", "deleted from it");
 					}
 				}
 			}

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -139,8 +139,10 @@ void ConflictCheck(const case_insensitive_map_t<reference_set_t<CatalogEntry>> &
 
 //! Returns which of `file_ids` (in table `table_id`) another transaction tombstoned via an inlined delete
 //! committed after this transaction's snapshot, for cross-store delete conflict detection (#1215).
-set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
-                                                      TableIndex table_id, const vector<idx_t> &file_ids) {
+set<DataFileIndex>
+GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                   const std::function<string(const string &)> &inlined_delete_exists_query,
+                                   TableIndex table_id, const vector<idx_t> &file_ids) {
 	set<DataFileIndex> result;
 	if (file_ids.empty()) {
 		return result;
@@ -154,11 +156,12 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 	}
 	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
 	// the inlined-file-deletion table is created lazily, so it is absent when the other transaction only
-	// deleted inlined data; treat a missing table as "no inlined-file deletes" instead of erroring the commit
-	auto exists_sql = StringUtil::Format(
-	    "SELECT 1 FROM information_schema.tables WHERE table_schema = {METADATA_SCHEMA_NAME_LITERAL} "
-	    "AND table_name = %s",
-	    DuckLakeUtil::SQLLiteralToString(table_name));
+	// deleted inlined data; probe its existence (backend-specific, reads live catalog state) and treat a
+	// missing table as "no inlined-file deletes" instead of erroring the commit
+	if (!inlined_delete_exists_query) {
+		throw InternalException("Missing inlined-delete existence query for cross-store conflict check");
+	}
+	auto exists_sql = inlined_delete_exists_query(table_name);
 	auto exists_result = executor(exists_sql);
 	bool table_exists = false;
 	for (auto &row : *exists_result) {
@@ -184,10 +187,10 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 
 } // namespace
 
-void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformation &changes,
-                                                 const SnapshotChangeInformation &other_changes,
-                                                 DuckLakeSnapshot transaction_snapshot,
-                                                 const std::function<unique_ptr<QueryResult>(string)> &executor) const {
+void DuckLakeTransactionState::CheckForConflicts(
+    const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
+    DuckLakeSnapshot transaction_snapshot, const std::function<unique_ptr<QueryResult>(string)> &executor,
+    const std::function<string(const string &)> &inlined_delete_exists_query) const {
 	// check if we are dropping the same table as another transaction
 	for (auto &dropped_idx : changes.dropped_tables) {
 		ConflictCheck(dropped_idx, other_changes.dropped_tables, "drop table", "dropped it already");
@@ -310,7 +313,8 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 				}
 				// also check our files against the other transaction's inlined deletes
 				if (other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
-					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, table_id, deleted_file_ids);
+					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, inlined_delete_exists_query,
+					                                                          table_id, deleted_file_ids);
 					for (auto &file_id : deleted_file_ids) {
 						ConflictCheck(DataFileIndex(file_id), inlined_deleted, "delete from file", "deleted from it");
 					}
@@ -1881,7 +1885,8 @@ WHERE idt.schema_version < (
 SnapshotAndStats
 DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
                                             const TransactionChangeInformation &changes,
-                                            const std::function<unique_ptr<QueryResult>(string)> &executor) {
+                                            const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                            const std::function<string(const string &)> &inlined_delete_exists_query) {
 	SnapshotAndStats snapshot_and_stats;
 	// get all changes made to the system after the current snapshot was started
 	auto changes_made = DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor);
@@ -1889,7 +1894,7 @@ DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapsho
 	auto other_changes = SnapshotChangeInformation::ParseChangesMade(changes_made.changes_made);
 
 	// now check for conflicts
-	CheckForConflicts(changes, other_changes, transaction_snapshot, executor);
+	CheckForConflicts(changes, other_changes, transaction_snapshot, executor, inlined_delete_exists_query);
 
 	return snapshot_and_stats;
 }
@@ -1910,7 +1915,8 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 				// we failed our first commit due to another transaction committing
 				// retry - but first check for conflicts
 				commit_stats_snapshot =
-				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
+				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor,
+				                      context.inlined_delete_exists_query);
 				stats = &commit_stats_snapshot.stats;
 			} else {
 				commit_stats_snapshot.snapshot = context.get_snapshot();

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -151,6 +151,20 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 		file_id_list += to_string(file_id);
 	}
 	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
+	// the inlined-file-deletion table is created lazily, so a missing table means no inlined-file deletes
+	auto exists_sql = StringUtil::Format(
+	    "SELECT 1 FROM information_schema.tables WHERE table_schema = {METADATA_SCHEMA_NAME_LITERAL} "
+	    "AND table_name = %s",
+	    DuckLakeUtil::SQLLiteralToString(table_name));
+	auto exists_result = executor(exists_sql);
+	bool table_exists = false;
+	for (auto &row : *exists_result) {
+		table_exists = true;
+		break;
+	}
+	if (!table_exists) {
+		return result;
+	}
 	auto sql = StringUtil::Format("SELECT DISTINCT file_id FROM {METADATA_CATALOG}.%s "
 	                              "WHERE file_id IN (%s) AND begin_snapshot > {SNAPSHOT_ID}",
 	                              table_name, file_id_list);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -137,6 +137,34 @@ void ConflictCheck(const case_insensitive_map_t<reference_set_t<CatalogEntry>> &
 	}
 }
 
+set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                                      TableIndex table_id, const vector<idx_t> &file_ids) {
+	set<DataFileIndex> result;
+	if (file_ids.empty()) {
+		return result;
+	}
+	string file_id_list;
+	for (auto &file_id : file_ids) {
+		if (!file_id_list.empty()) {
+			file_id_list += ", ";
+		}
+		file_id_list += to_string(file_id);
+	}
+	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
+	auto sql = StringUtil::Format("SELECT DISTINCT file_id FROM {METADATA_CATALOG}.%s "
+	                              "WHERE file_id IN (%s) AND begin_snapshot > {SNAPSHOT_ID}",
+	                              table_name, file_id_list);
+	auto query_result = executor(sql);
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw(
+		    "Failed to commit DuckLake transaction - failed to check for inlined delete conflicts:");
+	}
+	for (auto &row : *query_result) {
+		result.insert(DataFileIndex(row.GetValue<idx_t>(0)));
+	}
+	return result;
+}
+
 } // namespace
 
 void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformation &changes,
@@ -225,23 +253,48 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 		ConflictCheck(table_id, other_changes.inserted_tables, "delete from table", "inserted into it");
 		ConflictCheck(table_id, other_changes.tables_inserted_inlined, "delete from table", "inserted into it");
 	}
-	if (!changes.tables_deleted_from.empty()) {
+	// the same data file conflicts whether the delete is parquet or inlined (#1215)
+	bool self_deletes = !changes.tables_deleted_from.empty() || !changes.tables_deleted_inlined.empty();
+	bool other_deletes = !other_changes.tables_deleted_from.empty() || !other_changes.tables_deleted_inlined.empty();
+	if (self_deletes && other_deletes) {
+		// iterate the deleted-table id sets (not local file changes) so full-table file drops are included
 		bool check_for_matches = false;
-		for (auto &table_id : changes.tables_deleted_from) {
-			if (other_changes.tables_deleted_from.find(table_id) != other_changes.tables_deleted_from.end()) {
-				check_for_matches = true;
+		for (auto &deleted_set : {&changes.tables_deleted_from, &changes.tables_deleted_inlined}) {
+			for (auto &table_id : *deleted_set) {
+				if (other_changes.tables_deleted_from.find(table_id) != other_changes.tables_deleted_from.end() ||
+				    other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
+					check_for_matches = true;
+					break;
+				}
+			}
+			if (check_for_matches) {
 				break;
 			}
 		}
 		if (check_for_matches) {
-			// If we have deletes on the tables, check for files being deleted
 			const auto deleted_files = GetFilesDeletedOrDroppedAfterSnapshot(executor);
 			for (auto &entry : local_changes.Changes()) {
+				auto table_id = entry.GetTableIndex();
 				auto &table_changes = entry.GetTableChanges();
+				vector<idx_t> deleted_file_ids;
 				for (auto &file_entry : table_changes.new_delete_files) {
 					for (auto &file : file_entry.second) {
 						ConflictCheck(file.data_file_id, deleted_files.deleted_from_files, "delete from file",
 						              "deleted from it");
+						deleted_file_ids.push_back(file.data_file_id.index);
+					}
+				}
+				if (table_changes.new_inlined_file_deletes) {
+					for (auto &file_entry : table_changes.new_inlined_file_deletes->file_deletes) {
+						ConflictCheck(DataFileIndex(file_entry.first), deleted_files.deleted_from_files,
+						              "delete from file", "deleted from it");
+						deleted_file_ids.push_back(file_entry.first);
+					}
+				}
+				if (other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
+					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, table_id, deleted_file_ids);
+					for (auto &file_id : deleted_file_ids) {
+						ConflictCheck(DataFileIndex(file_id), inlined_deleted, "delete from file", "deleted from it");
 					}
 				}
 			}

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -137,8 +137,10 @@ void ConflictCheck(const case_insensitive_map_t<reference_set_t<CatalogEntry>> &
 	}
 }
 
-set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
-                                                      TableIndex table_id, const vector<idx_t> &file_ids) {
+set<DataFileIndex>
+GetInlinedFileDeletesAfterSnapshot(const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                   const std::function<string(const string &)> &inlined_delete_exists_query,
+                                   TableIndex table_id, const vector<idx_t> &file_ids) {
 	set<DataFileIndex> result;
 	if (file_ids.empty()) {
 		return result;
@@ -152,10 +154,10 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 	}
 	auto table_name = DuckLakeMetadataManager::InlinedFileDeletionTableName(table_id);
 	// the inlined-file-deletion table is created lazily, so a missing table means no inlined-file deletes
-	auto exists_sql = StringUtil::Format(
-	    "SELECT 1 FROM information_schema.tables WHERE table_schema = {METADATA_SCHEMA_NAME_LITERAL} "
-	    "AND table_name = %s",
-	    DuckLakeUtil::SQLLiteralToString(table_name));
+	if (!inlined_delete_exists_query) {
+		throw InternalException("Missing inlined-delete existence query for cross-store conflict check");
+	}
+	auto exists_sql = inlined_delete_exists_query(table_name);
 	auto exists_result = executor(exists_sql);
 	bool table_exists = false;
 	for (auto &row : *exists_result) {
@@ -181,10 +183,10 @@ set<DataFileIndex> GetInlinedFileDeletesAfterSnapshot(const std::function<unique
 
 } // namespace
 
-void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformation &changes,
-                                                 const SnapshotChangeInformation &other_changes,
-                                                 DuckLakeSnapshot transaction_snapshot,
-                                                 const std::function<unique_ptr<QueryResult>(string)> &executor) const {
+void DuckLakeTransactionState::CheckForConflicts(
+    const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
+    DuckLakeSnapshot transaction_snapshot, const std::function<unique_ptr<QueryResult>(string)> &executor,
+    const std::function<string(const string &)> &inlined_delete_exists_query) const {
 	// check if we are dropping the same table as another transaction
 	for (auto &dropped_idx : changes.dropped_tables) {
 		ConflictCheck(dropped_idx, other_changes.dropped_tables, "drop table", "dropped it already");
@@ -306,7 +308,8 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 					}
 				}
 				if (other_changes.tables_deleted_inlined.find(table_id) != other_changes.tables_deleted_inlined.end()) {
-					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, table_id, deleted_file_ids);
+					auto inlined_deleted = GetInlinedFileDeletesAfterSnapshot(executor, inlined_delete_exists_query,
+					                                                          table_id, deleted_file_ids);
 					for (auto &file_id : deleted_file_ids) {
 						ConflictCheck(DataFileIndex(file_id), inlined_deleted, "delete from file", "deleted from it");
 					}
@@ -1968,7 +1971,8 @@ WHERE idt.schema_version < (
 SnapshotAndStats
 DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
                                             const TransactionChangeInformation &changes,
-                                            const std::function<unique_ptr<QueryResult>(string)> &executor) {
+                                            const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                            const std::function<string(const string &)> &inlined_delete_exists_query) {
 	SnapshotAndStats snapshot_and_stats;
 	// get all changes made to the system after the current snapshot was started
 	auto changes_made = DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor);
@@ -1976,7 +1980,7 @@ DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapsho
 	auto other_changes = SnapshotChangeInformation::ParseChangesMade(changes_made.changes_made);
 
 	// now check for conflicts
-	CheckForConflicts(changes, other_changes, transaction_snapshot, executor);
+	CheckForConflicts(changes, other_changes, transaction_snapshot, executor, inlined_delete_exists_query);
 
 	return snapshot_and_stats;
 }
@@ -1997,7 +2001,8 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 				// we failed our first commit due to another transaction committing
 				// retry - but first check for conflicts
 				commit_stats_snapshot =
-				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
+				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor,
+				                      context.inlined_delete_exists_query);
 				stats = &commit_stats_snapshot.stats;
 			} else {
 				commit_stats_snapshot.snapshot = context.get_snapshot();

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -62,7 +62,14 @@
         "test/sql/transaction/transaction_conflict_inlining.test",
         "test/sql/transaction/transaction_conflicts.test",
         "test/sql/transaction/transaction_conflicts_delete.test",
-        "test/sql/transaction/transaction_conflicts_view.test"
+        "test/sql/transaction/transaction_conflicts_view.test",
+        "test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test"
+      ]
+    },
+    {
+      "reason": "FIXME: concurrent conflict aborts the transaction on quack's serializing backend (skipped on Postgres/SQLite for the same reason)",
+      "paths": [
+        "test/sql/deletion_inlining/test_deletion_inlining_concurrent.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -55,7 +55,8 @@
         "test/sql/transaction/transaction_conflicts_delete.test",
         "test/sql/transaction/transaction_conflicts_view.test",
         "test/sql/concurrent/file_level_conflict.test",
-        "test/sql/transaction/transaction_conflict_inlining.test"
+        "test/sql/transaction/transaction_conflict_inlining.test",
+        "test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test"
       ]
     },
     {

--- a/test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test
+++ b/test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test
@@ -184,3 +184,160 @@ statement error con2
 COMMIT
 ----
 conflict
+
+# ----------------------------------------------------------------------------------------------
+# Cross-store, different stores: an inlined-file delete concurrent with an inlined-data delete on one
+# table. The file-level check probes the inlined-file-delete table, which is created lazily and does
+# not exist when the other transaction only deleted inlined data. That probe must tolerate its absence:
+# a missing table means "no inlined-file deletes", not a commit error. The table-granular inlined check
+# still reports a conflict here (relaxed to a clean commit once the check is narrowed to inlined-data).
+# ----------------------------------------------------------------------------------------------
+
+# 100 rows land in a parquet data file; a small insert of 5 rows is kept as inlined data
+statement ok
+CREATE TABLE ducklake.test_e AS FROM range(100) t(i)
+
+statement ok
+INSERT INTO ducklake.test_e VALUES (1000), (1001), (1002), (1003), (1004)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: single-row delete of an inlined-data row (1000) -> inlined data delete, no delete table created
+query I con1
+DELETE FROM ducklake.test_e WHERE i = 1000
+----
+1
+
+# con2: single-row delete of a parquet-file row (5) -> inlined file delete on a different store
+query I con2
+DELETE FROM ducklake.test_e WHERE i = 5
+----
+1
+
+statement ok con1
+COMMIT
+
+# con2 must not crash on the absent inlined-delete table; it reports a proper conflict, not an internal error
+statement error con2
+COMMIT
+----
+conflict
+
+# ----------------------------------------------------------------------------------------------
+# Mirror of the case above: the inlined-file delete commits first, the inlined-data delete second.
+# The second committer records no inlined-file deletes, so it never probes the delete table; the
+# table-granular inlined check still reports a conflict. This must also avoid an internal error.
+# ----------------------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.test_f AS FROM range(100) t(i)
+
+statement ok
+INSERT INTO ducklake.test_f VALUES (1000), (1001), (1002), (1003), (1004)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: single-row delete of a parquet-file row (5) -> inlined file delete
+query I con1
+DELETE FROM ducklake.test_f WHERE i = 5
+----
+1
+
+# con2: single-row delete of an inlined-data row (1000) -> inlined data delete, no delete table created
+query I con2
+DELETE FROM ducklake.test_f WHERE i = 1000
+----
+1
+
+statement ok con1
+COMMIT
+
+statement error con2
+COMMIT
+----
+conflict
+
+# ----------------------------------------------------------------------------------------------
+# Concurrency preserved: cross-store deletes to different tables must not conflict. An inlined-file
+# delete on one table and an inlined-data delete on another share no table, so both must commit.
+# ----------------------------------------------------------------------------------------------
+
+# test_g_a has a parquet data file; test_g_b (5 rows) is kept as inlined data
+statement ok
+CREATE TABLE ducklake.test_g_a AS FROM range(100) t(i)
+
+statement ok
+CREATE TABLE ducklake.test_g_b AS FROM range(5) t(i)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: inlined file delete on test_g_a
+query I con1
+DELETE FROM ducklake.test_g_a WHERE i = 5
+----
+1
+
+# con2: inlined data delete on test_g_b (a different table)
+query I con2
+DELETE FROM ducklake.test_g_b WHERE i = 2
+----
+1
+
+statement ok con1
+COMMIT
+
+# different tables -> con2 must commit cleanly
+statement ok con2
+COMMIT
+
+# ----------------------------------------------------------------------------------------------
+# One transaction deleting from both stores of a table: con2 records an inlined-file delete and an
+# inlined-data delete on the same table, concurrent with con1's inlined-data delete on that table.
+# con2 probes the inlined-delete table for its own file delete while its inlined-data delete conflicts
+# with con1 at table granularity - the probe must tolerate the not-yet-created table, not error.
+# ----------------------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.test_h AS FROM range(100) t(i)
+
+statement ok
+INSERT INTO ducklake.test_h VALUES (1000), (1001), (1002), (1003), (1004)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: inlined data delete (1001)
+query I con1
+DELETE FROM ducklake.test_h WHERE i = 1001
+----
+1
+
+# con2: an inlined file delete (parquet row 5) and an inlined data delete (inline row 1000) at once
+query I con2
+DELETE FROM ducklake.test_h WHERE i = 5 OR i = 1000
+----
+2
+
+statement ok con1
+COMMIT
+
+# con2's inlined-data delete conflicts with con1 at table granularity; must be a conflict, not an error
+statement error con2
+COMMIT
+----
+conflict

--- a/test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test
+++ b/test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test
@@ -1,0 +1,186 @@
+# name: test/sql/issues/issue_1215_concurrent_inlined_parquet_delete_conflict.test
+# description: concurrent inlined + parquet deletes of the same row must conflict (issue #1215)
+# group: [issues]
+
+# Two concurrent transactions that delete the same row of the same data file both commit
+# when their delete sizes straddle DATA_INLINING_ROW_LIMIT: the small delete is written as an
+# inlined file delete, the large one as a parquet delete file, and the commit conflict check
+# never compares an inlined delete against a parquet delete (in either direction). The row's
+# position then ends up recorded in both stores - the write-path origin of the #1084 overlap.
+#
+# parquet+parquet and inlined+inlined deletes of the same row already conflict correctly; only
+# the cross-store combination slips through. This test asserts the cross-store case conflicts
+# too, in both commit orders.
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+# inlining row limit 10: a DELETE of <=10 rows is stored as inlined file deletes,
+# a DELETE of >10 rows is stored as a parquet delete file
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_1215_concurrent_inlined_parquet_delete_conflict', DATA_INLINING_ROW_LIMIT 10, METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+SET immediate_transaction_mode=true
+
+# ----------------------------------------------------------------------------------------------
+# Order A: inlined delete commits first, parquet delete commits second
+# ----------------------------------------------------------------------------------------------
+
+# 100 rows land in a parquet data file (100 > inlining limit)
+statement ok
+CREATE TABLE ducklake.test_a AS FROM range(100) t(i)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: single-row delete (1 <= 10) -> inlined file delete for the row at position 50
+query I con1
+DELETE FROM ducklake.test_a WHERE i = 50
+----
+1
+
+# con2: 30-row delete incl. value 50 (30 > 10) -> parquet delete file covering positions 50..79
+query I con2
+DELETE FROM ducklake.test_a WHERE i >= 50 AND i < 80
+----
+30
+
+statement ok con1
+COMMIT
+
+# con2 deletes row 50, which con1 already committed a delete for -> must conflict
+statement error con2
+COMMIT
+----
+conflict
+
+# ----------------------------------------------------------------------------------------------
+# Order B (mirror): parquet delete commits first, inlined delete commits second
+# ----------------------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.test_b AS FROM range(100) t(i)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: 30-row delete incl. value 50 (30 > 10) -> parquet delete file covering positions 50..79
+query I con1
+DELETE FROM ducklake.test_b WHERE i >= 50 AND i < 80
+----
+30
+
+# con2: single-row delete (1 <= 10) -> inlined file delete for the row at position 50
+query I con2
+DELETE FROM ducklake.test_b WHERE i = 50
+----
+1
+
+statement ok con1
+COMMIT
+
+# con2 deletes row 50, which con1 already committed a delete for -> must conflict
+statement error con2
+COMMIT
+----
+conflict
+
+# ----------------------------------------------------------------------------------------------
+# Concurrency preserved: cross-store deletes to different files of the same table must not conflict.
+# The conflict must be detected at file granularity, not table granularity - otherwise a correct fix
+# would needlessly serialize independent deletes. This is what distinguishes a file-level fix from a
+# coarse table-level one.
+# ----------------------------------------------------------------------------------------------
+
+# two parquet data files in one table: values 0..99 in file A, 100..199 in file B
+statement ok
+CREATE TABLE ducklake.test_c AS FROM range(100) t(i)
+
+statement ok
+INSERT INTO ducklake.test_c FROM range(100, 200)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: 30-row delete of values 150..179 (>10) -> parquet delete file on file B
+query I con1
+DELETE FROM ducklake.test_c WHERE i >= 150 AND i < 180
+----
+30
+
+# con2: single-row delete of value 5 (<=10) -> inlined file delete on file A (a different file)
+query I con2
+DELETE FROM ducklake.test_c WHERE i = 5
+----
+1
+
+statement ok con1
+COMMIT
+
+# different files -> no overlap -> con2 must commit cleanly
+statement ok con2
+COMMIT
+
+# both deletes took effect, nothing resurrected
+query I
+SELECT count(*) FROM ducklake.test_c
+----
+169
+
+query I
+SELECT count(*) FROM ducklake.test_c WHERE i = 5 OR (i >= 150 AND i < 180)
+----
+0
+
+# ----------------------------------------------------------------------------------------------
+# Granularity contract: cross-store deletes of different rows of the same file must still conflict.
+# The conflict is detected at file granularity (matching parquet+parquet), not row granularity - so
+# disjoint row sets on one data file still conflict. This guards against anyone "relaxing" the check
+# to row-level, which would silently reopen the #1084 overlap on a subtler path.
+# ----------------------------------------------------------------------------------------------
+
+# single data file, 100 rows in one parquet file
+statement ok
+CREATE TABLE ducklake.test_d AS FROM range(100) t(i)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+# con1: single-row delete of value 5 (<=10) -> inlined file delete
+query I con1
+DELETE FROM ducklake.test_d WHERE i = 5
+----
+1
+
+# con2: 30-row delete of values 50..79 (>10) -> parquet delete file. Disjoint rows, but the same file
+query I con2
+DELETE FROM ducklake.test_d WHERE i >= 50 AND i < 80
+----
+30
+
+statement ok con1
+COMMIT
+
+# same file (different rows) -> must conflict at file granularity
+statement error con2
+COMMIT
+----
+conflict


### PR DESCRIPTION
Closes #1215

Two concurrent transactions deleting the same row of the same data file could both commit when their delete sizes straddle `data_inlining_row_limit`: one tombstone is written as an inlined file delete, the other as a parquet delete file, and `CheckForConflicts` only compared parquet deletes against parquet deletes. This is the write-path origin of the overlap read back in #1084.

The fix extends the file-level conflict check to span both tombstone stores, so cross-store deletes of the same file conflict (in either commit order) while deletes to different files still commit.

On Postgres, the check for the other transaction's (lazily-created) inlined-delete table reads the live catalog via `postgres_query`, since DuckDB's cached view of an attached catalog can be stale for a table another transaction just created.

The new test is skipped on the SQLite catalog. SQLite allows only one writer, so the two transactions cannot both reach commit and the scenario is unreachable there rather than unfixed. It joins the sibling concurrency tests already listed for that reason.

Related read-path fix: #1208 (for #1084). It should land first, since this change makes #1208's current test construction conflict; I'll update that test in whichever PR merges second.