### PR TITLE
Fix: Cloud Path Separator corruption when httpfs not loaded

### DIFF
--- a/src/include/storage/ducklake_partition_data.hpp
+++ b/src/include/storage/ducklake_partition_data.hpp
@@ -30,6 +30,10 @@ struct DuckLakePartitionField {
 
 struct DuckLakePartition {
 	idx_t partition_id = 0;
+	//! The transaction-local id this partition was assigned when it was created. Data files written in
+	//! the same transaction reference this id. Commit attempts overwrite partition_id with the id of
+	//! that attempt, so on retry the data-file remap must key off the original transaction-local id.
+	optional_idx local_partition_id;
 	vector<DuckLakePartitionField> fields;
 };
 

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -189,8 +189,14 @@ void DuckLakeInitializer::LoadExistingDuckLake(DuckLakeTransaction &transaction)
 		}
 		if (tag.key == "data_path") {
 			if (options.data_path.empty()) {
-				options.data_path = metadata_manager.LoadPath(tag.value);
+				// Proper path extensions may not be loaded
+				options.data_path = tag.value;
+				// Autoloads relevant extensions if the data path uses a known pattern (e.g. starts with "s3://")
 				InitializeDataPath();
+				// LoadPath may modify the path (e.g. by adding/modifying a separator)
+				// On Windows, if the proper extension is not loaded, the path may be set to the wrong separator
+				// InitializeDataPath needs to be called before LoadPath to set the correct separator
+				options.data_path = metadata_manager.LoadPath(tag.value);
 			} else {
 				// verify that they match if override_data_path is not set to true
 				if (metadata_manager.StorePath(options.data_path) != tag.value && !options.override_data_path) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5010,6 +5010,9 @@ WHERE table_id IN (%s);)",
 				inlined_tables_to_drop.push_back(row.GetValue<string>(0));
 			}
 		}
+		for (auto &table_id : cleanup_tables) {
+			inlined_tables_to_drop.push_back(InlinedFileDeletionTableName(table_id));
+		}
 
 		tables_to_delete_from = {
 		    "ducklake_table",           "ducklake_table_stats",         "ducklake_table_column_stats",

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -597,17 +597,42 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 	return field;
 }
 
+static bool PartitionFieldsMatch(optional_ptr<DuckLakePartition> current_partition,
+                                 const DuckLakePartition &requested_partition) {
+	if (!current_partition) {
+		return requested_partition.fields.empty();
+	}
+	if (current_partition->fields.size() != requested_partition.fields.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < current_partition->fields.size(); i++) {
+		auto &current_field = current_partition->fields[i];
+		auto &requested_field = requested_partition.fields[i];
+		if (current_field.partition_key_index != requested_field.partition_key_index ||
+		    current_field.field_id != requested_field.field_id ||
+		    current_field.transform.type != requested_field.transform.type ||
+		    current_field.transform.bucket_count != requested_field.transform.bucket_count) {
+			return false;
+		}
+	}
+	return true;
+}
+
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &transaction, SetPartitionedByInfo &info) {
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	// create a complete copy of this table with the partition info added
 	auto partition_data = make_uniq<DuckLakePartition>();
 	partition_data->partition_id = transaction.GetLocalCatalogId();
+	partition_data->local_partition_id = partition_data->partition_id;
 	for (idx_t expr_idx = 0; expr_idx < info.partition_keys.size(); expr_idx++) {
 		auto &expr = *info.partition_keys[expr_idx];
 		auto partition_field = GetPartitionField(*this, expr);
 		partition_field.partition_key_index = expr_idx;
 		partition_data->fields.push_back(partition_field);
+	}
+	if (PartitionFieldsMatch(GetPartitionData(), *partition_data)) {
+		return nullptr;
 	}
 
 	auto new_entry = make_uniq<DuckLakeTableEntry>(*this, table_info, std::move(partition_data));

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1008,7 +1008,11 @@ DuckLakePartitionInfo DuckLakeTransaction::GetNewPartitionKey(DuckLakeCommitStat
 		// dropping partition data - insert the empty partition key data for this table
 		return partition_key;
 	}
-	auto local_partition_id = partition_data->partition_id;
+	// key the remap off the original transaction-local id: a previous failed commit attempt may have
+	// already overwritten partition_id, while data files still reference the transaction-local id
+	auto local_partition_id = partition_data->local_partition_id.IsValid()
+	                              ? partition_data->local_partition_id.GetIndex()
+	                              : partition_data->partition_id;
 	auto partition_id = commit_state.commit_snapshot.next_catalog_id++;
 	partition_key.id = partition_id;
 	partition_data->partition_id = partition_id;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -736,6 +736,9 @@ void DuckLakeTransaction::Commit() {
 		FlushChanges();
 	} else if (connection) {
 		connection->Commit();
+		if (!state->flushed_inlined_tables.empty()) {
+			DropEmptySupersededInlinedTablesClientSide();
+		}
 	}
 	connection.reset();
 	state->local_changes.Clear();

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -514,6 +514,10 @@ DuckLakeFileInfo DuckLakeTransactionState::GetNewDataFile(const DuckLakeDataFile
                                                           optional_idx row_id_start) {
 	auto data_file = DuckLakeTransaction::BuildDataFileInfo(file, commit_state.commit_snapshot, table_id, row_id_start);
 	commit_state.RemapPartitionId(data_file.partition_id);
+	if (data_file.partition_id.IsValid() &&
+	    data_file.partition_id.GetIndex() >= DuckLakeConstants::TRANSACTION_LOCAL_ID_START) {
+		throw InternalException("Cannot commit data file with transaction-local partition id");
+	}
 	commit_state.RemapMappingIndex(data_file.mapping_id);
 	return data_file;
 }

--- a/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
+++ b/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
@@ -1,0 +1,68 @@
+# name: test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
+# description: superseded empty inlined tables from ADD COLUMN must be reclaimed by maintenance routines
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/empty_inlined_alter_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.a(c0 INTEGER)
+
+statement ok
+ALTER TABLE ducklake.a ADD COLUMN c1 INTEGER
+
+statement ok
+ALTER TABLE ducklake.a ADD COLUMN c2 INTEGER
+
+statement ok
+ALTER TABLE ducklake.a ADD COLUMN c3 INTEGER
+
+statement ok
+ALTER TABLE ducklake.a ADD COLUMN c4 INTEGER
+
+statement ok
+ALTER TABLE ducklake.a ADD COLUMN c5 INTEGER
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake')
+
+statement ok
+CHECKPOINT ducklake
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_snapshot
+----
+1
+
+# only the inlined table for the current schema version may remain
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+1
+
+query I
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_%' AND table_name <> 'ducklake_inlined_data_tables'
+----
+1
+
+statement ok
+INSERT INTO ducklake.a VALUES (1, 2, 3, 4, 5, 6)
+
+query IIIIII
+SELECT c0, c1, c2, c3, c4, c5 FROM ducklake.a
+----
+1	2	3	4	5	6

--- a/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
+++ b/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
@@ -48,14 +48,12 @@ SELECT COUNT(*) FROM ducklake_meta.ducklake_snapshot
 ----
 1
 
-# only the inlined table for the current schema version may remain
+# only the inlined table for the current schema version may remain.
+# The registry row and its physical table are dropped together in one batch, so the
+# registry count is the backend-portable source of truth (duckdb_tables() cannot see
+# a remote quack-backed metadata catalog).
 query I
 SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
-----
-1
-
-query I
-SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_%' AND table_name <> 'ducklake_inlined_data_tables'
 ----
 1
 

--- a/test/sql/data_inlining/inlined_delete_table_drop_cleanup.test
+++ b/test/sql/data_inlining/inlined_delete_table_drop_cleanup.test
@@ -1,0 +1,52 @@
+# name: test/sql/data_inlining/inlined_delete_table_drop_cleanup.test
+# description: inlined delete tables must be reclaimed after DROP TABLE + expire + cleanup
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/inlined_delete_drop_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 10)
+
+statement ok
+CREATE TABLE ducklake.t AS SELECT range AS i FROM range(100)
+
+statement ok
+DELETE FROM ducklake.t WHERE i IN (3, 5, 7)
+
+statement ok
+INSERT INTO ducklake.t VALUES (200), (201)
+
+statement ok
+DROP TABLE ducklake.t
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
+
+statement ok
+CALL ducklake_delete_orphaned_files('ducklake', older_than => now())
+
+# the inlined data table of the dropped table is reclaimed
+query I
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_1%'
+----
+0
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+0
+
+# the inlined delete table must be reclaimed as well
+query I
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_delete_%'
+----
+0

--- a/test/sql/partitioning/partition_nop.test
+++ b/test/sql/partitioning/partition_nop.test
@@ -13,7 +13,7 @@ test-env DATA_PATH __TEST_DIR__
 
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partitioning_nop', METADATA_CATALOG 'ducklake_metadata')
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/ducklake_partitioning_nop', METADATA_CATALOG 'ducklake_metadata', DATA_INLINING_ROW_LIMIT 0)
 
 statement ok
 USE ducklake
@@ -41,6 +41,53 @@ query I
 select count(*) FROM ducklake_metadata.ducklake_partition_info
 ----
 1
+
+# A redundant partition change in a transaction that also writes files should keep
+# using the existing partition id.
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+DELETE FROM partitioned_tbl WHERE part_key = 0;
+
+statement ok
+INSERT INTO partitioned_tbl VALUES (0, 'replacement_a'), (0, 'replacement_b');
+
+statement ok
+COMMIT;
+
+statement ok
+SET VARIABLE expected_partition_id = (
+    SELECT partition_id
+    FROM ducklake_metadata.ducklake_partition_info
+    WHERE table_id = 1
+);
+
+query I
+SELECT COUNT(*)
+FROM ducklake_metadata.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL
+  AND partition_id IS DISTINCT FROM getvariable('expected_partition_id');
+----
+0
+
+query I
+SELECT COUNT(DISTINCT partition_id)
+FROM ducklake_metadata.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT MAX(schema_version)
+FROM ducklake_metadata.ducklake_snapshot;
+----
+2
 
 # This should now change the partition, since it's different
 statement ok

--- a/test/sql/partitioning/partition_nop_schema_version.test
+++ b/test/sql/partitioning/partition_nop_schema_version.test
@@ -1,0 +1,106 @@
+# name: test/sql/partitioning/partition_nop_schema_version.test
+# description: Verify repeated SET PARTITIONED BY does not increment schema_version or block compaction
+# group: [partitioning]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/partition_nop_schema_version')
+
+statement ok
+CREATE TABLE ducklake.test(part_key INTEGER, value VARCHAR);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+1
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+2
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 'before_1'), (1, 'before_2');
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+1
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+1
+
+# Setting the same partitioning again should be a no-op for schema versions too.
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+2
+
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+INSERT INTO ducklake.test VALUES (1, 'after_1'), (1, 'after_2');
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+2
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+2
+
+query III
+SELECT table_name, files_processed, files_created
+FROM ducklake_merge_adjacent_files('ducklake', 'test')
+----
+test	2	1
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true);
+
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'test')
+----
+1
+
+query I
+SELECT COUNT(*) FROM GLOB('${DATA_PATH}/partition_nop_schema_version/**/*.parquet')
+----
+1
+
+query II
+SELECT part_key, value FROM ducklake.test ORDER BY ALL
+----
+1	after_1
+1	after_2
+1	before_1
+1	before_2
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (part_key, value);
+
+query I
+SELECT max(schema_version) FROM __ducklake_metadata_ducklake.ducklake_schema_versions WHERE table_id = 1
+----
+3

--- a/test/sql/quack/noop_partition_alter_data_files.test
+++ b/test/sql/quack/noop_partition_alter_data_files.test
@@ -1,0 +1,63 @@
+# name: test/sql/quack/noop_partition_alter_data_files.test
+# description: Redundant partition alters must not poison Quack data-file metadata
+# group: [quack]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/quack_noop_partition_alter_data_files', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE partitioned_tbl(part_key INTEGER, values VARCHAR);
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+INSERT INTO partitioned_tbl SELECT i % 2, concat('value_', i) FROM range(5) t(i);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE partitioned_tbl SET PARTITIONED BY (part_key);
+
+statement ok
+DELETE FROM partitioned_tbl WHERE part_key = 0;
+
+statement ok
+INSERT INTO partitioned_tbl VALUES (0, 'replacement_a'), (0, 'replacement_b');
+
+statement ok
+COMMIT;
+
+query I
+SELECT COUNT(*)
+FROM __ducklake_metadata_ducklake.ducklake_partition_info
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT COUNT(DISTINCT partition_id)
+FROM __ducklake_metadata_ducklake.ducklake_data_file
+WHERE table_id = 1
+  AND end_snapshot IS NULL;
+----
+1
+
+query I
+SELECT MAX(schema_version)
+FROM __ducklake_metadata_ducklake.ducklake_snapshot;
+----
+2

--- a/test/sql/transaction/partition_commit_retry_remap.test
+++ b/test/sql/transaction/partition_commit_retry_remap.test
@@ -1,0 +1,130 @@
+# name: test/sql/transaction/partition_commit_retry_remap.test
+# description: data files keep a valid partition id when a commit attempt is retried after a concurrent snapshot
+# group: [transaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/repro_partition_retry/', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+statement ok
+USE ducklake;
+
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok
+COPY (
+    SELECT 1 AS id, 'google_ads_data_hub' AS source, 10 AS value
+    UNION ALL
+    SELECT 2 AS id, 'google_ads_data_hub' AS source, 20 AS value
+    UNION ALL
+    SELECT 3 AS id, 'bing' AS source, 30 AS value
+) TO '${DATA_PATH}/repro_slice.parquet' (FORMAT parquet);
+
+statement ok con1
+USE ducklake;
+
+statement ok con2
+USE ducklake;
+
+statement ok con1
+BEGIN;
+
+statement ok con1
+CREATE TABLE first_write AS SELECT * FROM read_parquet('${DATA_PATH}/repro_slice.parquet') LIMIT 0;
+
+statement ok con1
+ALTER TABLE first_write SET PARTITIONED BY (source);
+
+query I con1
+DELETE FROM first_write WHERE source IN ('google_ads_data_hub');
+----
+0
+
+statement ok con1
+INSERT INTO first_write BY NAME SELECT * FROM read_parquet('${DATA_PATH}/repro_slice.parquet');
+
+# concurrent unrelated commit forces con1's first commit attempt to fail retryably
+statement ok con2
+CREATE TABLE unrelated_table(i INTEGER);
+
+statement ok con1
+COMMIT;
+
+query I con1
+SELECT COUNT(*) FROM first_write;
+----
+3
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
+----
+0
+
+# every committed data file must reference a partition id that exists
+# (materialize the partition ids first - scanner-backed metadata catalogs do not
+# support multiple streaming scans in one query)
+statement ok
+SET VARIABLE known_partition_ids = (
+    SELECT LIST(partition_id)
+    FROM metadata.ducklake_partition_info
+);
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE partition_id IS NOT NULL
+  AND NOT list_contains(getvariable('known_partition_ids'), partition_id);
+----
+0
+
+# same scenario on a pre-existing table: re-partition + insert with a concurrent snapshot mid-transaction
+statement ok con1
+BEGIN;
+
+statement ok con1
+ALTER TABLE first_write SET PARTITIONED BY (id);
+
+statement ok con1
+INSERT INTO first_write BY NAME SELECT * FROM read_parquet('${DATA_PATH}/repro_slice.parquet');
+
+statement ok con2
+INSERT INTO unrelated_table VALUES (1);
+
+statement ok con1
+COMMIT;
+
+query I con1
+SELECT COUNT(*) FROM first_write;
+----
+6
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE table_id >= 9223372036854775808 OR partition_id >= 9223372036854775808;
+----
+0
+
+statement ok
+SET VARIABLE known_partition_ids = (
+    SELECT LIST(partition_id)
+    FROM metadata.ducklake_partition_info
+);
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE partition_id IS NOT NULL
+  AND NOT list_contains(getvariable('known_partition_ids'), partition_id);
+----
+0


### PR DESCRIPTION
Fixes #1032
Reimplements the fix for #239 by reapplying the same change from #244.
The change helps ensure relevant extensions such as httpfs are loaded on ATTACH to prevent the default file system path separators from being applied (i.e. Windows '\' separators used in a s3 path, corrupting the data path value).