### PR TITLE
Validate partition when adding data files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -114,6 +114,21 @@ struct HivePartition {
 	optional_idx partition_key_index;
 };
 
+static bool IsValidTransformedHivePartitionValue(const HivePartition &hive_partition,
+                                                 const DuckLakePartitionField &partition_field) {
+	if (partition_field.transform.type != DuckLakeTransformType::BUCKET) {
+		return true;
+	}
+	if (hive_partition.hive_value.IsNull()) {
+		return false;
+	}
+	auto bucket_value = hive_partition.hive_value.GetValue<int32_t>();
+	if (bucket_value < 0) {
+		return false;
+	}
+	return UnsafeNumericCast<idx_t>(bucket_value) < partition_field.transform.bucket_count;
+}
+
 struct ParquetFileMetadata {
 	string filename;
 	vector<unique_ptr<ParquetColumn>> columns;
@@ -1258,6 +1273,10 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 				}
 				if (!partition_field || partition_field->field_id != hive_partition_value.field_index ||
 				    !(partition_field->transform == hive_partition_value.transform)) {
+					invalid_partition = true;
+					break;
+				}
+				if (!IsValidTransformedHivePartitionValue(hive_partition_value, *partition_field)) {
 					invalid_partition = true;
 					break;
 				}

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -126,7 +126,7 @@ static bool IsValidTransformedHivePartitionValue(const HivePartition &hive_parti
 	if (bucket_value < 0) {
 		return false;
 	}
-	return UnsafeNumericCast<idx_t>(bucket_value) < partition_field.transform.bucket_count;
+	return NumericCast<idx_t>(bucket_value) < partition_field.transform.bucket_count;
 }
 
 struct ParquetFileMetadata {

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -120,7 +120,7 @@ static bool IsValidTransformedHivePartitionValue(const HivePartition &hive_parti
 		return true;
 	}
 	if (hive_partition.hive_value.IsNull()) {
-		return false;
+		return true;
 	}
 	auto bucket_value = hive_partition.hive_value.GetValue<int32_t>();
 	if (bucket_value < 0) {

--- a/test/sql/add_files/add_file_partitioned.test
+++ b/test/sql/add_files/add_file_partitioned.test
@@ -192,3 +192,25 @@ FROM multi_partition_t WHERE day(dt) = 20 order by id;
 ----
 3	c	2024-04-20
 12	z	2024-04-20
+
+# Bucket transform partition values must be valid bucket ids for the configured bucket count.
+statement ok
+CREATE TABLE bucket_partition_t(user_id VARCHAR, value INTEGER);
+
+statement ok
+ALTER TABLE bucket_partition_t SET PARTITIONED BY (bucket(4, user_id));
+
+statement ok
+COPY (
+  SELECT 'alice'::VARCHAR AS user_id, 42::INT AS value, 999::INT AS bucket
+) TO '{DATA_PATH}/add_file_partitioned/invalid_bucket' (FORMAT parquet, PARTITION_BY(bucket));
+
+statement error
+CALL ducklake_add_data_files(
+  'ducklake',
+  'bucket_partition_t',
+  '{DATA_PATH}/add_file_partitioned/invalid_bucket/bucket=999/*.parquet',
+  hive_partitioning => true
+)
+----
+contains an invalid partition value for the table configuration

--- a/test/sql/partitioning/bucket_partitioning.test
+++ b/test/sql/partitioning/bucket_partitioning.test
@@ -675,7 +675,7 @@ statement ok
 ALTER TABLE bucket_add_source SET PARTITIONED BY (bucket(4, user_id));
 
 statement ok
-INSERT INTO bucket_add_source VALUES ('alice', 1), ('bob', 2), ('charlie', 3);
+INSERT INTO bucket_add_source VALUES ('alice', 1), ('bob', 2), ('charlie', 3), (NULL, 4);
 
 # Capture the glob pattern for the files that were written
 query I
@@ -707,6 +707,7 @@ SELECT user_id, value FROM bucket_add_target ORDER BY user_id
 alice	1
 bob	2
 charlie	3
+NULL	4
 
 # ----------------------------------------------------------------------------------------------------------------------
 # DETACH/ATTACH round-trip test


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1291

The bug is: 
- When `ducklake_add_data_files` imports Hive-partitioned Parquet files, transformed partition directory values were accepted as trusted metadata even when they were invalid for DuckLake’s partition spec
- Later, bucket partition pruning uses DuckLake’s partition metadata to choose which files to scan. A filter such as user_id = 'alice' is folded to Alice’s real bucket value, so the file recorded as bucket=999 is pruned away and the query can return incorrect results.
- This PR rejects invalid imported bucket partition values during `ducklake_add_data_files`