### PR TITLE
Accept empty version on snapshot expiration

### DIFF
--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -32,16 +32,28 @@ static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &conte
 
 	for (auto &entry : input.named_parameters) {
 		if (entry.first == "dry_run") {
+			if (entry.second.IsNull()) {
+				throw BinderException("The dry_run option must be a non-null boolean.");
+			}
 			result->dry_run = BooleanValue::Get(entry.second);
 		} else if (entry.first == "versions") {
 			has_versions = true;
+			if (entry.second.IsNull()) {
+				continue;
+			}
 			for (auto &snapshot_id : ListValue::GetChildren(entry.second)) {
+				if (snapshot_id.IsNull()) {
+					continue;
+				}
 				if (!snapshot_list.empty()) {
 					snapshot_list += ", ";
 				}
 				snapshot_list += snapshot_id.ToString();
 			}
 		} else if (entry.first == "older_than") {
+			if (entry.second.IsNull()) {
+				throw BinderException("The older_than option must be a non-null timestamp.");
+			}
 			from_timestamp = entry.second.GetValue<timestamp_tz_t>();
 			has_timestamp = true;
 		} else {

--- a/src/functions/ducklake_expire_snapshots.cpp
+++ b/src/functions/ducklake_expire_snapshots.cpp
@@ -53,6 +53,11 @@ static unique_ptr<FunctionData> DuckLakeExpireSnapshotsBind(ClientContext &conte
 		    "ducklake_expire_snapshots: cannot specify both 'versions' and 'older_than' parameters at the "
 		    "same time. Please use only one criterion.");
 	}
+	// An explicitly empty version set expires no snapshots.
+	if (has_versions && snapshot_list.empty()) {
+		result->valid = false;
+		return std::move(result);
+	}
 	// No criteria given and no global default: silently no-op.
 	if (!has_versions && !has_timestamp && older_than_default.empty()) {
 		result->valid = false;

--- a/test/sql/compaction/expire_snapshots_empty_versions.test
+++ b/test/sql/compaction/expire_snapshots_empty_versions.test
@@ -1,0 +1,33 @@
+# name: test/sql/compaction/expire_snapshots_empty_versions.test
+# description: expiring an empty list of snapshot versions is a no-op
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+    DATA_PATH '{DATA_PATH}/ducklake_expire_empty_versions'
+)
+
+statement ok
+CREATE TABLE ducklake.test(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.test VALUES (42)
+
+query I
+SELECT count(*)
+FROM ducklake_expire_snapshots('ducklake', versions => [], dry_run => true)
+----
+0
+
+query I
+SELECT count(*) FROM ducklake.test
+----
+1

--- a/test/sql/compaction/expire_snapshots_empty_versions.test
+++ b/test/sql/compaction/expire_snapshots_empty_versions.test
@@ -28,6 +28,24 @@ FROM ducklake_expire_snapshots('ducklake', versions => [], dry_run => true)
 0
 
 query I
+SELECT count(*)
+FROM ducklake_expire_snapshots('ducklake', versions => NULL, dry_run => true)
+----
+0
+
+query I
+SELECT count(*)
+FROM ducklake_expire_snapshots('ducklake', versions => [NULL], dry_run => true)
+----
+0
+
+query I
+SELECT count(*)
+FROM ducklake_expire_snapshots('ducklake', versions => [1, NULL, 2], dry_run => true)
+----
+1
+
+query I
 SELECT count(*) FROM ducklake.test
 ----
 1

--- a/test/sql/compaction/expire_snapshots_invalid_params.test
+++ b/test/sql/compaction/expire_snapshots_invalid_params.test
@@ -36,3 +36,13 @@ statement error
 SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => true, versions => [1, 2], older_than => NOW())
 ----
 cannot specify both 'versions' and 'older_than'
+
+statement error
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', dry_run => NULL, versions => [1, 2])
+----
+dry_run option must be a non-null boolean
+
+statement error
+SELECT COUNT(*) FROM ducklake_expire_snapshots('ducklake', older_than => NULL, dry_run => true)
+----
+older_than option must be a non-null timestamp


### PR DESCRIPTION
Closes https://github.com/duckdb/ducklake/issues/1300

Another solution I thought about is to throw invalid input exception on empty version list, but I don't think it's invalid to do so.