### PR TITLE
Route Top-N file stats through backend-specific CTEs

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -331,7 +331,28 @@ string DuckLakeUtil::JoinPath(FileSystem &fs, const string &a, const string &b) 
 }
 
 shared_ptr<DynamicFilterData> DuckLakeUtil::GetOptionalDynamicFilterData(const TableFilter &filter) {
-	return ExpressionFilter::GetRootOptionalDynamicFilterData(filter);
+	auto dynamic_filter_data = ExpressionFilter::GetRootOptionalDynamicFilterData(filter);
+	if (dynamic_filter_data) {
+		return dynamic_filter_data;
+	}
+
+	auto &expression_filter =
+	    ExpressionFilter::GetExpressionFilter(filter, "DuckLakeUtil::GetOptionalDynamicFilterData");
+	if (expression_filter.expr->GetExpressionClass() != ExpressionClass::BOUND_CONJUNCTION) {
+		return nullptr;
+	}
+	auto &conjunction = expression_filter.expr->Cast<BoundConjunctionExpression>();
+	if (conjunction.GetExpressionType() != ExpressionType::CONJUNCTION_AND) {
+		return nullptr;
+	}
+	for (auto &child : conjunction.GetChildren()) {
+		ExpressionFilter child_filter(child->Copy());
+		dynamic_filter_data = GetOptionalDynamicFilterData(child_filter);
+		if (dynamic_filter_data) {
+			return dynamic_filter_data;
+		}
+	}
+	return nullptr;
 }
 
 bool DuckLakeUtil::IsInlinedSystemColumn(const string &name) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1753,51 +1753,14 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		}
 	}
 
-	string stats_select_list;
-	string stats_join_list;
-	string order_by_clause;
-	for (idx_t i = 0; i < dynamic_filter_columns.size(); i++) {
-		auto &dfc = dynamic_filter_columns[i];
-		auto alias = StringUtil::Format("stats_%d", NumericCast<int64_t>(i));
-		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", alias.c_str(), alias.c_str());
-		stats_join_list += StringUtil::Format(
-		    "\nLEFT JOIN {METADATA_CATALOG}.ducklake_file_column_stats %s ON %s.data_file_id = data.data_file_id AND "
-		    "%s.table_id = data.table_id AND %s.column_id = %d",
-		    alias.c_str(), alias.c_str(), alias.c_str(), alias.c_str(), NumericCast<int64_t>(dfc.column_field_index));
-
-		// Generate ORDER BY clause to optimize Top-N queries - order files by their min/max stats
-		// so we find satisfying rows early and can skip remaining files via dynamic filter pruning.
-		// We only order by the first dynamic filter column: Top-N typically has a single ordering column,
-		// and multiple columns would have conflicting requirements (e.g., ORDER BY a DESC, b ASC).
-		if (order_by_clause.empty()) {
-			const bool seeking_high_values = dfc.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-			                                 dfc.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
-			const bool seeking_low_values = dfc.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-			                                dfc.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
-			if (seeking_high_values) {
-				// For DESC Top-N (seeking high values), order by max_value DESC so files with highest values come first
-				auto cast_expr = CastStatsToTarget(alias + ".max_value", dfc.column_type);
-				order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", cast_expr);
-			} else if (seeking_low_values) {
-				// For ASC Top-N (seeking low values), order by min_value ASC so files with lowest values come first
-				auto cast_expr = CastStatsToTarget(alias + ".min_value", dfc.column_type);
-				order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", cast_expr);
-			}
-		}
-	}
-
-	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
-	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
-	                     GetDeleteFileSelectList("del") + stats_select_list;
-
 	string query;
 	string where_clause;
+	FilterSQLResult filter_result;
 
-	// Generate CTE section and WHERE clause if we have filter pushdown info
+	// Collect static filter CTE requirements before adding Top-N dynamic filter requirements.
 	if (filter_info && !filter_info->column_filters.empty()) {
-		auto components = GenerateFilterPushdownComponents(*filter_info, table);
-		query = components.cte_section;
-		where_clause = components.where_clause;
+		filter_result = ConvertFilterPushdownToSQL(*filter_info);
+		where_clause = filter_result.where_conditions;
 
 		// Add bucket-partition pruning for equality / IN-list predicates on bucket()-partitioned columns.
 		// Composes with the zone-map clause above — pruning narrows files, zone maps stay as a backstop.
@@ -1811,6 +1774,54 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 			}
 		}
 	}
+
+	for (auto &dfc : dynamic_filter_columns) {
+		auto entry = filter_result.required_ctes.find(dfc.column_field_index);
+		if (entry == filter_result.required_ctes.end()) {
+			filter_result.required_ctes.emplace(dfc.column_field_index,
+			                                    CTERequirement(dfc.column_field_index, {"min_value", "max_value"}));
+		} else {
+			entry->second.referenced_stats.insert("min_value");
+			entry->second.referenced_stats.insert("max_value");
+			// The static filter has two references to this CTE; the Top-N stats join adds one more.
+			entry->second.reference_count++;
+		}
+	}
+	query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id);
+
+	string stats_select_list;
+	string stats_join_list;
+	string order_by_clause;
+	for (auto &dfc : dynamic_filter_columns) {
+		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
+		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
+		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
+		                                      cte_name.c_str());
+
+		// Generate ORDER BY clause to optimize Top-N queries - order files by their min/max stats
+		// so we find satisfying rows early and can skip remaining files via dynamic filter pruning.
+		// We only order by the first dynamic filter column: Top-N typically has a single ordering column,
+		// and multiple columns would have conflicting requirements (e.g., ORDER BY a DESC, b ASC).
+		if (order_by_clause.empty()) {
+			const bool seeking_high_values = dfc.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+			                                 dfc.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+			const bool seeking_low_values = dfc.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+			                                dfc.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+			if (seeking_high_values) {
+				// For DESC Top-N (seeking high values), order by max_value DESC so files with highest values come first
+				auto cast_expr = CastStatsToTarget(cte_name + ".max_value", dfc.column_type);
+				order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", cast_expr);
+			} else if (seeking_low_values) {
+				// For ASC Top-N (seeking low values), order by min_value ASC so files with lowest values come first
+				auto cast_expr = CastStatsToTarget(cte_name + ".min_value", dfc.column_type);
+				order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", cast_expr);
+			}
+		}
+	}
+
+	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
+	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
+	                     GetDeleteFileSelectList("del") + stats_select_list;
 
 	// Add base query
 	query += StringUtil::Format(R"(

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -64,6 +64,7 @@ DuckLakeMultiFileList::DynamicFilterPushdown(ClientContext &context, const Multi
 		return nullptr;
 	}
 
+	// DuckDB passes the final filter set, including both static and Top-N dynamic filters.
 	auto pushdown_info = make_uniq<FilterPushdownInfo>();
 
 	for (auto &entry : filters) {

--- a/test/sql/stats/topn_file_pruning.test
+++ b/test/sql/stats/topn_file_pruning.test
@@ -68,6 +68,60 @@ EXPLAIN ANALYZE SELECT * FROM ducklake.events WHERE timestamp > TIMESTAMP '2026-
 ----
 analyzed_plan	<REGEX>:.*optional: Dynamic Filter.*
 
+# Log only the metadata query generated for the combined static and dynamic Top-N filter below.
+statement ok
+CALL enable_logging('DuckLakeMetadata')
+
+# Verify correctness when the static and dynamic filters use the same column.
+query II
+SELECT * FROM ducklake.events WHERE timestamp > TIMESTAMP '2026-01-02 00:00:00' ORDER BY timestamp DESC LIMIT 2
+----
+2026-01-04 00:01:39	d
+2026-01-04 00:01:38	d
+
+# The static predicate must be included only once when it shares a column with the Top-N dynamic filter.
+query I
+SELECT COUNT(*) = 1
+FROM duckdb_logs_parsed('DuckLakeMetadata')
+WHERE query LIKE '%LEFT JOIN col_1_stats%'
+  AND query LIKE '%2026-01-02 00:00:00%'
+  AND length(query) - length(replace(query, '2026-01-02 00:00:00', '')) =
+      length('2026-01-02 00:00:00');
+----
+true
+
+# PostgreSQL metadata uses a selective postgres_query() CTE for the Top-N min/max stats.
+statement ok
+USE ducklake
+
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COUNT(*) > 0
+     FROM duckdb_logs_parsed('DuckLakeMetadata')
+     WHERE query LIKE '%postgres_query%'
+       AND query LIKE '%ducklake_file_column_stats%'
+       AND query LIKE '%WHERE column_id = 1 AND table_id = 1%'
+       AND query LIKE '%col_1_stats AS MATERIALIZED%'
+       AND query LIKE '%LEFT JOIN col_1_stats%'
+       AND query LIKE '%min_value%'
+       AND query LIKE '%max_value%'
+       AND query LIKE '%value_count%'
+       AND length(query) - length(replace(query, 'col_1_stats AS MATERIALIZED', '')) =
+           length('col_1_stats AS MATERIALIZED'))
+    ELSE true END;
+----
+true
+
+# The Top-N query must not directly scan the attached PostgreSQL statistics relation.
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COUNT(*) = 0
+     FROM duckdb_logs_parsed('DuckLakeMetadata')
+     WHERE query LIKE '%"__ducklake_metadata_ducklake"."public".ducklake_file_column_stats%')
+    ELSE true END;
+----
+true
+
 # Test with multiple sort orders - should still prune using first column
 query II
 EXPLAIN ANALYZE SELECT * FROM ducklake.events ORDER BY timestamp DESC, user_id ASC LIMIT 1


### PR DESCRIPTION
Inspired by #1147 and extending the fix (filter pushdown to metadata manager instead of duckdb join which triggers metadata table scans) further.

Route Top-N `min_value`/`max_value` reads through the existing generated column-stats CTEs. Static and dynamic requirements for the same column are merged into one CTE, so PostgreSQL reuses the selective `postgres_query` path while other catalogs retain the attached metadata scan.

Adds regression coverage for same-column static/Top-N filters and PostgreSQL metadata SQL routing.

Tested `topn_file_pruning.test` and `filter_pushdown.test` with the default and PostgreSQL configurations.
