### PR TITLE
Fix transform partition stats

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1136,11 +1136,11 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 		column_stats.has_num_values = true;
 		column_stats.num_values = file_metadata.row_count.GetIndex();
 		column_stats.has_null_count = true;
-		if (!hive_value.IsNull()) {
+		if (entry.transform.type == DuckLakeTransformType::IDENTITY && !hive_value.IsNull()) {
 			column_stats.min = column_stats.max = hive_value.ToString();
 			column_stats.has_min = column_stats.has_max = true;
 		} else {
-			// All rows in this file have NULL for this partition column
+			// for non-identity transforms the partition value is the transform output, not a value of the source column
 			column_stats.null_count = file_metadata.row_count.GetIndex();
 			column_stats.any_valid = false;
 		};

--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -1130,13 +1130,19 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 		auto &field_type = entry.field_type;
 		auto &hive_value = entry.hive_value;
 
+		// the identity entry must take precedence: it reflects the actual column data
+		const auto is_identity = entry.transform.type == DuckLakeTransformType::IDENTITY;
+		if (!is_identity && result.column_stats.find(field_index) != result.column_stats.end()) {
+			continue;
+		}
+
 		DuckLakeColumnStats column_stats(field_type);
 		// num_values and null_count both needed to write count
 		// metadata in DuckLakeColumnStatsInfo::FromColumnStats
 		column_stats.has_num_values = true;
 		column_stats.num_values = file_metadata.row_count.GetIndex();
 		column_stats.has_null_count = true;
-		if (entry.transform.type == DuckLakeTransformType::IDENTITY && !hive_value.IsNull()) {
+		if (is_identity && !hive_value.IsNull()) {
 			column_stats.min = column_stats.max = hive_value.ToString();
 			column_stats.has_min = column_stats.has_max = true;
 		} else {
@@ -1145,7 +1151,11 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 			column_stats.any_valid = false;
 		};
 
-		result.column_stats.emplace(field_index, std::move(column_stats));
+		if (is_identity) {
+			result.column_stats.insert_or_assign(field_index, std::move(column_stats));
+		} else {
+			result.column_stats.emplace(field_index, std::move(column_stats));
+		}
 	}
 }
 

--- a/test/sql/add_files/add_files_transform_partition_missing_column_stats.test
+++ b/test/sql/add_files/add_files_transform_partition_missing_column_stats.test
@@ -1,0 +1,45 @@
+# name: test/sql/add_files/add_files_transform_partition_missing_column_stats.test
+# description: transformed partition values must not become source-column stats when the source column is missing
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_transform_missing_stats')
+
+statement ok
+CREATE TABLE ducklake.test(id INTEGER, dt DATE, payload VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (year(dt))
+
+# Partitioning the staging output by year creates year=2024 in the path while
+# leaving the partition key out of the Parquet file. The source column dt is
+# intentionally absent as well.
+statement ok
+COPY (
+    SELECT 1 AS id, 'a' AS payload, 2024 AS year
+) TO '{DATA_PATH}/ducklake_transform_missing_stats_staging' (
+    FORMAT parquet,
+    PARTITION_BY (year)
+)
+
+statement ok
+CALL ducklake_add_data_files(
+    'ducklake',
+    'test',
+    '{DATA_PATH}/ducklake_transform_missing_stats_staging/year=2024/*.parquet',
+    allow_missing => true
+)
+
+# The missing source column reads as NULL.
+query IIII
+SELECT COUNT(*), COUNT(dt), MIN(dt), MAX(dt) FROM ducklake.test
+----
+1	0	NULL	NULL

--- a/test/sql/add_files/add_files_transform_partition_with_source_column.test
+++ b/test/sql/add_files/add_files_transform_partition_with_source_column.test
@@ -1,0 +1,48 @@
+# name: test/sql/add_files/add_files_transform_partition_with_source_column.test
+# description: a column partitioned by both identity and a transform must let identity take precedence and read as non-NULL
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_transform_with_source')
+
+statement ok
+CREATE TABLE ducklake.test(id INTEGER, dt DATE)
+
+statement ok
+ALTER TABLE ducklake.test SET PARTITIONED BY (dt, year(dt))
+
+# Staging output is partitioned by both dt and year. The dt column is included
+# in the file so the source column for both partition keys is available.
+statement ok
+COPY (
+    SELECT 1 AS id, DATE '2024-06-15' AS dt, 2024 AS year
+) TO '{DATA_PATH}/ducklake_transform_with_source_staging' (
+    FORMAT parquet,
+    PARTITION_BY (dt, year)
+)
+
+statement ok
+CALL ducklake_add_data_files(
+    'ducklake',
+    'test',
+    '{DATA_PATH}/ducklake_transform_with_source_staging/dt=2024-06-15/year=2024/*.parquet',
+    allow_missing => true
+)
+
+query I
+SELECT COUNT(*) FROM ducklake.test
+----
+1
+
+query I
+SELECT COUNT(*) FROM ducklake.test WHERE dt IS NOT NULL
+----
+1


### PR DESCRIPTION
Closes [#1298](https://github.com/duckdb/ducklake/issues/1298)

Transformed partition values (e.g. `year=2024`) were being written as min/max stats for the source column when the source column was missing from the file.

The change is to only set min/max for `IDENTITY` transforms, for `YEAR/MONTH/DAY/HOUR` the source column reads as `NULL` (`BUCKET` is already ignored).

**Additional fix: identity partitions take precedence over transforms**

When a column is partitioned by both an identity and a transform (`PARTITIONED BY (dt, year(dt))`), both entries share the same field_index. `emplace` doesn't overwrite, so the transform entry (processed first) left the column with null_count = row_count and the pruner dropped the file for `IS NOT NULL` filters. Identity entries now overwrite via `insert_or_assign`, and transform entries are skipped if stats already exist.