### PR TITLE
Replace debug-only assertions with runtime bounds checks in deletion vector parsing

### DIFF
--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -64,45 +64,76 @@ unique_ptr<DuckLakeDeletionVectorData> DuckLakeDeletionVectorData::FromBlob(data
 	auto vector_size = Load<uint32_t>(blob_start);
 	vector_size = BSwap(vector_size);
 	blob_start += sizeof(uint32_t);
-	D_ASSERT(blob_start < blob_end);
+	if (blob_start >= blob_end) {
+		throw InvalidInputException("Deletion vector blob truncated after vector_size field");
+	}
 
 	auto checksummed_data_start = blob_start;
 	auto memcmp_res = memcmp(DELETION_VECTOR_MAGIC, blob_start, 4);
 	blob_start += 4;
+	if (vector_size < 4) {
+		throw InvalidInputException("Deletion vector vector_size too small for magic bytes");
+	}
 	vector_size -= 4;
-	D_ASSERT(blob_start < blob_end);
+	if (blob_start >= blob_end) {
+		throw InvalidInputException("Deletion vector blob truncated after magic bytes");
+	}
 
 	if (memcmp_res != 0) {
 		throw InvalidInputException("Magic bytes mismatch, deletion vector is corrupt!");
 	}
 
+	if (vector_size < sizeof(int64_t)) {
+		throw InvalidInputException("Deletion vector vector_size too small for bitmap count");
+	}
 	int64_t amount_of_bitmaps = Load<int64_t>(blob_start);
 	blob_start += sizeof(int64_t);
 	vector_size -= sizeof(int64_t);
-	D_ASSERT(blob_start < blob_end);
+	if (blob_start >= blob_end) {
+		throw InvalidInputException("Deletion vector blob truncated after bitmap count");
+	}
+	if (amount_of_bitmaps < 0) {
+		throw InvalidInputException("Deletion vector has negative bitmap count: %lld", amount_of_bitmaps);
+	}
 
 	auto result = make_uniq<DuckLakeDeletionVectorData>();
-	result->bitmaps.reserve(amount_of_bitmaps);
+	result->bitmaps.reserve(NumericCast<idx_t>(amount_of_bitmaps));
 	for (int64_t i = 0; i < amount_of_bitmaps; i++) {
+		if (vector_size < sizeof(int32_t)) {
+			throw InvalidInputException("Deletion vector vector_size too small for bitmap key at index %lld", i);
+		}
 		auto key = Load<int32_t>(blob_start);
 		blob_start += sizeof(int32_t);
 		vector_size -= sizeof(int32_t);
-		D_ASSERT(blob_start < blob_end);
+		if (blob_start >= blob_end) {
+			throw InvalidInputException("Deletion vector blob truncated at bitmap key %lld", i);
+		}
 
 		size_t bitmap_size =
 		    roaring::api::roaring_bitmap_portable_deserialize_size((const char *)blob_start, vector_size);
+		if (bitmap_size > vector_size) {
+			throw InvalidInputException("Deletion vector bitmap %lld exceeds remaining data", i);
+		}
 		auto bitmap = roaring::Roaring::readSafe((const char *)blob_start, bitmap_size);
 		blob_start += bitmap_size;
 		vector_size -= bitmap_size;
-		D_ASSERT(blob_start < blob_end);
+		if (blob_start >= blob_end) {
+			throw InvalidInputException("Deletion vector blob truncated after bitmap %lld", i);
+		}
 		result->bitmaps.emplace(key, std::move(bitmap));
 	}
 
 	//! Compute and compare the checksum
 	auto checksummed_data_length = blob_start - checksummed_data_start;
+	if (blob_start + sizeof(uint32_t) > blob_end) {
+		throw InvalidInputException("Deletion vector blob truncated before checksum");
+	}
 	auto stored_checksum = BSwap(Load<uint32_t>(blob_start));
 	blob_start += sizeof(uint32_t);
-	D_ASSERT(blob_start == blob_end);
+	if (blob_start != blob_end) {
+		throw InvalidInputException("Deletion vector blob has %lld unexpected trailing bytes",
+		                            static_cast<int64_t>(blob_end - blob_start));
+	}
 
 	CRC32 crc;
 	crc.Update(checksummed_data_start, checksummed_data_length);

--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -132,7 +132,7 @@ unique_ptr<DuckLakeDeletionVectorData> DuckLakeDeletionVectorData::FromBlob(data
 	blob_start += sizeof(uint32_t);
 	if (blob_start != blob_end) {
 		throw InvalidInputException("Deletion vector blob has %lld unexpected trailing bytes",
-		                            static_cast<int64_t>(blob_end - blob_start));
+		                            NumericCast<int64_t>(blob_end - blob_start));
 	}
 
 	CRC32 crc;

--- a/src/storage/ducklake_deletion_vector.cpp
+++ b/src/storage/ducklake_deletion_vector.cpp
@@ -1,6 +1,7 @@
 #include "storage/ducklake_deletion_vector.hpp"
 
 #include "duckdb/common/bswap.hpp"
+#include "duckdb/common/operator/numeric_cast.hpp"
 
 namespace duckdb {
 


### PR DESCRIPTION
## Summary

- `FromBlob()` in `ducklake_deletion_vector.cpp` uses `D_ASSERT` for all blob/data boundary validation when parsing deletion vectors from puffin files. These assertions compile out in release builds, allowing crafted inputs to cause out-of-bounds reads.
- Replace all six `D_ASSERT` calls with `InvalidInputException` throws that are active in all build configurations.
- Add underflow guards before each `vector_size` subtraction to prevent unsigned integer wraparound.
- Validate `amount_of_bitmaps` is non-negative before use in `reserve()` and the parsing loop.
- Check `bitmap_size` does not exceed remaining `vector_size` before deserialization.
- Use `NumericCast` for the `reserve()` call to safely convert `int64_t` to `idx_t`.

## Test plan

- [ ] Existing deletion vector round-trip tests continue to pass (valid blobs parse identically)
- [ ] Truncated blobs now throw `InvalidInputException` in release builds instead of reading out-of-bounds
- [ ] Negative bitmap count in crafted blob throws instead of causing undefined behavior in `reserve()`