### PR TITLE
Fix rewrites after partition evolution

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -575,7 +575,28 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	auto &columns = table.GetColumns();
 	string data_path;
 	if (partition_id.IsValid()) {
-		data_path = DuckLakePartitionUtils::BuildHivePartitionPath(table, partition_values, catalog.Separator());
+		auto partition_table = &table;
+		auto partition_data = partition_table->GetPartitionData();
+		if (!partition_data || partition_data->partition_id != partition_id.GetIndex()) {
+			auto partition_snapshot_id = source_files[0].partition_snapshot_id;
+			auto partition_schema_version = source_files[0].partition_schema_version;
+			if (!partition_snapshot_id.IsValid() || !partition_schema_version.IsValid()) {
+				throw InternalException("DuckLakeCompactor: failed to find partition schema");
+			}
+			DuckLakeSnapshot partition_snapshot(partition_snapshot_id.GetIndex(), partition_schema_version.GetIndex(),
+			                                    0, 0);
+			auto partition_entry = catalog.GetSchemaForSnapshot(transaction, partition_snapshot).GetEntryById(table_id);
+			if (!partition_entry) {
+				throw InternalException("DuckLakeCompactor: failed to find table entry for partition schema");
+			}
+			partition_table = &partition_entry->Cast<DuckLakeTableEntry>();
+		}
+		partition_data = partition_table->GetPartitionData();
+		if (!partition_data || partition_data->partition_id != partition_id.GetIndex()) {
+			throw InternalException("DuckLakeCompactor: failed to find partition spec");
+		}
+		data_path =
+		    DuckLakePartitionUtils::BuildHivePartitionPath(*partition_table, partition_values, catalog.Separator());
 	}
 
 	bool write_row_id = false;

--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -494,6 +494,30 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 	return std::move(projected);
 }
 
+optional_ptr<DuckLakeTableEntry>
+DuckLakeCompactor::ResolvePartitionSpecTable(DuckLakeTableEntry &table, const DuckLakeCompactionFileEntry &source_file,
+                                             idx_t partition_id) {
+	auto partition_data = table.GetPartitionData();
+	if (partition_data && partition_data->partition_id == partition_id) {
+		return &table;
+	}
+	if (!source_file.partition_snapshot_id.IsValid() || !source_file.partition_schema_version.IsValid()) {
+		return nullptr;
+	}
+	DuckLakeSnapshot partition_snapshot(source_file.partition_snapshot_id.GetIndex(),
+	                                    source_file.partition_schema_version.GetIndex(), 0, 0);
+	auto partition_entry = catalog.GetEntryById(transaction, partition_snapshot, table_id);
+	if (!partition_entry) {
+		throw InternalException("DuckLakeCompactor: failed to find table entry for partition schema");
+	}
+	auto &partition_table = partition_entry->Cast<DuckLakeTableEntry>();
+	partition_data = partition_table.GetPartitionData();
+	if (!partition_data || partition_data->partition_id != partition_id) {
+		throw InternalException("DuckLakeCompactor: failed to find partition spec");
+	}
+	return &partition_table;
+}
+
 unique_ptr<LogicalOperator>
 DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry> source_files,
                                              bool bind_to_latest_schema) {
@@ -575,28 +599,23 @@ DuckLakeCompactor::GenerateCompactionCommand(vector<DuckLakeCompactionFileEntry>
 	auto &columns = table.GetColumns();
 	string data_path;
 	if (partition_id.IsValid()) {
-		auto partition_table = &table;
-		auto partition_data = partition_table->GetPartitionData();
-		if (!partition_data || partition_data->partition_id != partition_id.GetIndex()) {
-			auto partition_snapshot_id = source_files[0].partition_snapshot_id;
-			auto partition_schema_version = source_files[0].partition_schema_version;
-			if (!partition_snapshot_id.IsValid() || !partition_schema_version.IsValid()) {
-				throw InternalException("DuckLakeCompactor: failed to find partition schema");
+		auto partition_table = ResolvePartitionSpecTable(table, source_files[0], partition_id.GetIndex());
+		if (partition_table) {
+			data_path =
+			    DuckLakePartitionUtils::BuildHivePartitionPath(*partition_table, partition_values, catalog.Separator());
+		} else {
+			auto &file_path = source_files[0].file.data.path;
+			auto &table_path = table.DataPath();
+			if (!StringUtil::StartsWith(file_path, table_path)) {
+				throw InternalException("DuckLakeCompactor: failed to resolve partition path");
 			}
-			DuckLakeSnapshot partition_snapshot(partition_snapshot_id.GetIndex(), partition_schema_version.GetIndex(),
-			                                    0, 0);
-			auto partition_entry = catalog.GetSchemaForSnapshot(transaction, partition_snapshot).GetEntryById(table_id);
-			if (!partition_entry) {
-				throw InternalException("DuckLakeCompactor: failed to find table entry for partition schema");
+			auto relative_path = file_path.substr(table_path.size());
+			auto separator_pos = relative_path.rfind(catalog.Separator());
+			if (separator_pos == string::npos) {
+				throw InternalException("DuckLakeCompactor: failed to resolve partition path");
 			}
-			partition_table = &partition_entry->Cast<DuckLakeTableEntry>();
+			data_path = relative_path.substr(0, separator_pos + catalog.Separator().size());
 		}
-		partition_data = partition_table->GetPartitionData();
-		if (!partition_data || partition_data->partition_id != partition_id.GetIndex()) {
-			throw InternalException("DuckLakeCompactor: failed to find partition spec");
-		}
-		data_path =
-		    DuckLakePartitionUtils::BuildHivePartitionPath(*partition_table, partition_values, catalog.Separator());
 	}
 
 	bool write_row_id = false;

--- a/src/include/functions/ducklake_compaction_functions.hpp
+++ b/src/include/functions/ducklake_compaction_functions.hpp
@@ -97,6 +97,10 @@ public:
 	                                               vector<OrderByNode> &pre_bound_orders);
 
 private:
+	optional_ptr<DuckLakeTableEntry> ResolvePartitionSpecTable(DuckLakeTableEntry &table,
+	                                                           const DuckLakeCompactionFileEntry &source_file,
+	                                                           idx_t partition_id);
+
 	ClientContext &context;
 	DuckLakeCatalog &catalog;
 	DuckLakeTransaction &transaction;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -472,6 +472,9 @@ struct DuckLakeCompactionFileEntry {
 	vector<DuckLakeCompactionDeleteFileData> delete_files;
 	optional_idx max_partial_file_snapshot;
 	idx_t schema_version;
+	//! Snapshot and schema version used to resolve the file's partition spec.
+	optional_idx partition_snapshot_id;
+	optional_idx partition_schema_version;
 	//! Inlined file deletions stored in the metadata database rather than delete files.
 	set<idx_t> inlined_file_deletions;
 	//! Whether this file has any inlined deletions (cheap flag; set for all compaction types).

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2273,7 +2273,9 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	    "data.data_file_id, data.record_count, data.row_id_start, data.begin_snapshot, "
 	    "data.end_snapshot, data.mapping_id, sr.schema_version , data.partial_max, "
 	    "data.partition_id, "
-	    "COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) AS partition_snapshot_id, "
+	    "CASE WHEN partition_spec.partition_id IS NOT NULL AND "
+	    "(partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot) "
+	    "THEN COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) END AS partition_snapshot_id, "
 	    "partition_sr.schema_version AS partition_schema_version, partition_info.keys, " +
 	    GetFileSelectList("data");
 	string delete_select_list = "del.data_file_id AS del_data_file_id,"
@@ -2320,7 +2322,9 @@ LEFT JOIN snapshot_ranges sr
 LEFT JOIN {METADATA_CATALOG}.ducklake_partition_info partition_spec
   ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
 LEFT JOIN snapshot_ranges partition_sr
-  ON COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
+  ON partition_spec.partition_id IS NOT NULL
+ AND (partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot)
+ AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
  AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
 LEFT JOIN (
 	SELECT *
@@ -4441,44 +4445,58 @@ string DuckLakeMetadataManager::WriteNewPartitionKeys(const vector<DuckLakeParti
 	string new_partition_values;
 	string insert_partition_cols;
 
-	auto new_partition_map = GetNewPartitions(existing_partitions, new_partitions);
-	if (new_partition_map.empty()) {
-		return {};
+	auto append_partition = [&](const DuckLakePartitionInfo &partition, const string &end_snapshot) {
+		if (!partition.id.IsValid()) {
+			return;
+		}
+		auto partition_id = partition.id.GetIndex();
+		if (!new_partition_values.empty()) {
+			new_partition_values += ", ";
+		}
+		new_partition_values +=
+		    StringUtil::Format("(%d, %d, {SNAPSHOT_ID}, %s)", partition_id, partition.table_id.index, end_snapshot);
+		for (auto &field : partition.fields) {
+			if (!insert_partition_cols.empty()) {
+				insert_partition_cols += ", ";
+			}
+			insert_partition_cols +=
+			    StringUtil::Format("(%d, %d, %d, %d, %s)", partition_id, partition.table_id.index,
+			                       field.partition_key_index, field.field_id.index, SQLString(field.transform));
+		}
+	};
+
+	unordered_map<idx_t, idx_t> last_partition_index;
+	for (idx_t i = 0; i < new_partitions.size(); i++) {
+		last_partition_index[new_partitions[i].table_id.index] = i;
 	}
+	for (idx_t i = 0; i < new_partitions.size(); i++) {
+		auto &partition = new_partitions[i];
+		if (i != last_partition_index[partition.table_id.index] && !partition.fields.empty()) {
+			// Files written before another partition change in the same transaction can still reference this spec.
+			append_partition(partition, "{SNAPSHOT_ID}");
+		}
+	}
+
+	auto new_partition_map = GetNewPartitions(existing_partitions, new_partitions);
 	for (auto &new_partition : new_partition_map) {
 		// set old partition data as no longer valid
 		if (!old_partition_table_ids.empty()) {
 			old_partition_table_ids += ", ";
 		}
 		old_partition_table_ids += to_string(new_partition.second.table_id.index);
-		if (!new_partition.second.id.IsValid()) {
-			// dropping partition data - we don't need to do anything
-			return {};
-		}
-		auto partition_id = new_partition.second.id.GetIndex();
-		if (!new_partition_values.empty()) {
-			new_partition_values += ", ";
-		}
-		new_partition_values +=
-		    StringUtil::Format(R"((%d, %d, {SNAPSHOT_ID}, NULL))", partition_id, new_partition.second.table_id.index);
-		for (auto &field : new_partition.second.fields) {
-			if (!insert_partition_cols.empty()) {
-				insert_partition_cols += ", ";
-			}
-			insert_partition_cols +=
-			    StringUtil::Format("(%d, %d, %d, %d, %s)", partition_id, new_partition.second.table_id.index,
-			                       field.partition_key_index, field.field_id.index, SQLString(field.transform));
-		}
+		append_partition(new_partition.second, "NULL");
 	}
 
-	// update old partition information for any tables that have been altered
-	auto update_partition_query = StringUtil::Format(R"(
+	string batch_query;
+	if (!old_partition_table_ids.empty()) {
+		// update old partition information for any tables that have been altered
+		batch_query = StringUtil::Format(R"(
 UPDATE {METADATA_CATALOG}.ducklake_partition_info
 SET end_snapshot = {SNAPSHOT_ID}
 WHERE table_id IN (%s) AND end_snapshot IS NULL
 ;)",
-	                                                 old_partition_table_ids);
-	string batch_query = update_partition_query;
+		                                 old_partition_table_ids);
+	}
 
 	if (!new_partition_values.empty()) {
 		new_partition_values =

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2269,10 +2269,13 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	// Determine the effective max file size threshold for filtering
 	idx_t effective_max_file_size =
 	    options.max_file_size.IsValid() ? options.max_file_size.GetIndex() : options.target_file_size;
-	string data_select_list = "data.data_file_id, data.record_count, data.row_id_start, data.begin_snapshot, "
-	                          "data.end_snapshot, data.mapping_id, sr.schema_version , data.partial_max, "
-	                          "data.partition_id, partition_info.keys, " +
-	                          GetFileSelectList("data");
+	string data_select_list =
+	    "data.data_file_id, data.record_count, data.row_id_start, data.begin_snapshot, "
+	    "data.end_snapshot, data.mapping_id, sr.schema_version , data.partial_max, "
+	    "data.partition_id, "
+	    "COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) AS partition_snapshot_id, "
+	    "partition_sr.schema_version AS partition_schema_version, partition_info.keys, " +
+	    GetFileSelectList("data");
 	string delete_select_list = "del.data_file_id AS del_data_file_id,"
 	                            "del.delete_file_id AS del_delete_file_id, "
 	                            "del.delete_count, "
@@ -2314,6 +2317,11 @@ SELECT %s
 FROM {METADATA_CATALOG}.ducklake_data_file data
 LEFT JOIN snapshot_ranges sr
   ON data.begin_snapshot >= sr.begin_snapshot AND data.begin_snapshot < sr.end_snapshot
+LEFT JOIN {METADATA_CATALOG}.ducklake_partition_info partition_spec
+  ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
+LEFT JOIN snapshot_ranges partition_sr
+  ON COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
+ AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
 LEFT JOIN (
 	SELECT *
     FROM {METADATA_CATALOG}.ducklake_delete_file
@@ -2357,6 +2365,10 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 		}
 		col_idx++;
 		new_entry.file.partition_id = row.IsNull(col_idx) ? optional_idx() : row.GetValue<idx_t>(col_idx);
+		col_idx++;
+		new_entry.partition_snapshot_id = row.IsNull(col_idx) ? optional_idx() : row.GetValue<idx_t>(col_idx);
+		col_idx++;
+		new_entry.partition_schema_version = row.IsNull(col_idx) ? optional_idx() : row.GetValue<idx_t>(col_idx);
 		col_idx++;
 		if (!row.IsNull(col_idx)) {
 			auto list_val = row.GetValue<Value>(col_idx);

--- a/test/sql/rewrite_data_files/test_rewrite_after_partition_evolution.test
+++ b/test/sql/rewrite_data_files/test_rewrite_after_partition_evolution.test
@@ -1,0 +1,130 @@
+# name: test/sql/rewrite_data_files/test_rewrite_after_partition_evolution.test
+# description: rewriting a file repeatedly after partition evolution remains valid
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/rewrite_after_partition_evolution', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t(source VARCHAR, dt DATE, v INTEGER)
+
+statement ok
+ALTER TABLE ducklake.t SET PARTITIONED BY (source)
+
+statement ok
+INSERT INTO ducklake.t VALUES
+	('same', DATE '2026-01-01', 1),
+	('same', DATE '2026-01-01', 2),
+	('same', DATE '2026-01-01', 3)
+
+statement ok
+ALTER TABLE ducklake.t SET PARTITIONED BY (source, year(dt), month(dt))
+
+statement ok
+DELETE FROM ducklake.t WHERE v = 1
+
+query III
+SELECT table_name, files_processed, files_created
+FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0)
+----
+t	1	1
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', versions => [1, 2, 3, 4, 5])
+
+statement ok
+DELETE FROM ducklake.t WHERE v = 2
+
+query III
+SELECT table_name, files_processed, files_created
+FROM ducklake_rewrite_data_files('ducklake', 't', delete_threshold => 0)
+----
+t	1	1
+
+query I
+SELECT v FROM ducklake.t ORDER BY ALL
+----
+3
+
+# A partition change with the same number of fields must use the old field name, not merely match value counts.
+
+statement ok
+CREATE TABLE ducklake.same_cardinality(source VARCHAR, id VARCHAR, v INTEGER)
+
+statement ok
+ALTER TABLE ducklake.same_cardinality SET PARTITIONED BY (source)
+
+statement ok
+INSERT INTO ducklake.same_cardinality VALUES
+	('old', 'new', 1),
+	('old', 'new', 2),
+	('old', 'new', 3)
+
+statement ok
+ALTER TABLE ducklake.same_cardinality SET PARTITIONED BY (id)
+
+statement ok
+DELETE FROM ducklake.same_cardinality WHERE v = 1
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'same_cardinality', delete_threshold => 0)
+
+statement ok
+DELETE FROM ducklake.same_cardinality WHERE v = 2
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'same_cardinality', delete_threshold => 0)
+
+query T
+SELECT regexp_extract(data_file, '.*(source=old)[/\\].*', 1)
+FROM ducklake_list_files('ducklake', 'same_cardinality')
+----
+source=old
+
+# Path construction must still resolve an old partition field after it has been dropped from the current schema.
+
+statement ok
+CREATE TABLE ducklake.dropped_field(source VARCHAR, v INTEGER)
+
+statement ok
+ALTER TABLE ducklake.dropped_field SET PARTITIONED BY (source)
+
+statement ok
+INSERT INTO ducklake.dropped_field VALUES ('old', 1), ('old', 2), ('old', 3)
+
+statement ok
+ALTER TABLE ducklake.dropped_field RESET PARTITIONED BY
+
+statement ok
+ALTER TABLE ducklake.dropped_field DROP COLUMN source
+
+statement ok
+DELETE FROM ducklake.dropped_field WHERE v = 1
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'dropped_field', delete_threshold => 0)
+
+statement ok
+DELETE FROM ducklake.dropped_field WHERE v = 2
+
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'dropped_field', delete_threshold => 0)
+
+query T
+SELECT regexp_extract(data_file, '.*(source=old)[/\\].*', 1)
+FROM ducklake_list_files('ducklake', 'dropped_field')
+----
+source=old
+
+query I
+SELECT v FROM ducklake.dropped_field
+----
+3

--- a/test/sql/rewrite_data_files/test_rewrite_after_partition_evolution.test
+++ b/test/sql/rewrite_data_files/test_rewrite_after_partition_evolution.test
@@ -60,6 +60,9 @@ statement ok
 CREATE TABLE ducklake.same_cardinality(source VARCHAR, id VARCHAR, v INTEGER)
 
 statement ok
+BEGIN
+
+statement ok
 ALTER TABLE ducklake.same_cardinality SET PARTITIONED BY (source)
 
 statement ok
@@ -70,6 +73,23 @@ INSERT INTO ducklake.same_cardinality VALUES
 
 statement ok
 ALTER TABLE ducklake.same_cardinality SET PARTITIONED BY (id)
+
+statement ok
+COMMIT
+
+statement ok
+SET VARIABLE known_partition_ids = (
+	SELECT LIST(partition_id)
+	FROM metadata.ducklake_partition_info
+)
+
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_data_file
+WHERE partition_id IS NOT NULL
+	AND NOT list_contains(getvariable('known_partition_ids'), partition_id)
+----
+0
 
 statement ok
 DELETE FROM ducklake.same_cardinality WHERE v = 1


### PR DESCRIPTION
Fixes repeated delete rewrites after a table's partition spec changes by resolving output paths from the data file's historical partition spec.

Tests: full DuckLake suite, deletion-vector config, and Quack-backed regression.