### PR TITLE
Tolerate missing mtime in orphaned file cleanup

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4864,6 +4864,14 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
 	return StringUtil::Replace(query, "{SEPARATOR}", separator);
 }
 
+//! Returns true for the specific "backend cannot supply per-object mtime" failure we tolerate
+//! during older_than orphan cleanup (ducklake#1042): a filesystem without mtime support (e.g.
+//! gcsfs reading a GCS composite object) surfaces this exact KeyError from its info() dictionary.
+//! Any other enumeration error (auth, network, ...) must still surface loudly.
+static bool IsMissingMTimeError(const ErrorData &error) {
+	return StringUtil::Contains(error.Message(), "KeyError: 'mtime'");
+}
+
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
                                                                                  const string &separator) {
 	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
@@ -4902,18 +4910,61 @@ vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup
 		}
 		appender.Close();
 
-		auto query = StringUtil::Format(R"(SELECT filename
+		// Enumerate orphan candidate files. When no timestamp filter is requested
+		// (cleanup_all mode), enumerate with `glob` rather than `read_blob`: glob
+		// only lists entries and never touches per-object metadata, so this mode
+		// does not depend on the storage backend supplying `mtime`.
+		//
+		// When a timestamp filter is requested (older_than mode - this includes
+		// CHECKPOINT, which runs ducklake_delete_orphaned_files with the default
+		// 'delete_older_than' setting), the `last_modified` comparison requires
+		// per-object mtime. Some backends cannot supply it for every object (e.g.
+		// gcsfs raises KeyError: 'mtime' for GCS composite objects, see
+		// ducklake#1042), which aborts the query - and with it the whole
+		// CHECKPOINT. That specific capability failure is tolerated by degrading
+		// to "retain all" for this round: skipping cleanup of orphans whose age
+		// cannot be determined is always safe (never over-delete), and they can
+		// still be removed via cleanup_all, which does not need mtime. Any other
+		// enumeration error (auth, network, ...) is rethrown - silently
+		// suppressing those would disable orphan cleanup without any signal.
+		unique_ptr<QueryResult> res;
+		if (filter.empty()) {
+			auto query = StringUtil::Format(R"(SELECT file
+FROM glob({DATA_PATH} || '**') files
+WHERE (suffix(file, '.parquet') OR suffix(file, '.puffin'))
+AND NOT EXISTS (
+	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.file, '\', '/')
+))",
+			                                temp_table_identifier);
+			SubstituteCatalogPlaceholders(query);
+			res = transaction.ExecuteRaw(query);
+			if (res->HasError()) {
+				res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			}
+		} else {
+			auto query = StringUtil::Format(R"(SELECT filename
 FROM read_blob({DATA_PATH} || '**') files
 WHERE (suffix(filename, '.parquet') OR suffix(filename, '.puffin'))
 AND NOT EXISTS (
 	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.filename, '\', '/')
 )
 %s)",
-		                                temp_table_identifier, filter);
-		SubstituteCatalogPlaceholders(query);
-		auto res = transaction.ExecuteRaw(query);
-		if (res->HasError()) {
-			res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			                                temp_table_identifier, filter);
+			SubstituteCatalogPlaceholders(query);
+			res = transaction.ExecuteRaw(query);
+			if (res->HasError()) {
+				auto &error = res->GetErrorObject();
+				if (IsMissingMTimeError(error)) {
+					// mtime-dependent enumeration failed (e.g. objects without mtime
+					// on the storage backend). Retain all orphans this round;
+					// CHECKPOINT must stay usable. The aged-out orphans will be
+					// picked up on a later run once the backend can supply mtime,
+					// or via cleanup_all.
+					drop_temp_table();
+					return {};
+				}
+				error.Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			}
 		}
 
 		vector<DuckLakeFileForCleanup> result;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5065,6 +5065,16 @@ FROM {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion f
 	return StringUtil::Replace(query, "{SEPARATOR}", separator);
 }
 
+//! Returns true for the specific "backend cannot supply per-object mtime" failure we tolerate
+//! during older_than orphan cleanup (ducklake#1042): a filesystem without mtime support (e.g.
+//! gcsfs reading a GCS composite object) surfaces this exact KeyError from its info() dictionary.
+//! Any other enumeration error (auth, network, ...) must still surface loudly.
+static bool IsMissingMTimeError(const ErrorData &error) {
+	// TODO: Remove this compatibility fallback once duckdb/duckdb-python#584 maps unsupported
+	// modification times to ExceptionType::NOT_IMPLEMENTED at the Python filesystem boundary.
+	return error.Type() == ExceptionType::INVALID && StringUtil::Contains(error.RawMessage(), "KeyError: 'mtime'");
+}
+
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
                                                                                  const string &separator) {
 	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
@@ -5103,18 +5113,61 @@ vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup
 		}
 		appender.Close();
 
-		auto query = StringUtil::Format(R"(SELECT filename
+		// Enumerate orphan candidate files. When no timestamp filter is requested
+		// (cleanup_all mode), enumerate with `glob` rather than `read_blob`: glob
+		// only lists entries and never touches per-object metadata, so this mode
+		// does not depend on the storage backend supplying `mtime`.
+		//
+		// When a timestamp filter is requested (older_than mode - this includes
+		// CHECKPOINT, which runs ducklake_delete_orphaned_files with the default
+		// 'delete_older_than' setting), the `last_modified` comparison requires
+		// per-object mtime. Some backends cannot supply it for every object (e.g.
+		// gcsfs raises KeyError: 'mtime' for GCS composite objects, see
+		// ducklake#1042), which aborts the query - and with it the whole
+		// CHECKPOINT. That specific capability failure is tolerated by degrading
+		// to "retain all" for this round: skipping cleanup of orphans whose age
+		// cannot be determined is always safe (never over-delete), and they can
+		// still be removed via cleanup_all, which does not need mtime. Any other
+		// enumeration error (auth, network, ...) is rethrown - silently
+		// suppressing those would disable orphan cleanup without any signal.
+		unique_ptr<QueryResult> res;
+		if (filter.empty()) {
+			auto query = StringUtil::Format(R"(SELECT file
+FROM glob({DATA_PATH} || '**') files
+WHERE (suffix(file, '.parquet') OR suffix(file, '.puffin'))
+AND NOT EXISTS (
+	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.file, '\', '/')
+))",
+			                                temp_table_identifier);
+			SubstituteCatalogPlaceholders(query);
+			res = transaction.ExecuteRaw(query);
+			if (res->HasError()) {
+				res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			}
+		} else {
+			auto query = StringUtil::Format(R"(SELECT filename
 FROM read_blob({DATA_PATH} || '**') files
 WHERE (suffix(filename, '.parquet') OR suffix(filename, '.puffin'))
 AND NOT EXISTS (
 	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.filename, '\', '/')
 )
 %s)",
-		                                temp_table_identifier, filter);
-		SubstituteCatalogPlaceholders(query);
-		auto res = transaction.ExecuteRaw(query);
-		if (res->HasError()) {
-			res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			                                temp_table_identifier, filter);
+			SubstituteCatalogPlaceholders(query);
+			res = transaction.ExecuteRaw(query);
+			if (res->HasError()) {
+				auto &error = res->GetErrorObject();
+				if (IsMissingMTimeError(error)) {
+					// mtime-dependent enumeration failed (e.g. objects without mtime
+					// on the storage backend). Retain all orphans this round;
+					// CHECKPOINT must stay usable. The aged-out orphans will be
+					// picked up on a later run once the backend can supply mtime,
+					// or via cleanup_all.
+					drop_temp_table();
+					return {};
+				}
+				error.Throw("Failed to get files scheduled for deletion from DuckLake: ");
+			}
 		}
 
 		vector<DuckLakeFileForCleanup> result;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5075,6 +5075,24 @@ static bool IsMissingMTimeError(const ErrorData &error) {
 	return error.Type() == ExceptionType::INVALID && StringUtil::Contains(error.RawMessage(), "KeyError: 'mtime'");
 }
 
+//! Orphan-candidate enumeration query shared by both cleanup modes: the suffix filter and the
+//! anti-join against the known-files temp table are identical. The modes differ only in the
+//! enumeration source and its path column (cleanup_all enumerates with glob, column "file";
+//! older_than with read_blob, column "filename") and in the trailing timestamp filter, which is
+//! empty for cleanup_all.
+static string GetOrphanCandidateQuery(const string &source, const string &path_column, const string &known_files_table,
+                                      const string &extra_filter) {
+	return StringUtil::Format(R"(SELECT %s
+FROM %s({DATA_PATH} || '**') files
+WHERE (suffix(%s, '.parquet') OR suffix(%s, '.puffin'))
+AND NOT EXISTS (
+	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.%s, '\', '/')
+)
+%s)",
+	                          path_column, source, path_column, path_column, known_files_table, path_column,
+	                          extra_filter);
+}
+
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup(const string &filter,
                                                                                  const string &separator) {
 	auto known_files_query = GetKnownFilesForCleanupQuery(separator);
@@ -5130,44 +5148,23 @@ vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOrphanFilesForCleanup
 		// still be removed via cleanup_all, which does not need mtime. Any other
 		// enumeration error (auth, network, ...) is rethrown - silently
 		// suppressing those would disable orphan cleanup without any signal.
-		unique_ptr<QueryResult> res;
-		if (filter.empty()) {
-			auto query = StringUtil::Format(R"(SELECT file
-FROM glob({DATA_PATH} || '**') files
-WHERE (suffix(file, '.parquet') OR suffix(file, '.puffin'))
-AND NOT EXISTS (
-	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.file, '\', '/')
-))",
-			                                temp_table_identifier);
-			SubstituteCatalogPlaceholders(query);
-			res = transaction.ExecuteRaw(query);
-			if (res->HasError()) {
-				res->GetErrorObject().Throw("Failed to get files scheduled for deletion from DuckLake: ");
+		const bool cleanup_all = filter.empty();
+		auto query = cleanup_all ? GetOrphanCandidateQuery("glob", "file", temp_table_identifier, string())
+		                         : GetOrphanCandidateQuery("read_blob", "filename", temp_table_identifier, filter);
+		SubstituteCatalogPlaceholders(query);
+		auto res = transaction.ExecuteRaw(query);
+		if (res->HasError()) {
+			auto &error = res->GetErrorObject();
+			if (!cleanup_all && IsMissingMTimeError(error)) {
+				// mtime-dependent enumeration failed (e.g. objects without mtime
+				// on the storage backend). Retain all orphans this round;
+				// CHECKPOINT must stay usable. The aged-out orphans will be
+				// picked up on a later run once the backend can supply mtime,
+				// or via cleanup_all.
+				drop_temp_table();
+				return {};
 			}
-		} else {
-			auto query = StringUtil::Format(R"(SELECT filename
-FROM read_blob({DATA_PATH} || '**') files
-WHERE (suffix(filename, '.parquet') OR suffix(filename, '.puffin'))
-AND NOT EXISTS (
-	SELECT 1 FROM %s known_files WHERE known_files.full_path = REPLACE(files.filename, '\', '/')
-)
-%s)",
-			                                temp_table_identifier, filter);
-			SubstituteCatalogPlaceholders(query);
-			res = transaction.ExecuteRaw(query);
-			if (res->HasError()) {
-				auto &error = res->GetErrorObject();
-				if (IsMissingMTimeError(error)) {
-					// mtime-dependent enumeration failed (e.g. objects without mtime
-					// on the storage backend). Retain all orphans this round;
-					// CHECKPOINT must stay usable. The aged-out orphans will be
-					// picked up on a later run once the backend can supply mtime,
-					// or via cleanup_all.
-					drop_temp_table();
-					return {};
-				}
-				error.Throw("Failed to get files scheduled for deletion from DuckLake: ");
-			}
+			error.Throw("Failed to get files scheduled for deletion from DuckLake: ");
 		}
 
 		vector<DuckLakeFileForCleanup> result;

--- a/test/sql/remove_orphans/puffin_orphan_minio.test
+++ b/test/sql/remove_orphans/puffin_orphan_minio.test
@@ -1,0 +1,77 @@
+# name: test/sql/remove_orphans/puffin_orphan_minio.test
+# description: ducklake_delete_orphaned_files (cleanup_all) finds and removes an orphaned puffin deletion vector on an S3-backed data path
+# group: [remove_orphans]
+
+require ducklake
+
+require parquet
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH s3://mybucket
+
+statement ok
+CREATE OR REPLACE SECRET __default_s3 (
+    TYPE S3,
+    KEY_ID 'admin',
+    SECRET 'password',
+    ENDPOINT '127.0.0.1:9000',
+    URL_STYLE 'path',
+    USE_SSL false,
+    REGION 'us-east-1'
+)
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+    DATA_PATH '{DATA_PATH}/ducklake_puffin_orphan_minio',
+    DATA_INLINING_ROW_LIMIT 0,
+    WRITE_DELETION_VECTORS true
+)
+
+statement ok
+CREATE TABLE ducklake.test AS SELECT i FROM range(100) t(i)
+
+statement ok
+DELETE FROM ducklake.test WHERE i < 10
+
+statement ok
+SET VARIABLE live_puffin = (
+    SELECT delete_file
+    FROM ducklake_list_files('ducklake', 'test')
+    WHERE delete_file IS NOT NULL
+    LIMIT 1
+)
+
+# Copy a live deletion vector byte-for-byte to a path that is not referenced by metadata.
+statement ok
+COPY (
+    SELECT content FROM read_blob(getvariable('live_puffin'))
+) TO '{DATA_PATH}/ducklake_puffin_orphan_minio/main/test/orphan-delete.puffin' (FORMAT BLOB)
+
+# The byte-for-byte copied puffin file should be discovered as an orphan via the
+# glob-based cleanup_all enumeration path (no per-object mtime required).
+query I
+SELECT count(*)
+FROM ducklake_delete_orphaned_files('ducklake', cleanup_all => true, dry_run => true)
+----
+1
+
+statement ok
+CALL ducklake_delete_orphaned_files('ducklake', cleanup_all => true)
+
+query I
+SELECT count(*)
+FROM glob('{DATA_PATH}/ducklake_puffin_orphan_minio/main/test/*-delete.puffin')
+WHERE ends_with(file, '/orphan-delete.puffin')
+----
+0
+
+# The referenced deletion vector remains live and table semantics are unchanged.
+query I
+SELECT count(*) FROM ducklake.test
+----
+90


### PR DESCRIPTION
## Problem

On GCS with a registered `gcsfs` filesystem, `CHECKPOINT` can abort with:

```
Failed to perform CHECKPOINT; in DuckLake: Failed to get files scheduled
for deletion from DuckLake: KeyError: 'mtime'
```

Closes #1042.

## Root cause

`CHECKPOINT` calls `ducklake_delete_orphaned_files` without arguments, so orphan enumeration runs in `older_than` mode and filters `read_blob(...).last_modified` against the configured retention period.

For a registered fsspec filesystem this calls `FileSystem::GetLastModifiedTime`. `gcsfs.modified()` indexes `info()["mtime"]`, but `mtime` is absent for some GCS object metadata (including the composite-object case from #1042) and synthesized directory entries. The resulting Python `KeyError: 'mtime'` aborts the query and therefore the checkpoint.

## Fix

`GetOrphanFilesForCleanup` now selects the enumeration strategy by cleanup mode:

- `cleanup_all` uses `glob`, which lists paths without requiring per-object modification metadata.
- `older_than` keeps `read_blob`, because the timestamp comparison genuinely requires `last_modified`. The narrowly scoped missing-mtime failure retains all orphan candidates for that cleanup round instead of aborting `CHECKPOINT`. Other authentication, network, and storage errors still surface.

Retaining files whose age cannot be established is the conservative direction: it cannot over-delete data, and those files can still be reclaimed with `cleanup_all`.

The compatibility fallback requires both `ExceptionType::INVALID` and the current gcsfs `KeyError: 'mtime'` signature, and uses `RawMessage()` rather than the formatted error. It is intentionally temporary. The Python filesystem boundary currently lets the Python exception reach DuckDB as `ExceptionType::INVALID`, so DuckLake has no provider-independent error code to inspect. duckdb/duckdb-python#584 tracks translating unsupported modification metadata to `ExceptionType::NOT_IMPLEMENTED`, which DuckDB core already converts to a `NULL` `last_modified` value. Once available in supported DuckDB versions, this fallback can be removed.

No DuckLake metadata schema or specification change is required.

## Testing

### CI regression test

`test/sql/remove_orphans/puffin_orphan_minio.test`, gated by `S3_TEST_SERVER_AVAILABLE`, covers the `cleanup_all -> glob` path on MinIO:

- creates a live Puffin deletion vector;
- copies it to an unreferenced orphan path;
- verifies dry-run discovery and deletion of the orphan;
- verifies the referenced deletion vector and table semantics remain intact.

The MinIO test does not claim to reproduce the Python/gcsfs missing-mtime exception: native httpfs/S3 supplies modification metadata.

### Python + gcsfs end-to-end verification

The actual failing path was separately verified with DuckDB 1.5.5, gcsfs 2026.7.0 registered through `register_filesystem`, and an in-process mock of the GCS JSON API whose object resources can omit `updated`:

| operation | released extension | with this fix |
|---|---|---|
| `read_blob` with `last_modified` filter | `KeyError: 'mtime'` | unchanged core behavior; tolerated by DuckLake |
| `CHECKPOINT` / default `older_than` cleanup | aborts with `KeyError: 'mtime'` | completes and retains candidates |
| explicit `older_than` cleanup | aborts with `KeyError: 'mtime'` | completes and retains candidates |
| `cleanup_all` | completes | deletes the mtime-less orphan through `glob` |

The mock reproduces the gcsfs-visible contract rather than using a real GCS account; a real-bucket smoke test is still welcome.

### Latest local verification

- formatting check: passed;
- `ducklake_metadata_manager.cpp` target object: compiled successfully against the checked-out DuckDB headers;
- the previous full PR CI matrix, including MinIO and all distribution builds, passed.
