### PR TITLE
Expire column tags on DROP COLUMN

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -276,6 +276,7 @@ public:
 	static string WriteNewSortKeys(const vector<DuckLakeSortInfo> &existing_sorts,
 	                               const vector<DuckLakeSortInfo> &new_sorts);
 	static string WriteDroppedColumns(const vector<DuckLakeDroppedColumn> &dropped_columns);
+	static string WriteExpiredColumnTags(const vector<DuckLakeDroppedColumn> &dropped_columns);
 	static string WriteNewColumns(const vector<DuckLakeNewColumn> &new_columns);
 	static string WriteNewTags(const vector<DuckLakeTagInfo> &new_tags);
 	static string WriteNewColumnTags(const vector<DuckLakeColumnTagInfo> &new_tags);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2867,6 +2867,30 @@ WHERE table_id=tid AND column_id=cid AND end_snapshot IS NULL
 	                          dropped_cols);
 }
 
+string DuckLakeMetadataManager::WriteExpiredColumnTags(const vector<DuckLakeDroppedColumn> &dropped_columns) {
+	if (dropped_columns.empty()) {
+		return {};
+	}
+	string dropped_cols;
+	for (auto &dropped_col : dropped_columns) {
+		if (!dropped_cols.empty()) {
+			dropped_cols += ", ";
+		}
+		dropped_cols += StringUtil::Format("(%d, %d)", dropped_col.table_id.index, dropped_col.field_id.index);
+	}
+	// expire any active tags of the dropped columns (GH #1310)
+	return StringUtil::Format(R"(
+WITH dropped_cols(tid, cid) AS (
+VALUES %s
+)
+UPDATE {METADATA_CATALOG}.ducklake_column_tag
+SET end_snapshot = {SNAPSHOT_ID}
+FROM dropped_cols
+WHERE table_id=tid AND column_id=cid AND end_snapshot IS NULL
+;)",
+	                          dropped_cols);
+}
+
 string DuckLakeMetadataManager::WriteNewColumns(const vector<DuckLakeNewColumn> &new_columns) {
 	if (new_columns.empty()) {
 		return {};

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -447,6 +447,28 @@ void HandleChangedFields(TableIndex table_id, const ColumnChangeInfo &change_inf
 		txn_added_fields[new_col_info.column_info.id.index] = result.new_columns.size();
 		result.new_columns.push_back(std::move(new_column));
 	}
+	// A field that is dropped without being re-added under the same field id in the same change
+	// (i.e. an actual DROP COLUMN, not a rename/alter type) ceases to exist - discard any column
+	// tags queued for it in this transaction; already-committed tags are expired when writing the
+	// dropped columns (GH #1310).
+	for (auto &dropped_field_id : change_info.dropped_fields) {
+		bool readded = false;
+		for (auto &new_col : change_info.new_fields) {
+			if (new_col.column_info.id.index == dropped_field_id.index) {
+				readded = true;
+				break;
+			}
+		}
+		if (readded) {
+			continue;
+		}
+		result.new_column_tags.erase(std::remove_if(result.new_column_tags.begin(), result.new_column_tags.end(),
+		                                            [&](const DuckLakeColumnTagInfo &tag) {
+			                                            return tag.table_id.index == table_id.index &&
+			                                                   tag.field_index.index == dropped_field_id.index;
+		                                            }),
+		                             result.new_column_tags.end());
+	}
 }
 
 void GetNewMacroInfo(DuckLakeCommitState &commit_state, reference<CatalogEntry> entry, NewMacroInfo &result) {
@@ -1625,6 +1647,23 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			batch_queries += DuckLakeMetadataManager::WriteNewViewColumnTags(result.new_view_column_tags);
 		}
 		batch_queries += DuckLakeMetadataManager::WriteDroppedColumns(result.dropped_columns);
+		// Truly dropped columns - i.e. not re-added under the same field id in this commit, as
+		// happens for RENAME/ALTER - also expire their committed column tags (GH #1310).
+		vector<DuckLakeDroppedColumn> expired_column_tags;
+		for (auto &dropped_col : result.dropped_columns) {
+			bool readded = false;
+			for (auto &new_col : result.new_columns) {
+				if (new_col.table_id.index == dropped_col.table_id.index &&
+				    new_col.column_info.id.index == dropped_col.field_id.index) {
+					readded = true;
+					break;
+				}
+			}
+			if (!readded) {
+				expired_column_tags.push_back(dropped_col);
+			}
+		}
+		batch_queries += DuckLakeMetadataManager::WriteExpiredColumnTags(expired_column_tags);
 		batch_queries += DuckLakeMetadataManager::WriteNewColumns(result.new_columns);
 		batch_queries += context.write_inlined_tables(commit_snapshot, result.new_inlined_data_tables);
 		batch_queries += DuckLakeMetadataManager::WriteNewSortKeys(existing_catalog.sorts, result.new_sort_keys);

--- a/test/sql/comments/comment_drop_column.test
+++ b/test/sql/comments/comment_drop_column.test
@@ -1,0 +1,124 @@
+# name: test/sql/comments/comment_drop_column.test
+# description: dropping a column closes its active column tags
+# group: [comments]
+
+require ducklake
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+    DATA_PATH '{DATA_PATH}/ducklake_comment_drop_column',
+    METADATA_CATALOG 'metadata'
+)
+
+# A tag committed before the column is dropped must be closed with the column.
+statement ok
+CREATE TABLE ducklake.test(a INTEGER, b INTEGER)
+
+statement ok
+COMMENT ON COLUMN ducklake.test.b IS 'drop me'
+
+statement ok
+ALTER TABLE ducklake.test DROP COLUMN b
+
+query I
+SELECT count(*)
+FROM metadata.ducklake_column_tag
+WHERE end_snapshot IS NULL
+----
+0
+
+# Adding, commenting on, and dropping a column in one transaction must not
+# commit a tag for a column that never becomes visible.
+statement ok
+CREATE TABLE ducklake.same_transaction(a INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.same_transaction ADD COLUMN b INTEGER
+
+statement ok
+COMMENT ON COLUMN ducklake.same_transaction.b IS 'never committed'
+
+statement ok
+ALTER TABLE ducklake.same_transaction DROP COLUMN b
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*)
+FROM metadata.ducklake_column_tag
+WHERE end_snapshot IS NULL
+----
+0
+
+# Commenting on an existing column and dropping it in one transaction must not
+# leave an active tag behind either.
+statement ok
+CREATE TABLE ducklake.comment_then_drop(a INTEGER, b INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+COMMENT ON COLUMN ducklake.comment_then_drop.b IS 'gone'
+
+statement ok
+ALTER TABLE ducklake.comment_then_drop DROP COLUMN b
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*)
+FROM metadata.ducklake_column_tag
+WHERE end_snapshot IS NULL AND value = 'gone'
+----
+0
+
+# Renaming re-adds the field under the same field id, so a committed comment
+# must survive a rename.
+statement ok
+CREATE TABLE ducklake.renamed(a INTEGER, c INTEGER)
+
+statement ok
+COMMENT ON COLUMN ducklake.renamed.c IS 'keep me'
+
+statement ok
+ALTER TABLE ducklake.renamed RENAME COLUMN c TO d
+
+query I
+SELECT count(*)
+FROM metadata.ducklake_column_tag
+WHERE end_snapshot IS NULL AND value = 'keep me'
+----
+1
+
+# A comment set and renamed in one transaction must survive as well.
+statement ok
+CREATE TABLE ducklake.comment_then_rename(a INTEGER, c INTEGER)
+
+statement ok
+BEGIN
+
+statement ok
+COMMENT ON COLUMN ducklake.comment_then_rename.c IS 'survives rename'
+
+statement ok
+ALTER TABLE ducklake.comment_then_rename RENAME COLUMN c TO d
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*)
+FROM metadata.ducklake_column_tag
+WHERE end_snapshot IS NULL AND value = 'survives rename'
+----
+1


### PR DESCRIPTION
Fixes #1310.

## Problem

`ALTER TABLE ... DROP COLUMN` expires the column's rows in `ducklake_column`, but leaves its rows in `ducklake_column_tag` active (`end_snapshot IS NULL`) — column comments leak past the drop. Two manifestations, both from the reporter's repro:

1. A tag committed before the drop is still active after it.
2. `ADD COLUMN` + `COMMENT ON COLUMN` + `DROP COLUMN` in one transaction commits an active tag for a column that never becomes visible.

## Fix

`ducklake_column_tag` rows are keyed by `(table_id, column_id)`, where `column_id` is the field id — so a drop must expire the field's tags together with the field. Two complementary changes:

- **Committed tags** (`ducklake_transaction_state.cpp`): fields emitted in `dropped_columns` that are *not* re-added under the same field id in the same commit (RENAME / ALTER re-add the field and must keep their tags) are passed to a new `DuckLakeMetadataManager::WriteExpiredColumnTags`, which expires their active `ducklake_column_tag` rows in the same commit batch, mirroring the `WriteDroppedColumns` statement shape. This covers tags committed by earlier transactions, and tags queued earlier in the same transaction (those are inserted with `begin_snapshot = S` and then expired to `end_snapshot = S`, i.e. never visible).
- **Tags queued in the same transaction** (`HandleChangedFields`): when a field is added *and* dropped within one transaction, `CancelOrDropField` only erases it from `new_columns` and no `dropped_columns` entry is ever emitted. Tags queued in `new_column_tags` for such fields are now discarded as well; fields re-added under the same id within the same change (nested renames / alter type) are excluded so their comments survive.

## Testing

New `test/sql/comments/comment_drop_column.test` — the reporter's two repro cases verbatim, plus three boundary cases guarding against over-expiring:

- comment + drop of an existing column in one transaction → no active tag
- rename keeps a committed comment (rename re-adds under the same field id)
- comment + rename in one transaction keeps the comment
