### PR TITLE
fix: postgres isolation level

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -39,6 +39,7 @@ public:
 
 protected:
 	string GetLatestSnapshotQuery() const override;
+	string GetSnapshotAndStatsAndChangesQuery() override;
 	string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) override;
 
 private:

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -350,8 +350,10 @@ public:
 	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats);
 	static SnapshotChangeInfo
 	GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
-	                              const std::function<unique_ptr<QueryResult>(string)> &executor);
-	static string GetSnapshotAndStatsAndChangesQuery();
+	                              const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                              const std::function<string()> &query_builder);
+	static string BaseSnapshotAndStatsAndChangesQuery();
+	virtual string GetSnapshotAndStatsAndChangesQuery();
 	static SnapshotChangeInfo ParseSnapshotAndStatsAndChanges(QueryResult &result, SnapshotAndStats &current_snapshot);
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot();
 	virtual unique_ptr<DuckLakeSnapshot> GetSnapshot(BoundAtClause &at_clause, SnapshotBound bound);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -26,6 +26,8 @@ struct DuckLakeColumnSchemaEntry {
 struct DuckLakeCommitContext {
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
+	//! Builds the query text for GetSnapshotAndStatsAndChanges.
+	std::function<string()> snapshot_and_stats_query;
 	//! Returns the latest snapshot for the first commit attempt.
 	std::function<DuckLakeSnapshot()> get_snapshot;
 	//! Executes the batched snapshot/changes SQL against the metadata DB.
@@ -123,7 +125,8 @@ public:
 
 	SnapshotAndStats CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
 	                                   const TransactionChangeInformation &changes,
-	                                   const std::function<unique_ptr<QueryResult>(string)> &executor);
+	                                   const std::function<unique_ptr<QueryResult>(string)> &executor,
+	                                   const std::function<string()> &snapshot_and_stats_query);
 	void CheckForConflicts(const TransactionChangeInformation &changes, const SnapshotChangeInformation &other_changes,
 	                       DuckLakeSnapshot transaction_snapshot,
 	                       const std::function<unique_ptr<QueryResult>(string)> &executor) const;

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -131,6 +131,13 @@ string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 	)";
 }
 
+string PostgresMetadataManager::GetSnapshotAndStatsAndChangesQuery() {
+	auto inner_query = StringUtil::Replace(DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery(),
+	                                       "{METADATA_CATALOG}", "{METADATA_SCHEMA_ESCAPED}");
+	inner_query = StringUtil::Replace(inner_query, "'", "''");
+	return "SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, '" + inner_query + "')";
+}
+
 string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) {
 	string select_list = "data_file_id";
 	for (const auto &stat : req.referenced_stats) {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -39,13 +39,20 @@ string DuckLakeInitializer::GetAttachOptions() {
 			throw InternalException("Unsupported access mode in DuckLake attach");
 		}
 	}
+	bool has_isolation_level_override = false;
 	for (auto &option : options.metadata_parameters) {
+		if (StringUtil::CIEquals(option.first, "isolation_level")) {
+			has_isolation_level_override = true;
+		}
 		attach_options.push_back(option.first + " " + option.second.ToSQLString());
 	}
 	const string metadata_type = catalog.MetadataType();
 	if (metadata_type.empty() || metadata_type == "duckdb") {
 		// this is duckdb, we always do latest storage
 		attach_options.push_back(StringUtil::Format("STORAGE_VERSION '%s'", "latest"));
+	}
+	if ((metadata_type == "postgres" || metadata_type == "postgres_scanner") && !has_isolation_level_override) {
+		attach_options.push_back("isolation_level 'read committed'");
 	}
 	if (options.hide_metadata_catalog) {
 		attach_options.push_back("HIDDEN true");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4237,6 +4237,10 @@ string DuckLakeMetadataManager::WriteSnapshotChangesSql(const SnapshotChangeInfo
 }
 
 string DuckLakeMetadataManager::GetSnapshotAndStatsAndChangesQuery() {
+	return BaseSnapshotAndStatsAndChangesQuery();
+}
+
+string DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery() {
 	return R"(
 SELECT
     snapshot_id,
@@ -4294,6 +4298,10 @@ SnapshotChangeInfo DuckLakeMetadataManager::ParseSnapshotAndStatsAndChanges(Quer
 	bool first_row = true;
 	for (auto &row : result) {
 		if (first_row) {
+			if (row.IsNull(0)) {
+				throw TransactionException("Transaction conflict - attempting to read the current snapshot"
+				                           " - but another transaction has concurrently modified it");
+			}
 			current_snapshot.snapshot.snapshot_id = row.GetValue<idx_t>(0);
 			current_snapshot.snapshot.schema_version = row.GetValue<idx_t>(1);
 			current_snapshot.snapshot.next_catalog_id = row.GetValue<idx_t>(2);
@@ -4309,8 +4317,9 @@ SnapshotChangeInfo DuckLakeMetadataManager::ParseSnapshotAndStatsAndChanges(Quer
 
 SnapshotChangeInfo
 DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
-                                                       const std::function<unique_ptr<QueryResult>(string)> &executor) {
-	auto result = executor(GetSnapshotAndStatsAndChangesQuery());
+                                                       const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                                       const std::function<string()> &query_builder) {
+	auto result = executor(query_builder());
 	return ParseSnapshotAndStatsAndChanges(*result, current_snapshot);
 }
 

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -732,6 +732,9 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		auto sql = SubstitutePlaceholders(std::move(q), transaction_snapshot);
 		return unique_ptr_cast<MaterializedQueryResult, QueryResult>(fresh_conn.Query(sql));
 	};
+	ctx.snapshot_and_stats_query = []() {
+		return DuckLakeMetadataManager::BaseSnapshotAndStatsAndChangesQuery();
+	};
 	ctx.get_snapshot = [this]() {
 		return transaction_snapshot;
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1427,6 +1427,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 		}
 		return result;
 	};
+	context.snapshot_and_stats_query = [&]() {
+		return metadata_manager->GetSnapshotAndStatsAndChangesQuery();
+	};
 	context.get_snapshot = [&]() {
 		return GetSnapshot();
 	};

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -960,7 +960,8 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 
 static idx_t SubtractDroppedFileStat(idx_t value, idx_t decrement) {
 	if (decrement > value) {
-		throw InternalException("Dropped DuckLake file stats exceed current table stats");
+		throw TransactionException("Transaction conflict - attempting to drop file stats"
+		                           " - but another transaction has already dropped this data");
 	}
 	return value - decrement;
 }

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1861,10 +1861,12 @@ WHERE idt.schema_version < (
 SnapshotAndStats
 DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapshot,
                                             const TransactionChangeInformation &changes,
-                                            const std::function<unique_ptr<QueryResult>(string)> &executor) {
+                                            const std::function<unique_ptr<QueryResult>(string)> &executor,
+                                            const std::function<string()> &snapshot_and_stats_query) {
 	SnapshotAndStats snapshot_and_stats;
 	// get all changes made to the system after the current snapshot was started
-	auto changes_made = DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor);
+	auto changes_made =
+	    DuckLakeMetadataManager::GetSnapshotAndStatsAndChanges(snapshot_and_stats, executor, snapshot_and_stats_query);
 	// parse changes made by other transactions
 	auto other_changes = SnapshotChangeInformation::ParseChangesMade(changes_made.changes_made);
 
@@ -1890,7 +1892,8 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 				// we failed our first commit due to another transaction committing
 				// retry - but first check for conflicts
 				commit_stats_snapshot =
-				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
+				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor,
+				                      context.snapshot_and_stats_query);
 				stats = &commit_stats_snapshot.stats;
 			} else {
 				commit_stats_snapshot.snapshot = context.get_snapshot();

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -102,7 +102,8 @@
         "test/sql/autoloading/autoload_data_path.test",
         "test/sql/data_inlining/postgres_identifier_limit.test",
         "test/sql/issues/issue_sqlite_snapshot_time.test",
-        "test/sql/metadata/ducklake_settings_minio.test"
+        "test/sql/metadata/ducklake_settings_minio.test",
+        "test/sql/concurrent/postgres_isolation_level.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -99,7 +99,8 @@
       "reason": "Test only for Postgres as catalog",
       "paths": [
         "test/sql/metadata/ducklake_settings_postgres.test",
-        "test/sql/data_inlining/postgres_identifier_limit.test"
+        "test/sql/data_inlining/postgres_identifier_limit.test",
+        "test/sql/concurrent/postgres_isolation_level.test"
       ]
     },
     {

--- a/test/sql/concurrent/postgres_isolation_level.test
+++ b/test/sql/concurrent/postgres_isolation_level.test
@@ -1,0 +1,57 @@
+# name: test/sql/concurrent/postgres_isolation_level.test
+# description: DuckLake defaults postgres metadata connections to READ COMMITTED so commit-time conflict checks observe concurrent committers
+# group: [concurrent]
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+#FIXME: ADD THIS TO PG CI WHEN IT GETS BACK
+require-env DUCKLAKE_CI
+
+test-env DATA_PATH {TEST_DIR}
+
+# Scenario: no user override -> read committed applied
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl (DATA_PATH '{DATA_PATH}/iso_default', METADATA_SCHEMA 'iso_default')
+
+statement ok
+USE dl
+
+# create a table so the metadata connection has committed state to read back
+statement ok
+CREATE TABLE dl.t AS SELECT 1 AS x
+
+query I
+SELECT setting FROM postgres_query('__ducklake_metadata_dl', 'SELECT current_setting(''transaction_isolation'')') t(setting)
+----
+read committed
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl
+
+# Scenario: user override -> respected as-is (repeatable read, not read committed)
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl_override (DATA_PATH '{DATA_PATH}/iso_override', METADATA_SCHEMA 'iso_override', METADATA_PARAMETERS MAP {'isolation_level': 'repeatable read'})
+
+statement ok
+USE dl_override
+
+statement ok
+CREATE TABLE dl_override.t AS SELECT 1 AS x
+
+query I
+SELECT setting FROM postgres_query('__ducklake_metadata_dl_override', 'SELECT current_setting(''transaction_isolation'')') t(setting)
+----
+repeatable read
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl_override

--- a/test/sql/concurrent/postgres_isolation_level.test
+++ b/test/sql/concurrent/postgres_isolation_level.test
@@ -8,7 +8,6 @@ require parquet
 
 require postgres_scanner
 
-#FIXME: ADD THIS TO PG CI WHEN IT GETS BACK
 require-env DUCKLAKE_CI
 
 test-env DATA_PATH {TEST_DIR}


### PR DESCRIPTION
## Problem 

> [!NOTE]
> First of a handful of PRs that resolve #1094

Currently, the ducklake conflict check assumes the catalog can observe concurrent committers. With the postgres default isolation level of `REPEATABLE READ` however, it can not. A transaction can't see any commits that land after the transaction has started. This can result in conflicts being silently missed.

### Byproduct & resolution 

Under the previous isolation level two concurrent transactions deleting the same table was hidden. connection-2's first attempt never observed connection-1's commit mid-flight so it failed and got caught by retry logic. With `READ COMMITTED` postgres observes the concurrent action correctly, but that leads to a crash before the conflict check (and therefore the retry logic) even runs. Moving to `TransactionException` allows for a proper conflict check rather than a crash.

### Byproduct & resolution duex

`GetSnapshotAndStatsAndChangesQuery`'s `UNION ALL` ran as two separate remote scans against Postgres. This made it possible for concurrent writers to observe inconsistent results across the two scans intermittently crashing. Seen in  `flush_concurrent_insert.test`. The fix wraps the whole query in a single `postgres_query` call, making the read atomic.

## Fix

Set the default to `READ COMMITTED` at attach. If users choose to override the setting, that's respected. 

