### PR TITLE
[Dev] Use `global_state`'s `extra_columns`

### DIFF
--- a/src/include/storage/ducklake_multi_file_reader.hpp
+++ b/src/include/storage/ducklake_multi_file_reader.hpp
@@ -17,6 +17,29 @@ class DuckLakeMultiFileList;
 struct DuckLakeDeleteMap;
 class DuckLakeFieldData;
 
+struct DuckLakeMultiFileReaderGlobalState : public MultiFileReaderGlobalState {
+	DuckLakeMultiFileReaderGlobalState(const MultiFileList &file_list_p, bool internally_projected_rowid_p,
+	                                   optional_idx deletion_scan_rowid_col_p,
+	                                   optional_idx deletion_scan_snapshot_col_p,
+	                                   optional_idx deletion_scan_internal_rowid_col_p)
+	    : MultiFileReaderGlobalState(internally_projected_rowid_p ? vector<LogicalType> {LogicalType::BIGINT}
+	                                                              : vector<LogicalType> {},
+	                                 file_list_p),
+	      internally_projected_rowid(internally_projected_rowid_p), deletion_scan_rowid_col(deletion_scan_rowid_col_p),
+	      deletion_scan_snapshot_col(deletion_scan_snapshot_col_p),
+	      deletion_scan_internal_rowid_col(deletion_scan_internal_rowid_col_p) {
+	}
+
+	//! Whether row_id was internally projected (not in user's query)
+	//! This is necessary for DCF queries over inlined deletions
+	const bool internally_projected_rowid;
+	//! Output positions in global_column_ids order
+	const optional_idx deletion_scan_rowid_col;
+	const optional_idx deletion_scan_snapshot_col;
+	//! Position of the appended rowid expression
+	const optional_idx deletion_scan_internal_rowid_col;
+};
+
 struct DuckLakeMultiFileReader : public MultiFileReader {
 public:
 	static constexpr column_t COLUMN_IDENTIFIER_SNAPSHOT_ID = UINT64_C(10000000000000000000);
@@ -43,6 +66,12 @@ public:
 	void BindOptions(MultiFileOptions &options, MultiFileList &files, vector<LogicalType> &return_types,
 	                 vector<Identifier> &names, MultiFileReaderBindData &bind_data) override;
 
+	unique_ptr<MultiFileReaderGlobalState>
+	InitializeGlobalState(ClientContext &context, const MultiFileOptions &file_options,
+	                      const MultiFileReaderBindData &bind_data, const MultiFileList &file_list,
+	                      const vector<MultiFileColumnDefinition> &global_columns,
+	                      const vector<ColumnIndex> &global_column_ids) override;
+
 	ReaderInitializeType InitializeReader(MultiFileReaderData &reader_data, const MultiFileBindData &bind_data,
 	                                      const vector<MultiFileColumnDefinition> &global_columns,
 	                                      const vector<ColumnIndex> &global_column_ids,
@@ -55,6 +84,12 @@ public:
 	shared_ptr<BaseFileReader> CreateReader(ClientContext &context, const OpenFileInfo &file,
 	                                        BaseFileReaderOptions &options, const MultiFileOptions &file_options,
 	                                        MultiFileReaderInterface &interface) override;
+
+	ReaderInitializeType CreateMappingWithGlobalState(
+	    ClientContext &context, MultiFileReaderData &reader_data,
+	    const vector<MultiFileColumnDefinition> &global_columns, const vector<ColumnIndex> &global_column_ids,
+	    optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list, const MultiFileReaderBindData &bind_data,
+	    const virtual_column_map_t &virtual_columns, const DuckLakeMultiFileReaderGlobalState &global_state);
 
 	ReaderInitializeType CreateMapping(ClientContext &context, MultiFileReaderData &reader_data,
 	                                   const vector<MultiFileColumnDefinition> &global_columns,
@@ -79,28 +114,15 @@ public:
 
 private:
 	shared_ptr<BaseFileReader> TryCreateInlinedDataReader(const OpenFileInfo &file);
-	//! Gather per-row snapshot_id values; rowid_output_col/snapshot_output_col are positions within `chunk` (no-op if
-	//! invalid)
-	void GatherDeletionScanSnapshots(BaseFileReader &reader, const MultiFileReaderData &reader_data, DataChunk &chunk,
-	                                 optional_idx rowid_output_col, optional_idx snapshot_output_col) const;
+	//! Gather per-row snapshot_id values using the rowid values produced by the scan
+	void GatherDeletionScanSnapshots(BaseFileReader &reader, const MultiFileReaderData &reader_data,
+	                                 const Vector &rowid_vector, Vector &snapshot_vector, idx_t count) const;
 
 private:
 	unique_ptr<MultiFileColumnDefinition> row_id_column;
 	unique_ptr<MultiFileColumnDefinition> snapshot_id_column;
 	//! Inlined transaction-local data
 	shared_ptr<DuckLakeInlinedData> transaction_local_data;
-	//! For deletion scans: snapshot_id index in global_column_ids order, if projected; FinalizeChunk remaps it to the
-	//! output position
-	optional_idx deletion_scan_snapshot_col;
-	//! For deletion scans: rowid index in global_column_ids order, if projected; same remapping as
-	//! deletion_scan_snapshot_col
-	optional_idx deletion_scan_rowid_col;
-	//! For deletion scans with internally-projected rowid: index of the appended rowid expression, evaluated explicitly
-	//! when the executor omits it
-	optional_idx deletion_scan_internal_rowid_col;
-	//! Whether row_id was internally projected (not in user's query)
-	//! This is necessary for DCF queries over inlined deletions
-	bool internally_projected_rowid = false;
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_multi_file_reader.cpp
+++ b/src/storage/ducklake_multi_file_reader.cpp
@@ -234,6 +234,31 @@ void DuckLakeMultiFileReader::BindOptions(MultiFileOptions &options, MultiFileLi
                                           MultiFileReaderBindData &bind_data) {
 }
 
+unique_ptr<MultiFileReaderGlobalState>
+DuckLakeMultiFileReader::InitializeGlobalState(ClientContext &context, const MultiFileOptions &file_options,
+                                               const MultiFileReaderBindData &bind_data, const MultiFileList &file_list,
+                                               const vector<MultiFileColumnDefinition> &global_columns,
+                                               const vector<ColumnIndex> &global_column_ids) {
+	optional_idx deletion_scan_rowid_col;
+	optional_idx deletion_scan_snapshot_col;
+	auto internally_projected_rowid = false;
+	if (file_list.Cast<DuckLakeMultiFileList>().IsDeleteScan()) {
+		for (idx_t out_idx = 0; out_idx < global_column_ids.size(); out_idx++) {
+			auto primary_index = global_column_ids[out_idx].GetPrimaryIndex();
+			if (primary_index == COLUMN_IDENTIFIER_ROW_ID) {
+				deletion_scan_rowid_col = out_idx;
+			} else if (primary_index == COLUMN_IDENTIFIER_SNAPSHOT_ID) {
+				deletion_scan_snapshot_col = out_idx;
+			}
+		}
+		internally_projected_rowid = !deletion_scan_rowid_col.IsValid();
+	}
+	auto deletion_scan_internal_rowid_col =
+	    internally_projected_rowid ? optional_idx(global_column_ids.size()) : optional_idx();
+	return make_uniq<DuckLakeMultiFileReaderGlobalState>(file_list, internally_projected_rowid, deletion_scan_rowid_col,
+	                                                     deletion_scan_snapshot_col, deletion_scan_internal_rowid_col);
+}
+
 ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderData &reader_data,
                                                                const MultiFileBindData &bind_data,
                                                                const vector<MultiFileColumnDefinition> &global_columns,
@@ -295,8 +320,14 @@ ReaderInitializeType DuckLakeMultiFileReader::InitializeReader(MultiFileReaderDa
 			reader.deletion_filter = std::move(delete_filter);
 		}
 	}
-	auto result = MultiFileReader::InitializeReader(reader_data, bind_data, global_columns, global_column_ids,
-	                                                table_filters, context, gstate);
+
+	auto &global_state = gstate.multi_file_reader_state->Cast<DuckLakeMultiFileReaderGlobalState>();
+	FinalizeBind(reader_data, bind_data.file_options, bind_data.reader_bind, global_columns, global_column_ids, context,
+	             global_state);
+	auto result =
+	    CreateMappingWithGlobalState(context, reader_data, global_columns, global_column_ids, table_filters,
+	                                 gstate.file_list, bind_data.reader_bind, bind_data.virtual_columns, global_state);
+
 	// Handle snapshot filters for files with multiple snapshots (partial_max set)
 	if (file_entry.snapshot_filter_max.IsValid() || file_entry.snapshot_filter_min.IsValid()) {
 		// we have a snapshot filter - add it to the filter list
@@ -492,45 +523,24 @@ ReaderInitializeType DuckLakeMultiFileReader::CreateMapping(
     ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &global_columns,
     const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
     const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns) {
-	NormalizeListChildNames(reader_data.reader->columns);
+	throw InternalException("DuckLakeMultiFileReader::CreateMapping is unreachable");
+}
 
-	// For deletion scans, we may need to internally project row_id for snapshot lookups
-	// Check if this is a deletion scan and if row_id is not already in the user's query
-	auto &file_list = multi_file_list.Cast<DuckLakeMultiFileList>();
-	bool needs_internal_rowid = false;
-	if (file_list.IsDeleteScan()) {
-		// Locate the rowid and snapshot_id virtual columns by their position in global_column_ids, which is the
-		// order in which the columns appear in the FinalizeChunk output_chunk. The per-file local virtual-column
-		// index cannot be used: the snapshot_id virtual column is emitted as a constant expression and does not
-		// advance the local column counter, so it does not line up with the output_chunk layout.
-		deletion_scan_rowid_col = optional_idx();
-		deletion_scan_snapshot_col = optional_idx();
-		bool has_rowid = false;
-		for (idx_t out_idx = 0; out_idx < global_column_ids.size(); out_idx++) {
-			auto primary_index = global_column_ids[out_idx].GetPrimaryIndex();
-			if (primary_index == COLUMN_IDENTIFIER_ROW_ID) {
-				has_rowid = true;
-				deletion_scan_rowid_col = out_idx;
-			} else if (primary_index == COLUMN_IDENTIFIER_SNAPSHOT_ID) {
-				deletion_scan_snapshot_col = out_idx;
-			}
-		}
-		// We need internal row_id if it's not in the user's query
-		needs_internal_rowid = !has_rowid;
-	}
+ReaderInitializeType DuckLakeMultiFileReader::CreateMappingWithGlobalState(
+    ClientContext &context, MultiFileReaderData &reader_data, const vector<MultiFileColumnDefinition> &global_columns,
+    const vector<ColumnIndex> &global_column_ids, optional_ptr<TableFilterSet> filters, MultiFileList &multi_file_list,
+    const MultiFileReaderBindData &bind_data, const virtual_column_map_t &virtual_columns,
+    const DuckLakeMultiFileReaderGlobalState &global_state) {
+	NormalizeListChildNames(reader_data.reader->columns);
 
 	// Create extended column ids if we need to internally project row_id
 	vector<ColumnIndex> extended_column_ids;
-	internally_projected_rowid = needs_internal_rowid;
-	deletion_scan_internal_rowid_col = optional_idx();
-	if (needs_internal_rowid) {
-		// rowid is appended last, so its expression lands at this index in reader_data.expressions
-		deletion_scan_internal_rowid_col = global_column_ids.size();
+	if (global_state.internally_projected_rowid) {
 		extended_column_ids = global_column_ids;
 		extended_column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
 	}
 
-	const vector<ColumnIndex> &column_ids_to_use = needs_internal_rowid ? extended_column_ids : global_column_ids;
+	const auto &column_ids_to_use = global_state.internally_projected_rowid ? extended_column_ids : global_column_ids;
 
 	if (reader_data.reader->file.extended_info) {
 		auto &file_options = reader_data.reader->file.extended_info->options;
@@ -642,24 +652,15 @@ static optional_idx RemapDeletionScanOutputColumn(const ExpressionExecutor &exec
 }
 
 void DuckLakeMultiFileReader::GatherDeletionScanSnapshots(BaseFileReader &reader,
-                                                          const MultiFileReaderData &reader_data, DataChunk &chunk,
-                                                          optional_idx rowid_output_col,
-                                                          optional_idx snapshot_output_col) const {
+                                                          const MultiFileReaderData &reader_data,
+                                                          const Vector &rowid_vector, Vector &snapshot_vector,
+                                                          idx_t count) const {
 	auto &delete_filter = static_cast<DuckLakeDeleteFilter &>(*reader.deletion_filter);
-	// Positions are already resolved to `chunk` by the caller; do not fall back to the raw global_column_ids members
-	optional_idx snapshot_col_idx = snapshot_output_col;
-	optional_idx rowid_col_idx = rowid_output_col;
-
-	if (delete_filter.delete_data->scan_snapshot_map.empty() || !snapshot_col_idx.IsValid() ||
-	    !rowid_col_idx.IsValid()) {
+	if (delete_filter.delete_data->scan_snapshot_map.empty()) {
 		// We don't have anything to gather
 		return;
 	}
 
-	auto &rowid_vector = chunk.data[rowid_col_idx.GetIndex()];
-	auto &snapshot_vector = chunk.data[snapshot_col_idx.GetIndex()];
-
-	idx_t count = chunk.size();
 	snapshot_vector.Flatten();
 	auto snapshot_data = FlatVector::GetDataMutable<int64_t>(snapshot_vector);
 
@@ -702,52 +703,32 @@ void DuckLakeMultiFileReader::FinalizeChunk(ClientContext &context, const MultiF
                                             BaseFileReader &reader, const MultiFileReaderData &reader_data,
                                             DataChunk &input_chunk, DataChunk &output_chunk,
                                             ExpressionExecutor &executor,
-                                            optional_ptr<MultiFileReaderGlobalState> global_state) {
-	// If we internally projected row_id for deletion scan snapshot lookups,
-	// we need to use a temp chunk that includes the row_id column
-	if (internally_projected_rowid && read_info.scan_type == DuckLakeScanType::SCAN_DELETIONS) {
-		// Create a temp chunk with user columns + internally projected row_id
-		vector<LogicalType> temp_types;
-		for (idx_t i = 0; i < output_chunk.ColumnCount(); i++) {
-			temp_types.push_back(output_chunk.data[i].GetType());
-		}
-		temp_types.push_back(LogicalType::BIGINT); // row_id
+                                            optional_ptr<MultiFileReaderGlobalState> global_state_p) {
+	auto &global_state = global_state_p->Cast<DuckLakeMultiFileReaderGlobalState>();
+	MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, output_chunk, executor,
+	                               global_state);
 
-		DataChunk temp_chunk;
-		temp_chunk.Initialize(Allocator::DefaultAllocator(), temp_types);
-
-		// Call base FinalizeChunk with the temp chunk
-		MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, temp_chunk, executor,
-		                               global_state);
-
-		// Gather snapshots from temp_chunk (rowid at its last slot). Under filter-column removal the executor omits
-		// the internal rowid, so evaluate it explicitly; the snapshot_id column is remapped to its temp_chunk position.
-		if (reader.deletion_filter) {
-			idx_t internal_rowid_col = output_chunk.ColumnCount(); // last column in temp_chunk
-			if (executor.expressions.size() <= internal_rowid_col && deletion_scan_internal_rowid_col.IsValid() &&
-			    deletion_scan_internal_rowid_col.GetIndex() < reader_data.expressions.size()) {
-				ExpressionExecutor rowid_executor(
-				    context, *reader_data.expressions[deletion_scan_internal_rowid_col.GetIndex()]);
-				rowid_executor.ExecuteExpression(input_chunk, temp_chunk.data[internal_rowid_col]);
-			}
-			auto snapshot_out = RemapDeletionScanOutputColumn(executor, reader_data, deletion_scan_snapshot_col);
-			GatherDeletionScanSnapshots(reader, reader_data, temp_chunk, internal_rowid_col, snapshot_out);
-		}
-
-		// Copy only user columns (excluding internally projected row_id) to output_chunk
-		for (idx_t i = 0; i < output_chunk.ColumnCount(); i++) {
-			output_chunk.data[i].Reference(temp_chunk.data[i]);
-		}
-		output_chunk.SetChildCardinality(temp_chunk.size());
+	if (read_info.scan_type != DuckLakeScanType::SCAN_DELETIONS || !reader.deletion_filter) {
+		return;
+	}
+	// Gather snapshot_id for partial deletion files; remap the global_column_ids indices to output_chunk positions
+	auto snapshot_out = RemapDeletionScanOutputColumn(executor, reader_data, global_state.deletion_scan_snapshot_col);
+	if (!snapshot_out.IsValid()) {
+		return;
+	}
+	auto &snapshot_vector = output_chunk.data[snapshot_out.GetIndex()];
+	if (global_state.internally_projected_rowid) {
+		auto expression_idx = global_state.deletion_scan_internal_rowid_col.GetIndex();
+		D_ASSERT(expression_idx < reader_data.expressions.size());
+		Vector rowid_vector(LogicalType::BIGINT, input_chunk.size());
+		ExpressionExecutor rowid_executor(context, *reader_data.expressions[expression_idx]);
+		rowid_executor.ExecuteExpression(input_chunk, rowid_vector);
+		GatherDeletionScanSnapshots(reader, reader_data, rowid_vector, snapshot_vector, output_chunk.size());
 	} else {
-		MultiFileReader::FinalizeChunk(context, bind_data, reader, reader_data, input_chunk, output_chunk, executor,
-		                               global_state);
-
-		// Gather snapshot_id for partial deletion files; remap the global_column_ids indices to output_chunk positions
-		if (read_info.scan_type == DuckLakeScanType::SCAN_DELETIONS && reader.deletion_filter) {
-			auto rowid_out = RemapDeletionScanOutputColumn(executor, reader_data, deletion_scan_rowid_col);
-			auto snapshot_out = RemapDeletionScanOutputColumn(executor, reader_data, deletion_scan_snapshot_col);
-			GatherDeletionScanSnapshots(reader, reader_data, output_chunk, rowid_out, snapshot_out);
+		auto rowid_out = RemapDeletionScanOutputColumn(executor, reader_data, global_state.deletion_scan_rowid_col);
+		if (rowid_out.IsValid()) {
+			GatherDeletionScanSnapshots(reader, reader_data, output_chunk.data[rowid_out.GetIndex()], snapshot_vector,
+			                            output_chunk.size());
 		}
 	}
 }


### PR DESCRIPTION
Initially created as a patch for https://github.com/duckdb/duckdb/pull/24234

This PR implements `extra_columns`, which is better supported than the hacked-in method that DuckLake used for adding extra columns that are required in `FinalizeChunk`.

Added `DuckLakeMultiFileReaderGlobalState`, initialized in `InitializeGlobalState`.
This populates `extra_columns` if required.

`FinalizeChunk` gets much simpler because we don't have to hack in the extra columns into the `input_chunk`, now they're already provided to us.

The `MultiFileReaderGlobalState` doesn't get provided to `CreateMapping`, and we override `InitializeReader` anyways, so we deprecate `CreateMapping` (throw `InternalException("unreachable ...")`) and add `CreateMappingWithGlobalState` to replace it.