### PR TITLE
Reject data files that violate NOT NULL constraints in add_data_files

### DIFF
--- a/src/functions/ducklake_add_data_files.cpp
+++ b/src/functions/ducklake_add_data_files.cpp
@@ -147,6 +147,7 @@ private:
 	                                                    const vector<unique_ptr<DuckLakeFieldId>> &field_ids,
 	                                                    const string &prefix = string());
 	void MapColumnStats(ParquetFileMetadata &file_metadata, DuckLakeDataFile &result);
+	void CheckNotNullConstraints(const ParquetFileMetadata &file, const DuckLakeDataFile &data_file);
 	unique_ptr<DuckLakeNameMapEntry> MapHiveColumn(ParquetFileMetadata &file_metadata, const DuckLakeFieldId &field_id,
 	                                               const Value &hive_value);
 	void DetermineMapping(ParquetFileMetadata &file);
@@ -1086,6 +1087,50 @@ void DuckLakeFileProcessor::MapColumnStats(ParquetFileMetadata &file_metadata, D
 	}
 }
 
+void DuckLakeFileProcessor::CheckNotNullConstraints(const ParquetFileMetadata &file,
+                                                    const DuckLakeDataFile &data_file) {
+	auto not_null_fields = table.GetNotNullFields();
+	if (not_null_fields.empty()) {
+		return;
+	}
+	// gather the fields for which the file provides values - either as a column or as a hive partition
+	unordered_set<idx_t> provided_fields;
+	for (auto &entry : file.column_id_to_field_map) {
+		provided_fields.insert(entry.second.first.index);
+	}
+	for (auto &hive_partition : file.hive_partition_values) {
+		provided_fields.insert(hive_partition.field_index.index);
+	}
+	for (auto &field_id : table.GetFieldData().GetFieldIds()) {
+		if (!not_null_fields.count(field_id->Name())) {
+			continue;
+		}
+		auto field_index = field_id->GetFieldIndex();
+		auto stats_entry = data_file.column_stats.find(field_index);
+		if (stats_entry != data_file.column_stats.end()) {
+			auto &stats = stats_entry->second;
+			if (stats.has_null_count && stats.null_count > 0) {
+				throw InvalidInputException(
+				    "Failed to add file \"%s\" - column \"%s\" has a NOT NULL constraint, but the file contains %llu "
+				    "NULL value(s) for it",
+				    data_file.file_name, field_id->Name(), stats.null_count);
+			}
+			continue;
+		}
+		if (field_id->HasChildren() || provided_fields.count(field_index.index)) {
+			// nested columns are only checked through their statistics, and a column that is present in the file
+			// without statistics could contain any value - we cannot tell
+			continue;
+		}
+		if (data_file.row_count > 0 && field_id->GetColumnData().initial_default.IsNull()) {
+			// the file has rows but no values for this column - every row would read as NULL
+			throw InvalidInputException("Failed to add file \"%s\" - column \"%s\" has a NOT NULL constraint, but the "
+			                            "file does not contain values for it",
+			                            data_file.file_name, field_id->Name());
+		}
+	}
+}
+
 vector<unique_ptr<DuckLakeNameMapEntry>>
 DuckLakeFileProcessor::MapColumns(ParquetFileMetadata &file_metadata,
                                   vector<unique_ptr<ParquetColumn>> &parquet_columns,
@@ -1201,6 +1246,7 @@ DuckLakeDataFile DuckLakeFileProcessor::AddFileToTable(ParquetFileMetadata &file
 	auto name_map = make_uniq<DuckLakeNameMap>();
 	name_map->table_id = table.GetTableId();
 	MapColumnStats(file, result);
+	CheckNotNullConstraints(file, result);
 	name_map->column_maps = std::move(file.map_entries);
 
 	// we successfully mapped this file - register the name map and refer to it in the file

--- a/test/sql/add_files/add_files_not_null_constraints.test
+++ b/test/sql/add_files/add_files_not_null_constraints.test
@@ -1,0 +1,93 @@
+# name: test/sql/add_files/add_files_not_null_constraints.test
+# description: ducklake_add_data_files must reject files that violate NOT NULL constraints
+# group: [add_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/add_files_not_null', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+COPY (SELECT * FROM (VALUES (1, 10), (2, NULL)) v(id, x)) TO '{DATA_PATH}/not_null_with_nulls.parquet' (FORMAT parquet)
+
+statement ok
+COPY (SELECT * FROM (VALUES (3, 30), (4, 40)) v(id, x)) TO '{DATA_PATH}/not_null_no_nulls.parquet' (FORMAT parquet)
+
+statement ok
+CREATE TABLE ducklake.tbl(id INTEGER, x INTEGER NOT NULL)
+
+statement error
+CALL ducklake_add_data_files('ducklake', 'tbl', '{DATA_PATH}/not_null_with_nulls.parquet')
+----
+NOT NULL constraint
+
+# nothing was added
+query I
+SELECT COUNT(*) FROM ducklake_list_files('ducklake', 'tbl')
+----
+0
+
+# a file without NULL values is accepted
+statement ok
+CALL ducklake_add_data_files('ducklake', 'tbl', '{DATA_PATH}/not_null_no_nulls.parquet')
+
+query II
+SELECT id, x FROM ducklake.tbl ORDER BY id
+----
+3	30
+4	40
+
+# adding a violating file leaves the previously added file untouched
+statement error
+CALL ducklake_add_data_files('ducklake', 'tbl', '{DATA_PATH}/not_null_with_nulls.parquet')
+----
+NOT NULL constraint
+
+query II
+SELECT id, x FROM ducklake.tbl ORDER BY id
+----
+3	30
+4	40
+
+# NULL values in a column without the constraint are fine
+statement ok
+CREATE TABLE ducklake.nullable_tbl(id INTEGER, x INTEGER)
+
+statement ok
+CALL ducklake_add_data_files('ducklake', 'nullable_tbl', '{DATA_PATH}/not_null_with_nulls.parquet')
+
+query II
+SELECT id, x FROM ducklake.nullable_tbl ORDER BY id
+----
+1	10
+2	NULL
+
+# a missing column is all-NULL for the added file - rejected as well
+statement ok
+COPY (SELECT 5 AS id) TO '{DATA_PATH}/not_null_missing_column.parquet' (FORMAT parquet)
+
+statement error
+CALL ducklake_add_data_files('ducklake', 'tbl', '{DATA_PATH}/not_null_missing_column.parquet', allow_missing => true)
+----
+NOT NULL constraint
+
+# SET NOT NULL on an existing column also guards later adds
+statement ok
+CREATE TABLE ducklake.later_tbl(id INTEGER, x INTEGER)
+
+statement ok
+INSERT INTO ducklake.later_tbl VALUES (1, 1)
+
+statement ok
+ALTER TABLE ducklake.later_tbl ALTER COLUMN x SET NOT NULL
+
+statement error
+CALL ducklake_add_data_files('ducklake', 'later_tbl', '{DATA_PATH}/not_null_with_nulls.parquet')
+----
+NOT NULL constraint


### PR DESCRIPTION
Fixes #1295

## Problem

`ducklake_add_data_files` registers a Parquet file without checking the table's NOT NULL
constraints, so a column declared `NOT NULL` starts returning NULL values after the import:

```sql
COPY (SELECT * FROM (VALUES (1, 10), (2, NULL)) v(id, x)) TO 'f.parquet';
CREATE TABLE ducklake.tbl(id INTEGER, x INTEGER NOT NULL);
CALL ducklake_add_data_files('ducklake', 'tbl', 'f.parquet');  -- succeeds today
SELECT * FROM ducklake.tbl;                                     -- x IS NULL