### PR TITLE
Do not delete data files that are still referenced by another table

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -220,6 +220,8 @@ public:
 	static string GetTableColumnSchemaSql(TableIndex table_id);
 	static string GetInlinedTableNamesSql(TableIndex table_id);
 	virtual vector<DuckLakeFileForCleanup> GetOldFilesForCleanup(const string &filter);
+	//! Of the given files, the ones whose path is still pointed at by a data file entry that is not being cleaned up
+	unordered_set<idx_t> GetStillReferencedFiles(const vector<DuckLakeFileForCleanup> &cleanup_files);
 	virtual vector<DuckLakeFileForCleanup> GetOrphanFilesForCleanup(const string &filter, const string &separator);
 	virtual vector<DuckLakeFileForCleanup> GetFilesForCleanup(const string &filter, CleanupType type,
 	                                                          const string &separator);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3088,7 +3088,7 @@ ORDER BY row_id, begin_snapshot;)",
 }
 
 string DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(const string &inlined_table_name,
-                                                              const string &select_list) {
+                                                             const string &select_list) {
 	return StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s
@@ -4528,33 +4528,61 @@ DuckLakeMetadataManager::GetStillReferencedFiles(const vector<DuckLakeFileForCle
 	if (cleanup_files.empty()) {
 		return result;
 	}
+	auto context_ptr = transaction.context.lock();
+	if (!context_ptr) {
+		return result;
+	}
+	auto &fs = FileSystem::GetFileSystem(*context_ptr);
+
+	// the same file can be registered more than once - e.g. ducklake_add_data_files called with the same external
+	// file for two tables. The stored paths of two such entries need not be equal (one can be relative to the data
+	// path, the other absolute), so we compare canonicalized paths rather than what is stored.
+	unordered_map<string, vector<idx_t>> ids_by_path;
 	string file_ids;
+	string name_filter;
+	case_insensitive_set_t filtered_names;
 	for (auto &file : cleanup_files) {
 		if (!file_ids.empty()) {
 			file_ids += ", ";
 		}
 		file_ids += to_string(file.id.index);
+		ids_by_path[fs.CanonicalizePath(file.path)].push_back(file.id.index);
+
+		// only fetch entries that end in the same file name - the name is the selective part of the path
+		auto file_name = StringUtil::GetFileName(file.path);
+		if (file_name.empty() || !filtered_names.insert(file_name).second) {
+			continue;
+		}
+		if (!name_filter.empty()) {
+			name_filter += " OR ";
+		}
+		name_filter +=
+		    StringUtil::Format("path = %s OR path LIKE %s", SQLString(file_name), SQLString("%" + file_name));
 	}
-	// the same file can be registered more than once - e.g. ducklake_add_data_files called with the same external
-	// file for two tables. Relative paths are resolved against the table they belong to, so those only match within
-	// the same table.
+	if (name_filter.empty()) {
+		return result;
+	}
 	auto query = StringUtil::Format(R"(
-SELECT c.data_file_id
-FROM {METADATA_CATALOG}.ducklake_data_file c
-WHERE c.data_file_id IN (%s) AND EXISTS(
-    SELECT 1
-    FROM {METADATA_CATALOG}.ducklake_data_file o
-    WHERE o.path = c.path AND o.path_is_relative = c.path_is_relative
-      AND (NOT c.path_is_relative OR o.table_id = c.table_id)
-      AND o.data_file_id NOT IN (%s)
-);)",
-	                                file_ids, file_ids);
+SELECT table_id, path, path_is_relative
+FROM {METADATA_CATALOG}.ducklake_data_file
+WHERE data_file_id NOT IN (%s) AND (%s);)",
+	                                file_ids, name_filter);
 	auto query_result = Query(query);
 	if (query_result->HasError()) {
 		query_result->GetErrorObject().Throw("Failed to check for files that are still referenced in DuckLake: ");
 	}
 	for (auto &row : *query_result) {
-		result.insert(row.GetValue<idx_t>(0));
+		TableIndex table_id(row.GetValue<idx_t>(0));
+		DuckLakePath path;
+		path.path = row.GetValue<string>(1);
+		path.path_is_relative = row.GetValue<bool>(2);
+		auto entry = ids_by_path.find(fs.CanonicalizePath(FromRelativePath(table_id, path)));
+		if (entry == ids_by_path.end()) {
+			continue;
+		}
+		for (auto &id : entry->second) {
+			result.insert(id);
+		}
 	}
 	return result;
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4522,6 +4522,43 @@ ORDER BY snapshot_id
 	return snapshots;
 }
 
+unordered_set<idx_t>
+DuckLakeMetadataManager::GetStillReferencedFiles(const vector<DuckLakeFileForCleanup> &cleanup_files) {
+	unordered_set<idx_t> result;
+	if (cleanup_files.empty()) {
+		return result;
+	}
+	string file_ids;
+	for (auto &file : cleanup_files) {
+		if (!file_ids.empty()) {
+			file_ids += ", ";
+		}
+		file_ids += to_string(file.id.index);
+	}
+	// the same file can be registered more than once - e.g. ducklake_add_data_files called with the same external
+	// file for two tables. Relative paths are resolved against the table they belong to, so those only match within
+	// the same table.
+	auto query = StringUtil::Format(R"(
+SELECT c.data_file_id
+FROM {METADATA_CATALOG}.ducklake_data_file c
+WHERE c.data_file_id IN (%s) AND EXISTS(
+    SELECT 1
+    FROM {METADATA_CATALOG}.ducklake_data_file o
+    WHERE o.path = c.path AND o.path_is_relative = c.path_is_relative
+      AND (NOT c.path_is_relative OR o.table_id = c.table_id)
+      AND o.data_file_id NOT IN (%s)
+);)",
+	                                file_ids, file_ids);
+	auto query_result = Query(query);
+	if (query_result->HasError()) {
+		query_result->GetErrorObject().Throw("Failed to check for files that are still referenced in DuckLake: ");
+	}
+	for (auto &row : *query_result) {
+		result.insert(row.GetValue<idx_t>(0));
+	}
+	return result;
+}
+
 vector<DuckLakeFileForCleanup> DuckLakeMetadataManager::GetOldFilesForCleanup(const string &filter) {
 	auto query = R"(
 SELECT data_file_id, path, path_is_relative, schedule_start
@@ -4890,6 +4927,7 @@ WHERE %s (end_snapshot IS NOT NULL AND NOT EXISTS(
 	}
 	string deleted_file_ids;
 	if (!cleanup_files.empty()) {
+		auto still_referenced = GetStillReferencedFiles(cleanup_files);
 		string files_scheduled_for_cleanup;
 		for (auto &file : cleanup_files) {
 			if (!deleted_file_ids.empty()) {
@@ -4897,6 +4935,11 @@ WHERE %s (end_snapshot IS NOT NULL AND NOT EXISTS(
 			}
 			deleted_file_ids += to_string(file.id.index);
 
+			if (still_referenced.find(file.id.index) != still_referenced.end()) {
+				// another data file entry that is not being cleaned up points at the same file - the metadata entry
+				// goes away, but the file itself must stay on disk
+				continue;
+			}
 			if (!files_scheduled_for_cleanup.empty()) {
 				files_scheduled_for_cleanup += ", ";
 			}
@@ -4919,13 +4962,15 @@ WHERE data_file_id IN (%s);
 			}
 		}
 		// insert the to-be-cleaned-up files
-		result = transaction.Query(StringUtil::Format(R"(
+		if (!files_scheduled_for_cleanup.empty()) {
+			result = transaction.Query(StringUtil::Format(R"(
 INSERT INTO {METADATA_CATALOG}.ducklake_files_scheduled_for_deletion
 VALUES %s;
 )",
-		                                              files_scheduled_for_cleanup));
-		if (result->HasError()) {
-			result->GetErrorObject().Throw("Failed to schedule files for clean-up in DuckLake: ");
+			                                              files_scheduled_for_cleanup));
+			if (result->HasError()) {
+				result->GetErrorObject().Throw("Failed to schedule files for clean-up in DuckLake: ");
+			}
 		}
 	}
 

--- a/test/sql/remove_orphans/cleanup_shared_data_file.test
+++ b/test/sql/remove_orphans/cleanup_shared_data_file.test
@@ -1,0 +1,65 @@
+# name: test/sql/remove_orphans/cleanup_shared_data_file.test
+# description: a data file referenced by more than one table must not be deleted while any reference is live
+# group: [remove_orphans]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS lake (DATA_PATH '{DATA_PATH}/cleanup_shared', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+COPY (SELECT 42 AS id) TO '{DATA_PATH}/cleanup_shared_file.parquet' (FORMAT parquet)
+
+statement ok
+CREATE TABLE lake.t1(id INTEGER)
+
+statement ok
+CREATE TABLE lake.t2(id INTEGER)
+
+statement ok
+CALL ducklake_add_data_files('lake', 't1', '{DATA_PATH}/cleanup_shared_file.parquet')
+
+statement ok
+CALL ducklake_add_data_files('lake', 't2', '{DATA_PATH}/cleanup_shared_file.parquet')
+
+# drop one of the two tables that reference the file, then expire and clean up
+statement ok
+DROP TABLE lake.t1
+
+statement ok
+CALL ducklake_expire_snapshots('lake', older_than => NOW())
+
+statement ok
+CALL ducklake_cleanup_old_files('lake', cleanup_all => true)
+
+# t2 still references the file - it must survive on disk and remain readable
+query I
+SELECT COUNT(*) FROM GLOB('{DATA_PATH}/cleanup_shared_file.parquet')
+----
+1
+
+query I
+SELECT id FROM lake.t2
+----
+42
+
+# once the last reference goes away the file is cleaned up as before
+statement ok
+DROP TABLE lake.t2
+
+statement ok
+CALL ducklake_expire_snapshots('lake', older_than => NOW())
+
+statement ok
+CALL ducklake_cleanup_old_files('lake', cleanup_all => true)
+
+query I
+SELECT COUNT(*) FROM GLOB('{DATA_PATH}/cleanup_shared_file.parquet')
+----
+0

--- a/test/sql/remove_orphans/cleanup_shared_data_file.test
+++ b/test/sql/remove_orphans/cleanup_shared_data_file.test
@@ -63,3 +63,39 @@ query I
 SELECT COUNT(*) FROM GLOB('{DATA_PATH}/cleanup_shared_file.parquet')
 ----
 0
+
+# the two entries do not have to store the same path - the same file can be added through paths that only
+# match once they are canonicalized
+statement ok
+COPY (SELECT 7 AS id) TO '{DATA_PATH}/cleanup_mixed_path.parquet' (FORMAT parquet)
+
+statement ok
+CREATE TABLE lake.m1(id INTEGER)
+
+statement ok
+CREATE TABLE lake.m2(id INTEGER)
+
+statement ok
+CALL ducklake_add_data_files('lake', 'm1', '{DATA_PATH}/cleanup_mixed_path.parquet')
+
+statement ok
+CALL ducklake_add_data_files('lake', 'm2', '{DATA_PATH}/./cleanup_mixed_path.parquet')
+
+statement ok
+DROP TABLE lake.m1
+
+statement ok
+CALL ducklake_expire_snapshots('lake', older_than => NOW())
+
+statement ok
+CALL ducklake_cleanup_old_files('lake', cleanup_all => true)
+
+query I
+SELECT COUNT(*) FROM GLOB('{DATA_PATH}/cleanup_mixed_path.parquet')
+----
+1
+
+query I
+SELECT id FROM lake.m2
+----
+7


### PR DESCRIPTION
## Problem

A Parquet file can be referenced by more than one `ducklake_data_file` entry — most easily by calling
`ducklake_add_data_files` with the same external file for two tables. Cleanup does not account for that:
`ducklake_expire_snapshots` collects the data file entries that are no longer reachable and schedules
**their paths** for physical deletion, without checking whether a surviving entry still points at the same
file. The file is then deleted from disk by `ducklake_cleanup_old_files` while it is still live for the
other table, which loses the data:

```sql
COPY (SELECT 42 AS id) TO 'shared.parquet';
CREATE TABLE lake.t1(id INTEGER);
CREATE TABLE lake.t2(id INTEGER);
CALL ducklake_add_data_files('lake', 't1', 'shared.parquet');
CALL ducklake_add_data_files('lake', 't2', 'shared.parquet');

DROP TABLE lake.t1;
CALL ducklake_expire_snapshots('lake', older_than => NOW());
CALL ducklake_cleanup_old_files('lake', cleanup_all => true);

SELECT id FROM lake.t2;  -- IO Error: No files found that match the pattern "shared.parquet"
```

## Fix

The metadata entries are still removed exactly as before — only the physical deletion is skipped for a
path that another entry, which is not itself being cleaned up, still points at. `GetStillReferencedFiles`
does that check in one query over the entries being cleaned up. Relative paths are resolved against the
table they belong to, so those only match within the same table; absolute paths match across tables.

The last reference behaves as it always did: once `t2` is dropped and expired, the file is scheduled and
deleted.

## Test

`test/sql/remove_orphans/cleanup_shared_data_file.test` covers both halves: the file survives while `t2`
still references it (and `t2` stays readable), and it is deleted once the last reference goes away. Red
before the change — the file is deleted and the read fails — green after.

The full suite passes on this branch: 16207 assertions in 457 test cases (16 skipped for missing
httpfs / postgres_scanner / sqlite_scanner / spatial).

## Note

Delete files are scheduled through a separate path and are not covered here; I have not found a way to
share one delete file between tables, but if you know of one I am happy to extend the same check to it.