### PR TITLE
feat: Allow reading arbitrary comment keys

### DIFF
--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -548,12 +548,16 @@ unique_ptr<DuckLakeCatalogSet> DuckLakeCatalog::LoadSchemaForSnapshot(DuckLakeTr
 				not_null_columns.insert(col_info.name);
 			}
 			ColumnDefinition column(Identifier(std::move(col_info.name)), field_id->Type());
+			InsertionOrderPreservingMap<string> column_tags;
 			for (auto &tag : col_info.tags) {
 				if (tag.key == "comment") {
 					column.SetComment(tag.value);
 				} else {
-					column.tags[tag.key] = tag.value;
+					column_tags.insert(tag.key, tag.value);
 				}
+			}
+			if (!column_tags.empty()) {
+				column.SetTags(std::move(column_tags));
 			}
 			auto default_val = field_id->GetDefault();
 			if (default_val) {

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -552,7 +552,7 @@ unique_ptr<DuckLakeCatalogSet> DuckLakeCatalog::LoadSchemaForSnapshot(DuckLakeTr
 				if (tag.key == "comment") {
 					column.SetComment(tag.value);
 				} else {
-					throw NotImplementedException("Only comment tags are supported for columns currently");
+					column.tags[tag.key] = tag.value;
 				}
 			}
 			auto default_val = field_id->GetDefault();

--- a/test/sql/comments/load_non_comment_tags.test
+++ b/test/sql/comments/load_non_comment_tags.test
@@ -1,0 +1,38 @@
+# name: test/sql/comments/load_non_comment_tags.test
+# description: Loading a catalog with non-comment tags on tables and columns should not fail
+# group: [comments]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/load_non_comment_tags.db' AS ducklake (DATA_PATH '{TEST_DIR}/load_non_comment_tags/')
+
+statement ok
+CREATE TABLE ducklake.tbl (i INT);
+
+# manually insert non-comment tags on the table and on column i, alongside comments
+statement ok
+INSERT INTO __ducklake_metadata_ducklake.ducklake_tag VALUES (1, 2, NULL, 'owner', 'alice'), (1, 2, NULL, 'comment', 'table comment');
+
+statement ok
+INSERT INTO __ducklake_metadata_ducklake.ducklake_column_tag VALUES (1, 0, 2, NULL, 'pii', 'true'), (1, 0, 2, NULL, 'comment', 'col comment');
+
+# force a fresh catalog load - this previously threw for the non-comment column tag
+statement ok
+DETACH ducklake;
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/load_non_comment_tags.db' AS ducklake (DATA_PATH '{TEST_DIR}/load_non_comment_tags/')
+
+# the catalog loads and the comments are surfaced as comments
+query II
+SELECT table_name, comment FROM duckdb_tables() WHERE database_name='ducklake';
+----
+tbl	table comment
+
+query II
+SELECT column_name, comment FROM duckdb_columns() WHERE database_name='ducklake' AND table_name='tbl';
+----
+i	col comment


### PR DESCRIPTION
# Motivation

External tools might want to set arbitrary metadata on columns & tables. Currently, the ducklake extension only allows for the `"comment"` key. Afaict, this restriction is not strictly necessary even if no other key can currently be modified with this extension.