### PR TITLE
Respect preserve_insertion_order when planning DuckLake writes

### DIFF
--- a/src/storage/ducklake_insert.cpp
+++ b/src/storage/ducklake_insert.cpp
@@ -718,7 +718,14 @@ PhysicalOperator &DuckLakeInsert::PlanCopyForInsert(ClientContext &context, Phys
 	physical_copy.partition_columns = std::move(copy_options.partition_columns);
 	physical_copy.names = copy_options.names;
 	physical_copy.expected_types = std::move(copy_options.expected_types);
-	physical_copy.parallel = true;
+	// a fully parallel copy interleaves row groups and loses the input order
+	const bool preserve_insertion_order = plan ? PhysicalPlanGenerator::PreserveInsertionOrder(context, *plan) : false;
+	// no batch index: PhysicalBatchCopyToFile does not support the options set above
+	auto execution_mode = CopyFunctionExecutionMode::PARALLEL_COPY_TO_FILE;
+	if (physical_copy.function.execution_mode) {
+		execution_mode = physical_copy.function.execution_mode(preserve_insertion_order, false);
+	}
+	physical_copy.parallel = execution_mode == CopyFunctionExecutionMode::PARALLEL_COPY_TO_FILE;
 	physical_copy.hive_file_pattern =
 	    copy_input.catalog.UseHiveFilePattern(!is_encrypted, copy_input.schema_id, copy_input.table_id);
 	if (plan) {


### PR DESCRIPTION
Fixes #1356.

PlanCopyForInsert hardcoded PhysicalCopyToFile::parallel = true, so DuckLake writes always took the fully parallel copy path. That path interleaves row groups from multiple threads and discards the input order, which is exactly the behaviour parquet's ParquetWriteExecutionMode reserves for preserve_insertion_order = false. As a result CREATE TABLE AS lost the input order even with the setting at its default of true, silently, and only once the reader went parallel.

Derive the flag from the copy function's execution_mode callback instead, the same way core does in plan_copy_to_file.cpp. supports_batch_index is passed as false because the options set here (per_thread_output, file_size_bytes, partition_output) are not supported by PhysicalBatchCopyToFile, so an order-preserving write falls back to REGULAR_COPY_TO_FILE and runs single threaded. Keeping order and write parallelism together would need batch index support in the partitioning and rotating writer, which is a larger change.

Repro, 8,000,000 row CSV with id ascending in file order, default threads:

```sql
SET preserve_insertion_order = true;
CREATE TABLE t AS SELECT * FROM read_csv('f.csv');
```

Reading back single threaded, 7,877,120 of 8,000,000 rows were not stored in input order before this change, and 0 after. A native DuckDB table stores 0 out of order with the same statement, which is the asymmetry that pointed here. With preserve_insertion_order = false the parallel path is unchanged.

Tested on a source build of main (7c0eafc8) against the pinned duckdb (c97bd8b9), macOS 26.2 arm64, 10 cores.

I have not added a test. The disorder only appears above roughly 500,000 rows, so a fixture large enough to catch it means generating a multi-megabyte CSV, which seemed too slow for the suite. Happy to add one if you want it, or to put it somewhere other than sqllogictest.