### PR TITLE
Pin schema cache entries for the transaction lifetime

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -78,10 +78,9 @@ struct DuckLakeSchemaCacheEntry : public ObjectCacheEntry {
 	optional_idx GetEstimatedCacheMemory() const override;
 };
 
-//! Query-scoped pin for DuckLake schema cache entries, which guarantee memory safety before transaction finishes.
-class DuckLakeSchemaPinState : public ClientContextState {
+//! Holds pins on DuckLake schema cache entries, keeping them alive while they are still referenced.
+class DuckLakeSchemaPinState {
 public:
-	void QueryEnd(ClientContext &context) override;
 	void Pin(shared_ptr<DuckLakeSchemaCacheEntry> entry);
 	//! Clear all pinned schema cache entries for this pin state.
 	void Clear();
@@ -312,12 +311,9 @@ private:
 	//! Look up (or load) the ObjectCache entry for a given snapshot.
 	shared_ptr<DuckLakeSchemaCacheEntry> GetSchemaCacheEntry(DuckLakeTransaction &transaction,
 	                                                         DuckLakeSnapshot snapshot);
-	//! Pin a schema cache entry for the duration of the current query to ensure safe memory access.
-	void PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry);
 	void LoadNameMaps(DuckLakeTransaction &transaction);
 	string StatsCacheKey(idx_t next_file_id, TableIndex table_id) const;
 	string SchemaCacheKey(idx_t schema_version) const;
-	string SchemaPinStateKey() const;
 	ObjectCache &GetObjectCacheInstance();
 
 private:

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -203,10 +203,14 @@ public:
 	unique_ptr<QueryResult> ExecuteRaw(string query);
 	Connection &GetConnection();
 
+	//! Keep a schema cache entry alive for as long as this transaction lives. Transaction-local catalog entries hold
+	//! bare references into the cached catalog set, and those references are read again at commit time, so the entry
+	//! must not be evicted from the ObjectCache in between.
+	void PinSchemaCacheEntry(shared_ptr<DuckLakeSchemaCacheEntry> entry);
+
 	DuckLakeSnapshot GetSnapshot();
 	DuckLakeSnapshot GetSnapshot(optional_ptr<BoundAtClause> at_clause,
 	                             SnapshotBound bound = SnapshotBound::UPPER_BOUND);
-	void PinSchemaCacheEntry(shared_ptr<DuckLakeSchemaCacheEntry> entry);
 
 	static DuckLakeTransaction &Get(ClientContext &context, Catalog &catalog);
 

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -166,10 +166,6 @@ optional_idx DuckLakeSchemaCacheEntry::GetEstimatedCacheMemory() const {
 	return EstimateCatalogSetMemory(catalog_set);
 }
 
-void DuckLakeSchemaPinState::QueryEnd(ClientContext &context) {
-	Clear();
-}
-
 void DuckLakeSchemaPinState::Clear() {
 	lock_guard<mutex> guard(lock);
 	pins.clear();
@@ -369,22 +365,9 @@ shared_ptr<DuckLakeSchemaCacheEntry> DuckLakeCatalog::GetSchemaCacheEntry(DuckLa
 
 DuckLakeCatalogSet &DuckLakeCatalog::GetSchemaForSnapshot(DuckLakeTransaction &transaction, DuckLakeSnapshot snapshot) {
 	auto entry = GetSchemaCacheEntry(transaction, snapshot);
-	transaction.PinSchemaCacheEntry(entry);
-	PinSchemaForQuery(transaction, entry);
-	return entry->catalog_set;
-}
-
-void DuckLakeCatalog::PinSchemaForQuery(DuckLakeTransaction &transaction, shared_ptr<DuckLakeSchemaCacheEntry> entry) {
-	if (!entry) {
-		return;
-	}
-	auto context_ref = transaction.context.lock();
-	if (!context_ref) {
-		return;
-	}
-	auto &registered = *context_ref->registered_state;
-	auto pin_state = registered.GetOrCreate<DuckLakeSchemaPinState>(SchemaPinStateKey());
-	pin_state->Pin(std::move(entry));
+	auto &catalog_set = entry->catalog_set;
+	transaction.PinSchemaCacheEntry(std::move(entry));
+	return catalog_set;
 }
 
 static unique_ptr<DuckLakeFieldId> TransformColumnType(DuckLakeColumnInfo &col) {
@@ -1136,10 +1119,6 @@ void DuckLakeCatalog::InvalidateSchemaCache(idx_t schema_version) {
 void DuckLakeCatalog::InvalidateNameMapCache(MappingIndex mapping_id) {
 	lock_guard<mutex> guard(name_maps_lock);
 	name_maps.Remove(mapping_id);
-}
-
-string DuckLakeCatalog::SchemaPinStateKey() const {
-	return StringUtil::Format("ducklake_schema_pin:%s:%s:%s", GetName(), MetadataPath(), instance_id);
 }
 
 ObjectCache &DuckLakeCatalog::GetObjectCacheInstance() {

--- a/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
+++ b/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
@@ -1,0 +1,48 @@
+# name: test/sql/issues/issue_1248_concurrent_commit_schema_id.test
+# description: https://github.com/duckdb/ducklake/issues/1248 - concurrent transactions must commit their new tables into the right schema
+# group: [issues]
+
+require notwindows
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+
+test-env DATA_PATH __TEST_DIR__
+
+statement ok
+ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/issue_1248')
+
+statement ok
+SET memory_limit='2GB'
+
+# Committing used to pick up a bogus schema id when another transaction committed in the meantime.
+concurrentloop threadid 0 8
+
+loop i 0 5
+
+statement ok
+BEGIN
+
+statement ok
+CREATE OR REPLACE TABLE ducklake.t_${threadid}_${i} AS SELECT r AS id, r % 100 AS grp FROM range(1000) t(r)
+
+statement ok
+COMMIT
+
+endloop
+
+endloop
+
+query I
+SELECT count(*) FROM duckdb_tables() WHERE database_name='ducklake'
+----
+40
+
+# The tables must have landed in a schema we can still reach them through.
+query I
+SELECT count(*) FROM ducklake.t_0_0
+----
+1000

--- a/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
+++ b/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
@@ -8,12 +8,12 @@ require ducklake
 
 require parquet
 
-test-env DUCKLAKE_CONNECTION __TEST_DIR__/{UUID}.db
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
 
-test-env DATA_PATH __TEST_DIR__
+test-env DATA_PATH {TEST_DIR}
 
 statement ok
-ATTACH 'ducklake:${DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '${DATA_PATH}/issue_1248')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_1248')
 
 statement ok
 SET memory_limit='2GB'
@@ -27,7 +27,7 @@ statement ok
 BEGIN
 
 statement ok
-CREATE OR REPLACE TABLE ducklake.t_${threadid}_${i} AS SELECT r AS id, r % 100 AS grp FROM range(1000) t(r)
+CREATE OR REPLACE TABLE ducklake.t_{threadid}_{i} AS SELECT r AS id, r % 100 AS grp FROM range(1000) t(r)
 
 statement ok
 COMMIT

--- a/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
+++ b/test/sql/issues/issue_1248_concurrent_commit_schema_id.test
@@ -18,6 +18,11 @@ ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issu
 statement ok
 SET memory_limit='2GB'
 
+# Concurrent commits can legitimately collide on metadata IDs. Keep retry exhaustion from masking
+# the schema-cache lifetime regression this test targets.
+statement ok
+SET ducklake_max_retry_count=100
+
 # Committing used to pick up a bogus schema id when another transaction committed in the meantime.
 concurrentloop threadid 0 8
 

--- a/test/sql/view/view_schema_cache_eviction.test_slow
+++ b/test/sql/view/view_schema_cache_eviction.test_slow
@@ -1,0 +1,131 @@
+# name: test/sql/view/view_schema_cache_eviction.test_slow
+# description: test that a view created in a long-running transaction lands in the right schema under memory pressure
+# group: [view]
+
+require ducklake
+
+require parquet
+
+# con1 creates a view and holds its transaction open while con2 churns the schema under a low memory
+# limit. The view must still land in its own schema when con1 finally commits.
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/view_schema_cache.db' AS ducklake (DATA_PATH '__TEST_DIR__/view_schema_cache_files', METADATA_CATALOG 'metadata')
+
+# Several schemas, so a misfiled view has somewhere else to land.
+statement ok
+CREATE SCHEMA ducklake.target
+
+loop i 0 8
+
+statement ok
+CREATE SCHEMA ducklake.filler_${i}
+
+endloop
+
+# Many tables, so each cached copy of the schema is big enough to be evicted under the memory limit.
+loop i 0 100
+
+statement ok
+CREATE TABLE ducklake.t${i} (id INTEGER, a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
+
+endloop
+
+# A single table that we'll ALTER to churn the schema.
+statement ok
+CREATE TABLE ducklake.churn (id INTEGER)
+
+# Disable temp_directory so DuckDB cannot spill blocks for temporary tables to disk.
+# This directs the memory pressure below onto the cached schemas instead.
+statement ok
+SET temp_directory=''
+
+statement ok
+SET memory_limit='100MB'
+
+# con1 creates a view in `target` and leaves the transaction open.
+statement ok con1
+BEGIN
+
+statement ok con1
+CREATE VIEW ducklake.target.v1 AS SELECT 42 AS i
+
+# Phase 1: con2 churns the schema, so the version con1 read is no longer the current one.
+loop i 0 30
+
+statement ok con2
+ALTER TABLE ducklake.churn ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+
+statement ok con2
+SELECT COUNT(*) FROM ducklake.churn
+
+endloop
+
+# Phase 2: allocate blocks that cannot be spilled, so the schema con1 read is evicted from the cache.
+statement ok con2
+CREATE TEMP TABLE mem_filler(i INTEGER, pad VARCHAR)
+
+loop j 0 3
+
+statement ok con2
+INSERT INTO mem_filler SELECT i + ${j} * 5000, repeat('x', 1000) FROM range(5000) t(i)
+
+endloop
+
+# Phase 3: more churn, so the memory the evicted copy occupied is reused.
+loop i 30 400
+
+statement ok con2
+ALTER TABLE ducklake.churn ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+
+statement ok con2
+SELECT COUNT(*) FROM ducklake.churn
+
+endloop
+
+# con1 commits, long after the schema it read was evicted.
+statement ok con1
+COMMIT
+
+# The view must be recorded against `target`.
+query II
+SELECT s.schema_name, v.view_name
+FROM metadata.ducklake_view v
+JOIN metadata.ducklake_schema s ON s.schema_id = v.schema_id
+WHERE v.end_snapshot IS NULL
+----
+target	v1
+
+query II
+SELECT schema_name, view_name FROM duckdb_views() WHERE database_name='ducklake'
+----
+target	v1
+
+query I
+SELECT * FROM ducklake.target.v1
+----
+42
+
+# No live view may point at a dropped schema, otherwise the catalog fails to load.
+query I
+SELECT COUNT(*)
+FROM metadata.ducklake_view v
+WHERE v.end_snapshot IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM metadata.ducklake_schema s
+    WHERE s.schema_id = v.schema_id AND s.end_snapshot IS NULL
+  )
+----
+0
+
+# Reloading the catalog from scratch must find the view again.
+statement ok
+DETACH ducklake
+
+statement ok
+ATTACH 'ducklake:__TEST_DIR__/view_schema_cache.db' AS ducklake (DATA_PATH '__TEST_DIR__/view_schema_cache_files')
+
+query I
+SELECT * FROM ducklake.target.v1
+----
+42

--- a/test/sql/view/view_schema_cache_eviction.test_slow
+++ b/test/sql/view/view_schema_cache_eviction.test_slow
@@ -10,7 +10,7 @@ require parquet
 # limit. The view must still land in its own schema when con1 finally commits.
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/view_schema_cache.db' AS ducklake (DATA_PATH '__TEST_DIR__/view_schema_cache_files', METADATA_CATALOG 'metadata')
+ATTACH 'ducklake:{TEST_DIR}/view_schema_cache.db' AS ducklake (DATA_PATH '{TEST_DIR}/view_schema_cache_files', METADATA_CATALOG 'metadata')
 
 # Several schemas, so a misfiled view has somewhere else to land.
 statement ok
@@ -19,7 +19,7 @@ CREATE SCHEMA ducklake.target
 loop i 0 8
 
 statement ok
-CREATE SCHEMA ducklake.filler_${i}
+CREATE SCHEMA ducklake.filler_{i}
 
 endloop
 
@@ -27,7 +27,7 @@ endloop
 loop i 0 100
 
 statement ok
-CREATE TABLE ducklake.t${i} (id INTEGER, a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
+CREATE TABLE ducklake.t{i} (id INTEGER, a INTEGER, b INTEGER, c INTEGER, d INTEGER, e INTEGER)
 
 endloop
 
@@ -54,7 +54,7 @@ CREATE VIEW ducklake.target.v1 AS SELECT 42 AS i
 loop i 0 30
 
 statement ok con2
-ALTER TABLE ducklake.churn ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+ALTER TABLE ducklake.churn ADD COLUMN col_{i} INTEGER DEFAULT {i}
 
 statement ok con2
 SELECT COUNT(*) FROM ducklake.churn
@@ -68,7 +68,7 @@ CREATE TEMP TABLE mem_filler(i INTEGER, pad VARCHAR)
 loop j 0 3
 
 statement ok con2
-INSERT INTO mem_filler SELECT i + ${j} * 5000, repeat('x', 1000) FROM range(5000) t(i)
+INSERT INTO mem_filler SELECT i + {j} * 5000, repeat('x', 1000) FROM range(5000) t(i)
 
 endloop
 
@@ -76,7 +76,7 @@ endloop
 loop i 30 400
 
 statement ok con2
-ALTER TABLE ducklake.churn ADD COLUMN col_${i} INTEGER DEFAULT ${i}
+ALTER TABLE ducklake.churn ADD COLUMN col_{i} INTEGER DEFAULT {i}
 
 statement ok con2
 SELECT COUNT(*) FROM ducklake.churn
@@ -123,7 +123,7 @@ statement ok
 DETACH ducklake
 
 statement ok
-ATTACH 'ducklake:__TEST_DIR__/view_schema_cache.db' AS ducklake (DATA_PATH '__TEST_DIR__/view_schema_cache_files')
+ATTACH 'ducklake:{TEST_DIR}/view_schema_cache.db' AS ducklake (DATA_PATH '{TEST_DIR}/view_schema_cache_files')
 
 query I
 SELECT * FROM ducklake.target.v1


### PR DESCRIPTION
Addresses #1248.

DuckLake catalog entries keep bare references to their parent schemas and may read them again at commit time. Because those schemas live in evictable cache entries, the entries must stay alive for the full transaction.

`main` already pins schema cache entries on `DuckLakeTransaction`. This PR removes the now-redundant query-scoped pin.