### PR TITLE
fix: make transient & typed conflicts retryable

### DIFF
--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -16,6 +16,7 @@
 namespace duckdb {
 
 ScalarFunction DuckLakeMurmur3Function();
+ScalarFunctionSet DuckLakeWouldRetryFunction();
 
 static void LoadInternal(ExtensionLoader &loader) {
 	loader.SetDescription("Adds support for DuckLake, SQL as a Lakehouse Format");
@@ -124,6 +125,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Register murmur3_32 scalar function for Iceberg-compatible bucket partitioning
 	auto murmur3_func = DuckLakeMurmur3Function();
 	loader.RegisterFunction(murmur3_func);
+
+	auto would_retry_func = DuckLakeWouldRetryFunction();
+	loader.RegisterFunction(would_retry_func);
 }
 
 void DucklakeExtension::Load(ExtensionLoader &loader) {

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library(
   ducklake_table_changes.cpp
   ducklake_table_info.cpp
   ducklake_table_insertions.cpp
-  ducklake_murmur3.cpp)
+  ducklake_murmur3.cpp
+  ducklake_retry_classification.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_functions>
     PARENT_SCOPE)

--- a/src/functions/ducklake_retry_classification.cpp
+++ b/src/functions/ducklake_retry_classification.cpp
@@ -1,0 +1,34 @@
+#include "storage/ducklake_transaction.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+static void WouldRetryFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto count = args.size();
+	auto &message_vec = args.data[0];
+	if (args.ColumnCount() == 1) {
+		UnaryExecutor::Execute<string_t, bool>(message_vec, result, count, [&](string_t message) {
+			return DuckLakeTransaction::RetryOnError(message.GetString());
+		});
+		return;
+	}
+	auto &type_vec = args.data[1];
+	BinaryExecutor::Execute<string_t, string_t, bool>(
+	    message_vec, type_vec, result, count, [&](string_t message, string_t type_name) {
+		    auto type = Exception::StringToExceptionType(type_name.GetString());
+		    return DuckLakeTransaction::RetryOnError(message.GetString(), type);
+	    });
+}
+
+ScalarFunctionSet DuckLakeWouldRetryFunction() {
+	ScalarFunctionSet set("ducklake_would_retry");
+	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::BOOLEAN, WouldRetryFunction));
+	set.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, WouldRetryFunction));
+	return set;
+}
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -195,6 +195,8 @@ public:
 
 	//! Returns true if `message` indicates a retryable conflict (PK/unique/conflict/concurrent).
 	static bool RetryOnError(const string &message);
+	//! As above, but also treats ExceptionType::TRANSACTION as a conflict.
+	static bool RetryOnError(const string &message, ExceptionType type);
 
 	DuckLakeCatalog &GetCatalog() {
 		return ducklake_catalog;

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -188,6 +188,8 @@ public:
 
 	//! Returns true if `message` indicates a retryable conflict (PK/unique/conflict/concurrent).
 	static bool RetryOnError(const string &message);
+	//! As above, but also treats ExceptionType::TRANSACTION as a conflict.
+	static bool RetryOnError(const string &message, ExceptionType type);
 
 	DuckLakeCatalog &GetCatalog() {
 		return ducklake_catalog;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1337,17 +1337,35 @@ DuckLakeDeleteFileInfo DuckLakeTransaction::GetNewDeleteFile(TableIndex table_id
 }
 
 bool DuckLakeTransaction::RetryOnError(const string &original_message) {
+	return RetryOnError(original_message, ExceptionType::INVALID);
+}
+
+bool DuckLakeTransaction::RetryOnError(const string &original_message, ExceptionType type) {
+	// DuckLake's own conflicts are typed; backend errors cross back untyped and fall through to
+	// the message checks below.
+	if (type == ExceptionType::TRANSACTION) {
+		return true;
+	}
 	auto message = StringUtil::Lower(original_message);
-	// retry on primary key errors
 	if (StringUtil::Contains(message, "primary key") || StringUtil::Contains(message, "unique")) {
 		return true;
 	}
-	// retry on conflicts
 	if (StringUtil::Contains(message, "conflict")) {
 		return true;
 	}
-	// retry on concurrent access
 	if (StringUtil::Contains(message, "concurrent")) {
+		return true;
+	}
+	// postgres 40001 serialization failure, 40P01 deadlock
+	if (StringUtil::Contains(message, "could not serialize")) {
+		return true;
+	}
+	if (StringUtil::Contains(message, "deadlock")) {
+		return true;
+	}
+	// dropped mid-commit: outcome unknown, re-attempt under the conflict check
+	if (StringUtil::Contains(message, "server closed the connection") ||
+	    StringUtil::Contains(message, "connection to server") || StringUtil::Contains(message, "connection reset")) {
 		return true;
 	}
 	return false;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1358,17 +1358,35 @@ DuckLakeDeleteFileInfo DuckLakeTransaction::GetNewDeleteFile(TableIndex table_id
 }
 
 bool DuckLakeTransaction::RetryOnError(const string &original_message) {
+	return RetryOnError(original_message, ExceptionType::INVALID);
+}
+
+bool DuckLakeTransaction::RetryOnError(const string &original_message, ExceptionType type) {
+	// DuckLake's own conflicts are typed; backend errors cross back untyped and fall through to
+	// the message checks below.
+	if (type == ExceptionType::TRANSACTION) {
+		return true;
+	}
 	auto message = StringUtil::Lower(original_message);
-	// retry on primary key errors
 	if (StringUtil::Contains(message, "primary key") || StringUtil::Contains(message, "unique")) {
 		return true;
 	}
-	// retry on conflicts
 	if (StringUtil::Contains(message, "conflict")) {
 		return true;
 	}
-	// retry on concurrent access
 	if (StringUtil::Contains(message, "concurrent")) {
+		return true;
+	}
+	// postgres 40001 serialization failure, 40P01 deadlock
+	if (StringUtil::Contains(message, "could not serialize")) {
+		return true;
+	}
+	if (StringUtil::Contains(message, "deadlock")) {
+		return true;
+	}
+	// dropped mid-commit: outcome unknown, re-attempt under the conflict check
+	if (StringUtil::Contains(message, "server closed the connection") ||
+	    StringUtil::Contains(message, "connection to server") || StringUtil::Contains(message, "connection reset")) {
 		return true;
 	}
 	return false;

--- a/test/sql/settings/retry_classification.test
+++ b/test/sql/settings/retry_classification.test
@@ -1,0 +1,96 @@
+# name: test/sql/settings/retry_classification.test
+# description: RetryOnError classification is a superset of prior behavior + adds transient categories + type-guards DuckLake conflicts
+# group: [settings]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/retry_classification_files')
+
+# 2.1 Superset regression: every message retriable before this change is still retriable.
+query I
+SELECT ducklake_would_retry('violates primary key constraint')
+----
+true
+
+query I
+SELECT ducklake_would_retry('duplicate key value violates unique constraint')
+----
+true
+
+query I
+SELECT ducklake_would_retry('Transaction conflict - attempting to insert')
+----
+true
+
+query I
+SELECT ducklake_would_retry('concurrent update detected')
+----
+true
+
+# 2.2 New transient categories (none contains a prior broad substring, so today they fail permanently).
+query I
+SELECT ducklake_would_retry('ERROR: could not serialize access')
+----
+true
+
+query I
+SELECT ducklake_would_retry('deadlock detected')
+----
+true
+
+query I
+SELECT ducklake_would_retry('server closed the connection unexpectedly')
+----
+true
+
+query I
+SELECT ducklake_would_retry('could not connect to server: connection to server at localhost failed')
+----
+true
+
+query I
+SELECT ducklake_would_retry('connection reset by peer')
+----
+true
+
+# 2.3 Type-guard: a TransactionException (ExceptionType::TRANSACTION -> text "TransactionContext")
+# is a conflict by TYPE, independent of wording.
+query I
+SELECT ducklake_would_retry('some message with no retriable words', 'TransactionContext')
+----
+true
+
+# The same non-retriable message WITHOUT the transaction type is classified by string only -> not retriable.
+# This proves the type branch is additive, not a gate that swallows the string path.
+query I
+SELECT ducklake_would_retry('some message with no retriable words', 'Invalid')
+----
+false
+
+query I
+SELECT ducklake_would_retry('some message with no retriable words')
+----
+false
+
+# 2.4 Negative: unrelated fatal errors with none of the retriable signals -> not retriable.
+query I
+SELECT ducklake_would_retry('Parser Error: syntax error at or near "slect"')
+----
+false
+
+query I
+SELECT ducklake_would_retry('Permission denied for relation foo')
+----
+false
+
+query I
+SELECT ducklake_would_retry('Out of Memory Error: could not allocate block')
+----
+false


### PR DESCRIPTION
Part of #1094 resolution

## Problem

Currently some retries rely on string-matching, even the ducklake `TransactionException` and some transient background failures like deadlocks, dropped connections, etc., are not considered retryable

## Fix

Added a typed `RetryOnError` overload that classifies a transaction by type. It also includes the transient pg exceptions. current callers remain unchanged. also added `ducklake_would_retry()` for testability.
