### PR TITLE
Add newer_than option to ducklake_merge_adjacent_files

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -292,6 +292,7 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 	filter_options.min_file_size = options.min_file_size;
 	filter_options.max_file_size = options.max_file_size;
 	filter_options.target_file_size = target_file_size;
+	filter_options.newer_than = options.newer_than;
 	// FIXME: pass in the sort_data so that list of files is approximately sorted in the same way
 	// (sorted by the min/max metadata)
 	auto files = metadata_manager.GetFilesForCompaction(table, type, delete_threshold, snapshot, filter_options);
@@ -784,12 +785,13 @@ static void GenerateCompaction(ClientContext &context, DuckLakeTransaction &tran
                                DuckLakeCatalog &ducklake_catalog, TableFunctionBindInput &input,
                                DuckLakeTableEntry &cur_table, CompactionType type, double delete_threshold,
                                uint64_t max_files, optional_idx min_file_size, optional_idx max_file_size,
-                               vector<unique_ptr<LogicalOperator>> &compactions) {
+                               const Value &newer_than, vector<unique_ptr<LogicalOperator>> &compactions) {
 	switch (type) {
 	case CompactionType::MERGE_ADJACENT_TABLES: {
 		DuckLakeMergeAdjacentOptions options;
 		options.min_file_size = min_file_size;
 		options.max_file_size = max_file_size;
+		options.newer_than = newer_than;
 		DuckLakeCompactor compactor(context, ducklake_catalog, transaction, *input.binder, cur_table.GetTableId(),
 		                            max_files, options);
 		compactor.GenerateCompactions(cur_table, compactions);
@@ -871,6 +873,15 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 		throw BinderException("The min_file_size must be less than max_file_size.");
 	}
 
+	Value newer_than;
+	auto newer_than_entry = input.named_parameters.find("newer_than");
+	if (newer_than_entry != input.named_parameters.end()) {
+		if (newer_than_entry->second.IsNull()) {
+			throw BinderException("The newer_than option must be a non-null timestamp.");
+		}
+		newer_than = newer_than_entry->second;
+	}
+
 	if (input.inputs.size() == 1) {
 		// No default schema/table, we will perform rewrites on deletes in the whole database
 		auto schemas = ducklake_catalog.GetSchemas(context);
@@ -883,7 +894,8 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 					                                             cur_table.GetTableId(), "true") == "true") {
 						auto delete_threshold = GetDeleteThreshold(&dl_cur_schema, cur_table, ducklake_catalog, input);
 						GenerateCompaction(context, transaction, ducklake_catalog, input, cur_table, type,
-						                   delete_threshold, max_files, min_file_size, max_file_size, compactions);
+						                   delete_threshold, max_files, min_file_size, max_file_size, newer_than,
+						                   compactions);
 					}
 				}
 			});
@@ -918,7 +930,7 @@ unique_ptr<LogicalOperator> BindCompaction(ClientContext &context, TableFunction
 	if (auto_compact) {
 		auto delete_threshold = GetDeleteThreshold(dl_schema, ducklake_table, ducklake_catalog, input);
 		GenerateCompaction(context, transaction, ducklake_catalog, input, ducklake_table, type, delete_threshold,
-		                   max_files, min_file_size, max_file_size, compactions);
+		                   max_files, min_file_size, max_file_size, newer_than, compactions);
 	}
 
 	return GenerateCompactionOperator(input, bind_index, compactions);
@@ -942,6 +954,7 @@ TableFunctionSet DuckLakeMergeAdjacentFilesFunction::GetFunctions() {
 		function.named_parameters["min_file_size"] = LogicalType::UBIGINT;
 		function.named_parameters["max_file_size"] = LogicalType::UBIGINT;
 		function.named_parameters["max_compacted_files"] = LogicalType::UBIGINT;
+		function.named_parameters["newer_than"] = LogicalType::TIMESTAMP_TZ;
 		if (type.size() == 2) {
 			function.named_parameters["schema"] = LogicalType::VARCHAR;
 		}

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -513,12 +513,16 @@ struct DuckLakeCompactedFileInfo {
 struct DuckLakeMergeAdjacentOptions {
 	optional_idx min_file_size;
 	optional_idx max_file_size;
+	//! If set, only files written at or after this timestamp are considered for compaction
+	Value newer_than;
 };
 
 struct DuckLakeFileSizeOptions {
 	optional_idx min_file_size;
 	optional_idx max_file_size;
 	idx_t target_file_size;
+	//! If set, only files written at or after this timestamp are considered for compaction
+	Value newer_than;
 };
 
 struct DuckLakeTableSizeInfo {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1,5 +1,6 @@
 #include "storage/ducklake_metadata_manager.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "functions/ducklake_table_functions.hpp"
 #include "storage/ducklake_transaction.hpp"
 #include "storage/ducklake_variant_stats.hpp"
 #include "common/ducklake_util.hpp"
@@ -2315,15 +2316,26 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 		// metadata-only inlined file deletions as rewrite candidates.
 		deletion_threshold_clause = " AND data.end_snapshot is null";
 	}
-	// Add file size filtering for MERGE_ADJACENT_TABLES compaction
-	string file_size_filter_clause;
+	// Add file filtering for MERGE_ADJACENT_TABLES compaction
+	string file_filter_clause;
 	if (type == CompactionType::MERGE_ADJACENT_TABLES) {
 		if (options.min_file_size.IsValid()) {
-			file_size_filter_clause +=
+			file_filter_clause +=
 			    StringUtil::Format(" AND data.file_size_bytes >= %llu", options.min_file_size.GetIndex());
 		}
-		file_size_filter_clause += StringUtil::Format(" AND data.file_size_bytes < %llu", effective_max_file_size);
-		file_size_filter_clause += " AND data.end_snapshot IS NULL";
+		file_filter_clause += StringUtil::Format(" AND data.file_size_bytes < %llu", effective_max_file_size);
+		file_filter_clause += " AND data.end_snapshot IS NULL";
+		if (!options.newer_than.IsNull()) {
+			// only consider files written at or after this timestamp - the timestamp is mapped to the first
+			// snapshot created at or after it, and files are filtered on their begin_snapshot
+			auto newer_than = options.newer_than.GetValue<timestamp_tz_t>();
+			auto timestamp_filter = DuckLakeTableFunctionUtil::FormatTimestampISO8601(timestamp_t(newer_than.value));
+			file_filter_clause +=
+			    StringUtil::Format(" AND data.begin_snapshot >= (SELECT COALESCE(MIN(snapshot_id), "
+			                       "9223372036854775807) FROM {METADATA_CATALOG}.ducklake_snapshot WHERE "
+			                       "snapshot_time::TIMESTAMPTZ >= '%s')",
+			                       timestamp_filter);
+		}
 	}
 	auto query = StringUtil::Format(R"(
 WITH snapshot_ranges AS (
@@ -2363,7 +2375,7 @@ WHERE data.table_id=%d %s%s
 ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
 		)",
 	                                table_id.index, select_list, table_id.index, table_id.index,
-	                                deletion_threshold_clause, file_size_filter_clause);
+	                                deletion_threshold_clause, file_filter_clause);
 	auto result = Query(query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get compaction file list from DuckLake: ");

--- a/test/sql/compaction/merge_adjacent_newer_than.test
+++ b/test/sql/compaction/merge_adjacent_newer_than.test
@@ -1,0 +1,120 @@
+# name: test/sql/compaction/merge_adjacent_newer_than.test
+# description: test ducklake merge adjacent files newer_than option
+# group: [compaction]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/merge_adjacent_newer_than/', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+USE ducklake;
+
+statement ok
+CREATE TABLE example (key integer, data varchar);
+
+# Batch 1: two small files
+statement ok
+INSERT INTO example SELECT i, 'batch_1' FROM range(10) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 10, 'batch_1' FROM range(10) t(i);
+
+# Create a snapshot that acts as the boundary between the two batches
+statement ok
+CREATE TABLE boundary_marker (i INTEGER);
+
+# Remember the time of the boundary snapshot - only files written from this point on qualify
+statement ok
+SET VARIABLE batch_boundary = (SELECT snapshot_time FROM ducklake_snapshots('ducklake') ORDER BY snapshot_id DESC LIMIT 1);
+
+# Batch 2: two small files written after the boundary
+statement ok
+INSERT INTO example SELECT i + 100, 'batch_2' FROM range(10) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 200, 'batch_2' FROM range(10) t(i);
+
+# We have 4 files
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+----
+4
+
+# Only files written from the boundary on are considered - the two batch-2 files are merged
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', newer_than => getvariable('batch_boundary'))
+----
+main	example	2	1
+
+# The merged file only contains the batch-2 rows - the batch-1 files are untouched
+query I
+SELECT record_count FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL ORDER BY record_count
+----
+10
+10
+20
+
+# All data is still there
+query I
+SELECT count(*) FROM example
+----
+40
+
+# A boundary in the future excludes all files - nothing to compact
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', newer_than => now()::TIMESTAMP + INTERVAL 1 DAY)
+----
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+----
+3
+
+# A boundary in the distant past includes all files - the remaining batch-1 files are merged
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', 'example', newer_than => now()::TIMESTAMP - INTERVAL 1 DAY)
+----
+main	example	3	1
+
+query I
+SELECT count(*) FROM __ducklake_metadata_ducklake.ducklake_data_file WHERE end_snapshot IS NULL
+----
+1
+
+# The catalog-wide invocation also accepts newer_than
+statement ok
+INSERT INTO example SELECT i + 300, 'batch_3' FROM range(10) t(i);
+
+statement ok
+INSERT INTO example SELECT i + 400, 'batch_3' FROM range(10) t(i);
+
+query IIII
+SELECT schema_name, table_name, files_processed, files_created FROM ducklake_merge_adjacent_files('ducklake', newer_than => now()::TIMESTAMP - INTERVAL 1 DAY)
+----
+main	example	3	1
+
+query I
+SELECT count(*) FROM example
+----
+60
+
+# Test error handling: newer_than cannot be NULL
+statement error
+CALL ducklake_merge_adjacent_files('ducklake', 'example', newer_than => NULL);
+----
+newer_than option must be a non-null timestamp
+
+# Verify data is still correct after all operations
+query II
+SELECT data, count(*) FROM example GROUP BY data ORDER BY data
+----
+batch_1	20
+batch_2	20
+batch_3	20


### PR DESCRIPTION
Implements the proposal in https://github.com/duckdb/ducklake/discussions/1362.

## What

Adds a `newer_than => TIMESTAMPTZ` named parameter to `ducklake_merge_adjacent_files`:

```sql
CALL ducklake_merge_adjacent_files('my_catalog', newer_than => now() - INTERVAL 1 DAY);
```

Only files written at or after the given timestamp are considered compaction candidates. The name mirrors the existing `older_than` option of `ducklake_expire_snapshots` / `ducklake_cleanup_old_files`.

## Why

For append-heavy time-series tables compacted on a schedule, every run currently evaluates metadata for all live files, so cost grows with total table history even though only recently written files can be new merge candidates. With `newer_than`, a cron job only pays for what changed since the last run.

## How

Since data files are immutable, the filter is on file creation time. The timestamp is mapped to the first snapshot with `snapshot_time >= newer_than`, and a `begin_snapshot >= <snapshot_id>` predicate is pushed into the catalog query in `GetFilesForCompaction` (alongside the existing file-size predicates), so historic files are never read from the metadata catalog. The boundary is inclusive, so scheduled jobs never silently skip boundary files. The timestamp handling reuses the same pattern as `ducklake_expire_snapshots(older_than => ...)`, so it works across catalog backends.
