### PR TITLE
fix: prevent concurrent inserts from losing global stats

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -37,12 +37,28 @@ public:
 
 	unique_ptr<QueryResult> Query(DuckLakeSnapshot snapshot, string &query) override;
 
+	idx_t AllocateNextSnapshotId(idx_t current_snapshot_id) override;
+	idx_t AllocateNextCatalogId(idx_t current_next_catalog_id) override;
+	idx_t AllocateNextFileId(idx_t current_next_file_id) override;
+	idx_t AllocateNextSchemaVersion(idx_t current_schema_version) override;
+	void AcquireCommitLock(const TransactionChangeInformation &changes) override;
+
+	void EnsureIdSequences() override;
+
 protected:
 	string GetLatestSnapshotQuery() const override;
 	string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) override;
 
 private:
 	unique_ptr<QueryResult> ExecuteQuery(DuckLakeSnapshot snapshot, string &query, string command);
+
+	idx_t FetchScalarSequenceValue(const string &seq_name);
+	idx_t EnsureCatalogClassid();
+	bool BootstrapObjectsPresent();
+
+	static constexpr int32_t DUCKLAKE_COMMIT_ADVISORY_SUBKEY = 0x44754C4B;
+	static constexpr int32_t DUCKLAKE_BOOTSTRAP_ADVISORY_SUBKEY = 0x42535452;
+	optional_idx catalog_classid;
 };
 
 } // namespace duckdb

--- a/src/include/metadata_manager/sqlite_metadata_manager.hpp
+++ b/src/include/metadata_manager/sqlite_metadata_manager.hpp
@@ -25,7 +25,13 @@ public:
 	bool SupportsAppender() const override {
 		return false;
 	}
-
+	//! sqlite_scanner rejects ON CONFLICT outright, so this backend keeps the pre-upsert path
+	//! and its concurrent-first-insert lost update. Lift once sqlite_scanner supports upserts.
+	bool SupportsUpsert() const override {
+		return false;
+	}
+	// No MIN/MAX override: sqlite_scanner means DuckDB parses this SQL, and DuckDB knows MIN/MAX
+	// only as aggregates. Inherited LEAST/GREATEST are correct here.
 	string GetColumnTypeInternal(const LogicalType &type) override;
 };
 

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -227,6 +227,12 @@ public:
 	void SetDuckLakeVersion(DuckLakeVersion version) {
 		ducklake_version = version;
 	}
+	//! Whether ducklake_table_column_stats has the (table_id, column_id) key the stats upsert
+	//! needs as its ON CONFLICT target (added in 1.1-dev1). A catalog pinned to an older version
+	//! has no key, so it keeps the pre-upsert write and its concurrent-first-insert lost update.
+	bool SupportsStatsUpsert() const {
+		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
+	}
 	//! Whether the metadata schema has the row_group_count columns (added in 1.1-dev1)
 	bool SupportsRowGroupCount() const {
 		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;

--- a/src/include/storage/ducklake_commit_state.hpp
+++ b/src/include/storage/ducklake_commit_state.hpp
@@ -18,6 +18,8 @@
 
 namespace duckdb {
 
+struct DuckLakeCommitContext;
+
 struct NewTableInfo {
 	vector<DuckLakeTableInfo> new_tables;
 	vector<DuckLakeViewInfo> new_views;
@@ -50,10 +52,16 @@ struct CompactionInformation {
 };
 
 struct DuckLakeCommitState {
-	explicit DuckLakeCommitState(DuckLakeSnapshot &snapshot) : commit_snapshot(snapshot) {
+	DuckLakeCommitState(DuckLakeSnapshot &snapshot, const DuckLakeCommitContext &context)
+	    : commit_snapshot(snapshot), context(context) {
 	}
 
 	DuckLakeSnapshot &commit_snapshot;
+	const DuckLakeCommitContext &context;
+
+	idx_t AllocateCatalogId() const;
+	idx_t AllocateFileId() const;
+
 	map<SchemaIndex, SchemaIndex> committed_schemas;
 	map<TableIndex, TableIndex> committed_tables;
 	map<idx_t, idx_t> committed_partition_ids;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -284,6 +284,9 @@ struct DuckLakeGlobalColumnStatsInfo {
 
 	string extra_stats;
 	bool has_extra_stats = false;
+
+	LogicalType type;
+	bool has_type = false;
 };
 
 struct DuckLakeGlobalStatsInfo {

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -186,6 +186,15 @@ public:
 	virtual string GetVersionString();
 	virtual DuckLakeMetadata LoadDuckLake();
 
+	virtual idx_t AllocateNextSnapshotId(idx_t current_snapshot_id);
+	virtual idx_t AllocateNextCatalogId(idx_t current_next_catalog_id);
+	virtual idx_t AllocateNextFileId(idx_t current_next_file_id);
+	virtual idx_t AllocateNextSchemaVersion(idx_t current_schema_version);
+	virtual void EnsureIdSequences() {
+	}
+	virtual void AcquireCommitLock(const TransactionChangeInformation &changes) {
+	}
+
 	virtual unique_ptr<QueryResult> Execute(DuckLakeSnapshot snapshot, string &query);
 	virtual unique_ptr<QueryResult> Execute(string &query);
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -129,7 +129,17 @@ public:
 	virtual bool SupportsAppender() const {
 		return true;
 	}
-
+	virtual const char *ScalarLeastFunction() const {
+		return "LEAST";
+	}
+	virtual const char *ScalarGreatestFunction() const {
+		return "GREATEST";
+	}
+	//! False only for SQLite. Backends returning false fall back to a non-atomic
+	//! insert-or-update, which cannot make two concurrent first-inserts merge.
+	virtual bool SupportsUpsert() const {
+		return true;
+	}
 	//! Probe the metadata server for optional capabilities, for now we only check for server-side retries
 	virtual void ProbeServerCapabilities() {
 	}
@@ -357,7 +367,21 @@ public:
 	static string InsertSnapshotSql();
 	static string WriteSnapshotChangesSql(const SnapshotChangeInfo &change_info,
 	                                      const DuckLakeSnapshotCommit &commit_info);
-	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats);
+	//! MERGE: incoming is a per-commit delta - widen, so concurrent appends cannot lose each other.
+	//! OVERWRITE: incoming was recomputed from every surviving file - it must be able to NARROW,
+	//! or compaction can never tighten bounds after deletes.
+	enum class GlobalStatsWrite { MERGE, OVERWRITE };
+	struct StatsMergeDialect {
+		const char *least_fn = "LEAST";
+		const char *greatest_fn = "GREATEST";
+		bool supports_upsert = true;
+		std::function<string(const LogicalType &)> column_type = [](const LogicalType &type) {
+			return type.ToString();
+		};
+	};
+	StatsMergeDialect GetStatsMergeDialect();
+	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats, GlobalStatsWrite write_mode,
+	                                        const StatsMergeDialect &dialect);
 	static SnapshotChangeInfo
 	GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
 	                              const std::function<unique_ptr<QueryResult>(string)> &executor);

--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -327,7 +327,7 @@ public:
 	static DuckLakeGlobalStatsInfo ConvertNewGlobalStats(TableIndex table_id,
 	                                                     const DuckLakeNewGlobalStats &new_global_stats);
 
-	static DuckLakeFileInfo BuildDataFileInfo(const DuckLakeDataFile &file, DuckLakeSnapshot &commit_snapshot,
+	static DuckLakeFileInfo BuildDataFileInfo(const DuckLakeDataFile &file, DuckLakeCommitState &commit_state,
 	                                          TableIndex table_id, optional_idx row_id_start);
 
 	static void AddTableChanges(TableIndex table_id, const LocalTableDataChanges &table_changes,

--- a/src/include/storage/ducklake_transaction_changes.hpp
+++ b/src/include/storage/ducklake_transaction_changes.hpp
@@ -43,6 +43,8 @@ struct TransactionChangeInformation {
 	set<TableIndex> tables_rewrite_delete;
 };
 
+bool RequiresCommitLock(const TransactionChangeInformation &changes);
+
 struct SnapshotChangeInformation {
 	case_insensitive_set_t created_schemas;
 	set<SchemaIndex> dropped_schemas;

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -24,6 +24,21 @@ struct DuckLakeColumnSchemaEntry {
 };
 
 struct DuckLakeCommitContext {
+	std::function<idx_t(idx_t)> allocate_snapshot_id = [](idx_t current) {
+		return current + 1;
+	};
+	std::function<idx_t(idx_t)> allocate_catalog_id = [](idx_t current) {
+		return current;
+	};
+	std::function<idx_t(idx_t)> allocate_file_id = [](idx_t current) {
+		return current;
+	};
+	std::function<idx_t(idx_t)> allocate_schema_version = [](idx_t current) {
+		return current + 1;
+	};
+	std::function<void(const TransactionChangeInformation &)> acquire_commit_lock =
+	    [](const TransactionChangeInformation &) {
+	    };
 	//! Runs a metadata-DB query during conflict resolution.
 	std::function<unique_ptr<QueryResult>(string)> conflict_query_executor;
 	//! Returns the latest snapshot for the first commit attempt.

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -87,6 +87,8 @@ struct DuckLakeCommitContext {
 	    };
 	//! Returns the current global table stats for a single table id (first-attempt path).
 	std::function<shared_ptr<DuckLakeTableStats>(TableIndex)> get_table_stats;
+	std::function<string(const DuckLakeGlobalStatsInfo &, DuckLakeMetadataManager::GlobalStatsWrite)>
+	    update_global_table_stats_sql;
 	//! Top-level columns of a table at the commit snapshot — needed by stats-refresh to iterate
 	//! columns and look up types when merging per-file stats.
 	std::function<vector<DuckLakeColumnSchemaEntry>(TableIndex)> get_table_column_schema = [](TableIndex) {
@@ -122,6 +124,11 @@ struct DuckLakeCommitContext {
 	bool skip_drop_empty_inlined = false;
 	//! Whether the metadata schema has the >= 1.1-dev1 additions.
 	bool supports_v1_1_metadata = false;
+
+	//! Throws if a required closure was left unassigned. TWO construction sites must assign each
+	//! one (DuckLakeTransaction::BuildContext and DuckLakeServerSideCommit::BuildContext);
+	//! updating only one yields bad_function_call on that backend alone - this has shipped twice.
+	void ValidateRequiredClosures() const;
 };
 
 //! Holds the per-transaction mutable change state (new/dropped/renamed catalog entries, local file

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/main/database.hpp"
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_transaction.hpp"
+#include "storage/ducklake_transaction_changes.hpp"
 #include "storage/ducklake_metadata_info.hpp"
 
 namespace duckdb {
@@ -129,6 +130,195 @@ string PostgresMetadataManager::GetLatestSnapshotQuery() const {
 		     SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot
 		 );')
 	)";
+}
+
+idx_t PostgresMetadataManager::FetchScalarSequenceValue(const string &seq_name) {
+	DuckLakeSnapshot dummy {0, 0, 0, 0};
+	string query = "SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, "
+	               "'SELECT nextval(''{METADATA_SCHEMA_ESCAPED}." +
+	               seq_name + "'')')";
+	auto result = Query(dummy, query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("Failed to allocate next value from " + seq_name + ": ");
+	}
+	auto chunk = result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		throw InternalException("ducklake: %s returned no value from nextval()", seq_name);
+	}
+	auto v = chunk->data[0].GetValue(0).GetValue<int64_t>();
+	if (v < 0) {
+		throw InternalException("ducklake: %s returned negative value: %lld", seq_name, (long long)v);
+	}
+	return static_cast<idx_t>(v);
+}
+
+idx_t PostgresMetadataManager::AllocateNextSnapshotId(idx_t /*current_snapshot_id*/) {
+	return FetchScalarSequenceValue("ducklake_snapshot_id_seq");
+}
+
+idx_t PostgresMetadataManager::AllocateNextCatalogId(idx_t /*current_next_catalog_id*/) {
+	return FetchScalarSequenceValue("ducklake_catalog_id_seq");
+}
+
+idx_t PostgresMetadataManager::AllocateNextFileId(idx_t /*current_next_file_id*/) {
+	return FetchScalarSequenceValue("ducklake_file_id_seq");
+}
+
+idx_t PostgresMetadataManager::AllocateNextSchemaVersion(idx_t /*current_schema_version*/) {
+	return FetchScalarSequenceValue("ducklake_schema_version_seq");
+}
+
+idx_t PostgresMetadataManager::EnsureCatalogClassid() {
+	if (catalog_classid.IsValid()) {
+		return catalog_classid.GetIndex();
+	}
+	DuckLakeSnapshot dummy {};
+	string probe = "SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, "
+	               "'SELECT hashtext(''{METADATA_SCHEMA_ESCAPED}'')::int4')";
+	auto probe_result = Query(dummy, probe);
+	if (probe_result->HasError()) {
+		probe_result->GetErrorObject().Throw("concurrent: failed to compute DuckLake advisory lock classid: ");
+	}
+	auto chunk = probe_result->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		throw InternalException("ducklake: hashtext probe returned no row");
+	}
+	catalog_classid = static_cast<idx_t>(static_cast<uint32_t>(chunk->data[0].GetValue(0).GetValue<int32_t>()));
+	return catalog_classid.GetIndex();
+}
+
+void PostgresMetadataManager::AcquireCommitLock(const TransactionChangeInformation &changes) {
+	if (!RequiresCommitLock(changes)) {
+		return;
+	}
+	DuckLakeSnapshot dummy {};
+	auto classid = EnsureCatalogClassid();
+
+	string set_timeout = "SET LOCAL lock_timeout = '30s'";
+	auto timeout_res = Execute(dummy, set_timeout);
+	if (timeout_res->HasError()) {
+		timeout_res->GetErrorObject().Throw("concurrent: failed to set lock_timeout: ");
+	}
+
+	string query = "SELECT pg_advisory_xact_lock(" + std::to_string(static_cast<int32_t>(classid)) + ", " +
+	               std::to_string(DUCKLAKE_COMMIT_ADVISORY_SUBKEY) + ")";
+	auto result = Execute(dummy, query);
+	if (result->HasError()) {
+		result->GetErrorObject().Throw("concurrent: DuckLake commit serialization lock failed: ");
+	}
+}
+
+bool PostgresMetadataManager::BootstrapObjectsPresent() {
+	DuckLakeSnapshot dummy {};
+	string probe = R"(
+SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL},
+'SELECT COUNT(*)::BIGINT FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = ''{METADATA_SCHEMA_ESCAPED}''
+  AND c.relname IN (
+    ''ducklake_snapshot_id_seq'',''ducklake_catalog_id_seq'',
+    ''ducklake_file_id_seq'',''ducklake_schema_version_seq'',
+    ''ducklake_schema_name_active_uidx'',''ducklake_table_name_active_uidx'',
+    ''ducklake_view_name_active_uidx'',''ducklake_delete_file_active_uidx''
+  )')
+)";
+	auto res = Query(dummy, probe);
+	if (res->HasError()) {
+		return false;
+	}
+	auto chunk = res->Fetch();
+	if (!chunk || chunk->size() == 0) {
+		return false;
+	}
+	auto v = chunk->data[0].GetValue(0).GetValue<int64_t>();
+	return v == 8;
+}
+
+void PostgresMetadataManager::EnsureIdSequences() {
+	DuckLakeSnapshot dummy {0, 0, 0, 0};
+
+	if (BootstrapObjectsPresent()) {
+		return;
+	}
+
+	auto classid = EnsureCatalogClassid();
+	string acquire = "SELECT pg_advisory_lock(" + std::to_string(static_cast<int32_t>(classid)) + ", " +
+	                 std::to_string(DUCKLAKE_BOOTSTRAP_ADVISORY_SUBKEY) + ")";
+	auto acq_res = Execute(dummy, acquire);
+	if (acq_res->HasError()) {
+		acq_res->GetErrorObject().Throw("concurrent: DuckLake bootstrap serialization lock failed: ");
+	}
+	string release = "SELECT pg_advisory_unlock(" + std::to_string(static_cast<int32_t>(classid)) + ", " +
+	                 std::to_string(DUCKLAKE_BOOTSTRAP_ADVISORY_SUBKEY) + ")";
+	auto release_lock = [&]() {
+		auto r = Execute(dummy, release);
+		(void)r;
+	};
+
+	if (BootstrapObjectsPresent()) {
+		release_lock();
+		return;
+	}
+
+	auto run = [&](string query) {
+		auto result = Execute(dummy, query);
+		if (result->HasError()) {
+			release_lock();
+			result->GetErrorObject().Throw("Failed to ensure DuckLake id sequences: ");
+		}
+	};
+
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq MINVALUE 0 START WITH 0 CACHE 1");
+	run("CREATE SEQUENCE IF NOT EXISTS {METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq CACHE 1");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot_id_seq),
+    GREATEST(1, COALESCE((SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(snapshot_id) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 1) >= 1
+))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_catalog_id_seq),
+    GREATEST(1, COALESCE((SELECT MAX(next_catalog_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(next_catalog_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0) >= 1
+))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_file_id_seq),
+    GREATEST(0, COALESCE((SELECT MAX(next_file_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(next_file_id) - 1 FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0) >= 1
+))");
+	run(R"(SELECT setval(
+  '{METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq',
+  GREATEST(
+    (SELECT last_value FROM {METADATA_SCHEMA_ESCAPED}.ducklake_schema_version_seq),
+    GREATEST(1, COALESCE((SELECT MAX(schema_version) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 0))
+  ),
+  COALESCE((SELECT MAX(schema_version) FROM {METADATA_SCHEMA_ESCAPED}.ducklake_snapshot), 1) >= 1
+))");
+
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_schema_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_schema (schema_name) "
+	    "WHERE end_snapshot IS NULL");
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_table_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_table (schema_id, table_name) "
+	    "WHERE end_snapshot IS NULL");
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_view_name_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_view (schema_id, view_name) "
+	    "WHERE end_snapshot IS NULL");
+	run("CREATE UNIQUE INDEX IF NOT EXISTS ducklake_delete_file_active_uidx "
+	    "ON {METADATA_SCHEMA_ESCAPED}.ducklake_delete_file (data_file_id) "
+	    "WHERE end_snapshot IS NULL");
+
+	release_lock();
 }
 
 string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) {

--- a/src/storage/ducklake_initializer.cpp
+++ b/src/storage/ducklake_initializer.cpp
@@ -116,6 +116,9 @@ void DuckLakeInitializer::Initialize() {
 	// swapped it out via SetVersionedMetadataManager, so the `metadata_manager` reference taken at the
 	// top of Initialize() would now dangle.
 	auto &current_metadata_manager = transaction.GetMetadataManager();
+	if (options.access_mode != AccessMode::READ_ONLY) {
+		current_metadata_manager.EnsureIdSequences();
+	}
 	// probe the metadata server for optional capabilities (e.g. server-side commit retries) once per attach
 	current_metadata_manager.ProbeServerCapabilities();
 	current_metadata_manager.ClearCache();

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3021,7 +3021,7 @@ string DuckLakeMetadataManager::WriteNewInlinedData(DuckLakeSnapshot &commit_sna
 			// write the new inlined table
 			string inlined_tables;
 			string inlined_table_queries;
-			commit_snapshot.schema_version++;
+			commit_snapshot.schema_version = AllocateNextSchemaVersion(commit_snapshot.schema_version);
 			inlined_table_name =
 			    GetInlinedTableQueries(commit_snapshot, table_info, inlined_tables, inlined_table_queries);
 			batch_query += "INSERT INTO {METADATA_CATALOG}.ducklake_inlined_data_tables VALUES " + inlined_tables + ";";
@@ -4281,6 +4281,22 @@ string DuckLakeMetadataManager::WriteNewColumnMappings(const vector<DuckLakeColu
 
 string DuckLakeMetadataManager::InsertSnapshotSql() {
 	return R"(INSERT INTO {METADATA_CATALOG}.ducklake_snapshot VALUES ({SNAPSHOT_ID}, NOW(), {SCHEMA_VERSION}, {NEXT_CATALOG_ID}, {NEXT_FILE_ID});)";
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextSnapshotId(idx_t current_snapshot_id) {
+	return current_snapshot_id + 1;
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextCatalogId(idx_t current_next_catalog_id) {
+	return current_next_catalog_id;
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextFileId(idx_t current_next_file_id) {
+	return current_next_file_id;
+}
+
+idx_t DuckLakeMetadataManager::AllocateNextSchemaVersion(idx_t current_schema_version) {
+	return current_schema_version + 1;
 }
 
 static string SQLStringOrNull(const string &str) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -4847,9 +4847,12 @@ static string MergeBoundExpression(const DuckLakeMetadataManager::StatsMergeDial
 	if (!col_stats.has_type || !RequiresValueComparison(col_stats.type)) {
 		return StringUtil::Format("%s(%s, %s)", fn, column, incoming);
 	}
+	// Compare as the declared type, but return the winning VARCHAR verbatim. Casting the comparison
+	// result back to VARCHAR would re-serialize the literal and lose its formatting ('1.0' -> '1').
 	auto cast_type = dialect.column_type(col_stats.type);
-	return StringUtil::Format("CAST(%s(CAST(%s AS %s), CAST(%s AS %s)) AS VARCHAR)", fn, column, cast_type, incoming,
-	                          cast_type);
+	auto cmp = is_min ? "<=" : ">=";
+	return StringUtil::Format("CASE WHEN CAST(%s AS %s) %s CAST(%s AS %s) THEN %s ELSE %s END", column, cast_type, cmp,
+	                          incoming, cast_type, column, incoming);
 }
 
 // `qualifier` prefixes the STORED row. Empty for a plain UPDATE; inside ON CONFLICT DO UPDATE it

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -433,17 +433,9 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_delete_file ADD COLUMN {IF_NOT_EXISTS} r
 CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 	view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR
 );
--- Give ducklake_table_column_stats its (table_id, column_id) PRIMARY KEY, which is what arbitrates
--- the ON CONFLICT in UpdateGlobalTableStatsSql. An existing table cannot acquire a key by ALTER on
--- these backends, so it is rebuilt and swapped - and since the rebuild is a GROUP BY, it also
--- collapses any duplicate rows, which a keyed table could not hold anyway.
--- Duplicates are never two facts: the row is meant to be one merged bound per column, and a seeding
--- bug shipped in development produced two. They are also already harmful - both stats readers
--- LEFT JOIN this table USING (table_id), so a duplicate fans the join out and feeds one column's
--- stats in twice. The collapse uses the same widen-only semantics as the merge itself (MIN/MAX
--- bounds, OR'd flags), so it can only relax a bound, never lose a row's contribution.
-DROP TABLE {IF_EXISTS} {METADATA_CATALOG}.__ducklake_column_stats_rebuild;
-CREATE TABLE {METADATA_CATALOG}.__ducklake_column_stats_rebuild(
+-- Rebuild-and-swap: an existing table cannot acquire a PRIMARY KEY by ALTER on these backends.
+-- The GROUP BY also collapses duplicate rows, which a keyed table could not hold.
+CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.__ducklake_column_stats_rebuild(
 	table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN,
 	min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, PRIMARY KEY(table_id, column_id)
 );

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -262,9 +262,12 @@ string DuckLakeMetadataManager::GetCreateTableStatements() {
 	                     "parent_column BIGINT, default_value_type VARCHAR, default_value_dialect VARCHAR);");
 	statements.push_back("CREATE TABLE {METADATA_CATALOG}.ducklake_table_stats(table_id BIGINT, record_count BIGINT, "
 	                     "next_row_id BIGINT, file_size_bytes BIGINT);");
+	// The composite PRIMARY KEY arbitrates the ON CONFLICT in UpdateGlobalTableStatsSql. Declared
+	// inline because DuckDB and SQLite reject each other's CREATE INDEX schema-qualification.
 	statements.push_back(
 	    "CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, contains_null "
-	    "BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR);");
+	    "BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, PRIMARY "
+	    "KEY(table_id, column_id));");
 	statements.push_back("CREATE TABLE {METADATA_CATALOG}.ducklake_partition_info(partition_id BIGINT, table_id "
 	                     "BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT);");
 	statements.push_back("CREATE TABLE {METADATA_CATALOG}.ducklake_partition_column(partition_id BIGINT, table_id "
@@ -430,6 +433,29 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_delete_file ADD COLUMN {IF_NOT_EXISTS} r
 CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 	view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR
 );
+-- Give ducklake_table_column_stats its (table_id, column_id) PRIMARY KEY, which is what arbitrates
+-- the ON CONFLICT in UpdateGlobalTableStatsSql. An existing table cannot acquire a key by ALTER on
+-- these backends, so it is rebuilt and swapped - and since the rebuild is a GROUP BY, it also
+-- collapses any duplicate rows, which a keyed table could not hold anyway.
+-- Duplicates are never two facts: the row is meant to be one merged bound per column, and a seeding
+-- bug shipped in development produced two. They are also already harmful - both stats readers
+-- LEFT JOIN this table USING (table_id), so a duplicate fans the join out and feeds one column's
+-- stats in twice. The collapse uses the same widen-only semantics as the merge itself (MIN/MAX
+-- bounds, OR'd flags), so it can only relax a bound, never lose a row's contribution.
+DROP TABLE {IF_EXISTS} {METADATA_CATALOG}.__ducklake_column_stats_rebuild;
+CREATE TABLE {METADATA_CATALOG}.__ducklake_column_stats_rebuild(
+	table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN,
+	min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, PRIMARY KEY(table_id, column_id)
+);
+INSERT INTO {METADATA_CATALOG}.__ducklake_column_stats_rebuild
+SELECT table_id, column_id,
+       MAX(CASE WHEN contains_null THEN 1 WHEN contains_null IS NULL THEN NULL ELSE 0 END) = 1,
+       MAX(CASE WHEN contains_nan THEN 1 WHEN contains_nan IS NULL THEN NULL ELSE 0 END) = 1,
+       MIN(min_value), MAX(max_value), MAX(extra_stats)
+FROM {METADATA_CATALOG}.ducklake_table_column_stats
+GROUP BY table_id, column_id;
+DROP TABLE {METADATA_CATALOG}.ducklake_table_column_stats;
+ALTER TABLE {METADATA_CATALOG}.__ducklake_column_stats_rebuild RENAME TO ducklake_table_column_stats;
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)";
 	ExecuteMigration(migrate_query, allow_failures, "1.0", "1.1-dev1");
@@ -4810,25 +4836,113 @@ struct ColumnStatsSQL {
 	}
 };
 
-string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats) {
+struct MergedColumnStatsSQL {
+	string contains_null;
+	string contains_nan;
+	string min_val;
+	string max_val;
+};
+
+// min_value/max_value are VARCHAR, so without the cast LEAST('9','10') would be '9'.
+static string MergeBoundExpression(const DuckLakeMetadataManager::StatsMergeDialect &dialect,
+                                   const DuckLakeGlobalColumnStatsInfo &col_stats, const string &column,
+                                   const string &incoming, bool is_min) {
+	auto fn = is_min ? dialect.least_fn : dialect.greatest_fn;
+	if (!col_stats.has_type || !RequiresValueComparison(col_stats.type)) {
+		return StringUtil::Format("%s(%s, %s)", fn, column, incoming);
+	}
+	auto cast_type = dialect.column_type(col_stats.type);
+	return StringUtil::Format("CAST(%s(CAST(%s AS %s), CAST(%s AS %s)) AS VARCHAR)", fn, column, cast_type, incoming,
+	                          cast_type);
+}
+
+// `qualifier` prefixes the STORED row. Empty for a plain UPDATE; inside ON CONFLICT DO UPDATE it
+// must be the table name - Postgres rejects a bare column reference there as ambiguous.
+static MergedColumnStatsSQL MergeColumnStatsAssignments(const DuckLakeMetadataManager::StatsMergeDialect &dialect,
+                                                        const DuckLakeGlobalColumnStatsInfo &col_stats,
+                                                        const ColumnStatsSQL &sql, const string &qualifier = string()) {
+	MergedColumnStatsSQL result;
+	auto stored = [&qualifier](const char *column) {
+		return qualifier.empty() ? string(column) : qualifier + "." + column;
+	};
+	auto stored_null = stored("contains_null");
+	auto stored_nan = stored("contains_nan");
+	auto stored_min = stored("min_value");
+	auto stored_max = stored("max_value");
+	// A NULL incoming bound means unknown (e.g. ALTER changed the type). Propagate it rather than
+	// preserving the stored value, which would resurrect a stale bound.
+	if (!col_stats.has_min || sql.min_val == "NULL") {
+		result.min_val = "NULL";
+	} else {
+		result.min_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_val,
+		                                    MergeBoundExpression(dialect, col_stats, stored_min, sql.min_val, true));
+	}
+	if (!col_stats.has_max || sql.max_val == "NULL") {
+		result.max_val = "NULL";
+	} else {
+		result.max_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_val,
+		                                    MergeBoundExpression(dialect, col_stats, stored_max, sql.max_val, false));
+	}
+	result.contains_null =
+	    sql.contains_null == "NULL"
+	        ? stored_null
+	        : StringUtil::Format("CAST(%s AS BOOLEAN) OR COALESCE(%s, FALSE)", sql.contains_null, stored_null);
+	result.contains_nan = sql.contains_nan == "NULL" ? stored_nan
+	                                                 : StringUtil::Format("CAST(%s AS BOOLEAN) OR COALESCE(%s, FALSE)",
+	                                                                      sql.contains_nan, stored_nan);
+	return result;
+}
+
+DuckLakeMetadataManager::StatsMergeDialect DuckLakeMetadataManager::GetStatsMergeDialect() {
+	StatsMergeDialect dialect;
+	dialect.least_fn = ScalarLeastFunction();
+	dialect.greatest_fn = ScalarGreatestFunction();
+	dialect.supports_upsert = SupportsUpsert();
+	dialect.column_type = [this](const LogicalType &type) {
+		return GetColumnTypeInternal(type);
+	};
+	return dialect;
+}
+
+string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats,
+                                                          GlobalStatsWrite write_mode,
+                                                          const StatsMergeDialect &dialect) {
 	string batch_query;
 
 	if (!stats.initialized) {
-		string column_stats_values;
-		for (auto &col_stats : stats.column_stats) {
-			if (!column_stats_values.empty()) {
-				column_stats_values += ",";
-			}
-			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
-			column_stats_values +=
-			    StringUtil::Format("(%d, %d, %s, %s, %s, %s, %s)", stats.table_id.index, col_stats.column_id.index,
-			                       sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats);
-		}
 		batch_query +=
 		    StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_stats VALUES (%d, %d, %d, %d);",
 		                       stats.table_id.index, stats.record_count, stats.next_row_id, stats.table_size_bytes);
-		batch_query += StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES %s;",
-		                                  column_stats_values);
+		// Upsert, NOT a plain INSERT: `initialized` comes from a pre-commit snapshot, so two
+		// concurrent first-inserts BOTH reach this branch and a plain INSERT lets one win wholesale,
+		// narrowing the range and pruning live rows.
+		if (!dialect.supports_upsert) {
+			// SQLite keeps the pre-upsert path and its lost update. See SQLiteMetadataManager.
+			string column_stats_values;
+			for (auto &col_stats : stats.column_stats) {
+				if (!column_stats_values.empty()) {
+					column_stats_values += ",";
+				}
+				auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
+				column_stats_values +=
+				    StringUtil::Format("(%d, %d, %s, %s, %s, %s, %s)", stats.table_id.index, col_stats.column_id.index,
+				                       sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats);
+			}
+			batch_query += StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES %s;",
+			                                  column_stats_values);
+			return batch_query;
+		}
+		for (auto &col_stats : stats.column_stats) {
+			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
+			auto assignments = MergeColumnStatsAssignments(dialect, col_stats, sql, "ducklake_table_column_stats");
+			batch_query += StringUtil::Format(
+			    "INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES (%d, %d, %s, %s, %s, %s, %s) "
+			    "ON CONFLICT (table_id, column_id) DO UPDATE SET "
+			    "contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, extra_stats=%s;",
+			    stats.table_id.index, col_stats.column_id.index, sql.contains_null, sql.contains_nan, sql.min_val,
+			    sql.max_val, sql.extra_stats, assignments.contains_null, assignments.contains_nan, assignments.min_val,
+			    assignments.max_val, sql.extra_stats);
+		}
 	} else {
 		// stats have been initialized - update them
 		batch_query += StringUtil::Format(
@@ -4846,14 +4960,20 @@ string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalSt
 		// `::boolean` operator: both DuckDB and Postgres accept ANSI CAST,
 		// and SQLite's parser rejects `::` outright (SQLITE_ERROR:
 		// unrecognized token ":").
+		// Under READ COMMITTED a self-referencing UPDATE blocks on the row lock and re-reads the
+		// committed value, so MERGE is atomic per row without a lock, CAS column or retry.
 		for (auto &col_stats : stats.column_stats) {
 			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
-			batch_query += StringUtil::Format(
-			    "UPDATE {METADATA_CATALOG}.ducklake_table_column_stats "
-			    "SET contains_null=CAST(%s AS BOOLEAN), contains_nan=CAST(%s AS BOOLEAN), min_value=%s, max_value=%s, "
-			    "extra_stats=%s WHERE table_id=%d AND column_id=%d;",
-			    sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats, stats.table_id.index,
-			    col_stats.column_id.index);
+			auto assignments =
+			    write_mode == GlobalStatsWrite::MERGE
+			        ? MergeColumnStatsAssignments(dialect, col_stats, sql)
+			        : MergedColumnStatsSQL {sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val};
+			batch_query += StringUtil::Format("UPDATE {METADATA_CATALOG}.ducklake_table_column_stats "
+			                                  "SET contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, "
+			                                  "extra_stats=%s WHERE table_id=%d AND column_id=%d;",
+			                                  assignments.contains_null, assignments.contains_nan, assignments.min_val,
+			                                  assignments.max_val, sql.extra_stats, stats.table_id.index,
+			                                  col_stats.column_id.index);
 		}
 	}
 	return batch_query;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -433,8 +433,12 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_delete_file ADD COLUMN {IF_NOT_EXISTS} r
 CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 	view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR
 );
--- Rebuild-and-swap: an existing table cannot acquire a PRIMARY KEY by ALTER on these backends.
--- The GROUP BY also collapses duplicate rows, which a keyed table could not hold.
+-- Rebuild-and-swap: an existing table cannot acquire a PRIMARY KEY by ALTER on these backends, and
+-- CREATE INDEX is not portable here (DuckDB and SQLite reject each other's schema-qualification).
+-- The GROUP BY collapses duplicate (table_id, column_id) rows, which a keyed table cannot hold and
+-- which a v1.0 catalog can genuinely contain: the pre-upsert INSERT branch had no key and no
+-- conflict clause, so two concurrent first-inserts into one table each wrote their own row.
+-- Both readers LEFT JOIN this table USING (table_id), so a duplicate fans the join out.
 CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.__ducklake_column_stats_rebuild(
 	table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN,
 	min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, PRIMARY KEY(table_id, column_id)
@@ -4889,7 +4893,7 @@ DuckLakeMetadataManager::StatsMergeDialect DuckLakeMetadataManager::GetStatsMerg
 	StatsMergeDialect dialect;
 	dialect.least_fn = ScalarLeastFunction();
 	dialect.greatest_fn = ScalarGreatestFunction();
-	dialect.supports_upsert = SupportsUpsert();
+	dialect.supports_upsert = SupportsUpsert() && transaction.GetCatalog().SupportsStatsUpsert();
 	dialect.column_type = [this](const LogicalType &type) {
 		return GetColumnTypeInternal(type);
 	};
@@ -4909,7 +4913,8 @@ string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalSt
 		// concurrent first-inserts BOTH reach this branch and a plain INSERT lets one win wholesale,
 		// narrowing the range and pruning live rows.
 		if (!dialect.supports_upsert) {
-			// SQLite keeps the pre-upsert path and its lost update. See SQLiteMetadataManager.
+			// Pre-upsert path, keeping its lost update: either the backend rejects ON CONFLICT
+			// (SQLite) or the catalog predates the key it targets (SupportsStatsUpsert).
 			string column_stats_values;
 			for (auto &col_stats : stats.column_stats) {
 				if (!column_stats_values.empty()) {

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -772,6 +772,12 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		auto it = existing_table_stats.find(table_id);
 		return it == existing_table_stats.end() ? nullptr : it->second;
 	};
+	ctx.update_global_table_stats_sql = [](const DuckLakeGlobalStatsInfo &stats,
+	                                       DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
+		// The quack server's metadata catalog is a plain DuckDB instance, so the default dialect applies.
+		return DuckLakeMetadataManager::UpdateGlobalTableStatsSql(stats, write_mode,
+		                                                          DuckLakeMetadataManager::StatsMergeDialect {});
+	};
 	ctx.build_stats_map = [this](vector<DuckLakeGlobalStatsInfo> &stats) {
 		return BuildStatsMap(stats);
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1025,6 +1025,22 @@ TransactionChangeInformation DuckLakeTransaction::GetTransactionChanges() const 
 
 // DuckLakeCommitState is defined in storage/ducklake_commit_state.hpp
 
+idx_t DuckLakeCommitState::AllocateCatalogId() const {
+	idx_t id = context.allocate_catalog_id(commit_snapshot.next_catalog_id);
+	if (id + 1 > commit_snapshot.next_catalog_id) {
+		commit_snapshot.next_catalog_id = id + 1;
+	}
+	return id;
+}
+
+idx_t DuckLakeCommitState::AllocateFileId() const {
+	idx_t id = context.allocate_file_id(commit_snapshot.next_file_id);
+	if (id + 1 > commit_snapshot.next_file_id) {
+		commit_snapshot.next_file_id = id + 1;
+	}
+	return id;
+}
+
 void DuckLakeTransaction::AddTableChanges(TableIndex table_id, const LocalTableDataChanges &table_changes,
                                           TransactionChangeInformation &changes) {
 	bool inserted_data = false;
@@ -1084,7 +1100,7 @@ DuckLakePartitionInfo DuckLakeTransaction::GetNewPartitionKey(DuckLakeCommitStat
 	auto local_partition_id = partition_data->local_partition_id.IsValid()
 	                              ? partition_data->local_partition_id.GetIndex()
 	                              : partition_data->partition_id;
-	auto partition_id = commit_state.commit_snapshot.next_catalog_id++;
+	auto partition_id = commit_state.AllocateCatalogId();
 	partition_key.id = partition_id;
 	partition_data->partition_id = partition_id;
 	for (auto &field : partition_data->fields) {
@@ -1133,7 +1149,7 @@ DuckLakeSortInfo DuckLakeTransaction::GetNewSortKey(DuckLakeCommitState &commit_
 		return sort_key;
 	}
 
-	auto sort_id = commit_state.commit_snapshot.next_catalog_id++;
+	auto sort_id = commit_state.AllocateCatalogId();
 	sort_key.id = sort_id;
 	sort_data->sort_id = sort_id;
 	for (auto &field : sort_data->fields) {
@@ -1181,7 +1197,7 @@ DuckLakeTableInfo DuckLakeTransaction::GetNewTable(DuckLakeCommitState &commit_s
 	auto original_id = table_entry.id;
 	bool is_new_table;
 	if (IsTransactionLocal(original_id.index)) {
-		table_entry.id = TableIndex(commit_state.commit_snapshot.next_catalog_id++);
+		table_entry.id = TableIndex(commit_state.AllocateCatalogId());
 		is_new_table = true;
 	} else {
 		// this table already has an id - keep it
@@ -1202,7 +1218,7 @@ DuckLakeViewInfo DuckLakeTransaction::GetNewView(DuckLakeCommitState &commit_sta
 	DuckLakeViewInfo view_entry;
 	auto original_id = view.GetViewId();
 	if (IsTransactionLocal(original_id.index)) {
-		view_entry.id = TableIndex(commit_state.commit_snapshot.next_catalog_id++);
+		view_entry.id = TableIndex(commit_state.AllocateCatalogId());
 	} else {
 		// this view already has an id - keep it
 		// this happens if e.g. this view is renamed
@@ -1291,10 +1307,10 @@ DuckLakeColumnStatsInfo DuckLakeColumnStatsInfo::FromColumnStats(FieldIndex fiel
 	return column_stats;
 }
 
-DuckLakeFileInfo DuckLakeTransaction::BuildDataFileInfo(const DuckLakeDataFile &file, DuckLakeSnapshot &commit_snapshot,
+DuckLakeFileInfo DuckLakeTransaction::BuildDataFileInfo(const DuckLakeDataFile &file, DuckLakeCommitState &commit_state,
                                                         TableIndex table_id, optional_idx row_id_start) {
 	DuckLakeFileInfo data_file;
-	data_file.id = DataFileIndex(commit_snapshot.next_file_id++);
+	data_file.id = DataFileIndex(commit_state.AllocateFileId());
 	data_file.table_id = table_id;
 	data_file.file_name = file.file_name;
 	data_file.row_count = file.row_count;
@@ -1321,7 +1337,7 @@ DuckLakeDeleteFileInfo DuckLakeTransaction::GetNewDeleteFile(TableIndex table_id
                                                              const DuckLakeCommitState &commit_state,
                                                              const DuckLakeDeleteFile &file) {
 	DuckLakeDeleteFileInfo delete_file;
-	delete_file.id = DataFileIndex(commit_state.commit_snapshot.next_file_id++);
+	delete_file.id = DataFileIndex(commit_state.AllocateFileId());
 	delete_file.table_id = table_id;
 	delete_file.data_file_id = file.data_file_id;
 	delete_file.path = file.file_name;
@@ -1429,6 +1445,21 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.get_snapshot = [&]() {
 		return GetSnapshot();
+	};
+	context.allocate_snapshot_id = [&](idx_t current) {
+		return metadata_manager->AllocateNextSnapshotId(current);
+	};
+	context.allocate_catalog_id = [&](idx_t current) {
+		return metadata_manager->AllocateNextCatalogId(current);
+	};
+	context.allocate_file_id = [&](idx_t current) {
+		return metadata_manager->AllocateNextFileId(current);
+	};
+	context.allocate_schema_version = [&](idx_t current) {
+		return metadata_manager->AllocateNextSchemaVersion(current);
+	};
+	context.acquire_commit_lock = [&](const TransactionChangeInformation &changes) {
+		metadata_manager->AcquireCommitLock(changes);
 	};
 	context.execute_commit_batch = [&](DuckLakeSnapshot snapshot, string &query) {
 		return metadata_manager->Execute(snapshot, query);

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1252,6 +1252,8 @@ DuckLakeGlobalStatsInfo DuckLakeTransaction::ConvertNewGlobalStats(TableIndex ta
 		if (column_stats.has_contains_nan) {
 			col_stats.contains_nan = column_stats.contains_nan;
 		}
+		col_stats.type = column_stats.type;
+		col_stats.has_type = true;
 		col_stats.has_min = column_stats.has_min;
 		if (column_stats.has_min) {
 			col_stats.min_val = column_stats.min;
@@ -1506,6 +1508,11 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.get_table_stats = [&](TableIndex table_id) {
 		return ducklake_catalog.GetTableStats(*this, table_id);
+	};
+	context.update_global_table_stats_sql = [&](const DuckLakeGlobalStatsInfo &stats,
+	                                            DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
+		return DuckLakeMetadataManager::UpdateGlobalTableStatsSql(stats, write_mode,
+		                                                          metadata_manager->GetStatsMergeDialect());
 	};
 	context.get_table_column_schema = [&](TableIndex table_id) {
 		// The full flattened schema at the commit snapshot: top-level roots (is_root=true) plus every nested

--- a/src/storage/ducklake_transaction_changes.cpp
+++ b/src/storage/ducklake_transaction_changes.cpp
@@ -218,4 +218,12 @@ SnapshotChangeInformation SnapshotChangeInformation::ParseChangesMade(const stri
 	return result;
 }
 
+bool RequiresCommitLock(const TransactionChangeInformation &changes) {
+	return !changes.created_tables.empty() || !changes.dropped_tables.empty() || !changes.created_schemas.empty() ||
+	       !changes.dropped_schemas.empty() || !changes.dropped_views.empty() ||
+	       !changes.created_scalar_macros.empty() || !changes.created_table_macros.empty() ||
+	       !changes.dropped_scalar_macros.empty() || !changes.dropped_table_macros.empty() ||
+	       !changes.altered_tables_with_schema_version_changes.empty();
+}
+
 } // namespace duckdb

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -476,7 +476,7 @@ void GetNewMacroInfo(DuckLakeCommitState &commit_state, reference<CatalogEntry> 
 	auto &macro_entry = entry.get().Cast<MacroCatalogEntry>();
 	auto &ducklake_schema = macro_entry.schema.Cast<DuckLakeSchemaEntry>();
 
-	new_macro_info.macro_id = MacroIndex(commit_state.commit_snapshot.next_catalog_id++);
+	new_macro_info.macro_id = MacroIndex(commit_state.AllocateCatalogId());
 	new_macro_info.macro_name = macro_entry.name.GetIdentifierName();
 	new_macro_info.schema_id = commit_state.GetSchemaId(ducklake_schema);
 	// Let's do the implementations
@@ -541,7 +541,7 @@ static void ConvertNameMapColumn(const DuckLakeNameMapEntry &name_map_entry, Map
 DuckLakeFileInfo DuckLakeTransactionState::GetNewDataFile(const DuckLakeDataFile &file,
                                                           DuckLakeCommitState &commit_state, TableIndex table_id,
                                                           optional_idx row_id_start) {
-	auto data_file = DuckLakeTransaction::BuildDataFileInfo(file, commit_state.commit_snapshot, table_id, row_id_start);
+	auto data_file = DuckLakeTransaction::BuildDataFileInfo(file, commit_state, table_id, row_id_start);
 	commit_state.RemapPartitionId(data_file.partition_id);
 	if (data_file.partition_id.IsValid() &&
 	    data_file.partition_id.GetIndex() >= DuckLakeConstants::TRANSACTION_LOCAL_ID_START) {
@@ -558,7 +558,7 @@ NewNameMapInfo DuckLakeTransactionState::GetNewNameMaps(DuckLakeCommitState &com
 		// generate a new mapping id
 		auto local_map_id = entry.first;
 		auto &mapping = *entry.second;
-		MappingIndex new_map_id(commit_state.commit_snapshot.next_file_id++);
+		MappingIndex new_map_id(commit_state.AllocateFileId());
 
 		DuckLakeColumnMappingInfo map_info;
 		map_info.table_id = commit_state.GetTableId(mapping.table_id);
@@ -1166,7 +1166,7 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 
 			if (table_changes.new_data_files.empty()) {
 				// force an increment of file_id to signal a data change if we have only inlined data changes
-				commit_state.commit_snapshot.next_file_id++;
+				commit_state.AllocateFileId();
 			}
 		}
 		if (clear_column_stats) {
@@ -1558,7 +1558,7 @@ vector<DuckLakeSchemaInfo> DuckLakeTransactionState::GetNewSchemas(DuckLakeCommi
 		auto &schema_entry = entry.second->Cast<DuckLakeSchemaEntry>();
 		auto old_id = schema_entry.GetSchemaId();
 		DuckLakeSchemaInfo schema_info;
-		schema_info.id = SchemaIndex(commit_state.commit_snapshot.next_catalog_id++);
+		schema_info.id = SchemaIndex(commit_state.AllocateCatalogId());
 		schema_info.uuid = schema_entry.GetSchemaUUID();
 		schema_info.name = schema_entry.name.GetIdentifierName();
 		schema_info.path = schema_entry.DataPath();
@@ -1925,23 +1925,19 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 		auto attempt_changes = transaction_changes;
 		auto attempt_dropped_file_stats = dropped_file_stats;
 		try {
+			can_retry = true;
+			context.acquire_commit_lock(attempt_changes);
 			can_retry = false;
-			if (i > 0) {
-				// we failed our first commit due to another transaction committing
-				// retry - but first check for conflicts
-				commit_stats_snapshot =
-				    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
-				stats = &commit_stats_snapshot.stats;
-			} else {
-				commit_stats_snapshot.snapshot = context.get_snapshot();
-			}
-			commit_snapshot.snapshot_id++;
+			commit_stats_snapshot =
+			    CheckForConflicts(transaction_snapshot, attempt_changes, context.conflict_query_executor);
+			stats = &commit_stats_snapshot.stats;
+			can_retry = true;
+			commit_snapshot.snapshot_id = context.allocate_snapshot_id(commit_snapshot.snapshot_id);
 			if (SchemaChangesMade()) {
 				// we changed the schema - need to get a new schema version
-				commit_snapshot.schema_version++;
+				commit_snapshot.schema_version = context.allocate_schema_version(commit_snapshot.schema_version);
 			}
-			can_retry = true;
-			DuckLakeCommitState commit_state(commit_snapshot);
+			DuckLakeCommitState commit_state(commit_snapshot, context);
 			// write the new snapshot
 			string batch_queries = DuckLakeMetadataManager::InsertSnapshotSql();
 			batch_queries += CommitChanges(commit_state, attempt_changes, stats, context, attempt_dropped_file_stats);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1116,7 +1116,11 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 			new_globals.stats = *current_stats;
 			new_globals.initialized = true;
 		}
+		bool dropped_files = attempt_dropped_file_stats.find(table_id) != attempt_dropped_file_stats.end();
 		bool clear_column_stats = ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
+		// This commit dropped every file, so the column stats below describe only rows it wrote itself:
+		// they are absolute, and merging them against the bounds of the rows just deleted resurrects them.
+		bool emptied_table = dropped_files && !clear_column_stats;
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
@@ -1182,7 +1186,8 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 		// update the global stats for this table based on the newly written data
 		batch_query +=
 		    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
-		                                          DuckLakeMetadataManager::GlobalStatsWrite::MERGE);
+		                                          emptied_table ? DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE
+		                                                        : DuckLakeMetadataManager::GlobalStatsWrite::MERGE);
 		if (clear_column_stats) {
 			batch_query += DeleteTableColumnStatsSql(table_id);
 		}

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -268,12 +268,14 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "compact table", "deleted from it");
 		ConflictCheck(table_id, other_changes.tables_merge_adjacent, "compact table", "compacted it");
 		ConflictCheck(table_id, other_changes.tables_rewrite_delete, "compact table", "compacted it");
+		ConflictCheck(table_id, other_changes.inserted_tables, "compact table", "inserted into it");
 	}
 	for (auto &table_id : changes.tables_rewrite_delete) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "compact table", "dropped it");
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "compact table", "deleted from it");
 		ConflictCheck(table_id, other_changes.tables_merge_adjacent, "compact table", "compacted it");
 		ConflictCheck(table_id, other_changes.tables_rewrite_delete, "compact table", "compacted it");
+		ConflictCheck(table_id, other_changes.inserted_tables, "compact table", "inserted into it");
 	}
 	for (auto &table_id : changes.altered_tables) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "alter table", "dropped it");
@@ -976,8 +978,10 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	DuckLakeNewGlobalStats new_globals;
 	new_globals.initialized = true;
 	new_globals.stats = std::move(new_stats);
-	batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+	// OVERWRITE: recomputed from every surviving file - a merge would make this a no-op.
+	batch_query +=
+	    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+	                                          DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE);
 }
 
 static idx_t SubtractDroppedFileStat(idx_t value, idx_t decrement) {
@@ -1063,8 +1067,10 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 			// the rows are deleted below - drop them from the update so we do not write values we then delete
 			new_globals.stats.column_stats.clear();
 		}
-		result += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+		// OVERWRITE: ApplyDroppedFileStats produces narrowing writes a merge would swallow.
+		result +=
+		    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+		                                          DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE);
 		if (delete_column_stats) {
 			result += DeleteTableColumnStatsSql(table_id);
 		}
@@ -1174,8 +1180,9 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 			new_stats.column_stats.clear();
 		}
 		// update the global stats for this table based on the newly written data
-		batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
+		batch_query +=
+		    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+		                                          DuckLakeMetadataManager::GlobalStatsWrite::MERGE);
 		if (clear_column_stats) {
 			batch_query += DeleteTableColumnStatsSql(table_id);
 		}
@@ -1914,9 +1921,37 @@ DuckLakeTransactionState::CheckForConflicts(DuckLakeSnapshot transaction_snapsho
 	return snapshot_and_stats;
 }
 
+void DuckLakeCommitContext::ValidateRequiredClosures() const {
+	struct RequiredClosure {
+		const char *name;
+		bool assigned;
+	};
+	const RequiredClosure required[] = {
+	    {"conflict_query_executor", static_cast<bool>(conflict_query_executor)},
+	    {"get_snapshot", static_cast<bool>(get_snapshot)},
+	    {"execute_commit_batch", static_cast<bool>(execute_commit_batch)},
+	    {"query_metadata", static_cast<bool>(query_metadata)},
+	    {"query_metadata_with_snapshot", static_cast<bool>(query_metadata_with_snapshot)},
+	    {"write_inlined_data", static_cast<bool>(write_inlined_data)},
+	    {"get_table_stats", static_cast<bool>(get_table_stats)},
+	    {"update_global_table_stats_sql", static_cast<bool>(update_global_table_stats_sql)},
+	    {"build_stats_map", static_cast<bool>(build_stats_map)},
+	    {"set_catalog_version", static_cast<bool>(set_catalog_version)},
+	    {"set_committed_snapshot_id", static_cast<bool>(set_committed_snapshot_id)},
+	};
+	for (auto &entry : required) {
+		if (!entry.assigned) {
+			throw InternalException(
+			    "DuckLakeCommitContext is missing required closure \"%s\" - a BuildContext site did not assign it",
+			    entry.name);
+		}
+	}
+}
+
 void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
                                       const TransactionChangeInformation &transaction_changes,
                                       const DuckLakeRetryConfig &retry_config, const DuckLakeCommitContext &context) {
+	context.ValidateRequiredClosures();
 	SnapshotAndStats commit_stats_snapshot;
 	auto &commit_snapshot = commit_stats_snapshot.snapshot;
 	optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats;

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -34,7 +34,8 @@
     {
       "reason": "Test only for Postgres as catalog",
       "paths": [
-        "test/sql/metadata/ducklake_settings_postgres.test"
+        "test/sql/metadata/ducklake_settings_postgres.test",
+        "test/sql/concurrent/postgres_id_sequences.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -99,7 +99,8 @@
       "reason": "Test only for Postgres as catalog",
       "paths": [
         "test/sql/metadata/ducklake_settings_postgres.test",
-        "test/sql/data_inlining/postgres_identifier_limit.test"
+        "test/sql/data_inlining/postgres_identifier_limit.test",
+        "test/sql/concurrent/postgres_id_sequences.test"
       ]
     },
     {

--- a/test/sql/concurrent/postgres_id_sequences.test
+++ b/test/sql/concurrent/postgres_id_sequences.test
@@ -1,0 +1,332 @@
+# name: test/sql/concurrent/postgres_id_sequences.test
+# description: Postgres metadata backend allocates ids from race-free sequences, calibrated and recoverable across bootstrap crashes
+# group: [concurrent]
+
+require ducklake
+
+require parquet
+
+require postgres_scanner
+
+require-env DUCKLAKE_CI
+
+test-env DATA_PATH {TEST_DIR}
+
+test-env MS {TEST_UUID}
+
+# Raw postgres attach used to inspect/manipulate the metadata schema directly, independent of
+# any DuckLake attach's own metadata sub-catalog (which disappears on DETACH).
+statement ok
+ATTACH 'dbname=ducklakedb' AS pgraw (TYPE postgres)
+
+# Scenario 5.1 + 5.3: fresh bootstrap creates all 8 objects, calibrated so the first nextval()
+# equals the next-to-assign id (MAX starts at 0 rows -> first snapshot_id must be 1)
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl (DATA_PATH '{DATA_PATH}/seq_fresh', METADATA_SCHEMA 'ms{MS}_s1')
+
+statement ok
+USE dl
+
+statement ok
+CREATE TABLE dl.t(i INTEGER)
+
+statement ok
+INSERT INTO dl.t VALUES (1)
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl
+
+query I
+SELECT COUNT(*) FROM pgraw.pg_catalog.pg_class c JOIN pgraw.pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'ms{MS}_s1' AND c.relname IN (
+  'ducklake_snapshot_id_seq','ducklake_catalog_id_seq',
+  'ducklake_file_id_seq','ducklake_schema_version_seq',
+  'ducklake_schema_name_active_uidx','ducklake_table_name_active_uidx',
+  'ducklake_view_name_active_uidx','ducklake_delete_file_active_uidx'
+)
+----
+8
+
+# snapshot_id sequence is calibrated: is_called is true, last_value covers every committed snapshot
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT is_called FROM "ms{MS}_s1".ducklake_snapshot_id_seq')
+----
+true
+
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT (SELECT last_value FROM "ms{MS}_s1".ducklake_snapshot_id_seq) >= (SELECT MAX(snapshot_id) FROM "ms{MS}_s1".ducklake_snapshot)')
+----
+true
+
+# Scenario 5.2: two concurrent connections inserting into the same table get distinct snapshot_ids
+# and neither hits the id-collision retry path
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl2 (DATA_PATH '{DATA_PATH}/seq_concurrent', METADATA_SCHEMA 'ms{MS}_s2')
+
+statement ok
+USE dl2
+
+statement ok
+CREATE TABLE dl2.t(i INTEGER)
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+INSERT INTO dl2.t VALUES (1)
+
+statement ok con2
+INSERT INTO dl2.t VALUES (2)
+
+statement ok con1
+COMMIT
+
+statement ok con2
+COMMIT
+
+query I
+SELECT COUNT(*) FROM dl2.t
+----
+2
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl2
+
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT COUNT(*) = COUNT(DISTINCT snapshot_id) FROM "ms{MS}_s2".ducklake_snapshot')
+----
+true
+
+# Scenario 5.7: two connections concurrently creating a same-named table -> exactly one active row survives
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl3 (DATA_PATH '{DATA_PATH}/seq_uidx', METADATA_SCHEMA 'ms{MS}_s3')
+
+statement ok
+USE dl3
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CREATE TABLE dl3.dup(i INTEGER)
+
+statement ok con2
+CREATE TABLE dl3.dup(i INTEGER)
+
+statement ok con1
+COMMIT
+
+statement error con2
+COMMIT
+----
+<REGEX>:.*(Transaction conflict|duplicate key).*
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl3
+
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT COUNT(*) FROM "ms{MS}_s3".ducklake_table WHERE table_name = ''dup'' AND end_snapshot IS NULL')
+----
+1
+
+# Scenario 5.4: partial-bootstrap recovery (C2/C3) - drop only the active-row indexes, re-attach,
+# and confirm EnsureIdSequences re-creates them without disturbing the already-calibrated sequences
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl4 (DATA_PATH '{DATA_PATH}/seq_partial', METADATA_SCHEMA 'ms{MS}_s4')
+
+statement ok
+USE dl4
+
+statement ok
+CREATE TABLE dl4.t(i INTEGER)
+
+statement ok
+INSERT INTO dl4.t VALUES (1)
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl4
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP INDEX "ms{MS}_s4".ducklake_table_name_active_uidx')
+
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl4b (DATA_PATH '{DATA_PATH}/seq_partial', METADATA_SCHEMA 'ms{MS}_s4')
+
+statement ok
+USE dl4b
+
+statement ok
+CREATE TABLE dl4b.t2(i INTEGER)
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl4b
+
+query I
+SELECT COUNT(*) FROM pgraw.pg_catalog.pg_class c JOIN pgraw.pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'ms{MS}_s4' AND c.relname = 'ducklake_table_name_active_uidx'
+----
+1
+
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT MAX(next_file_id) > 0 FROM "ms{MS}_s4".ducklake_snapshot')
+----
+true
+
+# Scenario 5.5: uncalibrated-sequence recovery (C1) - simulate a crash between CREATE SEQUENCE and
+# calibration by resetting a sequence to its born value below the catalog's true MAX; re-attach must
+# self-heal via the defensive setval before the next nextval() is issued
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl5 (DATA_PATH '{DATA_PATH}/seq_uncalibrated', METADATA_SCHEMA 'ms{MS}_s5')
+
+statement ok
+USE dl5
+
+statement ok
+CREATE TABLE dl5.t(i INTEGER)
+
+statement ok
+INSERT INTO dl5.t VALUES (1)
+
+statement ok
+INSERT INTO dl5.t VALUES (2)
+
+statement ok
+INSERT INTO dl5.t VALUES (3)
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl5
+
+# Roll the sequence back to a value below the catalog's true MAX(snapshot_id) - simulates C1
+statement ok
+CALL postgres_execute('pgraw', 'SELECT setval(''ms{MS}_s5.ducklake_snapshot_id_seq'', 1, true)')
+
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl5b (DATA_PATH '{DATA_PATH}/seq_uncalibrated', METADATA_SCHEMA 'ms{MS}_s5')
+
+statement ok
+USE dl5b
+
+statement ok
+INSERT INTO dl5b.t VALUES (4)
+
+query I
+SELECT COUNT(*) FROM dl5b.t
+----
+4
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl5b
+
+# every committed snapshot_id is distinct - no PK collision occurred on the post-heal commit
+query I
+SELECT * FROM postgres_query('pgraw', 'SELECT COUNT(*) = COUNT(DISTINCT snapshot_id) FROM "ms{MS}_s5".ducklake_snapshot')
+----
+true
+
+# Scenario 5.6: migration from a pre-sequence catalog - drop all 4 sequences (simulating a catalog
+# created before this change), re-attach, and confirm EnsureIdSequences recreates and calibrates them
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl6 (DATA_PATH '{DATA_PATH}/seq_migration', METADATA_SCHEMA 'ms{MS}_s6')
+
+statement ok
+USE dl6
+
+statement ok
+CREATE TABLE dl6.t(i INTEGER)
+
+statement ok
+INSERT INTO dl6.t VALUES (1)
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl6
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SEQUENCE "ms{MS}_s6".ducklake_snapshot_id_seq, "ms{MS}_s6".ducklake_catalog_id_seq, "ms{MS}_s6".ducklake_file_id_seq, "ms{MS}_s6".ducklake_schema_version_seq')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP INDEX "ms{MS}_s6".ducklake_schema_name_active_uidx, "ms{MS}_s6".ducklake_table_name_active_uidx, "ms{MS}_s6".ducklake_view_name_active_uidx, "ms{MS}_s6".ducklake_delete_file_active_uidx')
+
+statement ok
+ATTACH 'ducklake:postgres:dbname=ducklakedb' AS dl6b (DATA_PATH '{DATA_PATH}/seq_migration', METADATA_SCHEMA 'ms{MS}_s6')
+
+statement ok
+USE dl6b
+
+statement ok
+INSERT INTO dl6b.t VALUES (2)
+
+query I
+SELECT COUNT(*) FROM dl6b.t
+----
+2
+
+statement ok
+USE memory
+
+statement ok
+DETACH dl6b
+
+query I
+SELECT COUNT(*) FROM pgraw.pg_catalog.pg_class c JOIN pgraw.pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'ms{MS}_s6' AND c.relname IN (
+  'ducklake_snapshot_id_seq','ducklake_catalog_id_seq',
+  'ducklake_file_id_seq','ducklake_schema_version_seq',
+  'ducklake_schema_name_active_uidx','ducklake_table_name_active_uidx',
+  'ducklake_view_name_active_uidx','ducklake_delete_file_active_uidx'
+)
+----
+8
+
+statement ok
+USE memory
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s1" CASCADE')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s2" CASCADE')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s3" CASCADE')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s4" CASCADE')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s5" CASCADE')
+
+statement ok
+CALL postgres_execute('pgraw', 'DROP SCHEMA IF EXISTS "ms{MS}_s6" CASCADE')
+
+statement ok
+DETACH pgraw

--- a/test/sql/stats/global_stats_transactions.test
+++ b/test/sql/stats/global_stats_transactions.test
@@ -52,3 +52,41 @@ query I
 SELECT stats(i) FROM ducklake.test LIMIT 1
 ----
 <REGEX>:.*max.*84.*min.*42.*
+
+# compaction's recompute must conflict with a concurrent insert, or it loses the insert's bounds
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+CREATE TABLE ducklake.compact_test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.compact_test VALUES (10);
+
+statement ok
+INSERT INTO ducklake.compact_test VALUES (20);
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CALL ducklake_merge_adjacent_files('ducklake', 'compact_test');
+
+statement ok con2
+INSERT INTO ducklake.compact_test VALUES (999);
+
+statement ok con2
+COMMIT
+
+statement error con1
+COMMIT
+----
+Transaction conflict
+
+query I
+SELECT stats(i) FROM ducklake.compact_test LIMIT 1
+----
+<REGEX>:.*max.*999.*min.*10.*


### PR DESCRIPTION

> [!NOTE]
> There are 8 **known** tests that are failing. They need #1341 (`repeatable read` -> `read committed`, a concurrency friendly isolation level) in order to pass

## Problem

Concurrent inserts silently lose each other's stats.

The `min_value` & `max_value` then fail to cover rows that are committed. Since filter pruning trusts those bounds without question, the pruner drops files that contain live rows.

Using a two writer probe against a pg catalog, reading back through a fresh `attach` to defeat caching:

```
total=2 but key=1 -> 0   key=0 -> 2   (pruned live row)
```

`select count(*)` returns 2, and `where key = 1` returns 0 rows for a row that is committed and present. This can be reproduced on `main`

## Root cause

`UpdateGlobalTableStatsSql` branched on `!stats.initialized`:

- when there's no row yet -> `insert` of the committer's bounds
- when the row _does_ exist -> `update` overwriting with the committer's bounds

Both branches ignore what a concurrent committer wrote. `create table` doesn't write any stats rows, so two concurrent first inserts both take the `insert` branch with only one winning.

## Fix

One atomic write path for appends. The two branches collapse into a single upsert/merge hinging on a uniqueness constraint on `ducklake_table_column_stats (table_id, column_id)`. The merge is type-aware with bounds stored as `varchar`s holding string literals and flags  like `contains_null` or  `contains_nan` are or'd so they can't be forgotten.

> [!WARNING]
> There is a schema migration. It is non-invasive however

`ducklake_table_column_stats` gains a uniqueness constraint on `(table_id, column_id)`, added in both `CreateTables` (fresh catalogs) and a migration (existing ones). The `!initialized` branch results in a bare `insert`. No key or conflict handling. Two concurrent first  inserts each write their own row. It's the same as the lost update race. an `update` blindly overwrites and an `insert` dupes. The migration collapses any pre-existing duplicate rows using the same widen-only merge, so nothing is lost. Duplicates were already causing incorrect results since both readers `left join ... using (table_id)`.

### SQLite opts out

`duckdb-sqlite` doesn't support `merge into` or `on conflict`. It's behind `SupportsUpsert()` and can be lifted when the scanner gains support.

## Verification

| surface | result |
|---|---|
| two-writer probe (the wrong-results repro) | 6/6 pass, control 6/6 fail |
| postgres `test/sql/concurrent/*` | 8/8, 364 assertions |
| duckdb `test/sql/stats/*` | 21/21, 855 |
| duckdb `test/sql/alter/*` | 35/35, 1233 |
| duckdb `test/sql/compaction/*` | 43/43, 2255 |
| duckdb `test/sql/transaction/*` | 15/15, 321 |
| quack `test/sql/stats/*` | 18/18 |
| sqlite `test/sql/stats/*` | 20/20, 831 |

`concurrent_insert_data_inlining.test` fails on `main` and proves the bug. It passes here.

Throughput is unaffected. For disjoint tables, writes scale  ~ 9x to n = 16. one table remain flat at ~ 75-80 per second from n = 1 to n = 16.

