### PR TITLE
Guard required table stats from NULL in conflict checks

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1024,6 +1024,15 @@ ORDER BY sort.table_id, sort.sort_id, sort_expr.sort_key_index
 
 template <class ROW>
 void TransformGlobalStatsRow(const ROW &row, vector<DuckLakeGlobalStatsInfo> &global_stats, idx_t from_column = 0) {
+	static constexpr const char *REQUIRED_FIELDS[] = {"table_id", "record_count", "next_row_id", "file_size_bytes"};
+	static constexpr idx_t REQUIRED_FIELD_OFFSETS[] = {0, 2, 3, 4};
+	for (idx_t field_idx = 0; field_idx < 4; field_idx++) {
+		if (row.IsNull(REQUIRED_FIELD_OFFSETS[field_idx] + from_column)) {
+			throw TransactionException("DuckLake conflict metadata incomplete: ducklake_table_stats.%s is NULL",
+			                           REQUIRED_FIELDS[field_idx]);
+		}
+	}
+
 	auto table_id = TableIndex(row.template GetValue<uint64_t>(0 + from_column));
 
 	if (global_stats.empty() || global_stats.back().table_id != table_id) {

--- a/test/sql/stats/table_stats_null_required_field.test
+++ b/test/sql/stats/table_stats_null_required_field.test
@@ -1,0 +1,33 @@
+# name: test/sql/stats/table_stats_null_required_field.test
+# description: a NULL required table-stats field must fail cleanly without invalidating DuckDB
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/table_stats_null_required_field', METADATA_CATALOG 'dl', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t(i INTEGER)
+
+# A required table-level stats value must be validated before GetValueInternal.
+statement ok
+INSERT INTO dl.ducklake_table_stats VALUES (1, 5, NULL, 100)
+
+statement error
+INSERT INTO ducklake.t VALUES (100)
+----
+DuckLake conflict metadata incomplete: ducklake_table_stats.next_row_id is NULL
+
+# TransactionException is recoverable; unlike InternalException, it must not
+# invalidate the entire embedded DuckDB instance.
+query I
+SELECT 42
+----
+42


### PR DESCRIPTION
## Problem

The conflict metadata parser assumes required `ducklake_table_stats` values are always valid and calls `GetValue` without checking them. If a required value is NULL, DuckDB raises a fatal `GetValueInternal` InternalException and invalidates the entire embedded database.

This is a remaining path related to #1198. The earlier `column_id` guard protects optional column statistics, but required table-level statistics are still dereferenced unconditionally.

A deterministic reproduction is:

1. create a DuckLake table
2. insert a `ducklake_table_stats` row with `next_row_id = NULL`
3. commit another insert into the DuckLake table

That reaches `TransformGlobalStatsRow -> ParseSnapshotAndStatsAndChanges -> CheckForConflicts` and produces the fatal assertion.

## Fix

- validate `table_id`, `record_count`, `next_row_id`, and `file_size_bytes` before dereferencing them
- raise a field-specific TransactionException
- preserve the DuckDB instance so callers can handle the metadata inconsistency
- add a regression for the exact `next_row_id` case and verify a subsequent query succeeds on the same instance

The patch intentionally does not invent a fallback `next_row_id`; defaulting it could create duplicate row IDs. A named recoverable error is safer and preserves evidence about the inconsistent field.

## Verification

- `VCPKG_TOOLCHAIN_PATH=... VCPKG_TARGET_TRIPLET=arm64-osx GEN=ninja make release -j4`
- `./build/release/test/unittest test/sql/stats/table_stats_null_required_field.test` (5 assertions)
- `./build/release/test/unittest test/sql/stats/table_stats_without_column_stats.test` (6 assertions)
- `uv run --with black --with clang-format==11.0.1 --with cmake-format python3 duckdb/scripts/format.py --all --check --directories src test`

Generated with [OpenAI Codex](https://openai.com/codex)
