### PR TITLE
fix: prevent concurrent inserts from losing global stats

### DIFF
--- a/src/include/metadata_manager/sqlite_metadata_manager.hpp
+++ b/src/include/metadata_manager/sqlite_metadata_manager.hpp
@@ -26,6 +26,10 @@ public:
 		return false;
 	}
 	bool IsRetryableCommitError(const string &message) const override;
+	//! sqlite_scanner rejects ON CONFLICT, so this backend keeps the pre-upsert path and its lost update.
+	bool SupportsUpsert() const override {
+		return false;
+	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
 };

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -238,6 +238,10 @@ public:
 	bool SupportsV1_1Metadata() const {
 		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
 	}
+	//! Whether ducklake_table_column_stats has the (table_id, column_id) key the upsert needs (1.1-dev1).
+	bool SupportsStatsUpsert() const {
+		return SupportsV1_1Metadata();
+	}
 
 	void OnDetach(ClientContext &context) override;
 

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -289,6 +289,9 @@ struct DuckLakeGlobalColumnStatsInfo {
 
 	bool min_is_exact = false;
 	bool max_is_exact = false;
+
+	LogicalType type;
+	bool has_type = false;
 };
 
 struct DuckLakeGlobalStatsInfo {

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -148,7 +148,16 @@ public:
 	virtual bool SupportsAppender() const {
 		return true;
 	}
-
+	virtual const char *ScalarLeastFunction() const {
+		return "LEAST";
+	}
+	virtual const char *ScalarGreatestFunction() const {
+		return "GREATEST";
+	}
+	//! False falls back to a non-atomic insert-or-update, which cannot merge concurrent first-inserts.
+	virtual bool SupportsUpsert() const {
+		return true;
+	}
 	//! Probe the metadata server for optional capabilities, for now we only check for server-side retries
 	virtual void ProbeServerCapabilities() {
 	}
@@ -377,7 +386,22 @@ public:
 	static string InsertSnapshotSql();
 	static string WriteSnapshotChangesSql(const SnapshotChangeInfo &change_info,
 	                                      const DuckLakeSnapshotCommit &commit_info);
-	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats, bool write_stats_exactness);
+	//! MERGE: incoming is a per-commit delta - widen only, so concurrent appends cannot lose each
+	//! other. OVERWRITE: incoming was recomputed from every surviving file, so it must NARROW.
+	enum class GlobalStatsWrite { MERGE, OVERWRITE };
+	struct StatsMergeDialect {
+		const char *least_fn = "LEAST";
+		const char *greatest_fn = "GREATEST";
+		bool supports_upsert = true;
+		//! Whether the metadata schema has the min_is_exact/max_is_exact columns (>= 1.1-dev1).
+		bool write_stats_exactness = false;
+		std::function<string(const LogicalType &)> column_type = [](const LogicalType &type) {
+			return type.ToString();
+		};
+	};
+	StatsMergeDialect GetStatsMergeDialect();
+	static string UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats, GlobalStatsWrite write_mode,
+	                                        const StatsMergeDialect &dialect);
 	static SnapshotChangeInfo
 	GetSnapshotAndStatsAndChanges(SnapshotAndStats &current_snapshot,
 	                              const std::function<unique_ptr<QueryResult>(string)> &executor,

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -76,6 +76,8 @@ struct DuckLakeCommitContext {
 	    };
 	//! Returns the current global table stats for a single table id (first-attempt path).
 	std::function<shared_ptr<DuckLakeTableStats>(TableIndex)> get_table_stats;
+	std::function<string(const DuckLakeGlobalStatsInfo &, DuckLakeMetadataManager::GlobalStatsWrite)>
+	    update_global_table_stats_sql;
 	//! Top-level columns of a table at the commit snapshot — needed by stats-refresh to iterate
 	//! columns and look up types when merging per-file stats.
 	std::function<vector<DuckLakeColumnSchemaEntry>(TableIndex)> get_table_column_schema = [](TableIndex) {
@@ -118,6 +120,9 @@ struct DuckLakeCommitContext {
 	DuckLakeInlinedColNames InlinedColNames() const {
 		return DuckLakeInlinedColNames(supports_v1_1_metadata);
 	}
+
+	//! Throws if a closure was left unassigned. TWO construction sites must assign each one.
+	void ValidateRequiredClosures() const;
 };
 
 //! Holds the per-transaction mutable change state (new/dropped/renamed catalog entries, local file

--- a/src/metadata_manager/ducklake_metadata_manager_v1_1.cpp
+++ b/src/metadata_manager/ducklake_metadata_manager_v1_1.cpp
@@ -33,9 +33,11 @@ string DuckLakeMetadataManagerV1_1<Base>::GetFileColumnStatsTableStatement() {
 
 template <typename Base>
 string DuckLakeMetadataManagerV1_1<Base>::GetTableColumnStatsTableStatement() {
+	// PRIMARY KEY arbitrates the ON CONFLICT in UpdateGlobalTableStatsSql. Inline because DuckDB and
+	// SQLite reject each other's CREATE INDEX schema-qualification.
 	return "CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, "
 	       "contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, "
-	       "min_is_exact BOOLEAN, max_is_exact BOOLEAN);";
+	       "min_is_exact BOOLEAN, max_is_exact BOOLEAN, PRIMARY KEY(table_id, column_id));";
 }
 
 template <typename Base>

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -241,8 +241,11 @@ string DuckLakeMetadataManager::GetFileColumnStatsTableStatement() {
 }
 
 string DuckLakeMetadataManager::GetTableColumnStatsTableStatement() {
+	// PRIMARY KEY arbitrates the ON CONFLICT in UpdateGlobalTableStatsSql. Inline because DuckDB and
+	// SQLite reject each other's CREATE INDEX schema-qualification.
 	return "CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, "
-	       "contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR);";
+	       "contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, "
+	       "min_is_exact BOOLEAN, max_is_exact BOOLEAN, PRIMARY KEY(table_id, column_id));";
 }
 
 string DuckLakeMetadataManager::GetCreateTableStatements() {
@@ -450,6 +453,28 @@ ALTER TABLE {METADATA_CATALOG}.ducklake_table_column_stats ADD COLUMN {IF_NOT_EX
 CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 	view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR
 );
+-- Rebuild-and-swap: an existing table cannot acquire a PRIMARY KEY by ALTER on these backends, and
+-- CREATE INDEX is not portable here (DuckDB and SQLite reject each other's schema-qualification).
+-- The GROUP BY collapses duplicate (table_id, column_id) rows, which a keyed table cannot hold and
+-- which a v1.0 catalog can genuinely contain: the pre-upsert INSERT branch had no key and no
+-- conflict clause, so two concurrent first-inserts into one table each wrote their own row.
+-- Both readers LEFT JOIN this table USING (table_id), so a duplicate fans the join out.
+CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.__ducklake_column_stats_rebuild(
+	table_id BIGINT, column_id BIGINT, contains_null BOOLEAN, contains_nan BOOLEAN,
+	min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR,
+	min_is_exact BOOLEAN, max_is_exact BOOLEAN, PRIMARY KEY(table_id, column_id)
+);
+INSERT INTO {METADATA_CATALOG}.__ducklake_column_stats_rebuild
+SELECT table_id, column_id,
+       MAX(CASE WHEN contains_null THEN 1 WHEN contains_null IS NULL THEN NULL ELSE 0 END) = 1,
+       MAX(CASE WHEN contains_nan THEN 1 WHEN contains_nan IS NULL THEN NULL ELSE 0 END) = 1,
+       MIN(min_value), MAX(max_value), MAX(extra_stats),
+       MAX(CASE WHEN min_is_exact THEN 1 WHEN min_is_exact IS NULL THEN NULL ELSE 0 END) = 1,
+       MAX(CASE WHEN max_is_exact THEN 1 WHEN max_is_exact IS NULL THEN NULL ELSE 0 END) = 1
+FROM {METADATA_CATALOG}.ducklake_table_column_stats
+GROUP BY table_id, column_id;
+DROP TABLE {METADATA_CATALOG}.ducklake_table_column_stats;
+ALTER TABLE {METADATA_CATALOG}.__ducklake_column_stats_rebuild RENAME TO ducklake_table_column_stats;
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)";
 	// rename first so a conflict aborts while the catalog is still at v1.0
@@ -5057,30 +5082,157 @@ struct ColumnStatsSQL {
 	}
 };
 
+struct MergedColumnStatsSQL {
+	string contains_null;
+	string contains_nan;
+	string min_val;
+	string max_val;
+	string min_is_exact;
+	string max_is_exact;
+};
+
+// min_value/max_value are VARCHAR, so without the cast LEAST('9','10') would be '9'.
+static string MergeBoundExpression(const DuckLakeMetadataManager::StatsMergeDialect &dialect,
+                                   const DuckLakeGlobalColumnStatsInfo &col_stats, const string &column,
+                                   const string &incoming, bool is_min) {
+	auto fn = is_min ? dialect.least_fn : dialect.greatest_fn;
+	if (!col_stats.has_type || !RequiresValueComparison(col_stats.type)) {
+		return StringUtil::Format("%s(%s, %s)", fn, column, incoming);
+	}
+	// Return the winning VARCHAR verbatim: casting the result back re-serializes it ('1.0' -> '1').
+	auto cast_type = dialect.column_type(col_stats.type);
+	auto cmp = is_min ? "<=" : ">=";
+	return StringUtil::Format("CASE WHEN CAST(%s AS %s) %s CAST(%s AS %s) THEN %s ELSE %s END", column, cast_type, cmp,
+	                          incoming, cast_type, column, incoming);
+}
+
+// Picks the is_exact flag paired with whichever side MergeBoundExpression's comparison selects - exactness
+// describes a specific bound value, so it must travel with whichever value the merge kept.
+static string MergeExactnessExpression(const DuckLakeMetadataManager::StatsMergeDialect &dialect,
+                                       const DuckLakeGlobalColumnStatsInfo &col_stats, const string &column,
+                                       const string &incoming, const string &stored_is_exact,
+                                       const string &incoming_is_exact, bool is_min) {
+	if (!col_stats.has_type || !RequiresValueComparison(col_stats.type)) {
+		// LEAST/GREATEST ties keep the first argument (the stored value) on equality.
+		auto fn = is_min ? dialect.least_fn : dialect.greatest_fn;
+		return StringUtil::Format("CASE WHEN %s = %s(%s, %s) THEN %s ELSE %s END", column, fn, column, incoming,
+		                          stored_is_exact, incoming_is_exact);
+	}
+	auto cast_type = dialect.column_type(col_stats.type);
+	auto cmp = is_min ? "<=" : ">=";
+	return StringUtil::Format("CASE WHEN CAST(%s AS %s) %s CAST(%s AS %s) THEN %s ELSE %s END", column, cast_type, cmp,
+	                          incoming, cast_type, stored_is_exact, incoming_is_exact);
+}
+
+// `qualifier` must be the table name inside ON CONFLICT DO UPDATE - Postgres rejects a bare column there.
+static MergedColumnStatsSQL MergeColumnStatsAssignments(const DuckLakeMetadataManager::StatsMergeDialect &dialect,
+                                                        const DuckLakeGlobalColumnStatsInfo &col_stats,
+                                                        const ColumnStatsSQL &sql, const string &qualifier = string()) {
+	MergedColumnStatsSQL result;
+	auto stored = [&qualifier](const char *column) {
+		return qualifier.empty() ? string(column) : qualifier + "." + column;
+	};
+	auto stored_null = stored("contains_null");
+	auto stored_nan = stored("contains_nan");
+	auto stored_min = stored("min_value");
+	auto stored_max = stored("max_value");
+	auto stored_min_is_exact = stored("min_is_exact");
+	auto stored_max_is_exact = stored("max_is_exact");
+	// NULL incoming means unknown - propagate it, do not fall back to the stale stored bound.
+	if (!col_stats.has_min || sql.min_val == "NULL") {
+		result.min_val = "NULL";
+		result.min_is_exact = "NULL";
+	} else {
+		result.min_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_val,
+		                                    MergeBoundExpression(dialect, col_stats, stored_min, sql.min_val, true));
+		result.min_is_exact = StringUtil::Format(
+		    "CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_is_exact,
+		    MergeExactnessExpression(dialect, col_stats, stored_min, sql.min_val, stored_min_is_exact,
+		                             sql.min_is_exact, true));
+	}
+	if (!col_stats.has_max || sql.max_val == "NULL") {
+		result.max_val = "NULL";
+		result.max_is_exact = "NULL";
+	} else {
+		result.max_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_val,
+		                                    MergeBoundExpression(dialect, col_stats, stored_max, sql.max_val, false));
+		result.max_is_exact = StringUtil::Format(
+		    "CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_is_exact,
+		    MergeExactnessExpression(dialect, col_stats, stored_max, sql.max_val, stored_max_is_exact,
+		                             sql.max_is_exact, false));
+	}
+	result.contains_null =
+	    sql.contains_null == "NULL"
+	        ? stored_null
+	        : StringUtil::Format("CAST(%s AS BOOLEAN) OR COALESCE(%s, FALSE)", sql.contains_null, stored_null);
+	result.contains_nan = sql.contains_nan == "NULL" ? stored_nan
+	                                                 : StringUtil::Format("CAST(%s AS BOOLEAN) OR COALESCE(%s, FALSE)",
+	                                                                      sql.contains_nan, stored_nan);
+	return result;
+}
+
+DuckLakeMetadataManager::StatsMergeDialect DuckLakeMetadataManager::GetStatsMergeDialect() {
+	StatsMergeDialect dialect;
+	dialect.least_fn = ScalarLeastFunction();
+	dialect.greatest_fn = ScalarGreatestFunction();
+	dialect.supports_upsert = SupportsUpsert() && transaction.GetCatalog().SupportsStatsUpsert();
+	dialect.write_stats_exactness = transaction.GetCatalog().SupportsV1_1Metadata();
+	dialect.column_type = [this](const LogicalType &type) {
+		return GetColumnTypeInternal(type);
+	};
+	return dialect;
+}
+
 string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalStatsInfo &stats,
-                                                          bool write_stats_exactness) {
+                                                          GlobalStatsWrite write_mode,
+                                                          const StatsMergeDialect &dialect) {
 	string batch_query;
 
 	if (!stats.initialized) {
-		string column_stats_values;
-		for (auto &col_stats : stats.column_stats) {
-			if (!column_stats_values.empty()) {
-				column_stats_values += ",";
-			}
-			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
-			column_stats_values +=
-			    StringUtil::Format("(%d, %d, %s, %s, %s, %s, %s", stats.table_id.index, col_stats.column_id.index,
-			                       sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats);
-			if (write_stats_exactness) {
-				column_stats_values += StringUtil::Format(", %s, %s", sql.min_is_exact, sql.max_is_exact);
-			}
-			column_stats_values += ")";
-		}
 		batch_query +=
 		    StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_stats VALUES (%d, %d, %d, %d);",
 		                       stats.table_id.index, stats.record_count, stats.next_row_id, stats.table_size_bytes);
-		batch_query += StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES %s;",
-		                                  column_stats_values);
+		if (!dialect.supports_upsert) {
+			string column_stats_values;
+			for (auto &col_stats : stats.column_stats) {
+				if (!column_stats_values.empty()) {
+					column_stats_values += ",";
+				}
+				auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
+				column_stats_values +=
+				    StringUtil::Format("(%d, %d, %s, %s, %s, %s, %s", stats.table_id.index, col_stats.column_id.index,
+				                       sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats);
+				if (dialect.write_stats_exactness) {
+					column_stats_values += StringUtil::Format(", %s, %s", sql.min_is_exact, sql.max_is_exact);
+				}
+				column_stats_values += ")";
+			}
+			batch_query += StringUtil::Format("INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats VALUES %s;",
+			                                  column_stats_values);
+			return batch_query;
+		}
+		// Upsert, NOT a plain INSERT: `initialized` is read pre-commit, so two concurrent first-inserts
+		// both reach this branch and a plain INSERT lets one win wholesale.
+		for (auto &col_stats : stats.column_stats) {
+			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
+			auto assignments = MergeColumnStatsAssignments(dialect, col_stats, sql, "ducklake_table_column_stats");
+			string exactness_columns, exactness_values, exactness_set;
+			if (dialect.write_stats_exactness) {
+				exactness_columns = ", min_is_exact, max_is_exact";
+				exactness_values = StringUtil::Format(", %s, %s", sql.min_is_exact, sql.max_is_exact);
+				exactness_set = StringUtil::Format(", min_is_exact=%s, max_is_exact=%s", assignments.min_is_exact,
+				                                   assignments.max_is_exact);
+			}
+			batch_query += StringUtil::Format(
+			    "INSERT INTO {METADATA_CATALOG}.ducklake_table_column_stats (table_id, column_id, contains_null, "
+			    "contains_nan, min_value, max_value, extra_stats%s) VALUES (%d, %d, %s, %s, %s, %s, %s%s) "
+			    "ON CONFLICT (table_id, column_id) DO UPDATE SET "
+			    "contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, extra_stats=%s%s;",
+			    exactness_columns, stats.table_id.index, col_stats.column_id.index, sql.contains_null,
+			    sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats, exactness_values,
+			    assignments.contains_null, assignments.contains_nan, assignments.min_val, assignments.max_val,
+			    sql.extra_stats, exactness_set);
+		}
 	} else {
 		// stats have been initialized - update them
 		batch_query += StringUtil::Format(
@@ -5098,20 +5250,26 @@ string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalSt
 		// `::boolean` operator: both DuckDB and Postgres accept ANSI CAST,
 		// and SQLite's parser rejects `::` outright (SQLITE_ERROR:
 		// unrecognized token ":").
+		// Under READ COMMITTED a self-referencing UPDATE blocks on the row lock and re-reads the committed
+		// value, so MERGE needs no lock, CAS column or retry.
 		for (auto &col_stats : stats.column_stats) {
 			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
+			auto assignments =
+			    write_mode == GlobalStatsWrite::MERGE
+			        ? MergeColumnStatsAssignments(dialect, col_stats, sql)
+			        : MergedColumnStatsSQL {sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val,
+			                                sql.min_is_exact, sql.max_is_exact};
 			string exactness_set;
-			if (write_stats_exactness) {
-				exactness_set =
-				    StringUtil::Format(", min_is_exact=CAST(%s AS BOOLEAN), max_is_exact=CAST(%s AS BOOLEAN)",
-				                       sql.min_is_exact, sql.max_is_exact);
+			if (dialect.write_stats_exactness) {
+				exactness_set = StringUtil::Format(", min_is_exact=%s, max_is_exact=%s", assignments.min_is_exact,
+				                                   assignments.max_is_exact);
 			}
 			batch_query += StringUtil::Format(
 			    "UPDATE {METADATA_CATALOG}.ducklake_table_column_stats "
-			    "SET contains_null=CAST(%s AS BOOLEAN), contains_nan=CAST(%s AS BOOLEAN), min_value=%s, max_value=%s, "
+			    "SET contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, "
 			    "extra_stats=%s%s WHERE table_id=%d AND column_id=%d;",
-			    sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats, exactness_set,
-			    stats.table_id.index, col_stats.column_id.index);
+			    assignments.contains_null, assignments.contains_nan, assignments.min_val, assignments.max_val,
+			    sql.extra_stats, exactness_set, stats.table_id.index, col_stats.column_id.index);
 		}
 	}
 	return batch_query;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -245,7 +245,7 @@ string DuckLakeMetadataManager::GetTableColumnStatsTableStatement() {
 	// SQLite reject each other's CREATE INDEX schema-qualification.
 	return "CREATE TABLE {METADATA_CATALOG}.ducklake_table_column_stats(table_id BIGINT, column_id BIGINT, "
 	       "contains_null BOOLEAN, contains_nan BOOLEAN, min_value VARCHAR, max_value VARCHAR, extra_stats VARCHAR, "
-	       "min_is_exact BOOLEAN, max_is_exact BOOLEAN, PRIMARY KEY(table_id, column_id));";
+	       "PRIMARY KEY(table_id, column_id));";
 }
 
 string DuckLakeMetadataManager::GetCreateTableStatements() {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5145,10 +5145,10 @@ static MergedColumnStatsSQL MergeColumnStatsAssignments(const DuckLakeMetadataMa
 	} else {
 		result.min_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_val,
 		                                    MergeBoundExpression(dialect, col_stats, stored_min, sql.min_val, true));
-		result.min_is_exact = StringUtil::Format(
-		    "CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_is_exact,
-		    MergeExactnessExpression(dialect, col_stats, stored_min, sql.min_val, stored_min_is_exact,
-		                             sql.min_is_exact, true));
+		result.min_is_exact =
+		    StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_min, sql.min_is_exact,
+		                       MergeExactnessExpression(dialect, col_stats, stored_min, sql.min_val,
+		                                                stored_min_is_exact, sql.min_is_exact, true));
 	}
 	if (!col_stats.has_max || sql.max_val == "NULL") {
 		result.max_val = "NULL";
@@ -5156,10 +5156,10 @@ static MergedColumnStatsSQL MergeColumnStatsAssignments(const DuckLakeMetadataMa
 	} else {
 		result.max_val = StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_val,
 		                                    MergeBoundExpression(dialect, col_stats, stored_max, sql.max_val, false));
-		result.max_is_exact = StringUtil::Format(
-		    "CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_is_exact,
-		    MergeExactnessExpression(dialect, col_stats, stored_max, sql.max_val, stored_max_is_exact,
-		                             sql.max_is_exact, false));
+		result.max_is_exact =
+		    StringUtil::Format("CASE WHEN %s IS NULL THEN %s ELSE %s END", stored_max, sql.max_is_exact,
+		                       MergeExactnessExpression(dialect, col_stats, stored_max, sql.max_val,
+		                                                stored_max_is_exact, sql.max_is_exact, false));
 	}
 	result.contains_null =
 	    sql.contains_null == "NULL"
@@ -5228,10 +5228,9 @@ string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalSt
 			    "contains_nan, min_value, max_value, extra_stats%s) VALUES (%d, %d, %s, %s, %s, %s, %s%s) "
 			    "ON CONFLICT (table_id, column_id) DO UPDATE SET "
 			    "contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, extra_stats=%s%s;",
-			    exactness_columns, stats.table_id.index, col_stats.column_id.index, sql.contains_null,
-			    sql.contains_nan, sql.min_val, sql.max_val, sql.extra_stats, exactness_values,
-			    assignments.contains_null, assignments.contains_nan, assignments.min_val, assignments.max_val,
-			    sql.extra_stats, exactness_set);
+			    exactness_columns, stats.table_id.index, col_stats.column_id.index, sql.contains_null, sql.contains_nan,
+			    sql.min_val, sql.max_val, sql.extra_stats, exactness_values, assignments.contains_null,
+			    assignments.contains_nan, assignments.min_val, assignments.max_val, sql.extra_stats, exactness_set);
 		}
 	} else {
 		// stats have been initialized - update them
@@ -5254,22 +5253,21 @@ string DuckLakeMetadataManager::UpdateGlobalTableStatsSql(const DuckLakeGlobalSt
 		// value, so MERGE needs no lock, CAS column or retry.
 		for (auto &col_stats : stats.column_stats) {
 			auto sql = ColumnStatsSQL::FromColumnStats(col_stats);
-			auto assignments =
-			    write_mode == GlobalStatsWrite::MERGE
-			        ? MergeColumnStatsAssignments(dialect, col_stats, sql)
-			        : MergedColumnStatsSQL {sql.contains_null, sql.contains_nan, sql.min_val, sql.max_val,
-			                                sql.min_is_exact, sql.max_is_exact};
+			auto assignments = write_mode == GlobalStatsWrite::MERGE
+			                       ? MergeColumnStatsAssignments(dialect, col_stats, sql)
+			                       : MergedColumnStatsSQL {sql.contains_null, sql.contains_nan, sql.min_val,
+			                                               sql.max_val,       sql.min_is_exact, sql.max_is_exact};
 			string exactness_set;
 			if (dialect.write_stats_exactness) {
 				exactness_set = StringUtil::Format(", min_is_exact=%s, max_is_exact=%s", assignments.min_is_exact,
 				                                   assignments.max_is_exact);
 			}
-			batch_query += StringUtil::Format(
-			    "UPDATE {METADATA_CATALOG}.ducklake_table_column_stats "
-			    "SET contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, "
-			    "extra_stats=%s%s WHERE table_id=%d AND column_id=%d;",
-			    assignments.contains_null, assignments.contains_nan, assignments.min_val, assignments.max_val,
-			    sql.extra_stats, exactness_set, stats.table_id.index, col_stats.column_id.index);
+			batch_query += StringUtil::Format("UPDATE {METADATA_CATALOG}.ducklake_table_column_stats "
+			                                  "SET contains_null=%s, contains_nan=%s, min_value=%s, max_value=%s, "
+			                                  "extra_stats=%s%s WHERE table_id=%d AND column_id=%d;",
+			                                  assignments.contains_null, assignments.contains_nan, assignments.min_val,
+			                                  assignments.max_val, sql.extra_stats, exactness_set, stats.table_id.index,
+			                                  col_stats.column_id.index);
 		}
 	}
 	return batch_query;

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -792,7 +792,7 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		return it == existing_table_stats.end() ? nullptr : it->second;
 	};
 	ctx.update_global_table_stats_sql = [this](const DuckLakeGlobalStatsInfo &stats,
-	                                          DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
+	                                           DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
 		DuckLakeMetadataManager::StatsMergeDialect dialect;
 		dialect.supports_upsert = supports_v1_1_metadata;
 		dialect.write_stats_exactness = supports_v1_1_metadata;

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -791,6 +791,13 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		auto it = existing_table_stats.find(table_id);
 		return it == existing_table_stats.end() ? nullptr : it->second;
 	};
+	ctx.update_global_table_stats_sql = [this](const DuckLakeGlobalStatsInfo &stats,
+	                                          DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
+		DuckLakeMetadataManager::StatsMergeDialect dialect;
+		dialect.supports_upsert = supports_v1_1_metadata;
+		dialect.write_stats_exactness = supports_v1_1_metadata;
+		return DuckLakeMetadataManager::UpdateGlobalTableStatsSql(stats, write_mode, dialect);
+	};
 	ctx.build_stats_map = [this](vector<DuckLakeGlobalStatsInfo> &stats) {
 		return BuildStatsMap(stats);
 	};

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1253,6 +1253,8 @@ DuckLakeGlobalStatsInfo DuckLakeTransaction::ConvertNewGlobalStats(TableIndex ta
 		if (column_stats.has_contains_nan) {
 			col_stats.contains_nan = column_stats.contains_nan;
 		}
+		col_stats.type = column_stats.type;
+		col_stats.has_type = true;
 		col_stats.has_min = column_stats.has_min;
 		if (column_stats.has_min) {
 			col_stats.min_val = column_stats.min;
@@ -1499,6 +1501,11 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.get_table_stats = [&](TableIndex table_id) {
 		return ducklake_catalog.GetTableStats(*this, table_id);
+	};
+	context.update_global_table_stats_sql = [&](const DuckLakeGlobalStatsInfo &stats,
+	                                            DuckLakeMetadataManager::GlobalStatsWrite write_mode) {
+		return DuckLakeMetadataManager::UpdateGlobalTableStatsSql(stats, write_mode,
+		                                                          metadata_manager->GetStatsMergeDialect());
 	};
 	context.get_table_column_schema = [&](TableIndex table_id) {
 		// The full flattened schema at the commit snapshot: top-level roots (is_root=true) plus every nested

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -273,12 +273,14 @@ void DuckLakeTransactionState::CheckForConflicts(const TransactionChangeInformat
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "compact table", "deleted from it");
 		ConflictCheck(table_id, other_changes.tables_merge_adjacent, "compact table", "compacted it");
 		ConflictCheck(table_id, other_changes.tables_rewrite_delete, "compact table", "compacted it");
+		ConflictCheck(table_id, other_changes.inserted_tables, "compact table", "inserted into it");
 	}
 	for (auto &table_id : changes.tables_rewrite_delete) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "compact table", "dropped it");
 		ConflictCheck(table_id, other_changes.tables_deleted_from, "compact table", "deleted from it");
 		ConflictCheck(table_id, other_changes.tables_merge_adjacent, "compact table", "compacted it");
 		ConflictCheck(table_id, other_changes.tables_rewrite_delete, "compact table", "compacted it");
+		ConflictCheck(table_id, other_changes.inserted_tables, "compact table", "inserted into it");
 	}
 	for (auto &table_id : changes.altered_tables) {
 		ConflictCheck(table_id, other_changes.dropped_tables, "alter table", "dropped it");
@@ -988,8 +990,9 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	DuckLakeNewGlobalStats new_globals;
 	new_globals.initialized = true;
 	new_globals.stats = std::move(new_stats);
-	batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals), context.supports_v1_1_metadata);
+	batch_query +=
+	    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+	                                          DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE);
 }
 
 static idx_t SubtractDroppedFileStat(idx_t value, idx_t decrement) {
@@ -1075,8 +1078,9 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 			// the rows are deleted below - drop them from the update so we do not write values we then delete
 			new_globals.stats.column_stats.clear();
 		}
-		result += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals), context.supports_v1_1_metadata);
+		result +=
+		    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+		                                          DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE);
 		if (delete_column_stats) {
 			result += DeleteTableColumnStatsSql(table_id);
 		}
@@ -1122,7 +1126,11 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 			new_globals.stats = *current_stats;
 			new_globals.initialized = true;
 		}
+		bool dropped_files = attempt_dropped_file_stats.find(table_id) != attempt_dropped_file_stats.end();
 		bool clear_column_stats = ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
+		// Dropped every file, so the stats below cover only rows this commit wrote: merging them against
+		// the bounds of the rows just deleted would resurrect them.
+		bool emptied_table = dropped_files && !clear_column_stats;
 		auto &new_stats = new_globals.stats;
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
@@ -1186,8 +1194,10 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 			new_stats.column_stats.clear();
 		}
 		// update the global stats for this table based on the newly written data
-		batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
-		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals), context.supports_v1_1_metadata);
+		batch_query +=
+		    context.update_global_table_stats_sql(DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals),
+		                                          emptied_table ? DuckLakeMetadataManager::GlobalStatsWrite::OVERWRITE
+		                                                        : DuckLakeMetadataManager::GlobalStatsWrite::MERGE);
 		if (clear_column_stats) {
 			batch_query += DeleteTableColumnStatsSql(table_id);
 		}
@@ -1927,9 +1937,37 @@ SnapshotAndStats DuckLakeTransactionState::CheckForConflicts(
 	return snapshot_and_stats;
 }
 
+void DuckLakeCommitContext::ValidateRequiredClosures() const {
+	struct RequiredClosure {
+		const char *name;
+		bool assigned;
+	};
+	const RequiredClosure required[] = {
+	    {"conflict_query_executor", static_cast<bool>(conflict_query_executor)},
+	    {"get_snapshot", static_cast<bool>(get_snapshot)},
+	    {"execute_commit_batch", static_cast<bool>(execute_commit_batch)},
+	    {"query_metadata", static_cast<bool>(query_metadata)},
+	    {"query_metadata_with_snapshot", static_cast<bool>(query_metadata_with_snapshot)},
+	    {"write_inlined_data", static_cast<bool>(write_inlined_data)},
+	    {"get_table_stats", static_cast<bool>(get_table_stats)},
+	    {"update_global_table_stats_sql", static_cast<bool>(update_global_table_stats_sql)},
+	    {"build_stats_map", static_cast<bool>(build_stats_map)},
+	    {"set_catalog_version", static_cast<bool>(set_catalog_version)},
+	    {"set_committed_snapshot_id", static_cast<bool>(set_committed_snapshot_id)},
+	};
+	for (auto &entry : required) {
+		if (!entry.assigned) {
+			throw InternalException(
+			    "DuckLakeCommitContext is missing required closure \"%s\" - a BuildContext site did not assign it",
+			    entry.name);
+		}
+	}
+}
+
 void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
                                       const TransactionChangeInformation &transaction_changes,
                                       const DuckLakeRetryConfig &retry_config, const DuckLakeCommitContext &context) {
+	context.ValidateRequiredClosures();
 	SnapshotAndStats commit_stats_snapshot;
 	auto &commit_snapshot = commit_stats_snapshot.snapshot;
 	optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats;

--- a/test/sql/migration/v11_stats_exactness.test
+++ b/test/sql/migration/v11_stats_exactness.test
@@ -53,7 +53,7 @@ apple	zebra	true	true
 query IIII
 SELECT min_value, max_value, min_is_exact::BOOLEAN, max_is_exact::BOOLEAN FROM dl.ducklake_table_column_stats ORDER BY column_id
 ----
-1	4	true	true
+1	4	NULL	true
 apple	zebra	true	true
 
 # the flags survive a detach/re-attach round-trip through the global stats read path

--- a/test/sql/stats/global_stats_transactions.test
+++ b/test/sql/stats/global_stats_transactions.test
@@ -52,3 +52,41 @@ query I
 SELECT stats(i) FROM ducklake.test LIMIT 1
 ----
 <REGEX>:.*max.*84.*min.*42.*
+
+# compaction's recompute must conflict with a concurrent insert, or it loses the insert's bounds
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement ok
+CREATE TABLE ducklake.compact_test(i INTEGER);
+
+statement ok
+INSERT INTO ducklake.compact_test VALUES (10);
+
+statement ok
+INSERT INTO ducklake.compact_test VALUES (20);
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+CALL ducklake_merge_adjacent_files('ducklake', 'compact_test');
+
+statement ok con2
+INSERT INTO ducklake.compact_test VALUES (999);
+
+statement ok con2
+COMMIT
+
+statement error con1
+COMMIT
+----
+Transaction conflict
+
+query I
+SELECT stats(i) FROM ducklake.compact_test LIMIT 1
+----
+<REGEX>:.*max.*999.*min.*10.*


### PR DESCRIPTION
Part of #1094 resolution

## Problem

Concurrent inserts silently lose each other's stats.

The `min_value` & `max_value` then fail to cover rows that are committed. Since filter pruning trusts those bounds without question, the pruner drops files that contain live rows.

Using a two writer probe against a pg catalog, reading back through a fresh `attach` to defeat caching:

```
total=2 but key=1 -> 0   key=0 -> 2   (pruned live row)
```

`select count(*)` returns 2, and `where key = 1` returns 0 rows for a row that is committed and present. `concurrent_insert_data_inlining.test` fails on `main` and proves the bug. It passes here.

## Root cause

`UpdateGlobalTableStatsSql` branched on `!stats.initialized`:

- when there's no row yet -> `insert` of the committer's bounds
- when the row _does_ exist -> `update` overwriting with the committer's bounds

Both branches ignore what a concurrent committer wrote. `create table` doesn't write any stats rows, so two concurrent first inserts both take the `insert` branch with only one winning.

## Fix

One atomic write path for appends. The two branches collapse into a single upsert/merge hinging on a primary key on `ducklake_table_column_stats (table_id, column_id)`. The merge is type-aware with bounds stored as `varchar`s holding string literals and flags like `contains_null` or `contains_nan` are or'd so they can't be forgotten.

Appends merge, authoritative recomputes overwrite. An append carries a delta and must widen. A recompute (`RecomputeGlobalStatsAfterRewrite`, `UpdateStatsForDroppedFiles`) is computed from all surviving files, so it *is* the truth and has to be able to narrow. Routing a recompute through the widen-only merge made compaction's recompute a silent no-op while `min_max_exact` flipped back to `true`, folding stale bounds. The two kinds are threaded as an explicit `GlobalStatsWrite::{MERGE, OVERWRITE}` enum rather than a bool, since misrouting a writer is the exact bug it prevents.

Compaction now conflicts with a concurrent insert. Compaction takes no commit lock, so a recompute-overwrite could otherwise discard a concurrent append. Two additive `ConflictCheck` calls close it.

A commit that drops every file writes absolute stats, not a delta. Those bounds describe only the rows the commit wrote itself, so merging them against the bounds of the rows it just deleted resurrects them. That path routes to `OVERWRITE`.

Bound literals are returned verbatim. The merge compares as the declared type but returns the winning `varchar` unchanged, since casting the comparison result back re-serializes the literal and loses its formatting (`1.0` -> `1`).

> [!WARNING]
> There is a schema migration. It is non-invasive however

`ducklake_table_column_stats` gains a primary key on `(table_id, column_id)`, added in both `CreateTables` (fresh catalogs) and appended to the existing 1.0 -> 1.1-dev1 migration (existing ones). The `!initialized` branch results in a bare `insert`. No key or conflict handling. Two concurrent first inserts each write their own row. It's the same as the lost update race. an `update` blindly overwrites and an `insert` dupes. The migration collapses any pre-existing duplicate rows using the same widen-only merge, so nothing is lost. Duplicates were already causing incorrect results since both readers `left join ... using (table_id)`.

### SQLite opts out

`duckdb-sqlite` doesn't support `on conflict`. It's behind `SupportsUpsert()` and can be lifted when the scanner gains support.

### Catalogs pinned to v1.0 opt out

Catalogs pinned to `ducklake_default_version='1.0'` do not get this fix. The upsert needs the `(table_id, column_id)` primary key added by the 1.0 -> 1.1-dev1 migration. Pinned catalogs never run that. So those catalogs will keep the first-insert suffering a lost update under concurrency issue. Attaching without the version pin migrates the catalog and applies the fix.



