### PR TITLE
Only apply global statistics to current-snapshot table scans

### DIFF
--- a/src/include/storage/ducklake_multi_file_list.hpp
+++ b/src/include/storage/ducklake_multi_file_list.hpp
@@ -45,9 +45,6 @@ public:
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const override;
 	DuckLakeTableEntry &GetTable();
 	unique_ptr<MultiFileList> Copy() const override;
-	bool HasTransactionLocalData() const {
-		return !transaction_local_files.empty() || transaction_local_data;
-	}
 	vector<DuckLakeFileListExtendedEntry> GetFilesExtended() const;
 	const vector<DuckLakeFileListEntry> &GetFiles() const;
 	const DuckLakeFileListEntry &GetFileEntry(idx_t file_idx) const;
@@ -55,6 +52,7 @@ public:
 		return filter_info.get();
 	}
 
+	bool CanUseGlobalStats() const;
 	bool IsDeleteScan() const;
 	const DuckLakeDeleteScanEntry &GetDeleteScanEntry(idx_t file_idx);
 

--- a/src/include/storage/ducklake_scan.hpp
+++ b/src/include/storage/ducklake_scan.hpp
@@ -57,6 +57,7 @@ struct DuckLakeFunctionInfo : public TableFunctionInfo {
 	unique_ptr<DuckLakeSnapshot> start_snapshot;
 
 	shared_ptr<DuckLakeTransaction> GetTransaction();
+	bool CanUseGlobalStats();
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_multi_file_list.cpp
+++ b/src/storage/ducklake_multi_file_list.cpp
@@ -421,6 +421,10 @@ void DuckLakeMultiFileList::GetTableDeletions() const {
 	}
 }
 
+bool DuckLakeMultiFileList::CanUseGlobalStats() const {
+	return read_info.CanUseGlobalStats();
+}
+
 bool DuckLakeMultiFileList::IsDeleteScan() const {
 	return read_info.scan_type == DuckLakeScanType::SCAN_DELETIONS;
 }

--- a/src/storage/ducklake_scan.cpp
+++ b/src/storage/ducklake_scan.cpp
@@ -98,9 +98,7 @@ unique_ptr<BaseStatistics> DuckLakeStatistics(ClientContext &context, const Func
 	}
 	auto &multi_file_data = bind_data->Cast<MultiFileBindData>();
 	auto &file_list = multi_file_data.file_list->Cast<DuckLakeMultiFileList>();
-	if (file_list.HasTransactionLocalData()) {
-		// don't read stats if we have transaction-local inserts
-		// FIXME: we could unify the stats with the global stats
+	if (!file_list.CanUseGlobalStats()) {
 		return nullptr;
 	}
 	auto &table = file_list.GetTable();
@@ -174,8 +172,7 @@ vector<PartitionStatistics> DuckLakeGetPartitionStats(ClientContext &context, Ge
 	}
 	auto &func_info = input.table_function.function_info->Cast<DuckLakeFunctionInfo>();
 
-	// Only use partition stats for regular table scans
-	if (func_info.scan_type != DuckLakeScanType::SCAN_TABLE) {
+	if (!func_info.CanUseGlobalStats()) {
 		return result;
 	}
 
@@ -185,17 +182,6 @@ vector<PartitionStatistics> DuckLakeGetPartitionStats(ClientContext &context, Ge
 	auto transaction = func_info.GetTransaction();
 
 	auto table_id = table.GetTableId();
-
-	// Check if this is a time travel query - if so, fall back to scanning
-	// After merge_adjacent_files, multiple files are merged into one with a combined record_count.
-	// The merged file contains an embedded snapshot_id column for time travel filtering,
-	// but the metadata record_count represents ALL rows, not per-snapshot counts.
-	// Only a full scan can filter by snapshot_id to get the correct historical count.
-	// Time travel can occur via: (1) per-query AT clause, or (2) catalog attached at historical snapshot
-	auto current_snapshot = transaction->GetSnapshot();
-	if (func_info.snapshot.snapshot_id != current_snapshot.snapshot_id || transaction->GetCatalog().CatalogSnapshot()) {
-		return result;
-	}
 
 	// Check if this is a transaction-local table (no committed stats)
 	if (table.IsTransactionLocal()) {
@@ -283,6 +269,15 @@ shared_ptr<DuckLakeTransaction> DuckLakeFunctionInfo::GetTransaction() {
 		    "Scanning a DuckLake table after the transaction has ended - this use case is not yet supported");
 	}
 	return result;
+}
+
+bool DuckLakeFunctionInfo::CanUseGlobalStats() {
+	if (scan_type != DuckLakeScanType::SCAN_TABLE) {
+		return false;
+	}
+	auto active_transaction = GetTransaction();
+	return snapshot.snapshot_id == active_transaction->GetSnapshot().snapshot_id &&
+	       !active_transaction->GetCatalog().CatalogSnapshot();
 }
 
 void DuckLakeScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,

--- a/test/sql/stats/count_not_null_optimization_time_travel.test
+++ b/test/sql/stats/count_not_null_optimization_time_travel.test
@@ -1,0 +1,77 @@
+# name: test/sql/stats/count_not_null_optimization_time_travel.test
+# description: Column stats with time travel, change feeds and pinned catalogs (fall back, stay correct)
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/count_not_null_time_travel.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/count_not_null_time_travel', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.history(i INTEGER);
+
+# the only snapshot that ever contained a NULL
+statement ok
+INSERT INTO ducklake.history VALUES (NULL), (1);
+
+query I
+SELECT MAX(snapshot_id) FROM ducklake.snapshots();
+----
+2
+
+statement ok
+DELETE FROM ducklake.history WHERE i IS NULL;
+
+# REWRITE_DELETES recomputes exact global stats, which now record no NULLs
+statement ok
+CALL ducklake_rewrite_data_files('ducklake', 'history', delete_threshold => 0);
+
+# the current scan may still answer count(i) from those stats without reading files
+query II
+EXPLAIN ANALYZE SELECT count(i) FROM ducklake.history;
+----
+analyzed_plan	<!REGEX>:.*TABLE_SCAN.*
+
+query II
+SELECT count(i), count(*) FROM ducklake.history;
+----
+1	1
+
+# snapshot 2 still holds the NULL, so the current stats must not be applied to it
+query II
+SELECT count(i), count(*) FROM ducklake.history AT (VERSION => 2);
+----
+1	2
+
+# nor may they eliminate a predicate that the snapshot's rows do satisfy
+query I
+SELECT count(*) FROM ducklake.history AT (VERSION => 2) WHERE i IS NULL;
+----
+1
+
+# nor may they be applied to a change feed reading that snapshot
+query II
+SELECT count(i), count(*) FROM ducklake_table_insertions('ducklake', 'main', 'history', 2, 2);
+----
+1	2
+
+statement ok
+DETACH ducklake;
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (SNAPSHOT_VERSION 2);
+
+# nor to a catalog pinned at that snapshot
+query II
+SELECT count(i), count(*) FROM ducklake.history;
+----
+1	2

--- a/test/sql/stats/min_max_optimization_time_travel.test
+++ b/test/sql/stats/min_max_optimization_time_travel.test
@@ -65,7 +65,7 @@ SELECT MIN(i), MAX(i) FROM ducklake.tt;
 ----
 -5	9999
 
-# transaction-local data forces fallback via HasTransactionLocalData()
+# transaction-local inserts force a scan: GetTableStats returns no stats while they are pending
 query II
 EXPLAIN ANALYZE SELECT MIN(i), MAX(i) FROM ducklake.tt;
 ----


### PR DESCRIPTION
Fixes #1377

## Problem

DuckLake's global column statistics are not versioned. `DuckLakeStatistics` exposes them to every scan, including historical, change-feed, and snapshot-pinned scans whose rows differ from the current table. This can eliminate matching predicates or rewrite `count(column)` to `count(*)`, returning incorrect results.

## Fix

Only expose global column statistics when all three conditions hold:
- the scan is a regular table scan
- the scan snapshot matches the transaction snapshot
- the catalog is not snapshot-pinned

`DuckLakeGetPartitionStats` already applied the same scan-kind and snapshot checks inline. 
They now live in `DuckLakeFunctionInfo::CanUseGlobalStats()` and both call sites use it. Other scans return `nullptr`, so the optimizer falls back to reading the selected data.
