### PR TITLE
Fix main CI by dropping leaked scoped metadata schemas in the postgres test config

### DIFF
--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -1,6 +1,6 @@
 {
   "description": "Run DuckLake tests using Postgres as a catalog DBMS.",
-  "on_init": "ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg; SET pg_experimental_filter_pushdown=false; SET pg_order_pushdown=false;",
+  "on_init": "ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; DROP SCHEMA IF EXISTS scoped_meta_1064 CASCADE; DROP SCHEMA IF EXISTS junk_1064 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg; SET pg_experimental_filter_pushdown=false; SET pg_order_pushdown=false;",
   "autoloading": "none",
   "statically_loaded_extensions": [
     "core_functions",


### PR DESCRIPTION
Fix the failing Postgres job by dropping both leftover schemas in `on_init`. `metadata_schema_scoped_attach.test` leaves `scoped_meta_1064` and `junk_1064` in `ducklakedb`, and the `data_inlining` cleanup tests count inlined tables across all schemas.
