### PR TITLE
Cast inlined column references when building the flush sort order

### DIFF
--- a/src/functions/ducklake_compaction_functions.cpp
+++ b/src/functions/ducklake_compaction_functions.cpp
@@ -29,6 +29,9 @@
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 
 namespace duckdb {
 
@@ -414,6 +417,34 @@ void DuckLakeCompactor::GenerateCompactions(DuckLakeTableEntry &table,
 	}
 }
 
+namespace {
+
+// The resolver checks a reference against the child operator's types, so the cast has to sit above
+// the reference rather than replace its type.
+void RetypeSortColumnRefs(ClientContext &context, unique_ptr<Expression> &expr, const vector<ColumnBinding> &bindings,
+                          const vector<LogicalType> &plan_types) {
+	if (expr->GetExpressionType() == ExpressionType::BOUND_COLUMN_REF) {
+		auto &colref = expr->Cast<BoundColumnRefExpression>();
+		for (idx_t i = 0; i < bindings.size() && i < plan_types.size(); i++) {
+			if (!(colref.Binding() == bindings[i])) {
+				continue;
+			}
+			if (colref.GetReturnType() == plan_types[i]) {
+				return;
+			}
+			auto target_type = colref.GetReturnType();
+			colref.SetReturnType(plan_types[i]);
+			expr = BoundCastExpression::AddCastToType(context, std::move(expr), target_type);
+			return;
+		}
+		return;
+	}
+	ExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<Expression> &child) { RetypeSortColumnRefs(context, child, bindings, plan_types); });
+}
+
+} // namespace
+
 unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique_ptr<LogicalOperator> &plan,
                                                           DuckLakeTableEntry &table,
                                                           optional_ptr<DuckLakeSort> sort_data, bool add_tiebreakers) {
@@ -437,6 +468,12 @@ unique_ptr<LogicalOperator> DuckLakeCompactor::InsertSort(Binder &binder, unique
 
 	// Bind the ORDER BY expressions
 	auto orders = DuckLakeCompactor::BindSortOrders(binder, table, table_index, pre_bound_orders);
+
+	// The inlined table can still hold the column under its pre-ALTER type. The file is written with
+	// the current type, and the sort has to match the file.
+	for (auto &order : orders) {
+		RetypeSortColumnRefs(binder.context, order.expression, bindings, plan->types);
+	}
 
 	// Append (row_id, snapshot_id) as deterministic tiebreakers when requested so the file order
 	// exactly matches the deletes-position query's ORDER BY, including ties in the user sort key.

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -378,7 +378,8 @@ unique_ptr<LogicalOperator> DuckLakeDataFlusher::GenerateFlushCommand() {
 	auto sort_data = latest_table.GetSortData();
 	if (sort_data) {
 		root = DuckLakeCompactor::InsertSort(binder, root, latest_table, sort_data, /*add_tiebreakers=*/true);
-		sort_order_sql = DuckLakeSort::BuildSortOrderSQL(*sort_data, latest_table.GetColumns(), table.GetColumns());
+		sort_order_sql = DuckLakeSort::BuildSortOrderSQL(*sort_data, latest_table.GetColumns(), table.GetColumns(),
+		                                                 transaction.GetMetadataManager());
 	}
 
 	// generate the LogicalCopyToFile

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -188,6 +188,8 @@ public:
 
 	virtual string GetColumnTypeInternal(const LogicalType &column_type);
 	virtual string CastColumnToTarget(const string &column, const LogicalType &type);
+	//! Returns the column unchanged when no cast is needed, so callers can apply it unconditionally
+	virtual string CastInlinedColumnToTarget(const string &column, const LogicalType &type);
 
 	DuckLakeMetadataManager &Get(DuckLakeTransaction &transaction);
 

--- a/src/include/storage/ducklake_sort_data.hpp
+++ b/src/include/storage/ducklake_sort_data.hpp
@@ -14,6 +14,8 @@
 
 namespace duckdb {
 
+class DuckLakeMetadataManager;
+
 class ColumnList;
 
 struct DuckLakeSortField {
@@ -30,7 +32,7 @@ struct DuckLakeSort {
 
 	//! Build a SQL ORDER BY clause from the sort fields, mapping inlined columns
 	static string BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
-	                                const ColumnList &inlined_columns);
+	                                const ColumnList &inlined_columns, DuckLakeMetadataManager &metadata_manager);
 };
 
 } // namespace duckdb

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1334,6 +1334,15 @@ string DuckLakeMetadataManager::CastColumnToTarget(const string &column, const L
 	return "CAST(" + column + " AS " + type.ToString() + ")";
 }
 
+string DuckLakeMetadataManager::CastInlinedColumnToTarget(const string &column, const LogicalType &type) {
+	// only VARCHAR is exempt: casting it back escapes its non-printable bytes, which reorders it.
+	// every other type can reach the sort as text, where text order is not value order
+	if (type.id() == LogicalTypeId::VARCHAR) {
+		return column;
+	}
+	return CastColumnToTarget(column, type);
+}
+
 string DuckLakeMetadataManager::GenerateConstantFilter(ExpressionType comparison_type, const Value &constant,
                                                        const LogicalType &type,
                                                        unordered_set<string> &referenced_stats) {

--- a/src/storage/ducklake_sort_data.cpp
+++ b/src/storage/ducklake_sort_data.cpp
@@ -7,23 +7,48 @@
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/common/case_insensitive_map.hpp"
+#include "storage/ducklake_metadata_manager.hpp"
 
 namespace duckdb {
 
 // Round-trip user sort expressions through the parser so non-bare-column expressions (e.g.
 // `(id + 0)`) survive into the deletes-position query.
 
+namespace {
+
+// VisitExpressionMutable only exposes a reference, so it cannot swap a column ref for a cast
+void RewriteColumnRefs(unique_ptr<ParsedExpression> &expr,
+                       const std::function<void(unique_ptr<ParsedExpression> &)> &rewrite) {
+	if (expr->GetExpressionClass() == ExpressionClass::COLUMN_REF) {
+		rewrite(expr);
+		return;
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    *expr, [&](unique_ptr<ParsedExpression> &child) { RewriteColumnRefs(child, rewrite); });
+}
+
+} // namespace
+
 // FIXME: TODO: Macros and other user-catalog references will fail at bind time on the metadata connection
 string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const ColumnList &current_columns,
-                                       const ColumnList &inlined_columns) {
+                                       const ColumnList &inlined_columns, DuckLakeMetadataManager &metadata_manager) {
 	// Build rename map: current physical name -> inlined physical name (only entries that differ).
 	case_insensitive_map_t<string> rename_map;
+	case_insensitive_map_t<LogicalType> type_map;
+	bool any_cast = false;
 	auto column_count = MinValue(current_columns.PhysicalColumnCount(), inlined_columns.PhysicalColumnCount());
 	for (idx_t i = 0; i < column_count; i++) {
-		auto &current_name = current_columns.GetColumn(PhysicalIndex(i)).Name();
+		auto &current_column = current_columns.GetColumn(PhysicalIndex(i));
+		auto &current_name = current_column.Name();
 		auto &inlined_name = inlined_columns.GetColumn(PhysicalIndex(i)).Name();
 		if (current_name.GetIdentifierName() != inlined_name.GetIdentifierName()) {
 			rename_map[current_name.GetIdentifierName()] = inlined_name.GetIdentifierName();
+		}
+		auto &type = current_column.Type();
+		type_map[current_name.GetIdentifierName()] = type;
+		if (!any_cast) {
+			auto probe = SQLIdentifier::ToString(current_name.GetIdentifierName());
+			any_cast = metadata_manager.CastInlinedColumnToTarget(probe, type) != probe;
 		}
 	}
 
@@ -35,20 +60,31 @@ string DuckLakeSort::BuildSortOrderSQL(const DuckLakeSort &sort_data, const Colu
 		if (!result.empty()) {
 			result += ", ";
 		}
-		// Only re-parse + rewrite when columns were renamed between the inlined-table
-		// write and the flush.
-		if (rename_map.empty()) {
+		if (rename_map.empty() && !any_cast) {
 			result += field.expression;
 		} else {
 			auto parsed = Parser::ParseExpressionList(field.expression);
 			D_ASSERT(parsed.size() == 1);
-			ParsedExpressionIterator::VisitExpressionMutable<ColumnRefExpression>(
-			    *parsed[0], [&](ColumnRefExpression &colref) {
-				    auto entry = rename_map.find(colref.GetColumnName().GetIdentifierName());
-				    if (entry != rename_map.end()) {
-					    colref.ColumnNamesMutable().back() = Identifier(entry->second);
-				    }
-			    });
+			RewriteColumnRefs(parsed[0], [&](unique_ptr<ParsedExpression> &child) {
+				auto &colref = child->Cast<ColumnRefExpression>();
+				auto name = colref.GetColumnName().GetIdentifierName();
+				auto rename_entry = rename_map.find(name);
+				if (rename_entry != rename_map.end()) {
+					colref.ColumnNamesMutable().back() = Identifier(rename_entry->second);
+				}
+				auto type_entry = type_map.find(name);
+				if (type_entry == type_map.end()) {
+					return;
+				}
+				auto rendered = colref.ToString();
+				auto cast = metadata_manager.CastInlinedColumnToTarget(rendered, type_entry->second);
+				if (cast == rendered) {
+					return;
+				}
+				auto cast_expr = Parser::ParseExpressionList(cast);
+				D_ASSERT(cast_expr.size() == 1);
+				child = std::move(cast_expr[0]);
+			});
 			result += parsed[0]->ToString();
 		}
 		result += (field.sort_direction == OrderType::ASCENDING) ? " ASC" : " DESC";

--- a/test/sql/sorted_table/data_inlining_flush_sorted_text_stored_type.test
+++ b/test/sql/sorted_table/data_inlining_flush_sorted_text_stored_type.test
@@ -1,0 +1,343 @@
+# name: test/sql/sorted_table/data_inlining_flush_sorted_text_stored_type.test
+# description: Flushing a sorted table must derive delete positions from the column's type order, not the metadata catalog's text order
+# group: [sorted_table]
+
+#
+# Each type below names the catalog that stores it as text. The default config is a DuckDB
+# catalog, which stores every column in its own type, so that run is the control; the mismatch
+# needs --test-config postgres.json or sqlite.json.
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/flush_sorted_text_stored_type', DATA_INLINING_ROW_LIMIT 1000)
+
+statement ok
+USE ducklake
+
+# a Postgres catalog stores HUGEINT as VARCHAR, where '10' sorts before '9'
+statement ok
+CREATE TABLE t (id INTEGER, k HUGEINT)
+
+statement ok
+ALTER TABLE t SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO t VALUES (1, 9), (2, 10)
+
+statement ok
+DELETE FROM t WHERE id = 1
+
+query II
+SELECT id, k FROM t ORDER BY id
+----
+2	10
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 't', schema_name := 'main')
+
+query II
+SELECT id, k FROM t ORDER BY id
+----
+2	10
+
+# a SQLite catalog stores DOUBLE as VARCHAR, where '10.0' sorts before '9.0'
+statement ok
+CREATE TABLE d (id INTEGER, k DOUBLE)
+
+statement ok
+ALTER TABLE d SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO d VALUES (1, 9.0), (2, 10.0)
+
+statement ok
+DELETE FROM d WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'd', schema_name := 'main')
+
+query II
+SELECT id, k FROM d ORDER BY id
+----
+2	10.0
+
+# the cast has to reach a column ref nested inside the expression
+statement ok
+CREATE TABLE e (id INTEGER, k HUGEINT)
+
+statement ok
+ALTER TABLE e SET SORTED BY ((k + 0) ASC NULLS LAST)
+
+statement ok
+INSERT INTO e VALUES (1, 9), (2, 10)
+
+statement ok
+DELETE FROM e WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'e', schema_name := 'main')
+
+query II
+SELECT id, k FROM e ORDER BY id
+----
+2	10
+
+# the inlined table still carries the pre-rename name, so rename and cast happen in one rewrite
+statement ok
+CREATE TABLE r (id INTEGER, k HUGEINT)
+
+statement ok
+ALTER TABLE r SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO r VALUES (1, 9), (2, 10)
+
+statement ok
+DELETE FROM r WHERE id = 1
+
+statement ok
+ALTER TABLE r RENAME COLUMN k TO k2
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'r', schema_name := 'main')
+
+query II
+SELECT id, k2 FROM r ORDER BY id
+----
+2	10
+
+# VARCHAR is not cast: it arrives as BLOB and already orders bytewise, matching the file
+statement ok
+CREATE TABLE v (id INTEGER, k VARCHAR)
+
+statement ok
+ALTER TABLE v SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO v VALUES (1, 'Zebra'), (2, 'apple')
+
+statement ok
+DELETE FROM v WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'v', schema_name := 'main')
+
+query II
+SELECT id, k FROM v ORDER BY id
+----
+2	apple
+
+# casting a blob back escapes its bytes: 'ééé' (0xC3) sorts after 'zzz' (0x7A) but renders
+# as '\xC3\xA9..', and 0x5C sorts first. ASCII cannot show this, so the case above cannot either
+statement ok
+CREATE TABLE w (id INTEGER, k VARCHAR)
+
+statement ok
+ALTER TABLE w SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO w VALUES (1, 'zzz'), (2, 'ééé')
+
+statement ok
+DELETE FROM w WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'w', schema_name := 'main')
+
+query II
+SELECT id, k FROM w ORDER BY id
+----
+2	ééé
+
+# INTERVAL is neither numeric nor temporal by IsTemporal, so a stats-derived rule misses it:
+# '2 days' sorts after '10 days' as text
+statement ok
+CREATE TABLE i (id INTEGER, k INTERVAL)
+
+statement ok
+ALTER TABLE i SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO i VALUES (1, INTERVAL '2 days'), (2, INTERVAL '10 days')
+
+statement ok
+DELETE FROM i WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'i', schema_name := 'main')
+
+query I
+SELECT id FROM i ORDER BY id
+----
+2
+
+# nested types render element-wise as text, so '[10]' sorts before '[2]'
+statement ok
+CREATE TABLE l (id INTEGER, k INTEGER[])
+
+statement ok
+ALTER TABLE l SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO l VALUES (1, [2]), (2, [10])
+
+statement ok
+DELETE FROM l WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'l', schema_name := 'main')
+
+query I
+SELECT id FROM l ORDER BY id
+----
+2
+
+statement ok
+CREATE TABLE s (id INTEGER, k STRUCT(a INTEGER))
+
+statement ok
+ALTER TABLE s SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO s VALUES (1, {'a': 2}), (2, {'a': 10})
+
+statement ok
+DELETE FROM s WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 's', schema_name := 'main')
+
+query I
+SELECT id FROM s ORDER BY id
+----
+2
+
+statement ok
+CREATE TABLE m (id INTEGER, k MAP(VARCHAR, INTEGER))
+
+statement ok
+ALTER TABLE m SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO m VALUES (1, MAP{'x': 2}), (2, MAP{'x': 10})
+
+statement ok
+DELETE FROM m WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'm', schema_name := 'main')
+
+query I
+SELECT id FROM m ORDER BY id
+----
+2
+
+# BLOB is not exempt just because it shares VARCHAR's storage type on some backends
+statement ok
+CREATE TABLE b (id INTEGER, k BLOB)
+
+statement ok
+ALTER TABLE b SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO b VALUES (1, '\xC3'::BLOB), (2, 'z'::BLOB)
+
+statement ok
+DELETE FROM b WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'b', schema_name := 'main')
+
+query I
+SELECT id FROM b ORDER BY id
+----
+2
+
+# The position query numbers rows within one partition, so each file needs its own partition's
+# order, not a global one. The key is mixed: v is the exempt type and k is cast, in one ORDER BY.
+# Where VARCHAR round-trips as BLOB the non-ASCII v values also catch a wrong cast of v; where it
+# is stored natively that cast is a no-op and only the standalone case above can see it.
+statement ok
+CREATE TABLE pm (id INTEGER, p INTEGER, v VARCHAR, k HUGEINT)
+
+statement ok
+ALTER TABLE pm SET PARTITIONED BY (p)
+
+statement ok
+ALTER TABLE pm SET SORTED BY (v ASC NULLS LAST, k ASC NULLS LAST)
+
+statement ok
+INSERT INTO pm VALUES
+    (1, 0, 'zzz', 9), (2, 0, 'zzz', 10), (3, 0, 'ééé', 9), (4, 0, 'ééé', 10),
+    (5, 1, 'zzz', 9), (6, 1, 'zzz', 10), (7, 1, 'ééé', 9), (8, 1, 'ééé', 10)
+
+# deleting one row per partition keeps its position distinguishable: 0 when correct, 1 with no
+# cast on k, 2 with a wrong cast on v, 3 with both
+statement ok
+DELETE FROM pm WHERE v = 'zzz' AND k = 9
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'pm', schema_name := 'main')
+
+query IIII
+SELECT id, p, v, k FROM pm ORDER BY id
+----
+2	0	zzz	10
+3	0	ééé	9
+4	0	ééé	10
+6	1	zzz	10
+7	1	ééé	9
+8	1	ééé	10
+
+# the direction and null-placement suffixes have to survive the rewrite
+statement ok
+CREATE TABLE dn (id INTEGER, k HUGEINT)
+
+statement ok
+ALTER TABLE dn SET SORTED BY (k DESC NULLS FIRST)
+
+statement ok
+INSERT INTO dn VALUES (1, 9), (2, 10), (3, NULL)
+
+statement ok
+DELETE FROM dn WHERE id = 1
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'dn', schema_name := 'main')
+
+query II
+SELECT id, k FROM dn ORDER BY id
+----
+2	10
+3	NULL
+
+# the cast uses the column's current type, not the one the inlined text was written under
+statement ok
+CREATE TABLE atype (id INTEGER, k HUGEINT)
+
+statement ok
+ALTER TABLE atype SET SORTED BY (k ASC NULLS LAST)
+
+statement ok
+INSERT INTO atype VALUES (1, 9), (2, 10)
+
+statement ok
+DELETE FROM atype WHERE id = 1
+
+statement ok
+ALTER TABLE atype ALTER COLUMN k TYPE DOUBLE
+
+statement ok
+CALL ducklake_flush_inlined_data('ducklake', table_name := 'atype', schema_name := 'main')
+
+query II
+SELECT id, k FROM atype ORDER BY id
+----
+2	10.0


### PR DESCRIPTION
Closes #1385

`flush_inlined_data` works out delete positions by re-sorting the inlined table in the metadata catalog. Postgres and SQLite store types with no native equivalent as `VARCHAR`, so that sort ran on text while the Parquet file was written from a typed sort, and the tombstones landed on the wrong rows. A deleted row came back and a live one disappeared, with no error. A sort expression over such a column failed the flush outright instead, which also made the table impossible to `CHECKPOINT`.

`(k + 0)` has to become `CAST(k AS DOUBLE) + 0` rather than a cast around the whole expression, since wrapping it still hands `VARCHAR` to `+`.

The sort is built twice, and the same mismatch reaches the bound plan. `InsertSort` binds the sort expression against the table's current columns while the plan reads the inlined table, so after `ALTER COLUMN ... TYPE` the reference and the operator disagree and the flush fails with an internal error.

The other place this could go is the inlined reader, which already casts stored values to the current type for non-DuckDB catalogs. I kept it here because that change would affect every inlined scan, while this one only affects the flush sort. Whether it belongs in the reader instead is worth a separate look.

`VARCHAR` is deliberately exempt. `GetColumnTypeInternal` maps both `VARCHAR` and `BLOB` to `BYTEA`, so the value comes back as a `BLOB` and already orders bytewise, matching the file. Casting it back escapes non-printable bytes and reorders non-ASCII values, so casting unconditionally would introduce the same corruption on `VARCHAR` sort keys. `BLOB` still needs the cast, so the rule keys on the logical type rather than the storage type. The read path in `ducklake_inlined_data_reader.cpp` already