### PR TITLE
Reclaim inlined rows that no surviving snapshot can read

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5538,6 +5538,32 @@ WHERE end_snapshot IS NOT NULL AND NOT EXISTS(
 		}
 	}
 
+	// A v1.1 catalog prefixes the bound column names, so inlined tables cannot share the statement
+	// above. Runs after the drop block, so dropped tables are already unregistered and this needs
+	// no table_id filter.
+	{
+		auto inlined = Query("SELECT table_name FROM {METADATA_CATALOG}.ducklake_inlined_data_tables;");
+		if (inlined->HasError()) {
+			inlined->GetErrorObject().Throw("Failed to list inlined-data tables for cleanup in DuckLake: ");
+		}
+		auto col_names = InlinedColNames();
+		for (auto &row : *inlined) {
+			auto inlined_table_name = row.GetValue<string>(0);
+			auto result = Execute(StringUtil::Format(R"(
+DELETE FROM {METADATA_CATALOG}.%s
+WHERE %s IS NOT NULL AND NOT EXISTS(
+    SELECT snapshot_id
+    FROM {METADATA_CATALOG}.ducklake_snapshot
+    WHERE snapshot_id >= %s AND snapshot_id < %s
+);)",
+			                                         SQLIdentifier(inlined_table_name), col_names.end_snapshot,
+			                                         col_names.begin_snapshot, col_names.end_snapshot));
+			if (result->HasError()) {
+				result->GetErrorObject().Throw("Failed to delete from " + inlined_table_name + " in DuckLake: ");
+			}
+		}
+	}
+
 	// clean up macro implementation and parameters for deleted macros
 	tables_to_delete_from = {"ducklake_macro_impl", "ducklake_macro_parameters"};
 	for (auto &delete_tbl : tables_to_delete_from) {

--- a/test/sql/data_inlining/inlined_dead_rows_expire.test
+++ b/test/sql/data_inlining/inlined_dead_rows_expire.test
@@ -1,0 +1,90 @@
+# name: test/sql/data_inlining/inlined_dead_rows_expire.test
+# description: verify that inlined rows no surviving snapshot can read are reclaimed by expire_snapshots
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/inlined_dead_rows_expire_files', METADATA_CATALOG 'ducklake_meta', DATA_INLINING_ROW_LIMIT 100)
+
+statement ok
+CREATE TABLE ducklake.t1(i INTEGER)
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (1), (2), (3)
+
+statement ok
+DELETE FROM ducklake.t1 WHERE i=2
+
+# an older snapshot can still read the deleted row
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_1_1
+----
+3
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+statement ok
+CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
+
+# no snapshot can see it anymore
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_1_1
+----
+2
+
+query I
+SELECT * FROM ducklake.t1 ORDER BY i
+----
+1
+3
+
+# repeated insert/delete cycles do not accumulate
+statement ok
+INSERT INTO ducklake.t1 VALUES (4)
+
+statement ok
+DELETE FROM ducklake.t1 WHERE i=4
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (5)
+
+statement ok
+DELETE FROM ducklake.t1 WHERE i=5
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_1_1
+----
+2
+
+query I
+SELECT * FROM ducklake.t1 ORDER BY i
+----
+1
+3
+
+# the live inlined table is kept, the next insert reuses it
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables WHERE table_name='ducklake_inlined_data_1_1'
+----
+1
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (6)
+
+query I
+SELECT * FROM ducklake.t1 ORDER BY i
+----
+1
+3
+6


### PR DESCRIPTION
Closes #1390

`ducklake_expire_snapshots` never removes inlined rows whose `end_snapshot` has dropped below the oldest surviving snapshot. Once every snapshot that could read such a row has been expired the row is unreachable, but it stays in the metadata catalog, and nothing bounds how many pile up. 150 insert-then-delete cycles against a table with `DATA_INLINING_ROW_LIMIT 10` leave 0 live rows and 150 physical rows after `expire_snapshots` and `cleanup_old_files`, with nothing written to Parquet. The row limit counts live rows, so it never trips and never forces a flush.

Flushing was the only thing that reclaimed them, and a flush materializes the table to Parquet, which is the thing a workload that opts into inlining is trying to avoid. `rewrite_data_files` and `merge_adjacent_files` leave the rows alone, and `CHECKPOINT` clears them only because its first step is that same flush. So this is a no-op for anyone who checkpoints, and the people it helps are the ones calling `expire_snapshots` and `cleanup_old_files` directly and wanting the data to stay inlined.

## Changes

`ducklake_metadata_manager.cpp`: `DeleteSnapshots` already sweeps unreachable rows out of every other table carrying the `begin_snapshot` / `end_snapshot` pair. Inlined data tables were the one it skipped. It has to happen during expire rather than in `cleanup_old_files`, since expire is the only maintenance function that knows the surviving-snapshot set.

They get their own loop instead of joining the existing list because a v1.1 catalog prefixes the two bound columns with `_ducklake_`, so the statement text differs by catalog version. Running after the drop block means dropped tables are already unregistered, so no `table_id` filter is needed.

The inlined tables themselves are left alone. Keeping one alive for a live `(table_id, schema_version)` is intended, since the next insert reuses it.

Reverting just the `ducklake_metadata_manager.cpp` hunk makes the new test fail at its first post-expire assertion, 3 surviving rows where 2 is expected, on both the DuckDB and Postgres catalogs.