### PR TITLE
Rename DuckLake reserved columns for inlined tables

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -359,28 +359,38 @@ shared_ptr<DynamicFilterData> DuckLakeUtil::GetOptionalDynamicFilterData(const T
 	return nullptr;
 }
 
-bool DuckLakeUtil::IsInlinedSystemColumn(const string &name) {
+bool DuckLakeUtil::IsInlinedSystemColumn(const string &name, bool prefixed_inlined_columns) {
+	if (prefixed_inlined_columns) {
+		return StringUtil::StartsWith(StringUtil::Lower(name), "_ducklake_");
+	}
 	return StringUtil::CIEquals(name, "row_id") || StringUtil::CIEquals(name, "begin_snapshot") ||
 	       StringUtil::CIEquals(name, "end_snapshot") || StringUtil::CIEquals(name, "_ducklake_internal_snapshot_id") ||
 	       StringUtil::CIEquals(name, "_ducklake_internal_row_id");
 }
 
-void DuckLakeUtil::ValidateNoInlinedSystemColumns(const ColumnList &columns, const string &table_name) {
+void DuckLakeUtil::ValidateNoInlinedSystemColumns(const ColumnList &columns, bool prefixed_inlined_columns,
+                                                  const string &table_name) {
 	for (auto &col : columns.Logical()) {
-		if (IsInlinedSystemColumn(col.Name().GetIdentifierName())) {
-			if (table_name.empty()) {
-				throw BinderException(
-				    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
-				    "you must use this column name, disable inlining by calling "
-				    "ducklake_set_option('data_inlining_row_limit', 0).",
-				    col.Name().GetIdentifierName());
-			}
+		if (!IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
+			continue;
+		}
+		if (!table_name.empty()) {
 			throw BinderException(
 			    "Cannot enable data inlining for table \"%s\". Column \"%s\" conflicts with a reserved DuckLake "
 			    "internal column name used for inlining. To enable inlining for this table, rename or drop column "
 			    "\"%s\".",
 			    table_name, col.Name().GetIdentifierName(), col.Name().GetIdentifierName());
 		}
+		if (prefixed_inlined_columns) {
+			throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use: column names starting "
+			                      "with \"_ducklake_\" are not allowed.",
+			                      col.Name().GetIdentifierName());
+		}
+		throw BinderException(
+		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
+		    "you must use this column name, disable inlining by calling "
+		    "ducklake_set_option('data_inlining_row_limit', 0).",
+		    col.Name().GetIdentifierName());
 	}
 }
 

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -364,9 +364,7 @@ bool DuckLakeUtil::IsInlinedSystemColumn(const string &name, bool prefixed_inlin
 	if (prefixed_inlined_columns) {
 		return StringUtil::CIStartsWith(name, DuckLakeInlinedColNames::PREFIX);
 	}
-	return StringUtil::CIEquals(name, "row_id") || StringUtil::CIEquals(name, "begin_snapshot") ||
-	       StringUtil::CIEquals(name, "end_snapshot") || StringUtil::CIEquals(name, "_ducklake_internal_snapshot_id") ||
-	       StringUtil::CIEquals(name, "_ducklake_internal_row_id");
+	return DuckLakeInlinedColNames(false).ConflictsWith(name);
 }
 
 static void ThrowReservedInlinedColumn(const string &name, bool prefixed_inlined_columns) {
@@ -395,8 +393,14 @@ void DuckLakeUtil::ValidateInlinedSystemColumn(DuckLakeCatalog &catalog, ClientC
 
 void DuckLakeUtil::ValidateNoInlinedSystemColumns(DuckLakeCatalog &catalog, ClientContext &context,
                                                   SchemaIndex schema_id, const ColumnList &columns) {
+	bool prefixed_inlined_columns = catalog.SupportsV1_1Metadata();
+	if (!prefixed_inlined_columns && catalog.DataInliningRowLimit(context, schema_id, TableIndex()) == 0) {
+		return;
+	}
 	for (auto &col : columns.Logical()) {
-		ValidateInlinedSystemColumn(catalog, context, schema_id, TableIndex(), col.Name().GetIdentifierName());
+		if (IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
+			ThrowReservedInlinedColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns);
+		}
 	}
 }
 

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -362,7 +362,7 @@ shared_ptr<DynamicFilterData> DuckLakeUtil::GetOptionalDynamicFilterData(const T
 
 bool DuckLakeUtil::IsInlinedSystemColumn(const string &name, bool prefixed_inlined_columns) {
 	if (prefixed_inlined_columns) {
-		return StringUtil::StartsWith(StringUtil::Lower(name), "_ducklake_");
+		return StringUtil::CIStartsWith(name, DuckLakeInlinedColNames::PREFIX);
 	}
 	return StringUtil::CIEquals(name, "row_id") || StringUtil::CIEquals(name, "begin_snapshot") ||
 	       StringUtil::CIEquals(name, "end_snapshot") || StringUtil::CIEquals(name, "_ducklake_internal_snapshot_id") ||
@@ -372,8 +372,8 @@ bool DuckLakeUtil::IsInlinedSystemColumn(const string &name, bool prefixed_inlin
 static void ThrowReservedInlinedColumn(const string &name, bool prefixed_inlined_columns) {
 	if (prefixed_inlined_columns) {
 		throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use: column names starting "
-		                      "with \"_ducklake_\" are not allowed.",
-		                      name);
+		                      "with \"%s\" are not allowed.",
+		                      name, DuckLakeInlinedColNames::PREFIX);
 	}
 	throw BinderException(
 	    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
@@ -395,21 +395,16 @@ void DuckLakeUtil::ValidateInlinedSystemColumn(DuckLakeCatalog &catalog, ClientC
 
 void DuckLakeUtil::ValidateNoInlinedSystemColumns(DuckLakeCatalog &catalog, ClientContext &context,
                                                   SchemaIndex schema_id, const ColumnList &columns) {
-	bool prefixed_inlined_columns = catalog.SupportsV1_1Metadata();
-	if (!prefixed_inlined_columns && catalog.DataInliningRowLimit(context, schema_id, TableIndex()) == 0) {
-		return;
-	}
 	for (auto &col : columns.Logical()) {
-		if (IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
-			ThrowReservedInlinedColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns);
-		}
+		ValidateInlinedSystemColumn(catalog, context, schema_id, TableIndex(), col.Name().GetIdentifierName());
 	}
 }
 
 void DuckLakeUtil::ValidateCanEnableInlining(const ColumnList &columns, bool prefixed_inlined_columns,
                                              const string &table_name) {
+	DuckLakeInlinedColNames col_names(prefixed_inlined_columns);
 	for (auto &col : columns.Logical()) {
-		if (IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
+		if (col_names.ConflictsWith(col.Name().GetIdentifierName())) {
 			throw BinderException(
 			    "Cannot enable data inlining for table \"%s\". Column \"%s\" conflicts with a reserved DuckLake "
 			    "internal column name used for inlining. To enable inlining for this table, rename or drop column "

--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/planner/filter/table_filter_functions.hpp"
 #include "duckdb/function/scalar/variant_utils.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "storage/ducklake_catalog.hpp"
 #include "duckdb/main/database.hpp"
 
 #include <cmath>
@@ -368,29 +369,53 @@ bool DuckLakeUtil::IsInlinedSystemColumn(const string &name, bool prefixed_inlin
 	       StringUtil::CIEquals(name, "_ducklake_internal_row_id");
 }
 
-void DuckLakeUtil::ValidateNoInlinedSystemColumns(const ColumnList &columns, bool prefixed_inlined_columns,
-                                                  const string &table_name) {
+static void ThrowReservedInlinedColumn(const string &name, bool prefixed_inlined_columns) {
+	if (prefixed_inlined_columns) {
+		throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use: column names starting "
+		                      "with \"_ducklake_\" are not allowed.",
+		                      name);
+	}
+	throw BinderException(
+	    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
+	    "you must use this column name, disable inlining by calling "
+	    "ducklake_set_option('data_inlining_row_limit', 0).",
+	    name);
+}
+
+void DuckLakeUtil::ValidateInlinedSystemColumn(DuckLakeCatalog &catalog, ClientContext &context, SchemaIndex schema_id,
+                                               TableIndex table_id, const string &name) {
+	bool prefixed_inlined_columns = catalog.SupportsV1_1Metadata();
+	if (!prefixed_inlined_columns && catalog.DataInliningRowLimit(context, schema_id, table_id) == 0) {
+		return;
+	}
+	if (IsInlinedSystemColumn(name, prefixed_inlined_columns)) {
+		ThrowReservedInlinedColumn(name, prefixed_inlined_columns);
+	}
+}
+
+void DuckLakeUtil::ValidateNoInlinedSystemColumns(DuckLakeCatalog &catalog, ClientContext &context,
+                                                  SchemaIndex schema_id, const ColumnList &columns) {
+	bool prefixed_inlined_columns = catalog.SupportsV1_1Metadata();
+	if (!prefixed_inlined_columns && catalog.DataInliningRowLimit(context, schema_id, TableIndex()) == 0) {
+		return;
+	}
 	for (auto &col : columns.Logical()) {
-		if (!IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
-			continue;
+		if (IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
+			ThrowReservedInlinedColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns);
 		}
-		if (!table_name.empty()) {
+	}
+}
+
+void DuckLakeUtil::ValidateCanEnableInlining(const ColumnList &columns, bool prefixed_inlined_columns,
+                                             const string &table_name) {
+	for (auto &col : columns.Logical()) {
+		if (IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
 			throw BinderException(
 			    "Cannot enable data inlining for table \"%s\". Column \"%s\" conflicts with a reserved DuckLake "
 			    "internal column name used for inlining. To enable inlining for this table, rename or drop column "
 			    "\"%s\".",
 			    table_name, col.Name().GetIdentifierName(), col.Name().GetIdentifierName());
 		}
-		if (prefixed_inlined_columns) {
-			throw BinderException("Column name \"%s\" is reserved by DuckLake for internal use: column names starting "
-			                      "with \"_ducklake_\" are not allowed.",
-			                      col.Name().GetIdentifierName());
-		}
-		throw BinderException(
-		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
-		    "you must use this column name, disable inlining by calling "
-		    "ducklake_set_option('data_inlining_row_limit', 0).",
-		    col.Name().GetIdentifierName());
 	}
 }
 

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -170,6 +170,7 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 			                                                        inlined_table.table_name, col_names.begin_snapshot,
 			                                                        extra_filter, file_offset,
 			                                                        file_offset + file.row_count));
+			metadata_manager.CheckInlinedDataReadError(*deleted_rows_result, inlined_table.table_name);
 
 			for (auto &row : *deleted_rows_result) {
 				auto end_snap = row.GetValue<int64_t>(0);

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -130,8 +130,8 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 		// When the table has sort metadata, the file is written in sorted order.
 		// The ORDER BY must match the actual file order so delete positions are correct.
 		auto col_names = metadata_manager.InlinedColNames();
-		string order_by = StringUtil::Format("%s ASC NULLS LAST, %s ASC NULLS LAST", col_names.row_id,
-		                                     col_names.begin_snapshot);
+		string order_by =
+		    StringUtil::Format("%s ASC NULLS LAST, %s ASC NULLS LAST", col_names.row_id, col_names.begin_snapshot);
 		if (!sort_order_sql.empty()) {
 			order_by = sort_order_sql + ", " + order_by;
 		}
@@ -155,8 +155,9 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 
 			// Query deleted rows within this file's row range, filtered to its partition
 			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
-			auto deleted_rows_result =
-			    metadata_manager.Query(snapshot, StringUtil::Format(R"(
+			auto deleted_rows_result = metadata_manager.Query(
+			    snapshot,
+			    StringUtil::Format(R"(
 				WITH all_rows AS (
 					SELECT %s AS end_snapshot, ROW_NUMBER() OVER (ORDER BY %s) - 1 AS output_position
 					FROM {METADATA_CATALOG}.%s
@@ -166,10 +167,8 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 				FROM all_rows
 				WHERE end_snapshot IS NOT NULL
 				AND output_position >= %d AND output_position < %d;)",
-			                                                        col_names.end_snapshot, order_by,
-			                                                        inlined_table.table_name, col_names.begin_snapshot,
-			                                                        extra_filter, file_offset,
-			                                                        file_offset + file.row_count));
+			                       col_names.end_snapshot, order_by, inlined_table.table_name, col_names.begin_snapshot,
+			                       extra_filter, file_offset, file_offset + file.row_count));
 			metadata_manager.CheckInlinedDataReadError(*deleted_rows_result, inlined_table.table_name);
 
 			for (auto &row : *deleted_rows_result) {

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -127,6 +127,15 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 		DeletesPerFile deletes_per_file;
 		auto partition_sql_exprs = table.GetPartitionSQLExpressions();
 
+		// When the table has sort metadata, the file is written in sorted order.
+		// The ORDER BY must match the actual file order so delete positions are correct.
+		auto col_names = metadata_manager.InlinedColNames();
+		string order_by = StringUtil::Format("%s ASC NULLS LAST, %s ASC NULLS LAST", col_names.row_id,
+		                                     col_names.begin_snapshot);
+		if (!sort_order_sql.empty()) {
+			order_by = sort_order_sql + ", " + order_by;
+		}
+
 		// Track cumulative row offset per partition so each file knows its range
 		unordered_map<string, idx_t> partition_row_offsets;
 
@@ -146,14 +155,6 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 
 			// Query deleted rows within this file's row range, filtered to its partition
 			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
-			// When the table has sort metadata, the file is written in sorted order.
-			// The ORDER BY must match the actual file order so delete positions are correct.
-			auto col_names = metadata_manager.InlinedColNames();
-			string order_by = StringUtil::Format("%s ASC NULLS LAST, %s ASC NULLS LAST", col_names.row_id,
-			                                     col_names.begin_snapshot);
-			if (!sort_order_sql.empty()) {
-				order_by = sort_order_sql + ", " + order_by;
-			}
 			auto deleted_rows_result =
 			    metadata_manager.Query(snapshot, StringUtil::Format(R"(
 				WITH all_rows AS (

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -148,23 +148,27 @@ SinkFinalizeType DuckLakeFlushData::Finalize(Pipeline &pipeline, Event &event, C
 			string extra_filter = partition_filter.empty() ? "" : " AND " + partition_filter;
 			// When the table has sort metadata, the file is written in sorted order.
 			// The ORDER BY must match the actual file order so delete positions are correct.
-			string order_by = "row_id ASC NULLS LAST, begin_snapshot ASC NULLS LAST";
+			auto col_names = metadata_manager.InlinedColNames();
+			string order_by = StringUtil::Format("%s ASC NULLS LAST, %s ASC NULLS LAST", col_names.row_id,
+			                                     col_names.begin_snapshot);
 			if (!sort_order_sql.empty()) {
-				order_by = sort_order_sql + ", row_id ASC NULLS LAST, begin_snapshot ASC NULLS LAST";
+				order_by = sort_order_sql + ", " + order_by;
 			}
 			auto deleted_rows_result =
 			    metadata_manager.Query(snapshot, StringUtil::Format(R"(
 				WITH all_rows AS (
-					SELECT end_snapshot, ROW_NUMBER() OVER (ORDER BY %s) - 1 AS output_position
+					SELECT %s AS end_snapshot, ROW_NUMBER() OVER (ORDER BY %s) - 1 AS output_position
 					FROM {METADATA_CATALOG}.%s
-					WHERE {SNAPSHOT_ID} >= begin_snapshot%s
+					WHERE {SNAPSHOT_ID} >= %s%s
 				)
 				SELECT end_snapshot, output_position
 				FROM all_rows
 				WHERE end_snapshot IS NOT NULL
 				AND output_position >= %d AND output_position < %d;)",
-			                                                        order_by, inlined_table.table_name, extra_filter,
-			                                                        file_offset, file_offset + file.row_count));
+			                                                        col_names.end_snapshot, order_by,
+			                                                        inlined_table.table_name, col_names.begin_snapshot,
+			                                                        extra_filter, file_offset,
+			                                                        file_offset + file.row_count));
 
 			for (auto &row : *deleted_rows_result) {
 				auto end_snap = row.GetValue<int64_t>(0);

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -19,7 +19,7 @@ static void ValidateTableScope(ClientContext &context, Catalog &catalog, const s
 	    context, Identifier(schema_name), Identifier(table_name), OnEntryNotFound::THROW_EXCEPTION);
 	auto &ducklake_table = table_catalog_entry->Cast<DuckLakeTableEntry>();
 	DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
-	                                             catalog.Cast<DuckLakeCatalog>().SupportsPrefixedInlinedColumns(),
+	                                             catalog.Cast<DuckLakeCatalog>().SupportsV1_1Metadata(),
 	                                             ducklake_table.name.GetIdentifierName());
 }
 
@@ -34,7 +34,7 @@ static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck
 			return;
 		}
 		DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
-		                                             duck_catalog.SupportsPrefixedInlinedColumns(),
+		                                             duck_catalog.SupportsV1_1Metadata(),
 		                                             ducklake_table.name.GetIdentifierName());
 	});
 }

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -18,7 +18,9 @@ static void ValidateTableScope(ClientContext &context, Catalog &catalog, const s
 	auto table_catalog_entry = catalog.GetEntry<TableCatalogEntry>(
 	    context, Identifier(schema_name), Identifier(table_name), OnEntryNotFound::THROW_EXCEPTION);
 	auto &ducklake_table = table_catalog_entry->Cast<DuckLakeTableEntry>();
-	DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(), ducklake_table.name.GetIdentifierName());
+	DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
+	                                             catalog.Cast<DuckLakeCatalog>().SupportsPrefixedInlinedColumns(),
+	                                             ducklake_table.name.GetIdentifierName());
 }
 
 static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck_catalog,
@@ -32,6 +34,7 @@ static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck
 			return;
 		}
 		DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
+		                                             duck_catalog.SupportsPrefixedInlinedColumns(),
 		                                             ducklake_table.name.GetIdentifierName());
 	});
 }

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -18,9 +18,9 @@ static void ValidateTableScope(ClientContext &context, Catalog &catalog, const s
 	auto table_catalog_entry = catalog.GetEntry<TableCatalogEntry>(
 	    context, Identifier(schema_name), Identifier(table_name), OnEntryNotFound::THROW_EXCEPTION);
 	auto &ducklake_table = table_catalog_entry->Cast<DuckLakeTableEntry>();
-	DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
-	                                             catalog.Cast<DuckLakeCatalog>().SupportsV1_1Metadata(),
-	                                             ducklake_table.name.GetIdentifierName());
+	DuckLakeUtil::ValidateCanEnableInlining(ducklake_table.GetColumns(),
+	                                        catalog.Cast<DuckLakeCatalog>().SupportsV1_1Metadata(),
+	                                        ducklake_table.name.GetIdentifierName());
 }
 
 static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck_catalog,
@@ -33,9 +33,8 @@ static void ValidateTablesInSchema(ClientContext &context, DuckLakeCatalog &duck
 		    std::stoull(override_val) == 0) {
 			return;
 		}
-		DuckLakeUtil::ValidateNoInlinedSystemColumns(ducklake_table.GetColumns(),
-		                                             duck_catalog.SupportsV1_1Metadata(),
-		                                             ducklake_table.name.GetIdentifierName());
+		DuckLakeUtil::ValidateCanEnableInlining(ducklake_table.GetColumns(), duck_catalog.SupportsV1_1Metadata(),
+		                                        ducklake_table.name.GetIdentifierName());
 	});
 }
 

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -16,8 +16,10 @@
 #include "duckdb/common/types/value.hpp"
 
 namespace duckdb {
+class ClientContext;
 class DataChunk;
 class ColumnList;
+class DuckLakeCatalog;
 class DuckLakeMetadataManager;
 class FileSystem;
 class TableFilter;
@@ -68,9 +70,14 @@ public:
 
 	static string ChunkRowToSQL(DuckLakeMetadataManager &metadata_manager, ClientContext &context, DataChunk &chunk,
 	                            idx_t row);
-	//! Throws if any column in the list conflicts with inlined data system columns
-	static void ValidateNoInlinedSystemColumns(const ColumnList &columns, bool prefixed_inlined_columns,
-	                                           const string &table_name = "");
+	//! DDL guards: throw if a column name is reserved for inlined-data metadata on this catalog
+	static void ValidateInlinedSystemColumn(DuckLakeCatalog &catalog, ClientContext &context, SchemaIndex schema_id,
+	                                        TableIndex table_id, const string &name);
+	static void ValidateNoInlinedSystemColumns(DuckLakeCatalog &catalog, ClientContext &context, SchemaIndex schema_id,
+	                                           const ColumnList &columns);
+	//! Throws if a column conflicts with the inlined-data metadata columns when enabling inlining on table_name
+	static void ValidateCanEnableInlining(const ColumnList &columns, bool prefixed_inlined_columns,
+	                                      const string &table_name);
 
 	//! Copy extension-registered settings from one context onto another. Core engine settings
 	//! are not copied.

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -51,8 +51,10 @@ public:
 	//! single-quoted string literals and double-quoted identifiers.
 	static string ReplaceSkippingQuotes(const string &sql, const string &from, const string &to);
 
-	//! Returns true if the given column name conflicts with inlined data system columns
-	static bool IsInlinedSystemColumn(const string &name);
+	//! Returns true if the given column name conflicts with inlined data system columns.
+	//! With prefixed_inlined_columns (catalogs >= 1.1-dev1) the reserved namespace is the
+	//! _ducklake_ prefix, before that it is the fixed list of unprefixed names.
+	static bool IsInlinedSystemColumn(const string &name, bool prefixed_inlined_columns);
 
 	static string OptionalIdxOrNull(const optional_idx &v);
 
@@ -67,7 +69,8 @@ public:
 	static string ChunkRowToSQL(DuckLakeMetadataManager &metadata_manager, ClientContext &context, DataChunk &chunk,
 	                            idx_t row);
 	//! Throws if any column in the list conflicts with inlined data system columns
-	static void ValidateNoInlinedSystemColumns(const ColumnList &columns, const string &table_name = "");
+	static void ValidateNoInlinedSystemColumns(const ColumnList &columns, bool prefixed_inlined_columns,
+	                                           const string &table_name = "");
 
 	//! Copy extension-registered settings from one context onto another. Core engine settings
 	//! are not copied.

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -53,9 +53,7 @@ public:
 	//! single-quoted string literals and double-quoted identifiers.
 	static string ReplaceSkippingQuotes(const string &sql, const string &from, const string &to);
 
-	//! Returns true if the given column name conflicts with inlined data system columns.
-	//! With prefixed_inlined_columns (catalogs >= 1.1-dev1) the reserved namespace is the
-	//! _ducklake_ prefix, before that it is the fixed list of unprefixed names.
+	//! Returns true if the given column name conflicts with inlined data system columns
 	static bool IsInlinedSystemColumn(const string &name, bool prefixed_inlined_columns);
 
 	static string OptionalIdxOrNull(const optional_idx &v);
@@ -70,12 +68,12 @@ public:
 
 	static string ChunkRowToSQL(DuckLakeMetadataManager &metadata_manager, ClientContext &context, DataChunk &chunk,
 	                            idx_t row);
-	//! DDL guards: throw if a column name is reserved for inlined-data metadata on this catalog
+	//! Throws if a column name is reserved for inlined data metadata on this catalog
 	static void ValidateInlinedSystemColumn(DuckLakeCatalog &catalog, ClientContext &context, SchemaIndex schema_id,
 	                                        TableIndex table_id, const string &name);
 	static void ValidateNoInlinedSystemColumns(DuckLakeCatalog &catalog, ClientContext &context, SchemaIndex schema_id,
 	                                           const ColumnList &columns);
-	//! Throws if a column conflicts with the inlined-data metadata columns when enabling inlining on table_name
+	//! Throws if a column conflicts with inlined data metadata columns when enabling inlining
 	static void ValidateCanEnableInlining(const ColumnList &columns, bool prefixed_inlined_columns,
 	                                      const string &table_name);
 

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -31,7 +31,8 @@ public:
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
 	shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
-	                                                     const vector<LogicalType> &expected_types) override;
+	                                                     const vector<LogicalType> &expected_types,
+	                                                     const string &inlined_table_name) override;
 
 	unique_ptr<QueryResult> Execute(DuckLakeSnapshot snapshot, string &query) override;
 

--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -30,8 +30,7 @@ public:
 	}
 
 	string GetColumnTypeInternal(const LogicalType &type) override;
-	shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
-	                                                     const vector<LogicalType> &expected_types,
+	shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types,
 	                                                     const string &inlined_table_name) override;
 
 	unique_ptr<QueryResult> Execute(DuckLakeSnapshot snapshot, string &query) override;

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -231,7 +231,7 @@ public:
 	void SetDuckLakeVersion(DuckLakeVersion version) {
 		ducklake_version = version;
 	}
-	//! Whether the catalog has the 1.1-dev1 metadata features
+	//! Whether the catalog has the v1.1 metadata features
 	bool SupportsV1_1Metadata() const {
 		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
 	}

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -243,6 +243,10 @@ public:
 	bool SupportsEpochPartitionTransforms() const {
 		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
 	}
+	//! Whether inlined-data tables use _ducklake_-prefixed metadata columns (renamed in 1.1-dev1)
+	bool SupportsPrefixedInlinedColumns() const {
+		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
+	}
 
 	void OnDetach(ClientContext &context) override;
 

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -231,20 +231,8 @@ public:
 	void SetDuckLakeVersion(DuckLakeVersion version) {
 		ducklake_version = version;
 	}
-	//! Whether the metadata schema has the row_group_count columns (added in 1.1-dev1)
-	bool SupportsRowGroupCount() const {
-		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
-	}
-	//! Whether the metadata schema has view column tags (added in 1.1-dev1)
-	bool SupportsViewColumnTags() const {
-		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
-	}
-	//! Whether the catalog may contain epoch partition transforms (added in 1.1-dev1)
-	bool SupportsEpochPartitionTransforms() const {
-		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
-	}
-	//! Whether inlined-data tables use _ducklake_-prefixed metadata columns (renamed in 1.1-dev1)
-	bool SupportsPrefixedInlinedColumns() const {
+	//! Whether the catalog has the 1.1-dev1 metadata features
+	bool SupportsV1_1Metadata() const {
 		return ducklake_version >= DuckLakeVersion::V1_1_DEV_1;
 	}
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -47,6 +47,14 @@ enum class SnapshotBound { LOWER_BOUND, UPPER_BOUND };
 
 //! Metadata column names inside ducklake_inlined_data_<table_id>_<schema_version> tables.
 struct DuckLakeInlinedColNames {
+	explicit DuckLakeInlinedColNames(bool prefixed_inlined_columns) {
+		if (prefixed_inlined_columns) {
+			row_id = "_ducklake_row_id";
+			begin_snapshot = "_ducklake_begin_snapshot";
+			end_snapshot = "_ducklake_end_snapshot";
+		}
+	}
+
 	string row_id = "row_id";
 	string begin_snapshot = "begin_snapshot";
 	string end_snapshot = "end_snapshot";
@@ -416,6 +424,10 @@ public:
 	virtual void MigrateV03(bool allow_failures = false);
 	virtual void MigrateV04();
 	virtual void MigrateV10(bool allow_failures = false);
+	//! Renames row_id/begin_snapshot/end_snapshot to their _ducklake_ prefixed variants in every
+	//! registered inlined-data table. Probe-based: tables that are already renamed are skipped, so
+	//! this is safe to re-run on every in-place 1.1-dev1 evolution.
+	virtual void MigrateInlinedColumnNames(bool allow_failures);
 	virtual void ExecuteMigration(string migrate_query, bool allow_failures, const string &from_version,
 	                              const string &to_version);
 

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -265,8 +265,7 @@ public:
 	virtual idx_t GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot);
 	//! SQL builders for stats-refresh metadata lookups; caller substitutes placeholders + executes.
 	static string GetNetDataFileRowCountSql(TableIndex table_id, const string &inlined_deletion_table);
-	static string GetNetInlinedRowCountSql(const string &inlined_table_name,
-	                                       const DuckLakeInlinedColNames &col_names);
+	static string GetNetInlinedRowCountSql(const string &inlined_table_name, const DuckLakeInlinedColNames &col_names);
 	static string GetTableColumnSchemaSql(TableIndex table_id);
 	static string GetInlinedTableNamesSql(TableIndex table_id);
 	virtual vector<DuckLakeFileForCleanup> GetOldFilesForCleanup(const string &filter);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -424,9 +424,7 @@ public:
 	virtual void MigrateV03(bool allow_failures = false);
 	virtual void MigrateV04();
 	virtual void MigrateV10(bool allow_failures = false);
-	//! Renames row_id/begin_snapshot/end_snapshot to their _ducklake_ prefixed variants in every
-	//! registered inlined-data table. Probe-based: tables that are already renamed are skipped, so
-	//! this is safe to re-run on every in-place 1.1-dev1 evolution.
+	//! Renames inlined metadata columns to the prefixed variants, skipping already renamed tables
 	virtual void MigrateInlinedColumnNames(bool allow_failures);
 	virtual void ExecuteMigration(string migrate_query, bool allow_failures, const string &from_version,
 	                              const string &to_version);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -45,6 +45,13 @@ struct FlushedInlinedTableInfo;
 
 enum class SnapshotBound { LOWER_BOUND, UPPER_BOUND };
 
+//! Metadata column names inside ducklake_inlined_data_<table_id>_<schema_version> tables.
+struct DuckLakeInlinedColNames {
+	string row_id = "row_id";
+	string begin_snapshot = "begin_snapshot";
+	string end_snapshot = "end_snapshot";
+};
+
 struct CTERequirement {
 	idx_t column_field_index;
 	unordered_set<string> referenced_stats;
@@ -244,7 +251,8 @@ public:
 	virtual idx_t GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot);
 	//! SQL builders for stats-refresh metadata lookups; caller substitutes placeholders + executes.
 	static string GetNetDataFileRowCountSql(TableIndex table_id, const string &inlined_deletion_table);
-	static string GetNetInlinedRowCountSql(const string &inlined_table_name);
+	static string GetNetInlinedRowCountSql(const string &inlined_table_name,
+	                                       const DuckLakeInlinedColNames &col_names);
 	static string GetTableColumnSchemaSql(TableIndex table_id);
 	static string GetInlinedTableNamesSql(TableIndex table_id);
 	virtual vector<DuckLakeFileForCleanup> GetOldFilesForCleanup(const string &filter);
@@ -297,7 +305,8 @@ public:
 	                                   const vector<DuckLakeInlinedDataInfo> &new_data,
 	                                   const vector<DuckLakeTableInfo> &new_tables,
 	                                   const vector<DuckLakeTableInfo> &new_inlined_data_tables_result);
-	static string WriteNewInlinedDeletes(const vector<DuckLakeDeletedInlinedDataInfo> &new_deletes);
+	static string WriteNewInlinedDeletes(const vector<DuckLakeDeletedInlinedDataInfo> &new_deletes,
+	                                     const DuckLakeInlinedColNames &col_names);
 	//! Creates the INSERT INTO {METADATA_CATALOG}.<inlined_table_name> VALUES (...) batch.
 	static string FormatInlinedDataInsert(const string &inlined_table_name, idx_t row_id_start,
 	                                      bool has_preserved_row_ids, const vector<int64_t> *row_ids,
@@ -320,7 +329,9 @@ public:
 	virtual string GetInlinedTableQueries(DuckLakeSnapshot commit_snapshot, const DuckLakeTableInfo &table,
 	                                      string &inlined_tables, string &inlined_table_queries);
 	static string InlinedTableNameFor(idx_t table_id, idx_t schema_version);
-	static string InlinedTableDdlSql(const string &table_name, const string &column_defs);
+	static string InlinedTableDdlSql(const string &table_name, const string &column_defs,
+	                                 const DuckLakeInlinedColNames &col_names);
+	DuckLakeInlinedColNames InlinedColNames() const;
 	static string InlinedTableRegistrationTuple(idx_t table_id, const string &table_name, idx_t schema_version);
 	static string LatestInlinedTableQuery(idx_t table_id);
 	static string DropDataFiles(const set<DataFileIndex> &dropped_files);
@@ -373,7 +384,8 @@ public:
 	                                                           const vector<string> &columns_to_read);
 	//! SQL builders for the stats-refresh queries used by DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite.
 	//! Caller substitutes `{METADATA_CATALOG}` / `{SNAPSHOT_ID}` and executes via the commit context's executor.
-	static string ReadInlinedDataAggregatesSql(const string &inlined_table_name, const string &select_list);
+	static string ReadInlinedDataAggregatesSql(const string &inlined_table_name, const string &select_list,
+	                                           const DuckLakeInlinedColNames &col_names);
 	static string ReadFileColumnStatsForTableSql(TableIndex table_id);
 	virtual shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
 	                                                             const vector<LogicalType> &expected_types);
@@ -382,7 +394,8 @@ public:
 	//! We delete at the flush
 	virtual void DeleteFlushedInlinedData(const DuckLakeInlinedTableInfo &inlined_table, idx_t flush_snapshot_id);
 	//! If it conflicts we batch everything at the retry
-	static string GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables);
+	static string GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables,
+	                                               const DuckLakeInlinedColNames &col_names);
 	static string InsertNewSchema(const DuckLakeSnapshot &snapshot, const set<TableIndex> &table_ids);
 
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -402,9 +402,10 @@ public:
 	                                           const DuckLakeInlinedColNames &col_names);
 	static string ReadFileColumnStatsForTableSql(TableIndex table_id);
 	//! Throws on a failed inlined data read, hinting at the migration for legacy named catalogs
-	void CheckInlinedDataReadError(QueryResult &result);
+	void CheckInlinedDataReadError(QueryResult &result, const string &inlined_table_name);
 	virtual shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
-	                                                             const vector<LogicalType> &expected_types);
+	                                                             const vector<LogicalType> &expected_types,
+	                                                             const string &inlined_table_name);
 
 	virtual void DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table);
 	//! We delete at the flush

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -47,13 +47,19 @@ enum class SnapshotBound { LOWER_BOUND, UPPER_BOUND };
 
 //! Metadata column names inside ducklake_inlined_data_<table_id>_<schema_version> tables.
 struct DuckLakeInlinedColNames {
+	//! Column name prefix reserved for DuckLake internal use
+	static constexpr const char *PREFIX = "_ducklake_";
+
 	explicit DuckLakeInlinedColNames(bool prefixed_inlined_columns) {
 		if (prefixed_inlined_columns) {
-			row_id = "_ducklake_row_id";
-			begin_snapshot = "_ducklake_begin_snapshot";
-			end_snapshot = "_ducklake_end_snapshot";
+			row_id = PREFIX + row_id;
+			begin_snapshot = PREFIX + begin_snapshot;
+			end_snapshot = PREFIX + end_snapshot;
 		}
 	}
+
+	//! Whether a user column name collides with the metadata columns written for inlining
+	bool ConflictsWith(const string &name) const;
 
 	string row_id = "row_id";
 	string begin_snapshot = "begin_snapshot";

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -395,6 +395,8 @@ public:
 	static string ReadInlinedDataAggregatesSql(const string &inlined_table_name, const string &select_list,
 	                                           const DuckLakeInlinedColNames &col_names);
 	static string ReadFileColumnStatsForTableSql(TableIndex table_id);
+	//! Throws on a failed inlined data read, hinting at the migration for legacy named catalogs
+	void CheckInlinedDataReadError(QueryResult &result);
 	virtual shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
 	                                                             const vector<LogicalType> &expected_types);
 
@@ -425,7 +427,7 @@ public:
 	virtual void MigrateV04();
 	virtual void MigrateV10(bool allow_failures = false);
 	//! Renames inlined metadata columns to the prefixed variants, skipping already renamed tables
-	virtual void MigrateInlinedColumnNames(bool allow_failures);
+	virtual void MigrateInlinedColumnNames();
 	virtual void ExecuteMigration(string migrate_query, bool allow_failures, const string &from_version,
 	                              const string &to_version);
 

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -107,6 +107,10 @@ struct DuckLakeCommitContext {
 	bool skip_drop_empty_inlined = false;
 	//! Whether the metadata schema has the >= 1.1-dev1 additions.
 	bool supports_v1_1_metadata = false;
+	//! Column names of the inlined data tables under this catalog version.
+	DuckLakeInlinedColNames InlinedColNames() const {
+		return DuckLakeInlinedColNames(supports_v1_1_metadata);
+	}
 };
 
 //! Holds the per-transaction mutable change state (new/dropped/renamed catalog entries, local file

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -145,8 +145,9 @@ string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 
 // We need a specialized function here to do a reinterpret for postgres from BLOB to VARCHAR
 shared_ptr<DuckLakeInlinedData>
-PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types) {
-	CheckInlinedDataReadError(result);
+PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types,
+                                              const string &inlined_table_name) {
+	CheckInlinedDataReadError(result, inlined_table_name);
 	bool needs_reinterpret = false;
 	if (!expected_types.empty()) {
 		auto &result_types = result.GetTypes();
@@ -164,7 +165,7 @@ PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<
 		}
 	}
 	if (!needs_reinterpret) {
-		return DuckLakeMetadataManager::TransformInlinedData(result, expected_types);
+		return DuckLakeMetadataManager::TransformInlinedData(result, expected_types, inlined_table_name);
 	}
 
 	auto context = transaction.context.lock();

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -144,9 +144,9 @@ string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 }
 
 // We need a specialized function here to do a reinterpret for postgres from BLOB to VARCHAR
-shared_ptr<DuckLakeInlinedData>
-PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types,
-                                              const string &inlined_table_name) {
+shared_ptr<DuckLakeInlinedData> PostgresMetadataManager::TransformInlinedData(QueryResult &result,
+                                                                              const vector<LogicalType> &expected_types,
+                                                                              const string &inlined_table_name) {
 	CheckInlinedDataReadError(result, inlined_table_name);
 	bool needs_reinterpret = false;
 	if (!expected_types.empty()) {

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -146,9 +146,7 @@ string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 // We need a specialized function here to do a reinterpret for postgres from BLOB to VARCHAR
 shared_ptr<DuckLakeInlinedData>
 PostgresMetadataManager::TransformInlinedData(QueryResult &result, const vector<LogicalType> &expected_types) {
-	if (result.HasError()) {
-		result.GetErrorObject().Throw("Failed to read inlined data from DuckLake: ");
-	}
+	CheckInlinedDataReadError(result);
 	bool needs_reinterpret = false;
 	if (!expected_types.empty()) {
 		auto &result_types = result.GetTypes();

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -38,6 +38,7 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 		auto transaction = read_info.GetTransaction();
 		auto &metadata_manager = transaction->GetMetadataManager();
 		auto &ducklake_catalog = transaction->GetCatalog();
+		auto col_names = metadata_manager.InlinedColNames();
 		// push the projections directly into the read
 		vector<string> columns_to_read;
 		vector<LogicalType> expected_types;
@@ -50,14 +51,14 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 				switch (identifier) {
 				case MultiFileReader::ORDINAL_FIELD_ID:
 				case MultiFileReader::ROW_ID_FIELD_ID:
-					virtual_column = "row_id";
+					virtual_column = col_names.row_id;
 					break;
 				case MultiFileReader::LAST_UPDATED_SEQUENCE_NUMBER_ID:
 					if (read_info.scan_type == DuckLakeScanType::SCAN_DELETIONS) {
 						// when scanning deletions end_snapshot is the snapshot marker
-						virtual_column = "end_snapshot";
+						virtual_column = col_names.end_snapshot;
 					} else {
-						virtual_column = "begin_snapshot";
+						virtual_column = col_names.begin_snapshot;
 					}
 					break;
 				default:
@@ -90,13 +91,13 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 				scan_column_ids.push_back(i);
 				virtual_columns.push_back(InlinedVirtualColumn::NONE);
 			}
-			columns_to_read.push_back(SQLIdentifier::ToString("row_id"));
+			columns_to_read.push_back(SQLIdentifier::ToString(col_names.row_id));
 			expected_types.push_back(LogicalType::BIGINT);
 			virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_EMPTY);
 		}
 		if (columns_to_read.empty()) {
 			// COUNT(*) - read row_id but don't emit
-			columns_to_read.push_back(SQLIdentifier::ToString("row_id"));
+			columns_to_read.push_back(SQLIdentifier::ToString(col_names.row_id));
 			expected_types.push_back(LogicalType::BIGINT);
 			virtual_columns.emplace_back(InlinedVirtualColumn::COLUMN_EMPTY);
 		}

--- a/src/storage/ducklake_inlined_data_reader.cpp
+++ b/src/storage/ducklake_inlined_data_reader.cpp
@@ -126,7 +126,7 @@ bool DuckLakeInlinedDataReader::TryInitializeScan(ClientContext &context, Global
 		default:
 			throw InternalException("Unknown DuckLake scan type");
 		}
-		data = metadata_manager.TransformInlinedData(*query_result, expected_types);
+		data = metadata_manager.TransformInlinedData(*query_result, expected_types, table_name);
 		if (!virtual_columns.empty()) {
 			auto scan_types = data->data->Types();
 			scan_chunk.Initialize(context, scan_types);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -116,7 +116,7 @@ bool DuckLakeMetadataManager::SupportsInliningColumns(const vector<DuckLakeColum
 
 bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
-	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsPrefixedInlinedColumns();
+	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsV1_1Metadata();
 	for (auto &col : columns.Logical()) {
 		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
 			return false;
@@ -133,7 +133,7 @@ bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 
 bool DuckLakeMetadataManager::CanInlineColumns(const vector<DuckLakeColumnInfo> &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
-	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsPrefixedInlinedColumns();
+	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsV1_1Metadata();
 	for (auto &col : columns) {
 		if (DuckLakeUtil::IsInlinedSystemColumn(col.name, prefixed_inlined_columns)) {
 			return false;
@@ -756,7 +756,7 @@ DuckLakeCatalogInfo DuckLakeMetadataManager::GetCatalogForSnapshot(DuckLakeSnaps
 	auto &ducklake_catalog = transaction.GetCatalog();
 	return BuildCatalogForSnapshot(
 	    snapshot, [this](DuckLakeSnapshot s, string q) { return Query(s, q); }, ducklake_catalog.DataPath(),
-	    ducklake_catalog.Separator(), ducklake_catalog.SupportsViewColumnTags());
+	    ducklake_catalog.Separator(), ducklake_catalog.SupportsV1_1Metadata());
 }
 
 DuckLakeCatalogInfo DuckLakeMetadataManager::BuildCatalogForSnapshot(
@@ -2786,7 +2786,7 @@ string DuckLakeMetadataManager::InlinedTableNameFor(idx_t table_id, idx_t schema
 }
 
 DuckLakeInlinedColNames DuckLakeMetadataManager::InlinedColNames() const {
-	return DuckLakeInlinedColNames(transaction.GetCatalog().SupportsPrefixedInlinedColumns());
+	return DuckLakeInlinedColNames(transaction.GetCatalog().SupportsV1_1Metadata());
 }
 
 string DuckLakeMetadataManager::InlinedTableDdlSql(const string &table_name, const string &column_defs,
@@ -3866,7 +3866,7 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 	Appender variant_stats_appender(connection, Identifier(db_name), schema_name,
 	                                Identifier("ducklake_file_variant_stats"));
 
-	bool write_row_group_count = catalog.SupportsRowGroupCount();
+	bool write_row_group_count = catalog.SupportsV1_1Metadata();
 	for (auto &file : new_files) {
 		auto data_file_index = static_cast<int64_t>(file.id.index);
 		auto table_id = static_cast<int64_t>(file.table_id.index);
@@ -4103,7 +4103,7 @@ string DuckLakeMetadataManager::WriteNewDataFiles(DuckLakeSnapshot &commit_snaps
 	for (auto &file : new_files) {
 		resolved_paths.push_back(GetRelativePath(file.table_id, file.file_name, new_tables, new_schemas_result));
 	}
-	return WriteNewDataFilesSqlBatch(new_files, resolved_paths, transaction.GetCatalog().SupportsRowGroupCount());
+	return WriteNewDataFilesSqlBatch(new_files, resolved_paths, transaction.GetCatalog().SupportsV1_1Metadata());
 }
 
 string DuckLakeMetadataManager::WriteNewDataFilesSqlBatch(const vector<DuckLakeFileInfo> &new_files,
@@ -5477,7 +5477,7 @@ WHERE table_id IN (%s);)",
 
 	// delete any views, schemas, macros, etc that are no longer referenced
 	tables_to_delete_from = {"ducklake_schema", "ducklake_view", "ducklake_tag", "ducklake_macro"};
-	if (transaction.GetCatalog().SupportsViewColumnTags()) {
+	if (transaction.GetCatalog().SupportsV1_1Metadata()) {
 		tables_to_delete_from.insert(tables_to_delete_from.begin() + 2, "ducklake_view_column_tag");
 	}
 	for (auto &delete_tbl : tables_to_delete_from) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -449,27 +449,46 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
 	}
 	DuckLakeInlinedColNames old_names(false);
 	DuckLakeInlinedColNames new_names(true);
+	vector<pair<string, string>> col_renames {{old_names.row_id, new_names.row_id},
+	                                          {old_names.begin_snapshot, new_names.begin_snapshot},
+	                                          {old_names.end_snapshot, new_names.end_snapshot}};
 	for (auto &row : *tables) {
 		auto table_name = row.GetValue<string>(0);
-		auto probe = Query(StringUtil::Format("SELECT %s FROM {METADATA_CATALOG}.%s LIMIT 0", old_names.row_id,
-		                                      SQLIdentifier(table_name)));
+		auto probe =
+		    Query(StringUtil::Format("SELECT * FROM {METADATA_CATALOG}.%s LIMIT 0", SQLIdentifier(table_name)));
 		if (probe->HasError()) {
-			// already renamed (or the table is gone) - nothing to do
+			if (allow_failures) {
+				continue;
+			}
+			probe->GetErrorObject().Throw(StringUtil::Format(
+			    "Failed to read inlined-data table \"%s\" while migrating to v1.1-dev1: ", table_name));
+		}
+		case_insensitive_set_t columns;
+		for (auto &name : probe->GetNames()) {
+			columns.insert(name.GetIdentifierName());
+		}
+		string renames;
+		for (auto &entry : col_renames) {
+			bool has_old = columns.count(entry.first);
+			bool has_new = columns.count(entry.second);
+			if (has_old && has_new) {
+				throw InvalidInputException(
+				    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-dev1: the table "
+				    "has both a \"%s\" and a \"%s\" column - rename user column \"%s\" before migrating",
+				    table_name, entry.first, entry.second, entry.second);
+			}
+			if (has_old) {
+				renames += StringUtil::Format("ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
+				                              SQLIdentifier(table_name), entry.first, entry.second);
+			}
+		}
+		if (renames.empty()) {
 			continue;
 		}
-		auto result = Execute(StringUtil::Format(
-		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;"
-		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;"
-		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
-		    SQLIdentifier(table_name), old_names.row_id, new_names.row_id, SQLIdentifier(table_name),
-		    old_names.begin_snapshot, new_names.begin_snapshot, SQLIdentifier(table_name), old_names.end_snapshot,
-		    new_names.end_snapshot));
+		auto result = Execute(renames);
 		if (result->HasError() && !allow_failures) {
-			result->GetErrorObject().Throw(
-			    StringUtil::Format("Failed to rename inlined-data metadata columns of \"%s\" while migrating to "
-			                       "v1.1-dev1 - if the table has a user column named \"%s\", \"%s\" or \"%s\", rename "
-			                       "it before migrating: ",
-			                       table_name, new_names.row_id, new_names.begin_snapshot, new_names.end_snapshot));
+			result->GetErrorObject().Throw(StringUtil::Format(
+			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-dev1: ", table_name));
 		}
 	}
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -463,24 +463,41 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
 			probe->GetErrorObject().Throw(StringUtil::Format(
 			    "Failed to read inlined-data table \"%s\" while migrating to v1.1-dev1: ", table_name));
 		}
-		case_insensitive_set_t columns;
-		for (auto &name : probe->GetNames()) {
-			columns.insert(name.GetIdentifierName());
+		// the metadata columns are always the first three columns, user columns follow
+		auto &names = probe->GetNames();
+		case_insensitive_set_t user_columns;
+		for (idx_t i = col_renames.size(); i < names.size(); i++) {
+			user_columns.insert(names[i].GetIdentifierName());
 		}
 		string renames;
-		for (auto &entry : col_renames) {
-			bool has_old = columns.count(entry.first);
-			bool has_new = columns.count(entry.second);
-			if (has_old && has_new) {
+		bool unexpected_layout = names.size() < col_renames.size();
+		for (idx_t i = 0; i < col_renames.size() && !unexpected_layout; i++) {
+			auto &entry = col_renames[i];
+			auto name = names[i].GetIdentifierName();
+			if (StringUtil::CIEquals(name, entry.second)) {
+				continue;
+			}
+			if (!StringUtil::CIEquals(name, entry.first)) {
+				unexpected_layout = true;
+				break;
+			}
+			if (user_columns.count(entry.second)) {
 				throw InvalidInputException(
-				    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-dev1: the table "
-				    "has both a \"%s\" and a \"%s\" column - rename user column \"%s\" before migrating",
-				    table_name, entry.first, entry.second, entry.second);
+				    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1: the table "
+				    "has a user column \"%s\" colliding with the renamed metadata column, rename it before migrating",
+				    table_name, entry.second);
 			}
-			if (has_old) {
-				renames += StringUtil::Format("ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
-				                              SQLIdentifier(table_name), entry.first, entry.second);
+			renames += StringUtil::Format("ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
+			                              SQLIdentifier(table_name), entry.first, entry.second);
+		}
+		if (unexpected_layout) {
+			if (allow_failures) {
+				continue;
 			}
+			throw InvalidInputException(
+			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-: the table has "
+			    "an unexpected column layout",
+			    table_name);
 		}
 		if (renames.empty()) {
 			continue;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -116,8 +116,9 @@ bool DuckLakeMetadataManager::SupportsInliningColumns(const vector<DuckLakeColum
 
 bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
+	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsPrefixedInlinedColumns();
 	for (auto &col : columns.Logical()) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name().GetIdentifierName())) {
+		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
 			return false;
 		}
 		if (col.Name().size() > max_identifier_length) {
@@ -132,8 +133,9 @@ bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 
 bool DuckLakeMetadataManager::CanInlineColumns(const vector<DuckLakeColumnInfo> &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
+	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsPrefixedInlinedColumns();
 	for (auto &col : columns) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.name)) {
+		if (DuckLakeUtil::IsInlinedSystemColumn(col.name, prefixed_inlined_columns)) {
 			return false;
 		}
 		if (col.name.size() > max_identifier_length) {
@@ -432,7 +434,44 @@ CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 );
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)";
+	// rename first: a conflict aborts the migration while the catalog is still at v1.0
+	MigrateInlinedColumnNames(allow_failures);
 	ExecuteMigration(migrate_query, allow_failures, "1.0", "1.1-dev1");
+}
+
+void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
+	auto tables = Query("SELECT table_name FROM {METADATA_CATALOG}.ducklake_inlined_data_tables");
+	if (tables->HasError()) {
+		if (allow_failures) {
+			return;
+		}
+		tables->GetErrorObject().Throw("Failed to list inlined-data tables while migrating to v1.1-dev1: ");
+	}
+	DuckLakeInlinedColNames old_names(false);
+	DuckLakeInlinedColNames new_names(true);
+	for (auto &row : *tables) {
+		auto table_name = row.GetValue<string>(0);
+		auto probe = Query(StringUtil::Format("SELECT %s FROM {METADATA_CATALOG}.%s LIMIT 0", old_names.row_id,
+		                                      SQLIdentifier(table_name)));
+		if (probe->HasError()) {
+			// already renamed (or the table is gone) - nothing to do
+			continue;
+		}
+		auto result = Execute(StringUtil::Format(
+		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;"
+		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;"
+		    "ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
+		    SQLIdentifier(table_name), old_names.row_id, new_names.row_id, SQLIdentifier(table_name),
+		    old_names.begin_snapshot, new_names.begin_snapshot, SQLIdentifier(table_name), old_names.end_snapshot,
+		    new_names.end_snapshot));
+		if (result->HasError() && !allow_failures) {
+			result->GetErrorObject().Throw(
+			    StringUtil::Format("Failed to rename inlined-data metadata columns of \"%s\" while migrating to "
+			                       "v1.1-dev1 - if the table has a user column named \"%s\", \"%s\" or \"%s\", rename "
+			                       "it before migrating: ",
+			                       table_name, new_names.row_id, new_names.begin_snapshot, new_names.end_snapshot));
+		}
+	}
 }
 
 DuckLakeMetadata DuckLakeMetadataManager::LoadDuckLake() {
@@ -2728,7 +2767,7 @@ string DuckLakeMetadataManager::InlinedTableNameFor(idx_t table_id, idx_t schema
 }
 
 DuckLakeInlinedColNames DuckLakeMetadataManager::InlinedColNames() const {
-	return DuckLakeInlinedColNames();
+	return DuckLakeInlinedColNames(transaction.GetCatalog().SupportsPrefixedInlinedColumns());
 }
 
 string DuckLakeMetadataManager::InlinedTableDdlSql(const string &table_name, const string &column_defs,

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -653,17 +653,19 @@ idx_t DuckLakeMetadataManager::GetNetDataFileRowCount(TableIndex table_id, DuckL
 	return 0;
 }
 
-string DuckLakeMetadataManager::GetNetInlinedRowCountSql(const string &inlined_table_name) {
+string DuckLakeMetadataManager::GetNetInlinedRowCountSql(const string &inlined_table_name,
+                                                         const DuckLakeInlinedColNames &col_names) {
 	return StringUtil::Format(R"(
 SELECT COUNT(*)
 FROM {METADATA_CATALOG}.%s
-WHERE {SNAPSHOT_ID} >= begin_snapshot
-  AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL))",
-	                          inlined_table_name);
+WHERE {SNAPSHOT_ID} >= %s
+  AND ({SNAPSHOT_ID} < %s OR %s IS NULL))",
+	                          inlined_table_name, col_names.begin_snapshot, col_names.end_snapshot,
+	                          col_names.end_snapshot);
 }
 
 idx_t DuckLakeMetadataManager::GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot) {
-	auto result = Query(snapshot, GetNetInlinedRowCountSql(inlined_table_name));
+	auto result = Query(snapshot, GetNetInlinedRowCountSql(inlined_table_name, InlinedColNames()));
 	for (auto &row : *result) {
 		return row.GetValue<idx_t>(0);
 	}
@@ -2725,10 +2727,16 @@ string DuckLakeMetadataManager::InlinedTableNameFor(idx_t table_id, idx_t schema
 	return StringUtil::Format("ducklake_inlined_data_%d_%d", table_id, schema_version);
 }
 
-string DuckLakeMetadataManager::InlinedTableDdlSql(const string &table_name, const string &column_defs) {
-	return StringUtil::Format("CREATE TABLE IF NOT EXISTS {METADATA_CATALOG}.%s(row_id BIGINT, begin_snapshot BIGINT, "
-	                          "end_snapshot BIGINT, %s);",
-	                          SQLIdentifier(table_name), column_defs);
+DuckLakeInlinedColNames DuckLakeMetadataManager::InlinedColNames() const {
+	return DuckLakeInlinedColNames();
+}
+
+string DuckLakeMetadataManager::InlinedTableDdlSql(const string &table_name, const string &column_defs,
+                                                   const DuckLakeInlinedColNames &col_names) {
+	return StringUtil::Format("CREATE TABLE IF NOT EXISTS {METADATA_CATALOG}.%s(%s BIGINT, %s BIGINT, "
+	                          "%s BIGINT, %s);",
+	                          SQLIdentifier(table_name), col_names.row_id, col_names.begin_snapshot,
+	                          col_names.end_snapshot, column_defs);
 }
 
 string DuckLakeMetadataManager::InlinedTableRegistrationTuple(idx_t table_id, const string &table_name,
@@ -2754,7 +2762,7 @@ string DuckLakeMetadataManager::GetInlinedTableQuery(const DuckLakeTableInfo &ta
 	}
 	// We created a table here, flag we need to clear our cache at commit
 	MarkPendingCacheClear();
-	return InlinedTableDdlSql(table_name, column_defs);
+	return InlinedTableDdlSql(table_name, column_defs, InlinedColNames());
 }
 
 string DuckLakeMetadataManager::WriteNewTables(const vector<DuckLakeTableInfo> &new_tables,
@@ -3069,7 +3077,8 @@ string DuckLakeMetadataManager::FormatInlinedDataInsert(const string &inlined_ta
 	                          values);
 }
 
-string DuckLakeMetadataManager::WriteNewInlinedDeletes(const vector<DuckLakeDeletedInlinedDataInfo> &new_deletes) {
+string DuckLakeMetadataManager::WriteNewInlinedDeletes(const vector<DuckLakeDeletedInlinedDataInfo> &new_deletes,
+                                                       const DuckLakeInlinedColNames &col_names) {
 	string batch_queries;
 	if (new_deletes.empty()) {
 		return batch_queries;
@@ -3089,11 +3098,12 @@ WITH deleted_row_list(deleted_row_id) AS (
 VALUES %s
 )
 UPDATE {METADATA_CATALOG}.%s
-SET end_snapshot = {SNAPSHOT_ID}
+SET %s = {SNAPSHOT_ID}
 FROM deleted_row_list
-WHERE row_id=deleted_row_id AND end_snapshot IS NULL AND begin_snapshot != {SNAPSHOT_ID};
+WHERE %s=deleted_row_id AND %s IS NULL AND %s != {SNAPSHOT_ID};
 )",
-		                                    row_id_list, entry.table_name);
+		                                    row_id_list, entry.table_name, col_names.end_snapshot, col_names.row_id,
+		                                    col_names.end_snapshot, col_names.begin_snapshot);
 	}
 	return batch_queries;
 }
@@ -3328,12 +3338,15 @@ unique_ptr<QueryResult> DuckLakeMetadataManager::ReadInlinedData(DuckLakeSnapsho
                                                                  const string &inlined_table_name,
                                                                  const vector<string> &columns_to_read) {
 	auto projection = GetProjection(columns_to_read);
+	auto col_names = InlinedColNames();
 	auto result = Query(snapshot, StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s inlined_data
-WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
-ORDER BY row_id;)",
-	                                                 projection, inlined_table_name));
+WHERE {SNAPSHOT_ID} >= %s AND ({SNAPSHOT_ID} < %s OR %s IS NULL)
+ORDER BY %s;)",
+	                                                 projection, inlined_table_name, col_names.begin_snapshot,
+	                                                 col_names.end_snapshot, col_names.end_snapshot,
+	                                                 col_names.row_id));
 	return result;
 }
 
@@ -3342,11 +3355,13 @@ unique_ptr<QueryResult> DuckLakeMetadataManager::ReadInlinedDataInsertions(DuckL
                                                                            const string &inlined_table_name,
                                                                            const vector<string> &columns_to_read) {
 	auto projection = GetProjection(columns_to_read);
+	auto col_names = InlinedColNames();
 	auto result = Query(end_snapshot, StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s inlined_data
-WHERE inlined_data.begin_snapshot >= %d AND inlined_data.begin_snapshot <= {SNAPSHOT_ID};)",
-	                                                     projection, inlined_table_name, start_snapshot.snapshot_id));
+WHERE inlined_data.%s >= %d AND inlined_data.%s <= {SNAPSHOT_ID};)",
+	                                                     projection, inlined_table_name, col_names.begin_snapshot,
+	                                                     start_snapshot.snapshot_id, col_names.begin_snapshot));
 	return result;
 }
 
@@ -3355,11 +3370,13 @@ unique_ptr<QueryResult> DuckLakeMetadataManager::ReadInlinedDataDeletions(DuckLa
                                                                           const string &inlined_table_name,
                                                                           const vector<string> &columns_to_read) {
 	auto projection = GetProjection(columns_to_read);
+	auto col_names = InlinedColNames();
 	auto result = Query(end_snapshot, StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s inlined_data
-WHERE inlined_data.end_snapshot >= %d AND inlined_data.end_snapshot <= {SNAPSHOT_ID};)",
-	                                                     projection, inlined_table_name, start_snapshot.snapshot_id));
+WHERE inlined_data.%s >= %d AND inlined_data.%s <= {SNAPSHOT_ID};)",
+	                                                     projection, inlined_table_name, col_names.end_snapshot,
+	                                                     start_snapshot.snapshot_id, col_names.end_snapshot));
 	return result;
 }
 
@@ -3367,23 +3384,27 @@ unique_ptr<QueryResult> DuckLakeMetadataManager::ReadAllInlinedDataForFlush(Duck
                                                                             const string &inlined_table_name,
                                                                             const vector<string> &columns_to_read) {
 	auto projection = GetProjection(columns_to_read);
+	auto col_names = InlinedColNames();
 	auto result = Query(snapshot, StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s inlined_data
-WHERE {SNAPSHOT_ID} >= begin_snapshot
-ORDER BY row_id, begin_snapshot;)",
-	                                                 projection, inlined_table_name));
+WHERE {SNAPSHOT_ID} >= %s
+ORDER BY %s, %s;)",
+	                                                 projection, inlined_table_name, col_names.begin_snapshot,
+	                                                 col_names.row_id, col_names.begin_snapshot));
 	return result;
 }
 
 string DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(const string &inlined_table_name,
-                                                             const string &select_list) {
+                                                             const string &select_list,
+                                                             const DuckLakeInlinedColNames &col_names) {
 	return StringUtil::Format(R"(
 SELECT %s
 FROM {METADATA_CATALOG}.%s
-WHERE {SNAPSHOT_ID} >= begin_snapshot AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL);
+WHERE {SNAPSHOT_ID} >= %s AND ({SNAPSHOT_ID} < %s OR %s IS NULL);
 )",
-	                          select_list, inlined_table_name);
+	                          select_list, inlined_table_name, col_names.begin_snapshot, col_names.end_snapshot,
+	                          col_names.end_snapshot);
 }
 
 string DuckLakeMetadataManager::ReadFileColumnStatsForTableSql(TableIndex table_id) {
@@ -5531,9 +5552,10 @@ void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &
 void DuckLakeMetadataManager::DeleteFlushedInlinedData(const DuckLakeInlinedTableInfo &inlined_table,
                                                        idx_t flush_snapshot_id) {
 	auto result = Execute(StringUtil::Format(R"(
-		DELETE FROM {METADATA_CATALOG}.%s WHERE begin_snapshot <= %d
+		DELETE FROM {METADATA_CATALOG}.%s WHERE %s <= %d
 )",
-	                                         SQLIdentifier(inlined_table.table_name), flush_snapshot_id));
+	                                         SQLIdentifier(inlined_table.table_name), InlinedColNames().begin_snapshot,
+	                                         flush_snapshot_id));
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to delete flushed inlined data in DuckLake from table " +
 		                               inlined_table.table_name + ": ");
@@ -5541,11 +5563,13 @@ void DuckLakeMetadataManager::DeleteFlushedInlinedData(const DuckLakeInlinedTabl
 }
 
 string
-DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables) {
+DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables,
+                                                          const DuckLakeInlinedColNames &col_names) {
 	string result;
 	for (auto &flushed : flushed_tables) {
-		result += StringUtil::Format("DELETE FROM {METADATA_CATALOG}.%s WHERE begin_snapshot <= %d;\n",
-		                             SQLIdentifier(flushed.inlined_table.table_name), flushed.flush_snapshot_id);
+		result += StringUtil::Format("DELETE FROM {METADATA_CATALOG}.%s WHERE %s <= %d;\n",
+		                             SQLIdentifier(flushed.inlined_table.table_name), col_names.begin_snapshot,
+		                             flushed.flush_snapshot_id);
 	}
 	return result;
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3377,21 +3377,28 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 	return string();
 }
 
-void DuckLakeMetadataManager::CheckInlinedDataReadError(QueryResult &result) {
+void DuckLakeMetadataManager::CheckInlinedDataReadError(QueryResult &result, const string &inlined_table_name) {
 	if (!result.HasError()) {
 		return;
 	}
-	if (transaction.GetCatalog().SupportsV1_1Metadata() && StringUtil::Contains(result.GetError(), "_ducklake_")) {
-		result.GetErrorObject().Throw(
-		    "Failed to read inlined data from DuckLake. If this catalog was written by an older DuckLake version, "
-		    "reattach with AUTOMATIC_MIGRATION TRUE to rename the inlined metadata columns: ");
+	if (transaction.GetCatalog().SupportsV1_1Metadata() && !inlined_table_name.empty()) {
+		// unmigrated tables still lead with the legacy row_id metadata column
+		auto probe =
+		    Query(StringUtil::Format("SELECT * FROM {METADATA_CATALOG}.%s LIMIT 0", SQLIdentifier(inlined_table_name)));
+		if (!probe->HasError() && !probe->GetNames().empty() &&
+		    StringUtil::CIEquals(probe->GetNames()[0].GetIdentifierName(), DuckLakeInlinedColNames(false).row_id)) {
+			result.GetErrorObject().Throw(
+			    "Failed to read inlined data from DuckLake. If this catalog was written by an older DuckLake version, "
+			    "reattach with AUTOMATIC_MIGRATION TRUE to rename the inlined metadata columns: ");
+		}
 	}
 	result.GetErrorObject().Throw("Failed to read inlined data from DuckLake: ");
 }
 
 shared_ptr<DuckLakeInlinedData> DuckLakeMetadataManager::TransformInlinedData(QueryResult &result,
-                                                                              const vector<LogicalType> &) {
-	CheckInlinedDataReadError(result);
+                                                                              const vector<LogicalType> &,
+                                                                              const string &inlined_table_name) {
+	CheckInlinedDataReadError(result, inlined_table_name);
 
 	auto context = transaction.context.lock();
 	auto data = make_uniq<ColumnDataCollection>(*context, result.GetTypes());

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -743,6 +743,7 @@ WHERE {SNAPSHOT_ID} >= %s
 
 idx_t DuckLakeMetadataManager::GetNetInlinedRowCount(const string &inlined_table_name, DuckLakeSnapshot snapshot) {
 	auto result = Query(snapshot, GetNetInlinedRowCountSql(inlined_table_name, InlinedColNames()));
+	CheckInlinedDataReadError(*result, inlined_table_name);
 	for (auto &row : *result) {
 		return row.GetValue<idx_t>(0);
 	}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3382,15 +3382,23 @@ void DuckLakeMetadataManager::CheckInlinedDataReadError(QueryResult &result, con
 	if (!result.HasError()) {
 		return;
 	}
-	if (transaction.GetCatalog().SupportsV1_1Metadata() && !inlined_table_name.empty()) {
-		// unmigrated tables still lead with the legacy row_id metadata column
+	if (!inlined_table_name.empty()) {
+		// the leading metadata column reveals whether the table matches this session's catalog version
 		auto probe =
 		    Query(StringUtil::Format("SELECT * FROM {METADATA_CATALOG}.%s LIMIT 0", SQLIdentifier(inlined_table_name)));
-		if (!probe->HasError() && !probe->GetNames().empty() &&
-		    StringUtil::CIEquals(probe->GetNames()[0].GetIdentifierName(), DuckLakeInlinedColNames(false).row_id)) {
-			result.GetErrorObject().Throw(
-			    "Failed to read inlined data from DuckLake. If this catalog was written by an older DuckLake version, "
-			    "reattach with AUTOMATIC_MIGRATION TRUE to rename the inlined metadata columns: ");
+		if (!probe->HasError() && !probe->GetNames().empty()) {
+			auto &first_column = probe->GetNames()[0].GetIdentifierName();
+			bool prefixed_catalog = transaction.GetCatalog().SupportsV1_1Metadata();
+			if (prefixed_catalog && StringUtil::CIEquals(first_column, DuckLakeInlinedColNames(false).row_id)) {
+				result.GetErrorObject().Throw(
+				    "Failed to read inlined data from DuckLake. If this catalog was written by an older DuckLake "
+				    "version, reattach with AUTOMATIC_MIGRATION TRUE to rename the inlined metadata columns: ");
+			}
+			if (!prefixed_catalog && StringUtil::CIEquals(first_column, DuckLakeInlinedColNames(true).row_id)) {
+				result.GetErrorObject().Throw(
+				    "Failed to read inlined data from DuckLake. The catalog was migrated by another connection, "
+				    "reattach to pick up the new version: ");
+			}
 		}
 	}
 	result.GetErrorObject().Throw("Failed to read inlined data from DuckLake: ");
@@ -3440,8 +3448,7 @@ FROM {METADATA_CATALOG}.%s inlined_data
 WHERE {SNAPSHOT_ID} >= %s AND ({SNAPSHOT_ID} < %s OR %s IS NULL)
 ORDER BY %s;)",
 	                                                 projection, inlined_table_name, col_names.begin_snapshot,
-	                                                 col_names.end_snapshot, col_names.end_snapshot,
-	                                                 col_names.row_id));
+	                                                 col_names.end_snapshot, col_names.end_snapshot, col_names.row_id));
 	return result;
 }
 
@@ -5657,9 +5664,8 @@ void DuckLakeMetadataManager::DeleteFlushedInlinedData(const DuckLakeInlinedTabl
 	}
 }
 
-string
-DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables,
-                                                          const DuckLakeInlinedColNames &col_names) {
+string DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(const vector<FlushedInlinedTableInfo> &flushed_tables,
+                                                                 const DuckLakeInlinedColNames &col_names) {
 	string result;
 	for (auto &flushed : flushed_tables) {
 		result += StringUtil::Format("DELETE FROM {METADATA_CATALOG}.%s WHERE %s <= %d;\n",

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -434,7 +434,7 @@ CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 );
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)";
-	// rename first: a conflict aborts the migration while the catalog is still at v1.0
+	// rename first so a conflict aborts while the catalog is still at v1.0
 	MigrateInlinedColumnNames(allow_failures);
 	ExecuteMigration(migrate_query, allow_failures, "1.0", "1.1-dev1");
 }

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -114,11 +114,17 @@ bool DuckLakeMetadataManager::SupportsInliningColumns(const vector<DuckLakeColum
 	return true;
 }
 
+bool DuckLakeInlinedColNames::ConflictsWith(const string &name) const {
+	return StringUtil::CIEquals(name, row_id) || StringUtil::CIEquals(name, begin_snapshot) ||
+	       StringUtil::CIEquals(name, end_snapshot) || StringUtil::CIEquals(name, "_ducklake_internal_snapshot_id") ||
+	       StringUtil::CIEquals(name, "_ducklake_internal_row_id");
+}
+
 bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
-	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsV1_1Metadata();
+	auto col_names = InlinedColNames();
 	for (auto &col : columns.Logical()) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.Name().GetIdentifierName(), prefixed_inlined_columns)) {
+		if (col_names.ConflictsWith(col.Name().GetIdentifierName())) {
 			return false;
 		}
 		if (col.Name().size() > max_identifier_length) {
@@ -133,9 +139,9 @@ bool DuckLakeMetadataManager::CanInlineColumns(const ColumnList &columns) {
 
 bool DuckLakeMetadataManager::CanInlineColumns(const vector<DuckLakeColumnInfo> &columns) {
 	auto max_identifier_length = MaxIdentifierLength();
-	auto prefixed_inlined_columns = transaction.GetCatalog().SupportsV1_1Metadata();
+	auto col_names = InlinedColNames();
 	for (auto &col : columns) {
-		if (DuckLakeUtil::IsInlinedSystemColumn(col.name, prefixed_inlined_columns)) {
+		if (col_names.ConflictsWith(col.name)) {
 			return false;
 		}
 		if (col.name.size() > max_identifier_length) {
@@ -440,7 +446,10 @@ UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = '
 }
 
 void DuckLakeMetadataManager::MigrateInlinedColumnNames() {
-	auto tables = Query("SELECT table_name FROM {METADATA_CATALOG}.ducklake_inlined_data_tables");
+	auto tables = Query(R"(
+SELECT idt.table_name AS inlined_table_name, tbl.table_name AS user_table_name
+FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt
+LEFT JOIN {METADATA_CATALOG}.ducklake_table tbl ON idt.table_id = tbl.table_id AND tbl.end_snapshot IS NULL)");
 	if (tables->HasError()) {
 		tables->GetErrorObject().Throw("Failed to list inlined-data tables while migrating to v1.1-dev1: ");
 	}
@@ -451,6 +460,7 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames() {
 	                                          {old_names.end_snapshot, new_names.end_snapshot}};
 	for (auto &row : *tables) {
 		auto table_name = row.GetValue<string>(0);
+		auto user_table_name = row.IsNull(1) ? table_name : row.GetValue<string>(1);
 		auto probe =
 		    Query(StringUtil::Format("SELECT * FROM {METADATA_CATALOG}.%s LIMIT 0", SQLIdentifier(table_name)));
 		if (probe->HasError()) {
@@ -477,16 +487,17 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames() {
 			}
 			if (user_columns.count(entry.second)) {
 				throw InvalidInputException(
-				    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1: the table "
-				    "has a user column \"%s\" colliding with the renamed metadata column, rename it before migrating",
-				    table_name, entry.second);
+				    "Failed to rename inlined-data metadata columns while migrating to v1.1-dev1: table \"%s\" has a "
+				    "column \"%s\" colliding with the renamed metadata column. Rename the column and call "
+				    "ducklake_flush_inlined_data() before migrating",
+				    user_table_name, entry.second);
 			}
 			renames += StringUtil::Format("ALTER TABLE {METADATA_CATALOG}.%s RENAME COLUMN %s TO %s;",
 			                              SQLIdentifier(table_name), entry.first, entry.second);
 		}
 		if (unexpected_layout) {
 			throw InvalidInputException(
-			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-: the table has "
+			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-dev1: the table has "
 			    "an unexpected column layout",
 			    table_name);
 		}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -435,16 +435,13 @@ CREATE TABLE {IF_NOT_EXISTS} {METADATA_CATALOG}.ducklake_view_column_tag(
 UPDATE {METADATA_CATALOG}.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 	)";
 	// rename first so a conflict aborts while the catalog is still at v1.0
-	MigrateInlinedColumnNames(allow_failures);
+	MigrateInlinedColumnNames();
 	ExecuteMigration(migrate_query, allow_failures, "1.0", "1.1-dev1");
 }
 
-void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
+void DuckLakeMetadataManager::MigrateInlinedColumnNames() {
 	auto tables = Query("SELECT table_name FROM {METADATA_CATALOG}.ducklake_inlined_data_tables");
 	if (tables->HasError()) {
-		if (allow_failures) {
-			return;
-		}
 		tables->GetErrorObject().Throw("Failed to list inlined-data tables while migrating to v1.1-dev1: ");
 	}
 	DuckLakeInlinedColNames old_names(false);
@@ -457,9 +454,6 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
 		auto probe =
 		    Query(StringUtil::Format("SELECT * FROM {METADATA_CATALOG}.%s LIMIT 0", SQLIdentifier(table_name)));
 		if (probe->HasError()) {
-			if (allow_failures) {
-				continue;
-			}
 			probe->GetErrorObject().Throw(StringUtil::Format(
 			    "Failed to read inlined-data table \"%s\" while migrating to v1.1-dev1: ", table_name));
 		}
@@ -491,9 +485,6 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
 			                              SQLIdentifier(table_name), entry.first, entry.second);
 		}
 		if (unexpected_layout) {
-			if (allow_failures) {
-				continue;
-			}
 			throw InvalidInputException(
 			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-: the table has "
 			    "an unexpected column layout",
@@ -503,7 +494,7 @@ void DuckLakeMetadataManager::MigrateInlinedColumnNames(bool allow_failures) {
 			continue;
 		}
 		auto result = Execute(renames);
-		if (result->HasError() && !allow_failures) {
+		if (result->HasError()) {
 			result->GetErrorObject().Throw(StringUtil::Format(
 			    "Failed to rename inlined-data metadata columns of \"%s\" while migrating to v1.1-dev1: ", table_name));
 		}
@@ -3375,11 +3366,21 @@ string DuckLakeMetadataManager::GetInlinedDeletionTableName(TableIndex table_id,
 	return string();
 }
 
+void DuckLakeMetadataManager::CheckInlinedDataReadError(QueryResult &result) {
+	if (!result.HasError()) {
+		return;
+	}
+	if (transaction.GetCatalog().SupportsV1_1Metadata() && StringUtil::Contains(result.GetError(), "_ducklake_")) {
+		result.GetErrorObject().Throw(
+		    "Failed to read inlined data from DuckLake. If this catalog was written by an older DuckLake version, "
+		    "reattach with AUTOMATIC_MIGRATION TRUE to rename the inlined metadata columns: ");
+	}
+	result.GetErrorObject().Throw("Failed to read inlined data from DuckLake: ");
+}
+
 shared_ptr<DuckLakeInlinedData> DuckLakeMetadataManager::TransformInlinedData(QueryResult &result,
                                                                               const vector<LogicalType> &) {
-	if (result.HasError()) {
-		result.GetErrorObject().Throw("Failed to read inlined data from DuckLake: ");
-	}
+	CheckInlinedDataReadError(result);
 
 	auto context = transaction.context.lock();
 	auto data = make_uniq<ColumnDataCollection>(*context, result.GetTypes());

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -74,11 +74,8 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateTableExtended(CatalogTrans
 	                          base_info.on_conflict)) {
 		return nullptr;
 	}
-	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
-	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
-	if (prefixed_cols || duck_catalog.DataInliningRowLimit(transaction.GetContext(), schema_id, TableIndex()) > 0) {
-		DuckLakeUtil::ValidateNoInlinedSystemColumns(base_info.columns, prefixed_cols);
-	}
+	DuckLakeUtil::ValidateNoInlinedSystemColumns(catalog.Cast<DuckLakeCatalog>(), transaction.GetContext(), schema_id,
+	                                             base_info.columns);
 	//! get a local table-id
 	auto table_id = TableIndex(duck_transaction.GetLocalCatalogId());
 	// generate field ids based on the column ids

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -75,7 +75,7 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateTableExtended(CatalogTrans
 		return nullptr;
 	}
 	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
-	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
 	if (prefixed_cols || duck_catalog.DataInliningRowLimit(transaction.GetContext(), schema_id, TableIndex()) > 0) {
 		DuckLakeUtil::ValidateNoInlinedSystemColumns(base_info.columns, prefixed_cols);
 	}

--- a/src/storage/ducklake_schema_entry.cpp
+++ b/src/storage/ducklake_schema_entry.cpp
@@ -74,10 +74,10 @@ optional_ptr<CatalogEntry> DuckLakeSchemaEntry::CreateTableExtended(CatalogTrans
 	                          base_info.on_conflict)) {
 		return nullptr;
 	}
-	// reject columns with reserved DuckLake internal names when inlining is enabled
 	auto &duck_catalog = catalog.Cast<DuckLakeCatalog>();
-	if (duck_catalog.DataInliningRowLimit(transaction.GetContext(), schema_id, TableIndex()) > 0) {
-		DuckLakeUtil::ValidateNoInlinedSystemColumns(base_info.columns);
+	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	if (prefixed_cols || duck_catalog.DataInliningRowLimit(transaction.GetContext(), schema_id, TableIndex()) > 0) {
+		DuckLakeUtil::ValidateNoInlinedSystemColumns(base_info.columns, prefixed_cols);
 	}
 	//! get a local table-id
 	auto table_id = TableIndex(duck_transaction.GetLocalCatalogId());

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -813,13 +813,12 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		}
 		return 0;
 	};
-	bool prefixed_inlined_columns = ctx.supports_v1_1_metadata;
-	ctx.get_net_inlined_row_count = [this, prefixed_inlined_columns](TableIndex table_id) -> idx_t {
+	auto inlined_col_names = ctx.InlinedColNames();
+	ctx.get_net_inlined_row_count = [this, inlined_col_names](TableIndex table_id) -> idx_t {
 		idx_t total = 0;
 		for (auto &name : LookupInlinedTableNames(table_id)) {
 			auto sql = SubstitutePlaceholders(
-			    DuckLakeMetadataManager::GetNetInlinedRowCountSql(name, DuckLakeInlinedColNames(prefixed_inlined_columns)),
-			    transaction_snapshot);
+			    DuckLakeMetadataManager::GetNetInlinedRowCountSql(name, inlined_col_names), transaction_snapshot);
 			auto result = RunQuery(sql, "read net inlined row count");
 			for (auto &row : *result) {
 				total += row.GetValue<idx_t>(0);

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -816,8 +816,9 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 	ctx.get_net_inlined_row_count = [this](TableIndex table_id) -> idx_t {
 		idx_t total = 0;
 		for (auto &name : LookupInlinedTableNames(table_id)) {
-			auto sql =
-			    SubstitutePlaceholders(DuckLakeMetadataManager::GetNetInlinedRowCountSql(name), transaction_snapshot);
+			auto sql = SubstitutePlaceholders(
+			    DuckLakeMetadataManager::GetNetInlinedRowCountSql(name, DuckLakeInlinedColNames()),
+			    transaction_snapshot);
 			auto result = RunQuery(sql, "read net inlined row count");
 			for (auto &row : *result) {
 				total += row.GetValue<idx_t>(0);

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -813,11 +813,12 @@ DuckLakeCommitContext DuckLakeServerSideCommit::BuildContext(idx_t &committed_sn
 		}
 		return 0;
 	};
-	ctx.get_net_inlined_row_count = [this](TableIndex table_id) -> idx_t {
+	bool prefixed_inlined_columns = ctx.supports_v1_1_metadata;
+	ctx.get_net_inlined_row_count = [this, prefixed_inlined_columns](TableIndex table_id) -> idx_t {
 		idx_t total = 0;
 		for (auto &name : LookupInlinedTableNames(table_id)) {
 			auto sql = SubstitutePlaceholders(
-			    DuckLakeMetadataManager::GetNetInlinedRowCountSql(name, DuckLakeInlinedColNames()),
+			    DuckLakeMetadataManager::GetNetInlinedRowCountSql(name, DuckLakeInlinedColNames(prefixed_inlined_columns)),
 			    transaction_snapshot);
 			auto result = RunQuery(sql, "read net inlined row count");
 			for (auto &row : *result) {

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -594,7 +594,7 @@ DuckLakePartitionField GetPartitionField(DuckLakeTableEntry &table, ParsedExpres
 			                              name);
 		}
 		if (DuckLakePartitionUtils::IsEpochTransform(field.transform.type) &&
-		    !table.ParentCatalog().Cast<DuckLakeCatalog>().SupportsEpochPartitionTransforms()) {
+		    !table.ParentCatalog().Cast<DuckLakeCatalog>().SupportsV1_1Metadata()) {
 			throw InvalidInputException("DuckLake 1.0 does not support the %s partition transform - attach with "
 			                            "AUTOMATIC_MIGRATION set to TRUE to migrate the catalog to a newer version",
 			                            name);
@@ -748,7 +748,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
                                                         RenameColumnInfo &info) {
 	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
 	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name.GetIdentifierName(), prefixed_cols) &&
 	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
 		if (prefixed_cols) {
@@ -801,7 +801,7 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
                                                         AddColumnInfo &info) {
 	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
 	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name().GetIdentifierName(), prefixed_cols) &&
 	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
 		if (prefixed_cols) {

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -748,8 +748,14 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
                                                         RenameColumnInfo &info) {
 	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name.GetIdentifierName()) &&
-	    duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0) {
+	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name.GetIdentifierName(), prefixed_cols) &&
+	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
+		if (prefixed_cols) {
+			throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use: column names "
+			                       "starting with \"_ducklake_\" are not allowed.",
+			                       info.new_name.GetIdentifierName());
+		}
 		throw CatalogException(
 		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
 		    "you must use this column name, disable inlining by calling "
@@ -795,8 +801,14 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, 
                                                         AddColumnInfo &info) {
 	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
 	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name().GetIdentifierName()) &&
-	    duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0) {
+	bool prefixed_cols = duck_catalog.SupportsPrefixedInlinedColumns();
+	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name().GetIdentifierName(), prefixed_cols) &&
+	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
+		if (prefixed_cols) {
+			throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use: column names "
+			                       "starting with \"_ducklake_\" are not allowed.",
+			                       info.new_column.Name().GetIdentifierName());
+		}
 		throw CatalogException(
 		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
 		    "you must use this column name, disable inlining by calling "

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -746,22 +746,9 @@ unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(DuckLakeTransaction &tra
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, DuckLakeTransaction &transaction,
                                                         RenameColumnInfo &info) {
-	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
-	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_name.GetIdentifierName(), prefixed_cols) &&
-	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
-		if (prefixed_cols) {
-			throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use: column names "
-			                       "starting with \"_ducklake_\" are not allowed.",
-			                       info.new_name.GetIdentifierName());
-		}
-		throw CatalogException(
-		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
-		    "you must use this column name, disable inlining by calling "
-		    "ducklake_set_option('data_inlining_row_limit', 0).",
-		    info.new_name.GetIdentifierName());
-	}
+	DuckLakeUtil::ValidateInlinedSystemColumn(ParentCatalog().Cast<DuckLakeCatalog>(), context,
+	                                          ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId(), GetTableId(),
+	                                          info.new_name.GetIdentifierName());
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	if (!table_info.columns.ColumnExists(info.old_name)) {
@@ -799,22 +786,9 @@ void DuckLakeTableEntry::RequireNextColumnId(DuckLakeTransaction &transaction) {
 
 unique_ptr<CatalogEntry> DuckLakeTableEntry::AlterTable(ClientContext &context, DuckLakeTransaction &transaction,
                                                         AddColumnInfo &info) {
-	auto &duck_catalog = ParentCatalog().Cast<DuckLakeCatalog>();
-	auto &duck_schema = ParentSchema().Cast<DuckLakeSchemaEntry>();
-	bool prefixed_cols = duck_catalog.SupportsV1_1Metadata();
-	if (DuckLakeUtil::IsInlinedSystemColumn(info.new_column.Name().GetIdentifierName(), prefixed_cols) &&
-	    (prefixed_cols || duck_catalog.DataInliningRowLimit(context, duck_schema.GetSchemaId(), GetTableId()) > 0)) {
-		if (prefixed_cols) {
-			throw CatalogException("Column name \"%s\" is reserved by DuckLake for internal use: column names "
-			                       "starting with \"_ducklake_\" are not allowed.",
-			                       info.new_column.Name().GetIdentifierName());
-		}
-		throw CatalogException(
-		    "Column name \"%s\" is reserved by DuckLake for internal use when data inlining is enabled. If "
-		    "you must use this column name, disable inlining by calling "
-		    "ducklake_set_option('data_inlining_row_limit', 0).",
-		    info.new_column.Name().GetIdentifierName());
-	}
+	DuckLakeUtil::ValidateInlinedSystemColumn(ParentCatalog().Cast<DuckLakeCatalog>(), context,
+	                                          ParentSchema().Cast<DuckLakeSchemaEntry>().GetSchemaId(), GetTableId(),
+	                                          info.new_column.Name().GetIdentifierName());
 	auto create_info = GetInfo();
 	auto &table_info = create_info->Cast<CreateTableInfo>();
 	if (info.if_column_not_exists && ColumnExists(info.new_column.Name())) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1552,7 +1552,7 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 		ducklake_catalog.InvalidateTableStatsCache(next_file_id, table_id);
 	};
 	context.commit_info = state->commit_info;
-	context.supports_v1_1_metadata = ducklake_catalog.SupportsRowGroupCount();
+	context.supports_v1_1_metadata = ducklake_catalog.SupportsV1_1Metadata();
 	state->Commit(transaction_snapshot, transaction_changes, retry_config, context);
 }
 

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -797,7 +797,7 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnS
 		}
 		auto sql = DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(
 		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list,
-		    DuckLakeInlinedColNames(context.supports_v1_1_metadata));
+		    context.InlinedColNames());
 		auto result = context.query_metadata_with_snapshot(snapshot, sql);
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
@@ -1718,7 +1718,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 	if (!flushed_inlined_tables.empty()) {
 		batch_queries +=
 		    DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(
-		        flushed_inlined_tables, DuckLakeInlinedColNames(context.supports_v1_1_metadata));
+		        flushed_inlined_tables, context.InlinedColNames());
 	}
 
 	// drop data files
@@ -1755,7 +1755,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 		// write new inlined deletes (for inlined data tables)
 		auto inlined_deletes = GetNewInlinedDeletes(commit_state);
 		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(
-		    inlined_deletes, DuckLakeInlinedColNames(context.supports_v1_1_metadata));
+		    inlined_deletes, context.InlinedColNames());
 
 		// write new inlined file deletes (for parquet files)
 		auto inlined_file_deletes = GetNewInlinedFileDeletes(commit_state);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -796,7 +796,7 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnS
 			                                  col_ident, col_ident, nan_expr);
 		}
 		auto sql = DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(
-		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list);
+		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list, DuckLakeInlinedColNames());
 		auto result = context.query_metadata_with_snapshot(snapshot, sql);
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
@@ -1715,7 +1715,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 	// in case of a retry, we generate the deletion of inlined data from the tables
 	if (!flushed_inlined_tables.empty()) {
-		batch_queries += DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(flushed_inlined_tables);
+		batch_queries +=
+		    DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(flushed_inlined_tables, DuckLakeInlinedColNames());
 	}
 
 	// drop data files
@@ -1751,7 +1752,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 		// write new inlined deletes (for inlined data tables)
 		auto inlined_deletes = GetNewInlinedDeletes(commit_state);
-		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(inlined_deletes);
+		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(inlined_deletes, DuckLakeInlinedColNames());
 
 		// write new inlined file deletes (for parquet files)
 		auto inlined_file_deletes = GetNewInlinedFileDeletes(commit_state);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -796,8 +796,7 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnS
 			                                  col_ident, col_ident, nan_expr);
 		}
 		auto sql = DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(
-		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list,
-		    context.InlinedColNames());
+		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list, context.InlinedColNames());
 		auto result = context.query_metadata_with_snapshot(snapshot, sql);
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
@@ -1716,9 +1715,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 	// in case of a retry, we generate the deletion of inlined data from the tables
 	if (!flushed_inlined_tables.empty()) {
-		batch_queries +=
-		    DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(
-		        flushed_inlined_tables, context.InlinedColNames());
+		batch_queries += DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(flushed_inlined_tables,
+		                                                                           context.InlinedColNames());
 	}
 
 	// drop data files
@@ -1754,8 +1752,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 		// write new inlined deletes (for inlined data tables)
 		auto inlined_deletes = GetNewInlinedDeletes(commit_state);
-		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(
-		    inlined_deletes, context.InlinedColNames());
+		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(inlined_deletes, context.InlinedColNames());
 
 		// write new inlined file deletes (for parquet files)
 		auto inlined_file_deletes = GetNewInlinedFileDeletes(commit_state);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -796,7 +796,8 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnS
 			                                  col_ident, col_ident, nan_expr);
 		}
 		auto sql = DuckLakeMetadataManager::ReadInlinedDataAggregatesSql(
-		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list, DuckLakeInlinedColNames());
+		    DuckLakeUtil::SQLIdentifierToString(inlined_table_name), select_list,
+		    DuckLakeInlinedColNames(context.supports_v1_1_metadata));
 		auto result = context.query_metadata_with_snapshot(snapshot, sql);
 		if (result->HasError()) {
 			result->GetErrorObject().Throw("Failed to read inlined-data aggregates from DuckLake: ");
@@ -1716,7 +1717,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 	// in case of a retry, we generate the deletion of inlined data from the tables
 	if (!flushed_inlined_tables.empty()) {
 		batch_queries +=
-		    DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(flushed_inlined_tables, DuckLakeInlinedColNames());
+		    DuckLakeMetadataManager::GenerateDeleteFlushedInlinedData(
+		        flushed_inlined_tables, DuckLakeInlinedColNames(context.supports_v1_1_metadata));
 	}
 
 	// drop data files
@@ -1752,7 +1754,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 		// write new inlined deletes (for inlined data tables)
 		auto inlined_deletes = GetNewInlinedDeletes(commit_state);
-		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(inlined_deletes, DuckLakeInlinedColNames());
+		batch_queries += DuckLakeMetadataManager::WriteNewInlinedDeletes(
+		    inlined_deletes, DuckLakeInlinedColNames(context.supports_v1_1_metadata));
 
 		// write new inlined file deletes (for parquet files)
 		auto inlined_file_deletes = GetNewInlinedFileDeletes(commit_state);

--- a/src/storage/ducklake_view_entry.cpp
+++ b/src/storage/ducklake_view_entry.cpp
@@ -60,7 +60,7 @@ unique_ptr<CatalogEntry> DuckLakeViewEntry::AlterEntry(ClientContext &context, A
 }
 
 unique_ptr<CatalogEntry> DuckLakeViewEntry::Alter(DuckLakeTransaction &transaction, SetColumnCommentInfo &info) {
-	if (!transaction.GetCatalog().SupportsViewColumnTags()) {
+	if (!transaction.GetCatalog().SupportsV1_1Metadata()) {
 		throw InvalidInputException("DuckLake 1.0 does not support COMMENT ON COLUMN for views");
 	}
 

--- a/test/configs/ducklake_version.json
+++ b/test/configs/ducklake_version.json
@@ -45,6 +45,7 @@
         "test/sql/migration/inlined_column_rename_missing_table.test",
         "test/sql/migration/inlined_column_rename_remigrate.test",
         "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_reverse_hint.test",
         "test/sql/migration/inlined_column_rename_stats_hint.test",
         "test/sql/migration/inlined_column_rename_dev_missing_table.test"
       ]

--- a/test/configs/ducklake_version.json
+++ b/test/configs/ducklake_version.json
@@ -45,6 +45,7 @@
         "test/sql/migration/inlined_column_rename_missing_table.test",
         "test/sql/migration/inlined_column_rename_remigrate.test",
         "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_stats_hint.test",
         "test/sql/migration/inlined_column_rename_dev_missing_table.test"
       ]
     },

--- a/test/configs/ducklake_version.json
+++ b/test/configs/ducklake_version.json
@@ -34,6 +34,21 @@
       ]
     },
     {
+      "reason": "The _ducklake_ reserved prefix and the inlined column rename migration were added in 1.1-dev1 and are not exercised when ducklake_default_version is pinned to 1.0",
+      "paths": [
+        "test/sql/data_inlining/inlining_reserved_column_names.test",
+        "test/sql/alter/issue_944.test",
+        "test/sql/migration/inlined_column_rename.test",
+        "test/sql/migration/inlined_column_rename_conflict.test",
+        "test/sql/migration/inlined_column_rename_partial.test",
+        "test/sql/migration/inlined_column_rename_dev_conflict.test",
+        "test/sql/migration/inlined_column_rename_missing_table.test",
+        "test/sql/migration/inlined_column_rename_remigrate.test",
+        "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_dev_missing_table.test"
+      ]
+    },
+    {
       "reason": "Epoch partition transforms were added in 1.1-dev1 and are not available when ducklake_default_version is pinned to 1.0",
       "paths": [
         "test/sql/add_files/add_file_epoch_partitioned.test",

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -15,10 +15,22 @@
       ]
     },
     {
-      "reason": "Test asserts reserved column names are rejected, which requires inlining to be enabled",
+      "reason": "Test asserts small inserts are inlined and exercises inlining dependent guard behavior",
       "paths": [
-        "test/sql/data_inlining/inlining_reserved_column_names.test",
-        "test/sql/alter/issue_944.test"
+        "test/sql/data_inlining/inlining_reserved_column_names.test"
+      ]
+    },
+    {
+      "reason": "The inlined column rename migration requires inlined tables, which are never created with inlining disabled",
+      "paths": [
+        "test/sql/migration/inlined_column_rename.test",
+        "test/sql/migration/inlined_column_rename_conflict.test",
+        "test/sql/migration/inlined_column_rename_partial.test",
+        "test/sql/migration/inlined_column_rename_dev_conflict.test",
+        "test/sql/migration/inlined_column_rename_missing_table.test",
+        "test/sql/migration/inlined_column_rename_remigrate.test",
+        "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_dev_missing_table.test"
       ]
     }
   ]

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -30,6 +30,7 @@
         "test/sql/migration/inlined_column_rename_missing_table.test",
         "test/sql/migration/inlined_column_rename_remigrate.test",
         "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_reverse_hint.test",
         "test/sql/migration/inlined_column_rename_stats_hint.test",
         "test/sql/migration/inlined_column_rename_dev_missing_table.test"
       ]

--- a/test/configs/no_inline.json
+++ b/test/configs/no_inline.json
@@ -30,6 +30,7 @@
         "test/sql/migration/inlined_column_rename_missing_table.test",
         "test/sql/migration/inlined_column_rename_remigrate.test",
         "test/sql/migration/inlined_column_rename_hint.test",
+        "test/sql/migration/inlined_column_rename_stats_hint.test",
         "test/sql/migration/inlined_column_rename_dev_missing_table.test"
       ]
     }

--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -1,6 +1,6 @@
 {
   "description": "Run DuckLake tests using Postgres as a catalog DBMS.",
-  "on_init": "ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg; SET pg_experimental_filter_pushdown=false; SET pg_order_pushdown=false;",
+  "on_init": "ATTACH 'dbname=ducklakedb' AS pg (TYPE postgres); USE pg; DROP SCHEMA public CASCADE; DROP SCHEMA IF EXISTS metadata_s1 CASCADE; DROP SCHEMA IF EXISTS metadata_s2 CASCADE; DROP SCHEMA IF EXISTS junk_1064 CASCADE; DROP SCHEMA IF EXISTS scoped_meta_1064 CASCADE; CREATE SCHEMA public;USE memory; DETACH pg; SET pg_experimental_filter_pushdown=false; SET pg_order_pushdown=false;",
   "autoloading": "none",
   "statically_loaded_extensions": [
     "core_functions",

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -181,7 +181,7 @@
       ]
     },
     {
-      "reason": "FIXME: Column name \"begin_snapshot\" is reserved by DuckLake for internal use",
+      "reason": "FIXME: COPY FROM DATABASE on quack leaks metadata tables into the target, previously surfaced as a reserved column name error",
       "paths": [
         "test/sql/partitioning/partition_tpch.test_slow"
       ]

--- a/test/sql/alter/issue_944.test
+++ b/test/sql/alter/issue_944.test
@@ -1,5 +1,5 @@
 # name: test/sql/alter/issue_944.test
-# description: test ducklake cannot create, rename or rename a column to system colume name
+# description: test ducklake cannot create, add or rename a column to a system column name
 # group: [alter]
 
 require ducklake
@@ -15,19 +15,29 @@ statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/issue_944', METADATA_CATALOG 'xx')
 
 statement error
-CREATE TABLE ducklake.test(row_id INTEGER);
+CREATE TABLE ducklake.test(_ducklake_row_id INTEGER);
 ----
-Column name "row_id" is reserved by DuckLake for internal use
+Column name "_ducklake_row_id" is reserved by DuckLake for internal use
 
 statement ok
 CREATE TABLE ducklake.test(a INTEGER);
 
 statement error
-ALTER TABLE ducklake.test ADD COLUMN row_id INTEGER;
+ALTER TABLE ducklake.test ADD COLUMN _ducklake_col INTEGER;
 ----
-Column name "row_id" is reserved by DuckLake for internal use
+Column name "_ducklake_col" is reserved by DuckLake for internal use
 
 statement error
-ALTER TABLE ducklake.test RENAME COLUMN a TO row_id;
+ALTER TABLE ducklake.test RENAME COLUMN a TO _ducklake_col;
 ----
-Column name "row_id" is reserved by DuckLake for internal use
+Column name "_ducklake_col" is reserved by DuckLake for internal use
+
+# the names from the original issue are regular columns now
+statement ok
+CREATE TABLE ducklake.test2(row_id INTEGER);
+
+statement ok
+ALTER TABLE ducklake.test2 ADD COLUMN begin_snapshot INTEGER;
+
+statement ok
+ALTER TABLE ducklake.test2 RENAME COLUMN begin_snapshot TO end_snapshot;

--- a/test/sql/data_inlining/inlined_data_flush_cleanup.test
+++ b/test/sql/data_inlining/inlined_data_flush_cleanup.test
@@ -40,7 +40,7 @@ statement ok
 CALL ducklake_flush_inlined_data('ducklake')
 
 query I
-SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name = 'ducklake_inlined_data_1_1'
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND schema_name IN ('main', 'public') AND table_name = 'ducklake_inlined_data_1_1'
 ----
 0
 

--- a/test/sql/data_inlining/inlined_data_table_leak.test
+++ b/test/sql/data_inlining/inlined_data_table_leak.test
@@ -47,7 +47,7 @@ statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
 
 query I
-SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_1_%'
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND schema_name IN ('main', 'public') AND table_name LIKE 'ducklake_inlined_data_1_%'
 ----
 0
 

--- a/test/sql/data_inlining/inlined_delete_table_drop_cleanup.test
+++ b/test/sql/data_inlining/inlined_delete_table_drop_cleanup.test
@@ -36,7 +36,7 @@ CALL ducklake_delete_orphaned_files('ducklake', older_than => now())
 
 # the inlined data table of the dropped table is reclaimed
 query I
-SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_data_1%'
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND schema_name IN ('main', 'public') AND table_name LIKE 'ducklake_inlined_data_1%'
 ----
 0
 
@@ -47,6 +47,6 @@ SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
 
 # the inlined delete table must be reclaimed as well
 query I
-SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND table_name LIKE 'ducklake_inlined_delete_%'
+SELECT COUNT(*) FROM duckdb_tables() WHERE database_name='ducklake_meta' AND schema_name IN ('main', 'public') AND table_name LIKE 'ducklake_inlined_delete_%'
 ----
 0

--- a/test/sql/data_inlining/inlining_reserved_column_names.test
+++ b/test/sql/data_inlining/inlining_reserved_column_names.test
@@ -1,5 +1,5 @@
 # name: test/sql/data_inlining/inlining_reserved_column_names.test
-# description: the _ducklake_ prefix is reserved; legacy reserved names (row_id, begin_snapshot, end_snapshot) are regular columns
+# description: the _ducklake_ prefix is reserved and the legacy reserved names are regular columns
 # group: [data_inlining]
 
 require ducklake
@@ -16,7 +16,7 @@ CREATE TABLE ducklake.t1(row_id INTEGER, begin_snapshot INTEGER, end_snapshot IN
 statement ok
 INSERT INTO ducklake.t1 VALUES (1, 10, 100), (2, 20, 200);
 
-# the data is inlined - no files written
+# the data is inlined and no files are written
 query I
 SELECT COUNT(*) FROM GLOB('{TEST_DIR}/ducklake_reserved_cols_files/**')
 ----
@@ -112,7 +112,7 @@ CREATE TABLE dl10.t1(row_id INTEGER, v INTEGER);
 ----
 Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
 
-# a non-internal _ducklake_ name is not reserved on v1.0
+# other _ducklake_ names are not reserved on v1.0
 statement ok
 CREATE TABLE dl10.t3(_ducklake_free INTEGER);
 
@@ -145,7 +145,7 @@ CALL dl10.set_option('data_inlining_row_limit', 0);
 statement ok
 CREATE TABLE dl10.t1(row_id INTEGER, v INTEGER);
 
-# re-enabling inlining on a v1.0 table with legacy names is rejected
+# enabling inlining again on a v1.0 table with legacy names is rejected
 statement error
 CALL dl10.set_option('data_inlining_row_limit', 10, table_name => 't1');
 ----

--- a/test/sql/data_inlining/inlining_reserved_column_names.test
+++ b/test/sql/data_inlining/inlining_reserved_column_names.test
@@ -1,5 +1,5 @@
 # name: test/sql/data_inlining/inlining_reserved_column_names.test
-# description: test that reserved inlining column names are allowed when inlining is disabled
+# description: the _ducklake_ prefix is reserved; legacy reserved names (row_id, begin_snapshot, end_snapshot) are regular columns
 # group: [data_inlining]
 
 require ducklake
@@ -9,239 +9,147 @@ require parquet
 statement ok
 ATTACH 'ducklake:{TEST_DIR}/ducklake_reserved_cols.db' AS ducklake (DATA_PATH '{TEST_DIR}/ducklake_reserved_cols_files')
 
-statement error
-CREATE TABLE ducklake.t1(row_id INTEGER, v INTEGER);
-----
-reserved
-
-statement error
-CREATE TABLE ducklake.t1(begin_snapshot INTEGER, v INTEGER);
-----
-reserved
-
-statement error
-CREATE TABLE ducklake.t1(end_snapshot INTEGER, v INTEGER);
-----
-reserved
-
-# disable inlining globally, now reserved names should be allowed
+# legacy reserved names are regular columns now, even with inlining enabled
 statement ok
-CALL ducklake.set_option('data_inlining_row_limit', 0);
+CREATE TABLE ducklake.t1(row_id INTEGER, begin_snapshot INTEGER, end_snapshot INTEGER);
 
 statement ok
-CREATE TABLE ducklake.t1(row_id INTEGER, v INTEGER);
+INSERT INTO ducklake.t1 VALUES (1, 10, 100), (2, 20, 200);
 
-statement ok
-INSERT INTO ducklake.t1 VALUES (1, 10), (2, 20);
-
-query II
-SELECT * FROM ducklake.t1
-----
-1	10
-2	20
-
-# adding a reserved column name should work when inlining is disabled
-statement ok
-ALTER TABLE ducklake.t1 ADD COLUMN begin_snapshot INTEGER;
-
-query III
-SELECT * FROM ducklake.t1
-----
-1	10	NULL
-2	20	NULL
-
-# renaming to a reserved column name should work when inlining is disabled
-statement ok
-ALTER TABLE ducklake.t1 RENAME COLUMN v TO end_snapshot;
-
-query III
-SELECT * FROM ducklake.t1
-----
-1	10	NULL
-2	20	NULL
-
-# trying to enable inlining on a table with reserved column names should fail
-statement error
-CALL ducklake.set_option('data_inlining_row_limit', 10, table_name => 't1');
-----
-Cannot enable data inlining
-
-# trying to enable inlining globally should also fail because t1 has reserved column names
-statement error
-CALL ducklake.set_option('data_inlining_row_limit', 10);
-----
-Cannot enable data inlining
-
-# disable inlining specifically for t1 at the table level
-statement ok
-CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 't1');
-
-# now enabling inlining globally should succeed - t1 has a table-level override of 0
-statement ok
-CALL ducklake.set_option('data_inlining_row_limit', 10);
-
-# count existing files (t1 has data files since inlining was disabled for it)
-query I
-SELECT COUNT(*) AS baseline FROM GLOB('{TEST_DIR}/ducklake_reserved_cols_files/**')
-----
-1
-
-# create another table without reserved names - it should use inlining
-statement ok
-CREATE TABLE ducklake.t2(i INTEGER, j INTEGER);
-
-statement ok
-INSERT INTO ducklake.t2 VALUES (1, 2), (3, 4);
-
-# t2 data should be inlined - no new files created
+# the data is inlined - no files written
 query I
 SELECT COUNT(*) FROM GLOB('{TEST_DIR}/ducklake_reserved_cols_files/**')
 ----
-1
+0
 
-# t1 should still work with its reserved column names
+# the metadata columns of the inlined table are prefixed
+query I
+SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_ducklake.ducklake_inlined_data_1_1) WHERE column_name IN ('_ducklake_row_id', '_ducklake_begin_snapshot', '_ducklake_end_snapshot')
+----
+3
+
+query III
+SELECT * FROM ducklake.t1 ORDER BY row_id
+----
+1	10	100
+2	20	200
+
+query II
+SELECT rowid, row_id FROM ducklake.t1 ORDER BY rowid
+----
+0	1
+1	2
+
 statement ok
-INSERT INTO ducklake.t1 VALUES (3, 30, 300);
+UPDATE ducklake.t1 SET begin_snapshot = 11 WHERE row_id = 1;
+
+statement ok
+DELETE FROM ducklake.t1 WHERE end_snapshot = 200;
 
 query III
 SELECT * FROM ducklake.t1
 ----
-1	10	NULL
-2	20	NULL
-3	30	300
+1	11	100
 
-query II
-SELECT * FROM ducklake.t2
+statement ok
+ALTER TABLE ducklake.t1 ADD COLUMN extra INTEGER;
+
+statement ok
+ALTER TABLE ducklake.t1 RENAME COLUMN extra TO row_id2;
+
+# the _ducklake_ prefix is rejected with inlining enabled...
+statement error
+CREATE TABLE ducklake.t_fail(_ducklake_row_id INTEGER);
 ----
-1	2
-3	4
+Column name "_ducklake_row_id" is reserved by DuckLake for internal use
+
+statement error
+ALTER TABLE ducklake.t1 ADD COLUMN _ducklake_thing INTEGER;
+----
+reserved by DuckLake for internal use
+
+statement error
+ALTER TABLE ducklake.t1 RENAME COLUMN row_id2 TO _DUCKLAKE_upper;
+----
+reserved by DuckLake for internal use
+
+# ...and also with inlining disabled
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 0);
+
+statement error
+CREATE TABLE ducklake.t_fail(_ducklake_row_id INTEGER);
+----
+reserved by DuckLake for internal use
+
+statement error
+ALTER TABLE ducklake.t1 ADD COLUMN _ducklake_thing INTEGER;
+----
+reserved by DuckLake for internal use
+
+# enabling inlining on a table with legacy reserved names is allowed now
+statement ok
+CALL ducklake.set_option('data_inlining_row_limit', 10, table_name => 't1');
+
+statement ok
+INSERT INTO ducklake.t1 VALUES (5, 50, 500, 5000);
+
+query IIII
+SELECT * FROM ducklake.t1 ORDER BY row_id
+----
+1	11	100	NULL
+5	50	500	5000
 
 statement ok
 DETACH ducklake
 
-# test per-table inlining disable: global inlining on, table inlining off
+# catalogs pinned to v1.0 keep the legacy reserved names
 statement ok
-ATTACH 'ducklake:{TEST_DIR}/ducklake_reserved_cols2.db' AS ducklake (DATA_PATH '{TEST_DIR}/ducklake_reserved_cols2_files')
+ATTACH 'ducklake:{TEST_DIR}/ducklake_reserved_v10.db' AS dl10 (DATA_PATH '{TEST_DIR}/ducklake_reserved_v10_files', DUCKLAKE_VERSION '1.0')
 
-statement ok
-CREATE TABLE ducklake.t_normal(i INTEGER, j INTEGER);
-
-# disable inlining only for a specific table
-statement ok
-CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 't_normal');
-
-# now we should be able to add a column with a reserved name to this table
-statement ok
-ALTER TABLE ducklake.t_normal ADD COLUMN row_id INTEGER;
-
-# but creating a new table (governed by global inlining=10) should still fail with reserved names
 statement error
-CREATE TABLE ducklake.t_fail(row_id INTEGER, v INTEGER);
-----
-reserved
-
-# create a normal table without reserved names
-statement ok
-CREATE TABLE ducklake.t_ok(i INTEGER, j INTEGER);
-
-# this table should still have inlining enabled
-statement ok
-INSERT INTO ducklake.t_ok VALUES (1, 2);
-
-query II
-SELECT * FROM ducklake.t_ok
-----
-1	2
-
-
-# CREATE TABLE with reserved name while inlining is enabled - suggest disabling inlining
-statement error
-CREATE TABLE ducklake.t_msg(row_id INTEGER);
+CREATE TABLE dl10.t1(row_id INTEGER, v INTEGER);
 ----
 Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
 
-# ALTER TABLE ADD COLUMN with reserved name while inlining is enabled - suggest disabling inlining
-statement error
-ALTER TABLE ducklake.t_ok ADD COLUMN row_id INTEGER;
+# a non-internal _ducklake_ name is not reserved on v1.0
+statement ok
+CREATE TABLE dl10.t3(_ducklake_free INTEGER);
+
+statement ok
+INSERT INTO dl10.t3 VALUES (42);
+
+# v1.0 inlined tables keep unprefixed metadata columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl10.ducklake_inlined_data_1_1) WHERE column_name = 'row_id'
 ----
-Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
-
-# ALTER TABLE RENAME COLUMN to reserved name while inlining is enabled - suggest disabling inlining
-statement error
-ALTER TABLE ducklake.t_ok RENAME COLUMN i TO row_id;
-----
-Column name "row_id" is reserved by DuckLake for internal use when data inlining is enabled. If you must use this column name, disable inlining by calling ducklake_set_option('data_inlining_row_limit', 0).
-
-# enabling inlining on a table that already has reserved column names - suggest renaming or dropping
-statement error
-CALL ducklake.set_option('data_inlining_row_limit', 10, table_name => 't_normal');
-----
-Cannot enable data inlining for table "t_normal". Column "row_id" conflicts with a reserved DuckLake internal column name used for inlining. To enable inlining for this table, rename or drop column "row_id".
+1
 
 statement ok
-DETACH ducklake
-
-# Check Alter
-statement ok
-ATTACH 'ducklake:{TEST_DIR}/ducklake_reserved_cols3.db' AS ducklake (DATA_PATH '{TEST_DIR}/ducklake_reserved_cols3_files')
-
-statement ok
-SET ducklake_default_data_inlining_row_limit = 0;
-
-statement ok
-CREATE TABLE ducklake.t_setting(i INTEGER, j INTEGER);
-
-statement ok
-ALTER TABLE ducklake.t_setting ADD COLUMN row_id INTEGER;
-
-statement ok
-ALTER TABLE ducklake.t_setting RENAME COLUMN j TO begin_snapshot;
-
-# re-enabling inlining through the session setting makes the reserved names rejected again
-statement ok
-RESET ducklake_default_data_inlining_row_limit;
-
-statement ok
-CREATE TABLE ducklake.t_setting2(i INTEGER);
+CREATE TABLE dl10.t2(i INTEGER, j INTEGER);
 
 statement error
-ALTER TABLE ducklake.t_setting2 ADD COLUMN row_id INTEGER;
+ALTER TABLE dl10.t2 ADD COLUMN begin_snapshot INTEGER;
 ----
 reserved
 
 statement error
-ALTER TABLE ducklake.t_setting2 RENAME COLUMN i TO end_snapshot;
+ALTER TABLE dl10.t2 RENAME COLUMN i TO end_snapshot;
 ----
 reserved
 
-# inlining is enabled, but disabled only for a given table
+# disabling inlining frees the legacy names on v1.0
 statement ok
-CALL ducklake.set_option('data_inlining_row_limit', 0, table_name => 't_setting2');
-
-statement ok
-ALTER TABLE ducklake.t_setting2 ADD COLUMN row_id INTEGER;
+CALL dl10.set_option('data_inlining_row_limit', 0);
 
 statement ok
-ALTER TABLE ducklake.t_setting2 RENAME COLUMN i TO end_snapshot;
+CREATE TABLE dl10.t1(row_id INTEGER, v INTEGER);
 
-statement ok
-INSERT INTO ducklake.t_setting2 VALUES (1, 100);
-
-query II
-SELECT * FROM ducklake.t_setting2
-----
-1	100
-
-# other tables are still with the enabled inlining setting
-statement ok
-CREATE TABLE ducklake.t_setting3(i INTEGER);
-
+# re-enabling inlining on a v1.0 table with legacy names is rejected
 statement error
-ALTER TABLE ducklake.t_setting3 ADD COLUMN row_id INTEGER;
+CALL dl10.set_option('data_inlining_row_limit', 10, table_name => 't1');
 ----
-reserved
+Cannot enable data inlining for table "t1". Column "row_id" conflicts with a reserved DuckLake internal column name used for inlining. To enable inlining for this table, rename or drop column "row_id".
 
-statement error
-ALTER TABLE ducklake.t_setting3 RENAME COLUMN i TO begin_snapshot;
-----
-reserved
+statement ok
+DETACH dl10

--- a/test/sql/metadata/metadata_schema_scoped_attach.test
+++ b/test/sql/metadata/metadata_schema_scoped_attach.test
@@ -82,3 +82,13 @@ SELECT COUNT(*) FROM duckdb_schemas() WHERE database_name='pgmeta3' AND schema_n
 
 statement ok
 DETACH lake3
+
+# the metadata database is shared between tests - leave no schemas behind
+statement ok
+ATTACH 'postgres:dbname=ducklakedb' AS pg_cleanup
+
+statement ok
+CALL postgres_execute('pg_cleanup', 'DROP SCHEMA IF EXISTS junk_1064 CASCADE; DROP SCHEMA IF EXISTS scoped_meta_1064 CASCADE;')
+
+statement ok
+DETACH pg_cleanup

--- a/test/sql/migration/inlined_column_rename.test
+++ b/test/sql/migration/inlined_column_rename.test
@@ -1,0 +1,120 @@
+# name: test/sql/migration/inlined_column_rename.test
+# description: migrating a v1.0 catalog renames inlined-data metadata columns to the _ducklake_ prefix
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1, 2), (3, 4);
+
+# v1.0 inlined tables use unprefixed metadata columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name = 'row_id'
+----
+1
+
+statement ok
+DETACH dl
+
+# re-attaching without migration keeps the catalog readable at v1.0
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files')
+
+query II
+SELECT * FROM dl.t ORDER BY i
+----
+1	2
+3	4
+
+statement ok
+INSERT INTO dl.t VALUES (5, 6);
+
+statement ok
+DETACH dl
+
+# migrating to 1.1-dev1 renames the metadata columns
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', AUTOMATIC_MIGRATION TRUE)
+
+query I
+SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name = 'row_id'
+----
+0
+
+query I
+SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name IN ('_ducklake_row_id', '_ducklake_begin_snapshot', '_ducklake_end_snapshot')
+----
+3
+
+# row ids are preserved across the rename
+query III
+SELECT rowid, i, j FROM dl.t ORDER BY rowid
+----
+0	1	2
+1	3	4
+2	5	6
+
+statement ok
+INSERT INTO dl.t VALUES (7, 8);
+
+statement ok
+DELETE FROM dl.t WHERE i = 3;
+
+query II
+SELECT i, j FROM dl.t ORDER BY i
+----
+1	2
+5	6
+7	8
+
+statement ok
+DETACH dl
+
+# re-running the in-place dev migration is a no-op
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', AUTOMATIC_MIGRATION TRUE)
+
+query II
+SELECT i, j FROM dl.t ORDER BY i
+----
+1	2
+5	6
+7	8
+
+statement ok
+DETACH dl
+
+# a v1.0 user column that collides with the new metadata names aborts the migration cleanly
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dlc.c(_ducklake_row_id INTEGER);
+
+statement ok
+INSERT INTO dlc.c VALUES (1);
+
+statement ok
+DETACH dlc
+
+statement error
+ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# the catalog is still at v1.0 and fully usable
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files')
+
+query I
+SELECT * FROM dlc.c
+----
+1

--- a/test/sql/migration/inlined_column_rename.test
+++ b/test/sql/migration/inlined_column_rename.test
@@ -1,5 +1,5 @@
 # name: test/sql/migration/inlined_column_rename.test
-# description: migrating a v1.0 catalog renames inlined-data metadata columns to the _ducklake_ prefix
+# description: migrating a v1.0 catalog renames inlined data metadata columns to the _ducklake_ prefix
 # group: [migration]
 
 require ducklake
@@ -26,7 +26,7 @@ SELECT row_id, begin_snapshot, end_snapshot FROM dlmeta.ducklake_inlined_data_1_
 statement ok
 DETACH dl
 
-# re-attaching without migration keeps the catalog readable at v1.0
+# reattaching without migration keeps the catalog readable at v1.0
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta')
 
@@ -42,7 +42,7 @@ INSERT INTO dl.t VALUES (5, 6);
 statement ok
 DETACH dl
 
-# migrating to 1.1-dev1 renames the metadata columns
+# migrating to v1.1 renames the metadata columns
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta', AUTOMATIC_MIGRATION TRUE)
 
@@ -78,7 +78,7 @@ SELECT i, j FROM dl.t ORDER BY i
 statement ok
 DETACH dl
 
-# re-running the in-place dev migration is a no-op
+# rerunning the dev migration changes nothing
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta', AUTOMATIC_MIGRATION TRUE)
 

--- a/test/sql/migration/inlined_column_rename.test
+++ b/test/sql/migration/inlined_column_rename.test
@@ -6,8 +6,12 @@ require ducklake
 
 require parquet
 
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/inlined_column_rename.db
+
+test-env DATA_PATH {TEST_DIR}
+
 statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', DUCKLAKE_VERSION '1.0')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta', DUCKLAKE_VERSION '1.0')
 
 statement ok
 CREATE TABLE dl.t(i INTEGER, j INTEGER);
@@ -16,17 +20,15 @@ statement ok
 INSERT INTO dl.t VALUES (1, 2), (3, 4);
 
 # v1.0 inlined tables use unprefixed metadata columns
-query I
-SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name = 'row_id'
-----
-1
+statement ok
+SELECT row_id, begin_snapshot, end_snapshot FROM dlmeta.ducklake_inlined_data_1_1 LIMIT 0;
 
 statement ok
 DETACH dl
 
 # re-attaching without migration keeps the catalog readable at v1.0
 statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files')
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta')
 
 query II
 SELECT * FROM dl.t ORDER BY i
@@ -42,17 +44,15 @@ DETACH dl
 
 # migrating to 1.1-dev1 renames the metadata columns
 statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', AUTOMATIC_MIGRATION TRUE)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta', AUTOMATIC_MIGRATION TRUE)
 
-query I
-SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name = 'row_id'
+statement error
+SELECT row_id FROM dlmeta.ducklake_inlined_data_1_1 LIMIT 0;
 ----
-0
+row_id
 
-query I
-SELECT COUNT(*) FROM (DESCRIBE __ducklake_metadata_dl.ducklake_inlined_data_1_1) WHERE column_name IN ('_ducklake_row_id', '_ducklake_begin_snapshot', '_ducklake_end_snapshot')
-----
-3
+statement ok
+SELECT _ducklake_row_id, _ducklake_begin_snapshot, _ducklake_end_snapshot FROM dlmeta.ducklake_inlined_data_1_1 LIMIT 0;
 
 # row ids are preserved across the rename
 query III
@@ -80,7 +80,7 @@ DETACH dl
 
 # re-running the in-place dev migration is a no-op
 statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_rename.db' AS dl (DATA_PATH '{TEST_DIR}/inlined_rename_files', AUTOMATIC_MIGRATION TRUE)
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/inlined_rename_files', METADATA_CATALOG 'dlmeta', AUTOMATIC_MIGRATION TRUE)
 
 query II
 SELECT i, j FROM dl.t ORDER BY i
@@ -91,30 +91,3 @@ SELECT i, j FROM dl.t ORDER BY i
 
 statement ok
 DETACH dl
-
-# a v1.0 user column that collides with the new metadata names aborts the migration cleanly
-statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files', DUCKLAKE_VERSION '1.0')
-
-statement ok
-CREATE TABLE dlc.c(_ducklake_row_id INTEGER);
-
-statement ok
-INSERT INTO dlc.c VALUES (1);
-
-statement ok
-DETACH dlc
-
-statement error
-ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files', AUTOMATIC_MIGRATION TRUE)
-----
-Failed to rename inlined-data metadata columns
-
-# the catalog is still at v1.0 and fully usable
-statement ok
-ATTACH 'ducklake:{TEST_DIR}/inlined_conflict.db' AS dlc (DATA_PATH '{TEST_DIR}/inlined_conflict_files')
-
-query I
-SELECT * FROM dlc.c
-----
-1

--- a/test/sql/migration/inlined_column_rename_conflict.test
+++ b/test/sql/migration/inlined_column_rename_conflict.test
@@ -25,7 +25,7 @@ DETACH dlc
 statement error
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlc (DATA_PATH '{DATA_PATH}/inlined_conflict_files', METADATA_CATALOG 'dlcmeta', AUTOMATIC_MIGRATION TRUE)
 ----
-Failed to rename inlined-data metadata columns
+table "c" has a column "_ducklake_row_id" colliding with the renamed metadata column. Rename the column and call ducklake_flush_inlined_data() before migrating
 
 # the catalog is still at v1.0 and fully usable
 statement ok

--- a/test/sql/migration/inlined_column_rename_conflict.test
+++ b/test/sql/migration/inlined_column_rename_conflict.test
@@ -1,0 +1,40 @@
+# name: test/sql/migration/inlined_column_rename_conflict.test
+# description: a v1.0 user column colliding with the new inlined metadata names aborts the migration cleanly
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/inlined_column_rename_conflict.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlc (DATA_PATH '{DATA_PATH}/inlined_conflict_files', METADATA_CATALOG 'dlcmeta', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dlc.c(_ducklake_row_id INTEGER);
+
+statement ok
+INSERT INTO dlc.c VALUES (1);
+
+statement ok
+DETACH dlc
+
+statement error
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlc (DATA_PATH '{DATA_PATH}/inlined_conflict_files', METADATA_CATALOG 'dlcmeta', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# the catalog is still at v1.0 and fully usable
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlc (DATA_PATH '{DATA_PATH}/inlined_conflict_files', METADATA_CATALOG 'dlcmeta')
+
+query I
+SELECT * FROM dlc.c
+----
+1
+
+statement ok
+DETACH dlc

--- a/test/sql/migration/inlined_column_rename_dev_conflict.test
+++ b/test/sql/migration/inlined_column_rename_dev_conflict.test
@@ -1,0 +1,53 @@
+# name: test/sql/migration/inlined_column_rename_dev_conflict.test
+# description: in-place dev migration of a legacy-named 1.1-dev1 catalog must not half-rename on a column conflict
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_conflict.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_conflict_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(_ducklake_begin_snapshot INTEGER, _ducklake_end_snapshot INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (999999, 999999, 42);
+
+statement ok
+DETACH dl
+
+# simulate a 1.1-dev1 catalog created before the rename: legacy columns, dev1 version string
+statement ok
+ATTACH '{TEST_DIR}/dev1_conflict.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
+
+statement ok
+DETACH meta
+
+# the in-place dev migration must fail loudly instead of half-renaming the inlined table
+statement error
+ATTACH 'ducklake:{TEST_DIR}/dev1_conflict.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_conflict_files', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# retrying fails the same way
+statement error
+ATTACH 'ducklake:{TEST_DIR}/dev1_conflict.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_conflict_files', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# no column was renamed
+statement ok
+ATTACH '{TEST_DIR}/dev1_conflict.db' AS meta;
+
+query I
+SELECT COUNT(*) FROM duckdb_columns() WHERE database_name = 'meta' AND table_name = 'ducklake_inlined_data_1_1' AND column_name IN ('row_id', 'begin_snapshot', 'end_snapshot')
+----
+3
+
+statement ok
+DETACH meta

--- a/test/sql/migration/inlined_column_rename_dev_conflict.test
+++ b/test/sql/migration/inlined_column_rename_dev_conflict.test
@@ -1,5 +1,5 @@
 # name: test/sql/migration/inlined_column_rename_dev_conflict.test
-# description: in-place dev migration of a legacy-named 1.1-dev1 catalog must not half-rename on a column conflict
+# description: dev migration must not partially rename the inlined table on a column conflict
 # group: [migration]
 
 require ducklake
@@ -18,7 +18,7 @@ INSERT INTO dl.t VALUES (999999, 999999, 42);
 statement ok
 DETACH dl
 
-# simulate a 1.1-dev1 catalog created before the rename: legacy columns, dev1 version string
+# simulate a dev1 catalog created before the rename with legacy columns
 statement ok
 ATTACH '{TEST_DIR}/dev1_conflict.db' AS meta;
 
@@ -28,7 +28,7 @@ UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
 statement ok
 DETACH meta
 
-# the in-place dev migration must fail loudly instead of half-renaming the inlined table
+# the dev migration must fail loudly instead of partially renaming the inlined table
 statement error
 ATTACH 'ducklake:{TEST_DIR}/dev1_conflict.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_conflict_files', AUTOMATIC_MIGRATION TRUE)
 ----

--- a/test/sql/migration/inlined_column_rename_dev_missing_table.test
+++ b/test/sql/migration/inlined_column_rename_dev_missing_table.test
@@ -1,0 +1,45 @@
+# name: test/sql/migration/inlined_column_rename_dev_missing_table.test
+# description: the in place dev migration must report an unreadable registered inlined table instead of silently skipping it
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_missing.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_missing_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1);
+
+statement ok
+DETACH dl
+
+# simulate a dev1 catalog where the registered inlined table is gone
+statement ok
+ATTACH '{TEST_DIR}/dev1_missing.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
+
+statement ok
+DROP TABLE meta.ducklake_inlined_data_1_1;
+
+statement ok
+DETACH meta
+
+# the explicitly requested migration fails loudly
+statement error
+ATTACH 'ducklake:{TEST_DIR}/dev1_missing.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_missing_files', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to read inlined-data table
+
+# a plain attach still works
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_missing.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_missing_files')
+
+statement ok
+DETACH dl

--- a/test/sql/migration/inlined_column_rename_hint.test
+++ b/test/sql/migration/inlined_column_rename_hint.test
@@ -1,0 +1,63 @@
+# name: test/sql/migration/inlined_column_rename_hint.test
+# description: reading legacy named inlined tables on a dev1 catalog hints at the automatic migration
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_hint_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1, 2), (3, 4);
+
+statement ok
+DETACH dl
+
+# simulate a dev1 catalog created before the rename by applying the static dev1 schema by hand
+statement ok
+ATTACH '{TEST_DIR}/dev1_hint.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
+
+statement ok
+ALTER TABLE meta.ducklake_data_file ADD COLUMN row_group_count BIGINT;
+
+statement ok
+ALTER TABLE meta.ducklake_delete_file ADD COLUMN row_group_count BIGINT;
+
+statement ok
+CREATE TABLE meta.ducklake_view_column_tag(view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR);
+
+statement ok
+DETACH meta
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_hint_files')
+
+# reading the inlined data fails with a hint at the migration
+statement error
+SELECT * FROM dl.t
+----
+AUTOMATIC_MIGRATION
+
+statement ok
+DETACH dl
+
+# following the hint fixes the catalog
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_hint_files', AUTOMATIC_MIGRATION TRUE)
+
+query II
+SELECT * FROM dl.t ORDER BY i
+----
+1	2
+3	4
+
+statement ok
+DETACH dl

--- a/test/sql/migration/inlined_column_rename_missing_table.test
+++ b/test/sql/migration/inlined_column_rename_missing_table.test
@@ -1,0 +1,47 @@
+# name: test/sql/migration/inlined_column_rename_missing_table.test
+# description: an unreadable registered inlined data table must abort the migration instead of silently skipping its rename
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/missing_inlined.db' AS dl (DATA_PATH '{TEST_DIR}/missing_inlined_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1);
+
+statement ok
+DETACH dl
+
+# simulate drift where the registered inlined table is gone
+statement ok
+ATTACH '{TEST_DIR}/missing_inlined.db' AS meta;
+
+statement ok
+DROP TABLE meta.ducklake_inlined_data_1_1;
+
+statement ok
+DETACH meta
+
+# the migration must fail loudly instead of skipping the rename and bumping the version
+statement error
+ATTACH 'ducklake:{TEST_DIR}/missing_inlined.db' AS dl (DATA_PATH '{TEST_DIR}/missing_inlined_files', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to read inlined-data table
+
+# the catalog is still at v1.0
+statement ok
+ATTACH '{TEST_DIR}/missing_inlined.db' AS meta;
+
+query I
+SELECT value FROM meta.ducklake_metadata WHERE key = 'version'
+----
+1.0
+
+statement ok
+DETACH meta

--- a/test/sql/migration/inlined_column_rename_partial.test
+++ b/test/sql/migration/inlined_column_rename_partial.test
@@ -1,0 +1,56 @@
+# name: test/sql/migration/inlined_column_rename_partial.test
+# description: a conflicting user column must not leave the inlined table half-renamed
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/inlined_column_rename_partial.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta', DUCKLAKE_VERSION '1.0')
+
+# legal on v1.0: only row_id/begin_snapshot/end_snapshot were reserved
+statement ok
+CREATE TABLE dlp.t(_ducklake_begin_snapshot INTEGER, _ducklake_end_snapshot INTEGER, v INTEGER);
+
+statement ok
+INSERT INTO dlp.t VALUES (999999, 999999, 42);
+
+query III
+SELECT * FROM dlp.t
+----
+999999	999999	42
+
+statement ok
+DETACH dlp
+
+# the migration detects the conflict and renames nothing
+statement error
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# retrying fails the same way - the table was not left half-renamed
+statement error
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta', AUTOMATIC_MIGRATION TRUE)
+----
+Failed to rename inlined-data metadata columns
+
+# the catalog is still fully usable at v1.0
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta')
+
+query III
+SELECT * FROM dlp.t
+----
+999999	999999	42
+
+statement ok
+SELECT row_id, begin_snapshot, end_snapshot FROM dlpmeta.ducklake_inlined_data_1_1 LIMIT 0;
+
+statement ok
+DETACH dlp

--- a/test/sql/migration/inlined_column_rename_partial.test
+++ b/test/sql/migration/inlined_column_rename_partial.test
@@ -1,5 +1,5 @@
 # name: test/sql/migration/inlined_column_rename_partial.test
-# description: a conflicting user column must not leave the inlined table half-renamed
+# description: a conflicting user column must not leave the inlined table partially renamed
 # group: [migration]
 
 require ducklake
@@ -13,7 +13,7 @@ test-env DATA_PATH {TEST_DIR}
 statement ok
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta', DUCKLAKE_VERSION '1.0')
 
-# legal on v1.0: only row_id/begin_snapshot/end_snapshot were reserved
+# legal on v1.0 where only row_id, begin_snapshot and end_snapshot were reserved
 statement ok
 CREATE TABLE dlp.t(_ducklake_begin_snapshot INTEGER, _ducklake_end_snapshot INTEGER, v INTEGER);
 
@@ -34,7 +34,7 @@ ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_p
 ----
 Failed to rename inlined-data metadata columns
 
-# retrying fails the same way - the table was not left half-renamed
+# retrying fails the same way and the table was not partially renamed
 statement error
 ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dlp (DATA_PATH '{DATA_PATH}/inlined_partial_files', METADATA_CATALOG 'dlpmeta', AUTOMATIC_MIGRATION TRUE)
 ----

--- a/test/sql/migration/inlined_column_rename_remigrate.test
+++ b/test/sql/migration/inlined_column_rename_remigrate.test
@@ -1,0 +1,44 @@
+# name: test/sql/migration/inlined_column_rename_remigrate.test
+# description: automatic migration of an already migrated catalog must not flag legal user columns as conflicts
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/inlined_column_rename_remigrate.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/remigrate_files', METADATA_CATALOG 'dlmeta')
+
+statement ok
+CREATE TABLE dl.t(row_id INTEGER, begin_snapshot INTEGER, end_snapshot INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1, 10, 100);
+
+statement ok
+DETACH dl
+
+# reattaching with automatic migration keeps working
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS dl (DATA_PATH '{DATA_PATH}/remigrate_files', METADATA_CATALOG 'dlmeta', AUTOMATIC_MIGRATION TRUE)
+
+query III
+SELECT * FROM dl.t
+----
+1	10	100
+
+statement ok
+INSERT INTO dl.t VALUES (2, 20, 200);
+
+query III
+SELECT * FROM dl.t ORDER BY row_id
+----
+1	10	100
+2	20	200
+
+statement ok
+DETACH dl

--- a/test/sql/migration/inlined_column_rename_reverse_hint.test
+++ b/test/sql/migration/inlined_column_rename_reverse_hint.test
@@ -1,0 +1,69 @@
+# name: test/sql/migration/inlined_column_rename_reverse_hint.test
+# description: a v1.0 session reading inlined tables that were migrated underneath hints at reattaching
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/reverse_hint.db' AS dl (DATA_PATH '{TEST_DIR}/reverse_hint_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER, j INTEGER);
+
+statement ok
+INSERT INTO dl.t VALUES (1, 2), (3, 4);
+
+statement ok
+DETACH dl
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/reverse_hint.db' AS dl (DATA_PATH '{TEST_DIR}/reverse_hint_files', AUTOMATIC_MIGRATION TRUE)
+
+statement ok
+DETACH dl
+
+# simulate a session that attached at v1.0 before the catalog was migrated underneath it
+statement ok
+ATTACH '{TEST_DIR}/reverse_hint.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.0' WHERE key = 'version';
+
+statement ok
+DETACH meta
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/reverse_hint.db' AS dl (DATA_PATH '{TEST_DIR}/reverse_hint_files')
+
+# reading the migrated inlined table from the v1.0 session hints at reattaching
+statement error
+SELECT * FROM dl.t
+----
+migrated by another connection
+
+statement ok
+DETACH dl
+
+# a reattach at the migrated version reads the data
+statement ok
+ATTACH '{TEST_DIR}/reverse_hint.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
+
+statement ok
+DETACH meta
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/reverse_hint.db' AS dl (DATA_PATH '{TEST_DIR}/reverse_hint_files')
+
+query II
+SELECT * FROM dl.t ORDER BY i
+----
+1	2
+3	4
+
+statement ok
+DETACH dl

--- a/test/sql/migration/inlined_column_rename_stats_hint.test
+++ b/test/sql/migration/inlined_column_rename_stats_hint.test
@@ -1,0 +1,74 @@
+# name: test/sql/migration/inlined_column_rename_stats_hint.test
+# description: the rewrite stats refresh on a legacy named dev1 catalog hints at the automatic migration
+# group: [migration]
+
+require ducklake
+
+require parquet
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_stats_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_stats_hint_files', DUCKLAKE_VERSION '1.0')
+
+statement ok
+CREATE TABLE dl.t(i INTEGER);
+
+statement ok
+INSERT INTO dl.t FROM range(50);
+
+statement ok
+INSERT INTO dl.t FROM range(50, 100);
+
+statement ok
+INSERT INTO dl.t VALUES (1000), (1001);
+
+statement ok
+DELETE FROM dl.t WHERE i IN (5, 55);
+
+statement ok
+DETACH dl
+
+# simulate a dev1 catalog created before the rename by applying the static dev1 schema by hand
+statement ok
+ATTACH '{TEST_DIR}/dev1_stats_hint.db' AS meta;
+
+statement ok
+UPDATE meta.ducklake_metadata SET value = '1.1-dev1' WHERE key = 'version';
+
+statement ok
+ALTER TABLE meta.ducklake_data_file ADD COLUMN row_group_count BIGINT;
+
+statement ok
+ALTER TABLE meta.ducklake_delete_file ADD COLUMN row_group_count BIGINT;
+
+statement ok
+CREATE TABLE meta.ducklake_view_column_tag(view_id BIGINT, column_name VARCHAR, begin_snapshot BIGINT, end_snapshot BIGINT, key VARCHAR, value VARCHAR);
+
+statement ok
+DETACH meta
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_stats_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_stats_hint_files')
+
+# the rewrite commit refreshes stats from the inlined data and hints at the migration
+statement error
+CALL ducklake_rewrite_data_files('dl', 't', delete_threshold => 0);
+----
+AUTOMATIC_MIGRATION
+
+statement ok
+DETACH dl
+
+# following the hint fixes the catalog
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/dev1_stats_hint.db' AS dl (DATA_PATH '{TEST_DIR}/dev1_stats_hint_files', AUTOMATIC_MIGRATION TRUE)
+
+statement ok
+CALL ducklake_rewrite_data_files('dl', 't', delete_threshold => 0);
+
+query I
+SELECT COUNT(*) FROM dl.t
+----
+100
+
+statement ok
+DETACH dl


### PR DESCRIPTION
This PR renames the reserved column names in the inlined tables from:
* `row_id`
* `begin_snapshot`
* `end_snapshot`

to:
* `_ducklake_row_id`
* `_ducklake_begin_snapshot`
* `_ducklake_end_snapshot`

This allows for tables with the original column names to also be inlined.

The PR also migrates existing inlined tables, and verifies the renaming is correct (and it is also backwards compatible)