### PR TITLE
[Bug Fix] Retype stats

### DIFF
--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -40,12 +40,15 @@ class LogicalGet;
 struct DuckLakeTableStatsCacheEntry : public ObjectCacheEntry {
 	static constexpr idx_t ESTIMATED_BYTES_PER_COLUMN_STATS = 256;
 
-	explicit DuckLakeTableStatsCacheEntry(DuckLakeTableStats stats_p) : stats(std::move(stats_p)), has_stats(true) {
+	DuckLakeTableStatsCacheEntry(idx_t schema_version, DuckLakeTableStats stats_p)
+	    : schema_version(schema_version), stats(std::move(stats_p)), has_stats(true) {
 	}
 	//! Negative entry: table has no stats at this snapshot.
-	DuckLakeTableStatsCacheEntry() : has_stats(false) {
+	explicit DuckLakeTableStatsCacheEntry(idx_t schema_version) : schema_version(schema_version), has_stats(false) {
 	}
 
+	//! Schema version the column stats types were stamped from.
+	idx_t schema_version;
 	DuckLakeTableStats stats;
 	bool has_stats;
 

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -47,7 +47,7 @@ struct DuckLakeTableStatsCacheEntry : public ObjectCacheEntry {
 	explicit DuckLakeTableStatsCacheEntry(idx_t schema_version) : schema_version(schema_version), has_stats(false) {
 	}
 
-	//! Schema version the column stats types were stamped from.
+	//! Schema version that stamped the stats types
 	idx_t schema_version;
 	DuckLakeTableStats stats;
 	bool has_stats;

--- a/src/include/storage/ducklake_stats.hpp
+++ b/src/include/storage/ducklake_stats.hpp
@@ -43,6 +43,8 @@ struct DuckLakeColumnStats {
 	bool has_min = false;
 	bool has_max = false;
 	bool any_valid = true;
+	//! Invalidated bounds must never be reseeded
+	bool bounds_unknown = false;
 	bool has_contains_nan = false;
 
 	bool AnyValid() const {
@@ -55,7 +57,8 @@ struct DuckLakeColumnStats {
 	unique_ptr<DuckLakeColumnExtraStats> extra_stats;
 
 public:
-	static DuckLakeColumnStats FromGlobalStats(const LogicalType &type, const DuckLakeGlobalColumnStatsInfo &col);
+	static DuckLakeColumnStats FromGlobalStats(const LogicalType &type, const DuckLakeGlobalColumnStatsInfo &col,
+	                                           bool table_has_rows);
 	unique_ptr<BaseStatistics> ToStats() const;
 	void MergeStats(const DuckLakeColumnStats &new_stats);
 

--- a/src/include/storage/ducklake_stats.hpp
+++ b/src/include/storage/ducklake_stats.hpp
@@ -59,6 +59,7 @@ struct DuckLakeColumnStats {
 public:
 	static DuckLakeColumnStats FromGlobalStats(const LogicalType &type, const DuckLakeGlobalColumnStatsInfo &col,
 	                                           bool table_has_rows);
+	static bool BoundsSurviveTypePromotion(const LogicalType &source, const LogicalType &target);
 	unique_ptr<BaseStatistics> ToStats() const;
 	void MergeStats(const DuckLakeColumnStats &new_stats);
 

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -803,7 +803,7 @@ unique_ptr<DuckLakeStats> DuckLakeCatalog::ConstructStatsMap(vector<DuckLakeGlob
 				// column that this field id references was deleted
 				continue;
 			}
-			auto column_stats = DuckLakeColumnStats::FromGlobalStats(field->Type(), col_stats);
+			auto column_stats = DuckLakeColumnStats::FromGlobalStats(field->Type(), col_stats, stats.record_count > 0);
 			table_stats->column_stats.insert(make_pair(col_stats.column_id, std::move(column_stats)));
 		}
 		lake_stats->table_stats.insert(make_pair(stats.table_id, std::move(table_stats)));

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -820,7 +820,7 @@ shared_ptr<DuckLakeTableStats> DuckLakeCatalog::GetTableStats(DuckLakeTransactio
 	auto &cache = GetObjectCacheInstance();
 	auto key = StatsCacheKey(snapshot.next_file_id, table_id);
 	auto cached = cache.Get<DuckLakeTableStatsCacheEntry>(key);
-	if (cached) {
+	if (cached && cached->schema_version == snapshot.schema_version) {
 		if (!cached->has_stats) {
 			// cached negative result
 			return nullptr;
@@ -842,11 +842,11 @@ shared_ptr<DuckLakeTableStats> DuckLakeCatalog::GetTableStats(DuckLakeTransactio
 
 	if (!table_stats) {
 		// cache negative result to avoid repeated metadata queries on empty tables
-		cache.Put(std::move(key), make_shared_ptr<DuckLakeTableStatsCacheEntry>());
+		cache.Put(std::move(key), make_shared_ptr<DuckLakeTableStatsCacheEntry>(snapshot.schema_version));
 		return nullptr;
 	}
 
-	auto entry = make_shared_ptr<DuckLakeTableStatsCacheEntry>(std::move(*table_stats));
+	auto entry = make_shared_ptr<DuckLakeTableStatsCacheEntry>(snapshot.schema_version, std::move(*table_stats));
 	cache.Put(std::move(key), entry);
 	auto *raw = entry.get();
 	return shared_ptr<DuckLakeTableStats>(std::move(entry), &raw->stats);

--- a/src/storage/ducklake_server_side_commit.cpp
+++ b/src/storage/ducklake_server_side_commit.cpp
@@ -622,7 +622,8 @@ unique_ptr<DuckLakeTableStats> DuckLakeServerSideCommit::BuildTableStats(const D
 		if (type_it == column_types.end()) {
 			continue;
 		}
-		entry->column_stats.emplace(col.column_id, DuckLakeColumnStats::FromGlobalStats(type_it->second, col));
+		entry->column_stats.emplace(col.column_id,
+		                            DuckLakeColumnStats::FromGlobalStats(type_it->second, col, gs.record_count > 0));
 	}
 	return entry;
 }

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -40,6 +40,7 @@ DuckLakeColumnStats::DuckLakeColumnStats(const DuckLakeColumnStats &other) {
 	has_min = other.has_min;
 	has_max = other.has_max;
 	any_valid = other.any_valid;
+	bounds_unknown = other.bounds_unknown;
 	has_contains_nan = other.has_contains_nan;
 
 	if (other.extra_stats) {
@@ -63,6 +64,7 @@ DuckLakeColumnStats &DuckLakeColumnStats::operator=(const DuckLakeColumnStats &o
 	has_max = other.has_max;
 	has_num_values = other.has_num_values;
 	any_valid = other.any_valid;
+	bounds_unknown = other.bounds_unknown;
 	has_contains_nan = other.has_contains_nan;
 
 	if (other.extra_stats) {
@@ -74,7 +76,8 @@ DuckLakeColumnStats &DuckLakeColumnStats::operator=(const DuckLakeColumnStats &o
 }
 
 DuckLakeColumnStats DuckLakeColumnStats::FromGlobalStats(const LogicalType &type,
-                                                         const DuckLakeGlobalColumnStatsInfo &col) {
+                                                         const DuckLakeGlobalColumnStatsInfo &col,
+                                                         bool table_has_rows) {
 	DuckLakeColumnStats stats(type);
 	stats.has_null_count = col.has_contains_null;
 	if (col.has_contains_null) {
@@ -93,6 +96,8 @@ DuckLakeColumnStats DuckLakeColumnStats::FromGlobalStats(const LogicalType &type
 		stats.max = col.max_val;
 	}
 	stats.any_valid = stats.has_min || stats.has_max || col.has_extra_stats;
+	// absent bounds on a non-empty table are unknown, not all-NULL
+	stats.bounds_unknown = !stats.any_valid && table_has_rows;
 	if (col.has_extra_stats && stats.extra_stats) {
 		stats.extra_stats->Deserialize(col.extra_stats);
 	}
@@ -131,10 +136,15 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 		if (types_differ) {
 			has_min = false;
 			has_max = false;
+			bounds_unknown = true;
 		}
 		return;
 	}
 	if (!AnyValid()) {
+		if (bounds_unknown) {
+			// invalidated bounds
+			return;
+		}
 		// all values in the current stats are null - copy the min/max
 		min = new_stats.min;
 		has_min = new_stats.has_min;
@@ -147,6 +157,7 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 		// min/max from different types cannot be compared - invalidate them
 		has_min = false;
 		has_max = false;
+		bounds_unknown = true;
 	} else {
 		if (!new_stats.has_min) {
 			has_min = false;

--- a/src/storage/ducklake_stats.cpp
+++ b/src/storage/ducklake_stats.cpp
@@ -96,7 +96,7 @@ DuckLakeColumnStats DuckLakeColumnStats::FromGlobalStats(const LogicalType &type
 		stats.max = col.max_val;
 	}
 	stats.any_valid = stats.has_min || stats.has_max || col.has_extra_stats;
-	// absent bounds on a non-empty table are unknown, not all-NULL
+	// absent bounds on nonempty tables are unknown
 	stats.bounds_unknown = !stats.any_valid && table_has_rows;
 	if (col.has_extra_stats && stats.extra_stats) {
 		stats.extra_stats->Deserialize(col.extra_stats);
@@ -104,8 +104,17 @@ DuckLakeColumnStats DuckLakeColumnStats::FromGlobalStats(const LogicalType &type
 	return stats;
 }
 
+bool DuckLakeColumnStats::BoundsSurviveTypePromotion(const LogicalType &source, const LogicalType &target) {
+	// bound strings reread exactly at wider types
+	if (source.IsIntegral() && target.IsIntegral()) {
+		return true;
+	}
+	return source.id() == LogicalTypeId::DECIMAL && target.id() == LogicalTypeId::DECIMAL;
+}
+
 void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 	bool types_differ = type != new_stats.type;
+	bool bounds_survive = !types_differ || BoundsSurviveTypePromotion(type, new_stats.type);
 	if (types_differ) {
 		type = new_stats.type;
 	}
@@ -133,7 +142,7 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 
 	if (!new_stats.AnyValid()) {
 		// all values in the source are NULL - don't update min/max
-		if (types_differ) {
+		if (!bounds_survive) {
 			has_min = false;
 			has_max = false;
 			bounds_unknown = true;
@@ -153,8 +162,8 @@ void DuckLakeColumnStats::MergeStats(const DuckLakeColumnStats &new_stats) {
 		any_valid = true;
 		return;
 	}
-	if (types_differ) {
-		// min/max from different types cannot be compared - invalidate them
+	if (!bounds_survive) {
+		// bounds do not survive this retype
 		has_min = false;
 		has_max = false;
 		bounds_unknown = true;

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -283,6 +283,10 @@ unique_ptr<BaseStatistics> GetColumnStats(const DuckLakeFieldId &field_id, const
 		if (entry == table_stats.column_stats.end()) {
 			return nullptr;
 		}
+		if (entry->second.type != field_id.Type()) {
+			// don't serve stale stats from before a retype
+			return nullptr;
+		}
 		return entry->second.ToStats();
 	}
 	// nested type

--- a/test/sql/alter/alter_type_stale_stats_cache.test
+++ b/test/sql/alter/alter_type_stale_stats_cache.test
@@ -33,12 +33,7 @@ SELECT count(*) FROM ducklake.t WHERE c >= 10;
 ----
 90
 
-query I
-SELECT min(c) FROM ducklake.t WHERE c >= 10;
-----
-10
-
-# the retype refreshes the cached stats instead of dropping them
+# the retype must refresh the cached stats
 query I
 SELECT stats(c) FROM ducklake.t LIMIT 1;
 ----
@@ -98,7 +93,7 @@ SELECT count(*) FROM ducklake.t3 WHERE c >= 10;
 ----
 90
 
-# a rolled-back retype must keep the cached stats valid
+# rollback keeps the cached stats valid
 statement ok
 CREATE TABLE ducklake.t4(c INTEGER);
 

--- a/test/sql/alter/alter_type_stale_stats_cache.test
+++ b/test/sql/alter/alter_type_stale_stats_cache.test
@@ -1,0 +1,135 @@
+# name: test/sql/alter/alter_type_stale_stats_cache.test
+# description: cached table stats must not keep the pre-ALTER column type
+# group: [alter]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_stale_stats_cache')
+
+statement ok
+CREATE TABLE ducklake.t(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t SELECT range FROM range(100);
+
+# warm the stats cache before the retype
+query I
+SELECT count(*) FROM ducklake.t WHERE c >= 10;
+----
+90
+
+statement ok
+ALTER TABLE ducklake.t ALTER COLUMN c TYPE BIGINT;
+
+query I
+SELECT count(*) FROM ducklake.t WHERE c >= 10;
+----
+90
+
+query I
+SELECT min(c) FROM ducklake.t WHERE c >= 10;
+----
+10
+
+# the retype refreshes the cached stats instead of dropping them
+query I
+SELECT stats(c) FROM ducklake.t LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 99, 'min': 0}
+
+statement ok
+CREATE TABLE ducklake.t2(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t2 SELECT range FROM range(100);
+
+query I
+SELECT count(*) FROM ducklake.t2 WHERE c >= 10;
+----
+90
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t2 ALTER COLUMN c TYPE BIGINT;
+
+query I
+SELECT count(*) FROM ducklake.t2 WHERE c >= 10;
+----
+90
+
+statement ok
+COMMIT
+
+query I
+SELECT count(*) FROM ducklake.t2 WHERE c >= 10;
+----
+90
+
+query I
+SELECT stats(c) FROM ducklake.t2 LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 99, 'min': 0}
+
+statement ok
+CREATE TABLE ducklake.t3(c DECIMAL(9,2));
+
+statement ok
+INSERT INTO ducklake.t3 SELECT range FROM range(100);
+
+query I
+SELECT count(*) FROM ducklake.t3 WHERE c >= 10;
+----
+90
+
+statement ok
+ALTER TABLE ducklake.t3 ALTER COLUMN c TYPE DECIMAL(18,2);
+
+query I
+SELECT count(*) FROM ducklake.t3 WHERE c >= 10;
+----
+90
+
+# a rolled-back retype must keep the cached stats valid
+statement ok
+CREATE TABLE ducklake.t4(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t4 SELECT range FROM range(100);
+
+query I
+SELECT count(*) FROM ducklake.t4 WHERE c >= 10;
+----
+90
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t4 ALTER COLUMN c TYPE BIGINT;
+
+query I
+SELECT count(*) FROM ducklake.t4 WHERE c >= 10;
+----
+90
+
+statement ok
+ROLLBACK
+
+query I
+SELECT count(*) FROM ducklake.t4 WHERE c >= 10;
+----
+90
+
+query I
+SELECT stats(c) FROM ducklake.t4 LIMIT 1;
+----
+{'has_no_null': true, 'has_null': false, 'max': 99, 'min': 0}

--- a/test/sql/stats/alter_type_stats_reseed.test
+++ b/test/sql/stats/alter_type_stats_reseed.test
@@ -1,0 +1,145 @@
+# name: test/sql/stats/alter_type_stats_reseed.test
+# description: invalidated min/max must not be reseeded from a single later file
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_stats_reseed', METADATA_CATALOG 'ducklake_meta')
+
+statement ok
+CREATE TABLE ducklake.t(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t SELECT range + 1000 FROM range(1000);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't' AND t.end_snapshot IS NULL;
+----
+1000	1999
+
+# retype + INSERT in one transaction drops the bounds
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t ALTER COLUMN c TYPE BIGINT;
+
+statement ok
+INSERT INTO ducklake.t SELECT range + 4000 FROM range(100);
+
+statement ok
+COMMIT
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't' AND t.end_snapshot IS NULL;
+----
+NULL	NULL
+
+# a later INSERT must not reseed the bounds from its file alone
+statement ok
+INSERT INTO ducklake.t SELECT range + 6000 FROM range(100);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't' AND t.end_snapshot IS NULL;
+----
+NULL	NULL
+
+query I
+SELECT count(*) FROM ducklake.t;
+----
+1200
+
+query I
+SELECT count(*) FROM ducklake.t WHERE c < 1500;
+----
+500
+
+query I
+SELECT count(*) FROM ducklake.t WHERE c = 1200;
+----
+1
+
+query I
+SELECT count(*) FROM ducklake.t WHERE c BETWEEN 1000 AND 1499;
+----
+500
+
+query I
+SELECT count(*) FROM ducklake.t WHERE c >= 6000;
+----
+100
+
+query II
+SELECT min(c), max(c) FROM ducklake.t;
+----
+1000	6099
+
+# same chain for FLOAT -> DOUBLE
+statement ok
+CREATE TABLE ducklake.t_float(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.t_float SELECT range + 1000 FROM range(1000);
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t_float ALTER COLUMN c TYPE DOUBLE;
+
+statement ok
+INSERT INTO ducklake.t_float SELECT range + 4000 FROM range(100);
+
+statement ok
+COMMIT
+
+statement ok
+INSERT INTO ducklake.t_float SELECT range + 6000 FROM range(100);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't_float' AND t.end_snapshot IS NULL;
+----
+NULL	NULL
+
+query I
+SELECT count(*) FROM ducklake.t_float WHERE c < 1500;
+----
+500
+
+query II
+SELECT min(c), max(c) FROM ducklake.t_float;
+----
+1000.0	6099.0
+
+# control: retype and INSERT in separate transactions keeps the bounds
+statement ok
+CREATE TABLE ducklake.t_ctrl(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t_ctrl SELECT range + 1000 FROM range(1000);
+
+statement ok
+ALTER TABLE ducklake.t_ctrl ALTER COLUMN c TYPE BIGINT;
+
+statement ok
+INSERT INTO ducklake.t_ctrl SELECT range + 4000 FROM range(100);
+
+statement ok
+INSERT INTO ducklake.t_ctrl SELECT range + 6000 FROM range(100);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't_ctrl' AND t.end_snapshot IS NULL;
+----
+1000	6099
+
+query I
+SELECT count(*) FROM ducklake.t_ctrl WHERE c < 1500;
+----
+500

--- a/test/sql/stats/alter_type_stats_reseed.test
+++ b/test/sql/stats/alter_type_stats_reseed.test
@@ -24,7 +24,7 @@ SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOI
 ----
 1000	1999
 
-# retype + INSERT in one transaction drops the bounds
+# integral widening keeps bounds through the transaction
 statement ok
 BEGIN
 
@@ -40,16 +40,15 @@ COMMIT
 query II
 SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't' AND t.end_snapshot IS NULL;
 ----
-NULL	NULL
+1000	4099
 
-# a later INSERT must not reseed the bounds from its file alone
 statement ok
 INSERT INTO ducklake.t SELECT range + 6000 FROM range(100);
 
 query II
 SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't' AND t.end_snapshot IS NULL;
 ----
-NULL	NULL
+1000	6099
 
 query I
 SELECT count(*) FROM ducklake.t;
@@ -58,16 +57,6 @@ SELECT count(*) FROM ducklake.t;
 
 query I
 SELECT count(*) FROM ducklake.t WHERE c < 1500;
-----
-500
-
-query I
-SELECT count(*) FROM ducklake.t WHERE c = 1200;
-----
-1
-
-query I
-SELECT count(*) FROM ducklake.t WHERE c BETWEEN 1000 AND 1499;
 ----
 500
 
@@ -81,7 +70,7 @@ SELECT min(c), max(c) FROM ducklake.t;
 ----
 1000	6099
 
-# same chain for FLOAT -> DOUBLE
+# float widening drops bounds and never reseeds
 statement ok
 CREATE TABLE ducklake.t_float(c FLOAT);
 
@@ -118,7 +107,7 @@ SELECT min(c), max(c) FROM ducklake.t_float;
 ----
 1000.0	6099.0
 
-# control: retype and INSERT in separate transactions keeps the bounds
+# separate transactions keep the bounds
 statement ok
 CREATE TABLE ducklake.t_ctrl(c INTEGER);
 
@@ -141,5 +130,69 @@ SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOI
 
 query I
 SELECT count(*) FROM ducklake.t_ctrl WHERE c < 1500;
+----
+500
+
+# DECIMAL widening keeps the bounds
+statement ok
+CREATE TABLE ducklake.t_dec(c DECIMAL(9,2));
+
+statement ok
+INSERT INTO ducklake.t_dec SELECT range + 1000 FROM range(1000);
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t_dec ALTER COLUMN c TYPE DECIMAL(18,2);
+
+statement ok
+INSERT INTO ducklake.t_dec SELECT range + 4000 FROM range(100);
+
+statement ok
+COMMIT
+
+statement ok
+INSERT INTO ducklake.t_dec SELECT range + 6000 FROM range(100);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't_dec' AND t.end_snapshot IS NULL;
+----
+1000.00	6099.00
+
+query I
+SELECT count(*) FROM ducklake.t_dec WHERE c < 1500;
+----
+500
+
+# hugeint files carry no bounds at all
+statement ok
+CREATE TABLE ducklake.t_huge(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t_huge SELECT range + 1000 FROM range(1000);
+
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE ducklake.t_huge ALTER COLUMN c TYPE HUGEINT;
+
+statement ok
+INSERT INTO ducklake.t_huge SELECT range + 4000 FROM range(100);
+
+statement ok
+COMMIT
+
+statement ok
+INSERT INTO ducklake.t_huge SELECT range + 6000 FROM range(100);
+
+query II
+SELECT min_value, max_value FROM ducklake_meta.ducklake_table_column_stats s JOIN ducklake_meta.ducklake_table t USING (table_id) WHERE t.table_name = 't_huge' AND t.end_snapshot IS NULL;
+----
+NULL	NULL
+
+query I
+SELECT count(*) FROM ducklake.t_huge WHERE c < 1500;
 ----
 500


### PR DESCRIPTION
This PR fixes two issues related to the states of retyped columns
1. The stats cache is keyed on `next_file_id`, and retype wouldn't bump it, so the cache would serve the min/max in the old column type, then the filter would throw. In this PR the cache entries has a schema version, which refetch on a mismatch.
2. Retyping + Insert in the same transaction would invalidate the global min/max, then the insert would restart the stats which would break the file pruning. We now invalidate the bounds properly, if old bounds survive the retype we can keep them. They can be recalculated at file until `rewrite_data_files` recomputes exact stats.