### PR TITLE
Recast persisted min/max stats when a column type changes

### DIFF
--- a/src/include/storage/ducklake_commit_state.hpp
+++ b/src/include/storage/ducklake_commit_state.hpp
@@ -29,6 +29,8 @@ struct NewTableInfo {
 	vector<DuckLakeNewColumn> new_columns;
 	vector<DuckLakeTableInfo> new_inlined_data_tables;
 	vector<DuckLakeSortInfo> new_sort_keys;
+	//! Tables whose commit includes an ALTER ... TYPE.
+	set<TableIndex> retyped_tables;
 };
 
 struct NewMacroInfo {
@@ -42,7 +44,18 @@ struct NewNameMapInfo {
 struct NewDataInfo {
 	vector<DuckLakeFileInfo> new_files;
 	vector<DuckLakeInlinedDataInfo> new_inlined_data;
+	//! Tables whose global stats this commit rewrites from memory; RecastCommittedStats must not correct them again.
+	set<TableIndex> global_stats_written;
 };
+
+struct DuckLakeRetypedColumn {
+	//! The committed type before this ALTER. Only a guess at what the stats strings were rendered under, see
+	//! TryRecastStatsBound.
+	LogicalType source_type;
+	LogicalType target_type;
+};
+
+using DuckLakeRetypePlan = map<TableIndex, map<FieldIndex, DuckLakeRetypedColumn>>;
 
 struct CompactionInformation {
 	vector<DuckLakeCompactedFileInfo> compacted_files;

--- a/src/include/storage/ducklake_metadata_info.hpp
+++ b/src/include/storage/ducklake_metadata_info.hpp
@@ -361,6 +361,9 @@ struct DuckLakeNewColumn {
 	TableIndex table_id;
 	DuckLakeColumnInfo column_info;
 	optional_idx parent_idx;
+	//! Set only when an ALTER ... TYPE drops and re-creates this field; empty for ADD COLUMN and RENAME. Not
+	//! persisted - a table created and altered in the same transaction has no committed old type to look up.
+	string promoted_from_type;
 };
 
 struct DuckLakeCatalogInfo {

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -399,9 +399,19 @@ public:
 	//! Caller substitutes `{METADATA_CATALOG}` / `{SNAPSHOT_ID}` and executes via the commit context's executor.
 	static string ReadInlinedDataAggregatesSql(const string &inlined_table_name, const string &select_list,
 	                                           const DuckLakeInlinedColNames &col_names);
-	static string ReadFileColumnStatsForTableSql(TableIndex table_id);
+	//! An empty `column_ids` reads every column. The recast pass passes the retyped columns only: it runs over every
+	//! file of the table, so it must not also drag in every column of a wide one. A non-empty filter also drops files
+	//! that have no stats row at all, which the LEFT JOIN would otherwise keep.
+	static string ReadFileColumnStatsForTableSql(TableIndex table_id, const set<FieldIndex> &column_ids = {});
 	//! Throws on a failed inlined data read, hinting at the migration for legacy named catalogs
 	void CheckInlinedDataReadError(QueryResult &result, const string &inlined_table_name);
+	//! `min_value`/`max_value` are already-quoted SQL literals (see DuckLakeUtil::StatsToString); empty leaves that
+	//! column unwritten, and empty for both yields no statement.
+	static string UpdateFileColumnStatsMinMaxSql(const vector<DataFileIndex> &data_file_ids, FieldIndex column_id,
+	                                             const string &min_value, const string &max_value);
+	static string UpdateTableColumnStatsMinMaxSql(TableIndex table_id, FieldIndex column_id, const string &min_value,
+	                                              const string &max_value);
+	static string ReadTableColumnStatsMinMaxSql(TableIndex table_id);
 	virtual shared_ptr<DuckLakeInlinedData> TransformInlinedData(QueryResult &result,
 	                                                             const vector<LogicalType> &expected_types,
 	                                                             const string &inlined_table_name);

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "storage/ducklake_commit_state.hpp"
 #include "storage/ducklake_stats.hpp"
 #include "storage/ducklake_transaction.hpp"
 
@@ -154,13 +155,15 @@ public:
 	NewDataInfo GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
 	                            optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
 	                            const DuckLakeCommitContext &context,
-	                            map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	                            map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats,
+	                            const DuckLakeRetypePlan &retype_plan);
 	//! Decrement table-level stats for files dropped this commit; returns true if live rows remain.
 	static bool ApplyDroppedFileStats(TableIndex table_id, DuckLakeNewGlobalStats &new_stats,
 	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
 	string UpdateStatsForDroppedFiles(optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
 	                                  const DuckLakeCommitContext &context,
-	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats);
+	                                  map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats,
+	                                  const DuckLakeRetypePlan &retype_plan, set<TableIndex> &globals_written);
 	CompactionInformation GetCompactionChanges(DuckLakeCommitState &commit_state, CompactionType type);
 	//! After a REWRITE_DELETES compaction, recompute EXACT global stats for `table_id` from the post-rewrite file set
 	//! (+ committed inlined data) and append the UpdateGlobalTableStats SQL to `batch_query`. No-op (leaving the
@@ -170,6 +173,15 @@ public:
 	                                      const CompactionInformation &rewrite_changes,
 	                                      const set<DataFileIndex> &removed_source_ids,
 	                                      const DuckLakeCommitContext &context);
+	//! Min/max are persisted as strings written under the column's type, so an ALTER COLUMN TYPE reinterprets them
+	//! under the new type. Where that disagrees with the stored value widened through the old type, the bound stops
+	//! covering the data and the zone map prunes live rows.
+	//! Only rows already committed at `commit_snapshot`; rows this commit writes itself are corrected in memory
+	//! where they are built.
+	void RecastCommittedStats(string &batch_query, DuckLakeSnapshot commit_snapshot, const DuckLakeRetypePlan &plan,
+	                          const set<TableIndex> &globals_written,
+	                          const set<DataFileIndex> &files_written_this_commit,
+	                          const DuckLakeCommitContext &context);
 	//! Merge committed inlined data's per-column min/max into `target` via typed SQL aggregates. Returns false if the
 	//! inlined data cannot be accounted for exactly (e.g. a non-scalar column), in which case the caller must not
 	//! claim the recomputed stats are exact.

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -3521,7 +3521,18 @@ WHERE {SNAPSHOT_ID} >= %s AND ({SNAPSHOT_ID} < %s OR %s IS NULL);
 	                          col_names.end_snapshot);
 }
 
-string DuckLakeMetadataManager::ReadFileColumnStatsForTableSql(TableIndex table_id) {
+string DuckLakeMetadataManager::ReadFileColumnStatsForTableSql(TableIndex table_id, const set<FieldIndex> &column_ids) {
+	string column_filter;
+	if (!column_ids.empty()) {
+		string column_list;
+		for (auto &column_id : column_ids) {
+			if (!column_list.empty()) {
+				column_list += ", ";
+			}
+			column_list += to_string(column_id.index);
+		}
+		column_filter = "  AND stats.column_id IN (" + column_list + ")\n";
+	}
 	return StringUtil::Format(R"(
 SELECT data.data_file_id, data.record_count, data.file_size_bytes,
        stats.column_id, stats.value_count, stats.null_count, stats.min_value, stats.max_value,
@@ -3529,9 +3540,62 @@ SELECT data.data_file_id, data.record_count, data.file_size_bytes,
 FROM {METADATA_CATALOG}.ducklake_data_file data
 LEFT JOIN {METADATA_CATALOG}.ducklake_file_column_stats stats ON stats.data_file_id = data.data_file_id
 WHERE data.table_id = %d
-  AND {SNAPSHOT_ID} >= data.begin_snapshot
+%s  AND {SNAPSHOT_ID} >= data.begin_snapshot
   AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
 ORDER BY data.data_file_id;
+)",
+	                          table_id.index, column_filter);
+}
+
+static string BuildMinMaxSetClause(const string &min_value, const string &max_value) {
+	string set_clause;
+	if (!min_value.empty()) {
+		set_clause += "min_value=" + min_value;
+	}
+	if (!max_value.empty()) {
+		if (!set_clause.empty()) {
+			set_clause += ", ";
+		}
+		set_clause += "max_value=" + max_value;
+	}
+	return set_clause;
+}
+
+string DuckLakeMetadataManager::UpdateFileColumnStatsMinMaxSql(const vector<DataFileIndex> &data_file_ids,
+                                                               FieldIndex column_id, const string &min_value,
+                                                               const string &max_value) {
+	auto set_clause = BuildMinMaxSetClause(min_value, max_value);
+	if (set_clause.empty() || data_file_ids.empty()) {
+		return string();
+	}
+	string file_list;
+	for (auto &data_file_id : data_file_ids) {
+		if (!file_list.empty()) {
+			file_list += ", ";
+		}
+		file_list += to_string(data_file_id.index);
+	}
+	return StringUtil::Format(
+	    "UPDATE {METADATA_CATALOG}.ducklake_file_column_stats SET %s WHERE data_file_id IN (%s) AND column_id=%d;",
+	    set_clause, file_list, column_id.index);
+}
+
+string DuckLakeMetadataManager::UpdateTableColumnStatsMinMaxSql(TableIndex table_id, FieldIndex column_id,
+                                                                const string &min_value, const string &max_value) {
+	auto set_clause = BuildMinMaxSetClause(min_value, max_value);
+	if (set_clause.empty()) {
+		return string();
+	}
+	return StringUtil::Format(
+	    "UPDATE {METADATA_CATALOG}.ducklake_table_column_stats SET %s WHERE table_id=%d AND column_id=%d;", set_clause,
+	    table_id.index, column_id.index);
+}
+
+string DuckLakeMetadataManager::ReadTableColumnStatsMinMaxSql(TableIndex table_id) {
+	return StringUtil::Format(R"(
+SELECT column_id, min_value, max_value
+FROM {METADATA_CATALOG}.ducklake_table_column_stats
+WHERE table_id = %d;
 )",
 	                          table_id.index);
 }

--- a/src/storage/ducklake_table_entry.cpp
+++ b/src/storage/ducklake_table_entry.cpp
@@ -1067,6 +1067,7 @@ unique_ptr<DuckLakeFieldId> DuckLakeTableEntry::TypePromotion(const DuckLakeFiel
 	}
 	new_col.column_info.type = DuckLakeTypes::ToString(target);
 	new_col.parent_idx = parent_idx;
+	new_col.promoted_from_type = DuckLakeTypes::ToString(source_type);
 	result.new_fields.push_back(std::move(new_col));
 
 	return make_uniq<DuckLakeFieldId>(std::move(column_data), source_id.Name(), target);

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -444,6 +444,7 @@ void HandleChangedFields(TableIndex table_id, const ColumnChangeInfo &change_inf
 		new_column.table_id = table_id;
 		new_column.column_info = new_col_info.column_info;
 		new_column.parent_idx = new_col_info.parent_idx;
+		new_column.promoted_from_type = new_col_info.promoted_from_type;
 		txn_added_fields[new_col_info.column_info.id.index] = result.new_columns.size();
 		result.new_columns.push_back(std::move(new_column));
 	}
@@ -841,6 +842,90 @@ bool DuckLakeTransactionState::TryMergeInlinedStats(const vector<DuckLakeColumnS
 	return true;
 }
 
+//! DefaultTryCastAs throws rather than returning false when the error pointer is null, and a stat we cannot
+//! interpret must not abort the ALTER.
+static bool TryCastStatsValue(const Value &input, const LogicalType &target, Value &result) {
+	string error;
+	if (!input.DefaultTryCastAs(target, result, &error)) {
+		return false;
+	}
+	return !result.IsNull();
+}
+
+//! Returns the corrected bound, or empty if the stored string reads back unchanged, cannot be cast, or would not
+//! widen. Neither reading of it is authoritative, because the type it was rendered under cannot be recovered from
+//! the catalog, so the wider candidate wins: it over-covers rather than prunes. Comparing the candidates
+//! rather than classifying the promotion avoids an allow-list tracking DuckDB's cast rules.
+static string TryRecastStatsBound(const string &stored, const LogicalType &source, const LogicalType &target,
+                                  bool is_min, bool source_is_authoritative) {
+	Value stored_value(stored);
+	Value reinterpreted;
+	Value intermediate;
+	Value via_source;
+	if (!TryCastStatsValue(stored_value, target, reinterpreted)) {
+		return string();
+	}
+	if (!TryCastStatsValue(stored_value, source, intermediate)) {
+		return string();
+	}
+	if (!TryCastStatsValue(intermediate, target, via_source)) {
+		return string();
+	}
+	// When the source type is known to be the one the value was written under, casting through it is exactly what
+	// the reader will do, so take it in both directions. Otherwise only widen: NaN compares false both ways, so a
+	// stat that reads back as NaN keeps its stored form.
+	if (!source_is_authoritative) {
+		bool via_source_is_wider = is_min ? via_source < reinterpreted : via_source > reinterpreted;
+		if (!via_source_is_wider) {
+			return string();
+		}
+	}
+	auto corrected = via_source.ToString();
+	if (corrected == reinterpreted.ToString()) {
+		return string();
+	}
+	return corrected;
+}
+
+static void RecastColumnStats(DuckLakeColumnStats &stats, const DuckLakeRetypedColumn &retype,
+                              bool source_is_authoritative) {
+	// File stats are built with the field's type as of the write (ParseColumnStats in ducklake_insert.cpp), so a
+	// file staged after the ALTER in this same transaction already carries an exact bound under the target type.
+	// Widening that through the source would loosen it, and a folded MIN/MAX would then report a value no row holds.
+	if (stats.type == retype.target_type) {
+		return;
+	}
+	// And where that write-time type is what makes the correction exact, it is also the type to cast through. It is
+	// not always the plan's source type: two ALTERs in one transaction leave the plan holding the intermediate, and
+	// casting an INTEGER file through it rounds the bound off the data it is supposed to cover.
+	auto &source_type = source_is_authoritative ? stats.type : retype.source_type;
+	if (stats.has_min) {
+		auto corrected = TryRecastStatsBound(stats.min, source_type, retype.target_type, true, source_is_authoritative);
+		if (!corrected.empty()) {
+			stats.min = corrected;
+		}
+	}
+	if (stats.has_max) {
+		auto corrected =
+		    TryRecastStatsBound(stats.max, source_type, retype.target_type, false, source_is_authoritative);
+		if (!corrected.empty()) {
+			stats.max = corrected;
+		}
+	}
+}
+
+static void RecastColumnStatsMap(map<FieldIndex, DuckLakeColumnStats> &column_stats,
+                                 const map<FieldIndex, DuckLakeRetypedColumn> &retyped_fields,
+                                 bool source_is_authoritative) {
+	for (auto &entry : column_stats) {
+		auto retyped_entry = retyped_fields.find(entry.first);
+		if (retyped_entry == retyped_fields.end()) {
+			continue;
+		}
+		RecastColumnStats(entry.second, retyped_entry->second, source_is_authoritative);
+	}
+}
+
 void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_query, TableIndex table_id,
                                                                 DuckLakeSnapshot snapshot,
                                                                 const CompactionInformation &rewrite_changes,
@@ -980,6 +1065,150 @@ void DuckLakeTransactionState::RecomputeGlobalStatsAfterRewrite(string &batch_qu
 	    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
 }
 
+//! An exact source (integer, decimal, temporal) round-trips through its own text, so the two candidate readings
+//! coincide and the O(files) pass below would find nothing to write. Skipping those keeps a widening like
+//! INTEGER -> BIGINT the O(1) metadata operation it was.
+static bool SourceRenderingCanBeLossy(const LogicalType &source) {
+	auto physical = source.InternalType();
+	return physical == PhysicalType::FLOAT || physical == PhysicalType::DOUBLE;
+}
+
+static DuckLakeRetypePlan BuildRetypePlan(const NewTableInfo &new_table_info) {
+	DuckLakeRetypePlan plan;
+	if (new_table_info.retyped_tables.empty()) {
+		return plan;
+	}
+	map<TableIndex, vector<reference<const DuckLakeNewColumn>>> columns_by_table;
+	for (auto &new_col : new_table_info.new_columns) {
+		if (new_table_info.retyped_tables.count(new_col.table_id) == 0) {
+			continue;
+		}
+		columns_by_table[new_col.table_id].push_back(new_col);
+	}
+	for (auto &table_entry : columns_by_table) {
+		auto table_id = table_entry.first;
+		// ADD COLUMN and RENAME arrive on the same list; neither changes how the persisted strings read back.
+		map<FieldIndex, DuckLakeRetypedColumn> retyped_fields;
+		for (auto &new_col_ref : table_entry.second) {
+			auto &new_col = new_col_ref.get();
+			if (new_col.promoted_from_type.empty()) {
+				continue;
+			}
+			auto source_type = DuckLakeTypes::FromString(new_col.promoted_from_type);
+			auto target_type = DuckLakeTypes::FromString(new_col.column_info.type);
+			if (target_type == source_type || !SourceRenderingCanBeLossy(source_type)) {
+				continue;
+			}
+			retyped_fields.insert(make_pair(new_col.column_info.id, DuckLakeRetypedColumn {source_type, target_type}));
+		}
+		if (retyped_fields.empty()) {
+			continue;
+		}
+		plan.insert(make_pair(table_id, std::move(retyped_fields)));
+	}
+	return plan;
+}
+
+void DuckLakeTransactionState::RecastCommittedStats(string &batch_query, DuckLakeSnapshot commit_snapshot,
+                                                    const DuckLakeRetypePlan &plan,
+                                                    const set<TableIndex> &globals_written,
+                                                    const set<DataFileIndex> &files_written_this_commit,
+                                                    const DuckLakeCommitContext &context) {
+	for (auto &table_entry : plan) {
+		auto table_id = table_entry.first;
+		auto &retyped_fields = table_entry.second;
+
+		set<FieldIndex> retyped_column_ids;
+		for (auto &field_entry : retyped_fields) {
+			retyped_column_ids.insert(field_entry.first);
+		}
+		auto file_stats = context.query_metadata_with_snapshot(
+		    commit_snapshot, DuckLakeMetadataManager::ReadFileColumnStatsForTableSql(table_id, retyped_column_ids));
+		if (file_stats->HasError()) {
+			file_stats->GetErrorObject().Throw("Failed to read per-file column stats for retyping from DuckLake: ");
+		}
+		// One UPDATE per distinct corrected bound rather than per file. Files with distinct bounds, the usual case,
+		// still get one statement each.
+		map<pair<FieldIndex, pair<string, string>>, vector<DataFileIndex>> updates_by_bound;
+		for (auto &row : *file_stats) {
+			DataFileIndex data_file_id(static_cast<idx_t>(row.GetValue<int64_t>(0)));
+			if (files_written_this_commit.count(data_file_id) > 0) {
+				// The Appender fast path in write_data_files_sql inserts new file rows eagerly, so they are already
+				// visible to this read. Their stats were corrected in memory against the file's own write-time type,
+				// which is exact; re-applying the widened correction here would loosen them back.
+				continue;
+			}
+			// the column filter sits in the WHERE, so the LEFT JOIN's stats-less rows are already gone
+			if (row.IsNull(3)) {
+				throw InternalException("File column stats row without a column_id in the recast read");
+			}
+			FieldIndex column_id(static_cast<idx_t>(row.GetValue<int64_t>(3)));
+			auto retyped_entry = retyped_fields.find(column_id);
+			if (retyped_entry == retyped_fields.end()) {
+				continue;
+			}
+			auto &retype = retyped_entry->second;
+			string new_min;
+			string new_max;
+			if (!row.IsNull(6)) {
+				new_min =
+				    TryRecastStatsBound(row.GetValue<string>(6), retype.source_type, retype.target_type, true, false);
+			}
+			if (!row.IsNull(7)) {
+				new_max =
+				    TryRecastStatsBound(row.GetValue<string>(7), retype.source_type, retype.target_type, false, false);
+			}
+			if (new_min.empty() && new_max.empty()) {
+				continue;
+			}
+			updates_by_bound[make_pair(column_id, make_pair(new_min, new_max))].push_back(data_file_id);
+		}
+		for (auto &update_entry : updates_by_bound) {
+			auto &column_id = update_entry.first.first;
+			auto &new_min = update_entry.first.second.first;
+			auto &new_max = update_entry.first.second.second;
+			batch_query += DuckLakeMetadataManager::UpdateFileColumnStatsMinMaxSql(
+			    update_entry.second, column_id, new_min.empty() ? string() : DuckLakeUtil::StatsToString(new_min),
+			    new_max.empty() ? string() : DuckLakeUtil::StatsToString(new_max));
+		}
+
+		if (globals_written.count(table_id) > 0) {
+			// already corrected in memory; a correction derived from the pre-commit value would clobber the
+			// contribution of the files written by this commit
+			continue;
+		}
+		auto global_stats = context.query_metadata_with_snapshot(
+		    commit_snapshot, DuckLakeMetadataManager::ReadTableColumnStatsMinMaxSql(table_id));
+		if (global_stats->HasError()) {
+			global_stats->GetErrorObject().Throw("Failed to read global column stats for retyping from DuckLake: ");
+		}
+		for (auto &row : *global_stats) {
+			FieldIndex column_id(static_cast<idx_t>(row.GetValue<int64_t>(0)));
+			auto retyped_entry = retyped_fields.find(column_id);
+			if (retyped_entry == retyped_fields.end()) {
+				continue;
+			}
+			auto &retype = retyped_entry->second;
+			string new_min;
+			string new_max;
+			if (!row.IsNull(1)) {
+				new_min =
+				    TryRecastStatsBound(row.GetValue<string>(1), retype.source_type, retype.target_type, true, false);
+			}
+			if (!row.IsNull(2)) {
+				new_max =
+				    TryRecastStatsBound(row.GetValue<string>(2), retype.source_type, retype.target_type, false, false);
+			}
+			if (new_min.empty() && new_max.empty()) {
+				continue;
+			}
+			batch_query += DuckLakeMetadataManager::UpdateTableColumnStatsMinMaxSql(
+			    table_id, column_id, new_min.empty() ? string() : DuckLakeUtil::StatsToString(new_min),
+			    new_max.empty() ? string() : DuckLakeUtil::StatsToString(new_max));
+		}
+	}
+}
+
 static idx_t SubtractDroppedFileStat(idx_t value, idx_t decrement) {
 	if (decrement > value) {
 		throw InternalException("Dropped DuckLake file stats exceed current table stats");
@@ -1020,7 +1249,8 @@ bool DuckLakeTransactionState::ApplyDroppedFileStats(
 
 string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
     optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats, const DuckLakeCommitContext &context,
-    map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+    map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats, const DuckLakeRetypePlan &retype_plan,
+    set<TableIndex> &globals_written) {
 	if (attempt_dropped_file_stats.empty()) {
 		return string();
 	}
@@ -1063,6 +1293,11 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 			// the rows are deleted below - drop them from the update so we do not write values we then delete
 			new_globals.stats.column_stats.clear();
 		}
+		auto retype_entry = retype_plan.find(table_id);
+		if (retype_entry != retype_plan.end()) {
+			RecastColumnStatsMap(new_globals.stats.column_stats, retype_entry->second, false);
+			globals_written.insert(table_id);
+		}
 		result += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
 		    DuckLakeTransaction::ConvertNewGlobalStats(table_id, new_globals));
 		if (delete_column_stats) {
@@ -1072,9 +1307,11 @@ string DuckLakeTransactionState::UpdateStatsForDroppedFiles(
 	return result;
 }
 
-NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
-    string &batch_query, DuckLakeCommitState &commit_state, optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
-    const DuckLakeCommitContext &context, map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats) {
+NewDataInfo DuckLakeTransactionState::GetNewDataFiles(string &batch_query, DuckLakeCommitState &commit_state,
+                                                      optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
+                                                      const DuckLakeCommitContext &context,
+                                                      map<TableIndex, DroppedDataFileStats> &attempt_dropped_file_stats,
+                                                      const DuckLakeRetypePlan &retype_plan) {
 	NewDataInfo result;
 	// get the global table stats
 	DuckLakeNewGlobalStats new_globals;
@@ -1112,6 +1349,20 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 		}
 		bool clear_column_stats = ApplyDroppedFileStats(table_id, new_globals, attempt_dropped_file_stats);
 		auto &new_stats = new_globals.stats;
+		auto retype_entry = retype_plan.find(table_id);
+		// A column with no pre-commit bound takes its merged bound entirely from files this commit writes, and those
+		// carry their write-time type, so the correction can be exact. Once a committed bound is in the merge the
+		// provenance is only as good as the catalog's, which a promotion chain or a compaction can outdate.
+		set<FieldIndex> authoritative_fields;
+		if (retype_entry != retype_plan.end()) {
+			for (auto &field_entry : retype_entry->second) {
+				auto stats_entry = new_stats.column_stats.find(field_entry.first);
+				if (stats_entry == new_stats.column_stats.end() ||
+				    (!stats_entry->second.has_min && !stats_entry->second.has_max)) {
+					authoritative_fields.insert(field_entry.first);
+				}
+			}
+		}
 		vector<DuckLakeDeleteFile> delete_files;
 		for (auto &file : table_changes.new_data_files) {
 			// flushed files (with max_partial_file_snapshot) have embedded row_ids, we gotta use the original
@@ -1172,6 +1423,21 @@ NewDataInfo DuckLakeTransactionState::GetNewDataFiles(
 		if (clear_column_stats) {
 			// the rows are deleted below - drop them from the update so we do not write values we then delete
 			new_stats.column_stats.clear();
+		}
+		if (retype_entry != retype_plan.end()) {
+			// MergeStats invalidates min/max across a type change, so a surviving merged bound came from
+			// contributors of one type and correcting it once is equivalent to correcting each of them. Dropping it
+			// instead would be worse than leaving it stale: a NULL global is re-seeded from the next inserted file
+			// alone, excluding rows that are still there, and that prunes.
+			map<FieldIndex, DuckLakeRetypedColumn> exact_fields;
+			map<FieldIndex, DuckLakeRetypedColumn> widened_fields;
+			for (auto &field_entry : retype_entry->second) {
+				auto &target = authoritative_fields.count(field_entry.first) > 0 ? exact_fields : widened_fields;
+				target.insert(field_entry);
+			}
+			RecastColumnStatsMap(new_stats.column_stats, exact_fields, true);
+			RecastColumnStatsMap(new_stats.column_stats, widened_fields, false);
+			result.global_stats_written.insert(table_id);
 		}
 		// update the global stats for this table based on the newly written data
 		batch_query += DuckLakeMetadataManager::UpdateGlobalTableStatsSql(
@@ -1345,6 +1611,9 @@ void DuckLakeTransactionState::GetNewTableInfo(DuckLakeCommitState &commit_state
 			// drop the indicated column
 			// note that in case of nested types we might be dropping multiple columns here
 			HandleChangedFields(commit_state.GetTableId(table), table.GetChangedFields(), result, txn_added_fields);
+			if (local_change.type == LocalChangeType::CHANGE_COLUMN_TYPE) {
+				result.retyped_tables.insert(commit_state.GetTableId(table));
+			}
 			transaction_changes.altered_tables_with_schema_version_changes.insert(table_id);
 			column_schema_change = true;
 			break;
@@ -1628,6 +1897,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 	// write new tables
 	vector<DuckLakeTableInfo> new_tables_result;
 	vector<DuckLakeTableInfo> new_inlined_data_tables_result;
+	DuckLakeRetypePlan retype_plan;
 	if (!new_tables.empty()) {
 		auto result = GetNewTables(commit_state, transaction_changes);
 		vector<DuckLakePath> resolved_table_paths;
@@ -1667,6 +1937,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 		}
 		batch_queries += DuckLakeMetadataManager::WriteExpiredColumnTags(expired_column_tags);
 		batch_queries += DuckLakeMetadataManager::WriteNewColumns(result.new_columns);
+		retype_plan = BuildRetypePlan(result);
 		batch_queries += context.write_inlined_tables(commit_snapshot, result.new_inlined_data_tables);
 		batch_queries += DuckLakeMetadataManager::WriteNewSortKeys(existing_catalog.sorts, result.new_sort_keys);
 		new_tables_result = result.new_tables;
@@ -1684,9 +1955,17 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 		batch_queries += DuckLakeMetadataManager::WriteNewColumnMappings(result.new_column_mappings);
 	}
 
-	auto write_data_files_sql = [&](const vector<DuckLakeFileInfo> &files) {
+	auto write_data_files_sql = [&](vector<DuckLakeFileInfo> &files) {
 		if (files.empty()) {
 			return string();
+		}
+		// files staged before the retype carry old-type stats too, and they are inserted past the reach of the SQL
+		// rewrite in RecastCommittedStats
+		for (auto &file : files) {
+			auto retype_entry = retype_plan.find(file.table_id);
+			if (retype_entry != retype_plan.end()) {
+				RecastColumnStatsMap(file.column_stats, retype_entry->second, true);
+			}
 		}
 		if (context.try_append_data_files &&
 		    context.try_append_data_files(commit_snapshot, files, new_tables_result, new_schemas_result)) {
@@ -1706,11 +1985,18 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 
 	// write new data / data files
 	bool has_table_data_changes = local_changes.HasChanges();
+	set<TableIndex> globals_written_from_memory;
+	set<DataFileIndex> files_written_this_commit;
 	if (has_table_data_changes) {
-		auto result = GetNewDataFiles(batch_queries, commit_state, stats, context, attempt_dropped_file_stats);
+		auto result =
+		    GetNewDataFiles(batch_queries, commit_state, stats, context, attempt_dropped_file_stats, retype_plan);
 		batch_queries += write_data_files_sql(result.new_files);
 		batch_queries += context.write_inlined_data(commit_snapshot, result.new_inlined_data, new_tables_result,
 		                                            new_inlined_data_tables_result);
+		globals_written_from_memory = std::move(result.global_stats_written);
+		for (auto &file : result.new_files) {
+			files_written_this_commit.insert(file.id);
+		}
 	}
 
 	// in case of a retry, we generate the deletion of inlined data from the tables
@@ -1726,7 +2012,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			dropped_indexes.insert(entry.second);
 		}
 		batch_queries += DuckLakeMetadataManager::DropDataFiles(dropped_indexes);
-		batch_queries += UpdateStatsForDroppedFiles(stats, context, attempt_dropped_file_stats);
+		batch_queries += UpdateStatsForDroppedFiles(stats, context, attempt_dropped_file_stats, retype_plan,
+		                                            globals_written_from_memory);
 	}
 
 	if (has_table_data_changes) {
@@ -1791,6 +2078,12 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 				                                 compaction_rewrite_delete_changes, table_entry.second, context);
 			}
 		}
+	}
+
+	// last, so these UPDATEs land on top of every stats write above rather than under one
+	if (!retype_plan.empty()) {
+		RecastCommittedStats(batch_queries, commit_snapshot, retype_plan, globals_written_from_memory,
+		                     files_written_this_commit, context);
 	}
 
 	// Tracking for tables that had schema changes

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -193,6 +193,7 @@
         "test/sql/add_files/add_files_hive_partition_cast.test",
         "test/sql/add_files/add_files_nested_list_struct_nulls.test",
         "test/sql/alter/add_column_default_stats.test",
+        "test/sql/stats/alter_type_stats_recast_footprint.test",
         "test/sql/compaction/compaction_partitioned_non_adjacent.test",
         "test/sql/compaction/compaction_partitioned_table.test",
         "test/sql/compaction/merge_rewrite_partial_file_info.test",

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -48,6 +48,7 @@
         "test/sql/settings/max_retry_count.test",
         "test/sql/snapshot_info/ducklake_current_commit.test",
         "test/sql/snapshot_info/ducklake_last_commit.test",
+        "test/sql/stats/alter_type_stats_recast_concurrent.test",
         "test/sql/stats/global_stats_transactions.test",
         "test/sql/transaction/concurrent_table_creation.test",
         "test/sql/transaction/transaction_conflict_cleanup.test",

--- a/test/sql/stats/alter_type_stats_recast.test
+++ b/test/sql/stats/alter_type_stats_recast.test
@@ -1,0 +1,134 @@
+# name: test/sql/stats/alter_type_stats_recast.test
+# description: ALTER COLUMN TYPE must reinterpret persisted min/max through the source type (issue #1307)
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_stats', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+statement ok
+CREATE TABLE ducklake.t(c FLOAT);
+
+# 0.03 and 0.1 are the extremes and both widen "the wrong way":
+#   (FLOAT 0.03)::DOUBLE = 0.029999999329447746 < 0.03  -> a min recorded as "0.03" is too high
+#   (FLOAT 0.1)::DOUBLE  = 0.10000000149011612 > 0.1    -> a max recorded as "0.1"  is too low
+statement ok
+INSERT INTO ducklake.t VALUES (0.03), (0.05), (0.07), (0.1);
+
+# sanity: the data really is in a parquet file, not inlined
+query I
+SELECT count(*) FROM metadata.ducklake_data_file;
+----
+1
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats;
+----
+0.03	0.1
+
+statement ok
+ALTER TABLE ducklake.t ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+# the persisted strings are re-parsed as DOUBLE after the ALTER, so they must be rewritten to the
+# DOUBLE the stored FLOAT actually widens to
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats;
+----
+0.029999999329447746	0.10000000149011612
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_file_column_stats ORDER BY column_id;
+----
+1	0.029999999329447746	0.10000000149011612
+
+# pushdown returns 0 here whatever the persisted stats say, for a reason unrelated to #1307:
+# https://github.com/duckdb/duckdb/issues/24900, fixed in duckdb after the current pin
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+# WRONG RESULT before the fix: the row is above the recorded max 0.1, so the scan was pruned away
+query I
+SELECT count(*) FROM ducklake.t WHERE c > 0.1;
+----
+1
+
+# WRONG RESULT before the fix: the row is below the recorded min 0.03, so the scan was pruned away
+query I
+SELECT count(*) FROM ducklake.t WHERE c < 0.03;
+----
+1
+
+query I
+SELECT count(*) FROM ducklake.t;
+----
+4
+
+statement ok
+RESET disabled_optimizers;
+
+# unchanged columns keep their stats: a second column must not be touched by the ALTER
+statement ok
+CREATE TABLE ducklake.t2(a FLOAT, b FLOAT);
+
+statement ok
+INSERT INTO ducklake.t2 VALUES (0.03, 0.03), (0.1, 0.1);
+
+statement ok
+ALTER TABLE ducklake.t2 ALTER COLUMN a SET DATA TYPE DOUBLE;
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = 2 ORDER BY column_id;
+----
+1	0.029999999329447746	0.10000000149011612
+2	0.03	0.1
+
+# widenings that round-trip through the string exactly must not rewrite anything
+statement ok
+CREATE TABLE ducklake.t3(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.t3 VALUES (1), (2), (3);
+
+statement ok
+ALTER TABLE ducklake.t3 ALTER COLUMN c SET DATA TYPE BIGINT;
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = 3 ORDER BY column_id;
+----
+1	1	3
+
+# nested leaves under the altered column are rewritten too
+statement ok
+CREATE TABLE ducklake.t4(s STRUCT(f FLOAT));
+
+statement ok
+INSERT INTO ducklake.t4 VALUES ({'f': 0.03}), ({'f': 0.1});
+
+statement ok
+ALTER TABLE ducklake.t4 ALTER COLUMN s SET DATA TYPE STRUCT(f DOUBLE);
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = 4 ORDER BY column_id;
+----
+2	0.029999999329447746	0.10000000149011612
+
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = 4 ORDER BY column_id;
+----
+2	0.029999999329447746	0.10000000149011612
+
+# stats written after the ALTER stay consistent with the rewritten ones
+statement ok
+INSERT INTO ducklake.t VALUES (0.2);
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = 1;
+----
+0.029999999329447746	0.2

--- a/test/sql/stats/alter_type_stats_recast_concurrent.test
+++ b/test/sql/stats/alter_type_stats_recast_concurrent.test
@@ -1,0 +1,230 @@
+# name: test/sql/stats/alter_type_stats_recast_concurrent.test
+# description: the stats recast must survive a commit replay and a competing writer on the retyped column (issue #1307)
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_stats_concurrent', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+# without this a BEGIN does not pin a snapshot, so nothing below actually races.
+# the setting is per connection, so con1 needs it in its own right
+statement ok
+SET immediate_transaction_mode=true
+
+statement ok con1
+SET immediate_transaction_mode=true
+
+statement ok con2
+SET immediate_transaction_mode=true
+
+# -------------------------------------------------------
+# a retype whose commit loses a race replays CommitChanges, so the recast runs
+# twice; it must land on the same stats as the uncontended retype
+# -------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.serial(c FLOAT);
+
+statement ok
+CREATE TABLE ducklake.retried(c FLOAT);
+
+# unrelated table, so the competing commit advances the snapshot without conflicting
+statement ok
+CREATE TABLE ducklake.bystander(x INTEGER);
+
+statement ok
+INSERT INTO ducklake.serial VALUES (0.03), (0.05), (0.07), (0.1);
+
+statement ok
+INSERT INTO ducklake.retried VALUES (0.03), (0.05), (0.07), (0.1);
+
+statement ok
+ALTER TABLE ducklake.serial ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok con1
+BEGIN
+
+statement ok con1
+ALTER TABLE ducklake.retried ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok con2
+INSERT INTO ducklake.bystander VALUES (1);
+
+statement ok con1
+COMMIT
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retried');
+----
+0.029999999329447746	0.10000000149011612
+
+# byte-identical, not merely correct: a second recast pass that shifted a bound would agree
+# with neither
+query I
+SELECT (SELECT list(min_value || '|' || max_value) FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retried'))
+     = (SELECT list(min_value || '|' || max_value) FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'serial'));
+----
+true
+
+query I
+SELECT (SELECT list(min_value || '|' || max_value) FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retried'))
+     = (SELECT list(min_value || '|' || max_value) FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'serial'));
+----
+true
+
+# -------------------------------------------------------
+# a retype that also writes data in the same transaction: those files are staged
+# with the old-type stats and corrected in memory, in place, on the way into the
+# batch. that is the one recast that does not re-read the catalog, so a replay is
+# the only thing that would apply it twice
+# -------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.serial2(c FLOAT);
+
+statement ok
+CREATE TABLE ducklake.retried2(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.serial2 VALUES (0.03), (0.05);
+
+statement ok
+INSERT INTO ducklake.retried2 VALUES (0.03), (0.05);
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO ducklake.serial2 VALUES (0.07), (0.1);
+
+statement ok
+ALTER TABLE ducklake.serial2 ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT
+
+statement ok con1
+BEGIN
+
+statement ok con1
+INSERT INTO ducklake.retried2 VALUES (0.07), (0.1);
+
+statement ok con1
+ALTER TABLE ducklake.retried2 ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok con2
+INSERT INTO ducklake.bystander VALUES (2);
+
+statement ok con1
+COMMIT
+
+query I
+SELECT (SELECT list(min_value || '|' || max_value ORDER BY data_file_id) FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retried2'))
+     = (SELECT list(min_value || '|' || max_value ORDER BY data_file_id) FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'serial2'));
+----
+true
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retried2');
+----
+0.029999999329447746	0.10000000149011612
+
+# -------------------------------------------------------
+# competing writer on the retyped column itself: con2's file is written with
+# FLOAT-typed stats and commits first, so con1's retype must correct a file it
+# never saw when it started
+# -------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.contended(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.contended VALUES (0.03), (0.05);
+
+statement ok con1
+BEGIN
+
+statement ok con1
+ALTER TABLE ducklake.contended ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok con2
+INSERT INTO ducklake.contended VALUES (0.2);
+
+statement ok con1
+COMMIT
+
+query I
+SELECT count(*) FROM ducklake.contended;
+----
+3
+
+# two files: con1's, retyped from its own transaction, and con2's, which con1 had
+# never seen when it started. only the bounds that widen are rewritten - con2's
+# min stays the raw "0.2" because raising it to the DOUBLE that FLOAT 0.2 widens
+# to would narrow the range, and a narrowed bound prunes live rows
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'contended') ORDER BY data_file_id;
+----
+1	0.029999999329447746	0.05000000074505806
+1	0.2	0.20000000298023224
+
+# https://github.com/duckdb/duckdb/issues/24900 makes pushdown return 0 regardless of stats
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+# (FLOAT 0.2)::DOUBLE = 0.20000000298023224, so a max still persisted as "0.2"
+# prunes this row away
+query I
+SELECT count(*) FROM ducklake.contended WHERE c > 0.2;
+----
+1
+
+query I
+SELECT count(*) FROM ducklake.contended WHERE c < 0.03;
+----
+1
+
+statement ok
+RESET disabled_optimizers;
+
+# -------------------------------------------------------
+# two retypes of the same column must conflict rather than merge
+# -------------------------------------------------------
+
+statement ok
+CREATE TABLE ducklake.both(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.both VALUES (3), (10);
+
+statement ok con1
+BEGIN
+
+statement ok con2
+BEGIN
+
+statement ok con1
+ALTER TABLE ducklake.both ALTER COLUMN c SET DATA TYPE BIGINT;
+
+statement ok con2
+ALTER TABLE ducklake.both ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok con1
+COMMIT
+
+statement error con2
+COMMIT
+----
+Transaction conflict
+
+query I
+SELECT column_type FROM metadata.ducklake_column WHERE column_name = 'c' AND end_snapshot IS NULL AND table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'both');
+----
+int64

--- a/test/sql/stats/alter_type_stats_recast_footprint.test
+++ b/test/sql/stats/alter_type_stats_recast_footprint.test
@@ -1,0 +1,74 @@
+# name: test/sql/stats/alter_type_stats_recast_footprint.test
+# description: the #1307 recast must leave every stats row it did not correct byte-identical
+# group: [stats]
+
+# Separate file so the quack skip does not have to cover the rest of the regressions.
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_recast_footprint', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+# The recast writes catalog metadata in place, so it has to leave alone everything it did not
+# correct. Diffing the stats tables both ways round catches a neighbouring column losing a
+# tri-state contains_nan or an extra_stats payload, which asserting the retyped column's own bounds
+# never would.
+
+statement ok
+CREATE TABLE ducklake.footprint(x FLOAT, y FLOAT, z VARCHAR);
+
+statement ok
+INSERT INTO ducklake.footprint VALUES (0.1, 'NaN'::FLOAT, 'a'), (0.3, NULL, 'zz');
+
+# y carries contains_null and contains_nan, z carries string bounds and a NULL contains_nan, so the
+# untouched rows are not vacuous. CAST because a SQLite catalog stores the booleans as 0/1.
+query IIIII
+SELECT column_id, CAST(contains_null AS BOOLEAN), CAST(contains_nan AS BOOLEAN), min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint') ORDER BY column_id;
+----
+1	false	false	0.1	0.3
+2	true	true	NULL	NULL
+3	false	NULL	a	zz
+
+statement ok
+CREATE TEMP TABLE footprint_before_col AS SELECT * FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint');
+
+statement ok
+CREATE TEMP TABLE footprint_before_file AS SELECT * FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint');
+
+statement ok
+CREATE TEMP TABLE footprint_before_tbl AS SELECT * FROM metadata.ducklake_table_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint');
+
+statement ok
+ALTER TABLE ducklake.footprint ALTER COLUMN x SET DATA TYPE DOUBLE;
+
+query III
+SELECT column_id, min_value, max_value FROM (SELECT * FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint') EXCEPT ALL SELECT * FROM footprint_before_col) ORDER BY column_id;
+----
+1	0.1	0.30000001192092896
+
+query III
+SELECT column_id, min_value, max_value FROM (SELECT * FROM footprint_before_col EXCEPT ALL SELECT * FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint')) ORDER BY column_id;
+----
+1	0.1	0.3
+
+query III
+SELECT column_id, min_value, max_value FROM (SELECT * FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint') EXCEPT ALL SELECT * FROM footprint_before_file) ORDER BY column_id;
+----
+1	0.1	0.30000001192092896
+
+query III
+SELECT column_id, min_value, max_value FROM (SELECT * FROM footprint_before_file EXCEPT ALL SELECT * FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint')) ORDER BY column_id;
+----
+1	0.1	0.3
+
+# record_count, next_row_id and file_size_bytes are monotonic and are not the recast's to rewrite
+query I
+SELECT count(*) FROM ((SELECT * FROM metadata.ducklake_table_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint') EXCEPT ALL SELECT * FROM footprint_before_tbl) UNION ALL (SELECT * FROM footprint_before_tbl EXCEPT ALL SELECT * FROM metadata.ducklake_table_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'footprint')));
+----
+0

--- a/test/sql/stats/alter_type_stats_recast_regressions.test
+++ b/test/sql/stats/alter_type_stats_recast_regressions.test
@@ -1,0 +1,631 @@
+# name: test/sql/stats/alter_type_stats_recast_regressions.test
+# description: promotion chains, failed casts, and retype-plus-insert in one transaction, where a naive #1307 recast writes a bound that excludes live rows
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/alter_type_recast_regr', METADATA_CATALOG 'metadata', DATA_INLINING_ROW_LIMIT 0);
+
+# F1: a promotion chain leaves the catalog holding an intermediate type the parquet file never had.
+# A catalog-only retype never rewrites the file, so the reader casts the file's physical INTEGER
+# straight to DOUBLE. Casting the stored string through the catalog's FLOAT instead applies a
+# rounding step the data never underwent, and the recorded bound stops covering the row.
+# 16777217 is 2^24+1, the first integer FLOAT cannot represent.
+
+statement ok
+CREATE TABLE ducklake.chain(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.chain VALUES (16777217);
+
+statement ok
+ALTER TABLE ducklake.chain ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+ALTER TABLE ducklake.chain ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+# The file still holds the exact integer, so both bounds have to cover it. Each takes the wider of the
+# two candidate readings, which leaves the max on the string it already had.
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'chain');
+----
+16777216.0	16777217
+
+query I
+SELECT count(*) FROM ducklake.chain WHERE c = 16777217.0;
+----
+1
+
+# F1, time travel. Stats rows are rewritten in place and carry no snapshot range, so a wrong recast
+# also corrupts what a pre-ALTER snapshot prunes with. At this version the column is still INTEGER.
+query I
+SELECT count(*) FROM ducklake.chain AT (VERSION => 2) WHERE c = 16777217;
+----
+1
+
+# F2: DefaultTryCastAs with a null error pointer throws instead of returning false, so the guards
+# around it are unreachable and a stats string that will not parse aborts the whole commit. The
+# recast is best-effort by design: a stat it cannot interpret must be left alone, not fatal.
+
+statement ok
+CREATE TABLE ducklake.faraway(c DATE);
+
+statement ok
+INSERT INTO ducklake.faraway VALUES ('5000-01-01'::DATE);
+
+statement ok
+ALTER TABLE ducklake.faraway ALTER COLUMN c SET DATA TYPE TIMESTAMP_NS;
+
+query I
+SELECT column_type FROM metadata.ducklake_column WHERE column_name = 'c' AND end_snapshot IS NULL AND table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'faraway');
+----
+timestamp_ns
+
+# F3: a transaction that both writes and retypes. GetNewDataFiles emits its global-stats write after
+# the recast, overwriting it, and the new file's own per-file stats are never recast at all. This
+# shape is not a regression from the recast, it is #1307 surviving in the case a migration script is
+# most likely to use.
+
+statement ok
+CREATE TABLE ducklake.mixed(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.mixed VALUES (0.03), (0.1);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.mixed VALUES (0.2), (0.3);
+
+statement ok
+ALTER TABLE ducklake.mixed ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'mixed');
+----
+0.029999999329447746	0.30000001192092896
+
+# the file this same commit wrote was staged before the retype, so its stats are rendered under FLOAT
+# just like the committed file's
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'mixed') ORDER BY data_file_id;
+----
+0.029999999329447746	0.10000000149011612
+0.20000000298023224	0.30000001192092896
+
+# pushdown is wrong here whatever the persisted stats say, see alter_type_stats_recast.test
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query I
+SELECT count(*) FROM ducklake.mixed WHERE c > 0.3;
+----
+1
+
+statement ok
+RESET disabled_optimizers;
+
+# min/max come off the stats, so a stale bound reports a value no row holds
+query II
+SELECT min(c), max(c) FROM ducklake.mixed;
+----
+0.029999999329447746	0.30000001192092896
+
+# Compaction does write a new file, but under the sources' physical type rather than the catalog's
+# current one: the merged file here is still INT32 after the ALTER to FLOAT, and it inherits its
+# sources' begin_snapshot rather than taking the compaction's. So a merged file can carry a physical
+# type two catalog types stale, and it is only reachable at all by a per-file read that resolves files
+# by snapshot range.
+
+statement ok
+CREATE TABLE ducklake.compacted(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.compacted VALUES (16777217);
+
+statement ok
+INSERT INTO ducklake.compacted VALUES (16777219);
+
+statement ok
+ALTER TABLE ducklake.compacted ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+CALL ducklake_merge_adjacent_files('ducklake', 'compacted');
+
+# one live file, and its begin_snapshot predates the compaction that created it
+query II
+SELECT count(*), sum(CASE WHEN begin_snapshot < (SELECT max(snapshot_id) FROM metadata.ducklake_snapshot) THEN 1 ELSE 0 END) FROM metadata.ducklake_data_file WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'compacted') AND end_snapshot IS NULL;
+----
+1	1
+
+statement ok
+ALTER TABLE ducklake.compacted ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+# widened in both directions, because through FLOAT 16777217 rounds down and 16777219 rounds up
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'compacted') AND data_file_id IN (SELECT data_file_id FROM metadata.ducklake_data_file WHERE end_snapshot IS NULL);
+----
+16777216.0	16777220.0
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+# the INT32 the file still holds reads back exact, so both rows sit strictly inside that envelope
+query I
+SELECT count(*) FROM ducklake.compacted WHERE c BETWEEN 16777217.0 AND 16777219.0;
+----
+2
+
+statement ok
+RESET disabled_optimizers;
+
+# nothing under this table was written under the catalog's FLOAT type, the merged file included
+query I
+SELECT DISTINCT type FROM parquet_schema('{DATA_PATH}/alter_type_recast_regr/main/compacted/*.parquet') WHERE name = 'c';
+----
+INT32
+
+# One-sided rewrites. FLOAT 0.03 widens downwards and 0.6 upwards, so each table moves exactly one
+# bound and the UPDATE must leave the other column alone rather than writing it back as NULL.
+
+statement ok
+CREATE TABLE ducklake.min_only(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.min_only VALUES (0.03), (0.5);
+
+statement ok
+ALTER TABLE ducklake.min_only ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'min_only');
+----
+0.029999999329447746	0.5
+
+statement ok
+CREATE TABLE ducklake.max_only(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.max_only VALUES (0.5), (0.6);
+
+statement ok
+ALTER TABLE ducklake.max_only ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'max_only');
+----
+0.5	0.6000000238418579
+
+# NULL stats: an all-NULL column has no min/max to recast, and the ALTER must not invent one
+
+statement ok
+CREATE TABLE ducklake.all_null(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.all_null VALUES (NULL), (NULL);
+
+statement ok
+ALTER TABLE ducklake.all_null ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+query II
+SELECT min_value IS NULL, max_value IS NULL FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'all_null');
+----
+true	true
+
+query I
+SELECT count(*) FROM ducklake.all_null WHERE c IS NULL;
+----
+2
+
+# Multiple files, one ALTER: every file's stats are corrected, not just the first one read. Each file
+# holds a single value, so only the bound that has to move moves: 0.03 widens FLOAT->DOUBLE downwards
+# and rewrites the min, 0.1 and 0.2 widen upwards and rewrite the max.
+
+statement ok
+CREATE TABLE ducklake.many(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.many VALUES (0.03);
+
+statement ok
+INSERT INTO ducklake.many VALUES (0.1);
+
+statement ok
+INSERT INTO ducklake.many VALUES (0.2);
+
+statement ok
+ALTER TABLE ducklake.many ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'many') ORDER BY data_file_id;
+----
+0.029999999329447746	0.03
+0.1	0.10000000149011612
+0.2	0.20000000298023224
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query I
+SELECT count(*) FROM ducklake.many WHERE c > 0.2;
+----
+1
+
+query I
+SELECT count(*) FROM ducklake.many WHERE c < 0.03;
+----
+1
+
+statement ok
+RESET disabled_optimizers;
+
+# Retype plus data in one transaction, in both orders, with no bound to inherit from before the
+# commit. File stats are built with the field's type as of the write, so that type says which side of
+# the ALTER a staged file landed on: a file written before it needs correcting, one written after is
+# already exact and must be left alone. With no committed bound in the merge the write-time type is
+# the whole provenance, so the correction is exact in both directions rather than widened - a widened
+# bound covers, but a folded MIN or MAX off it reports a value no row holds. Both bounds are asserted
+# in both orders for that reason.
+
+statement ok
+CREATE TABLE ducklake.insert_then_retype(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.insert_then_retype VALUES (NULL);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.insert_then_retype VALUES (0.2);
+
+statement ok
+ALTER TABLE ducklake.insert_then_retype ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+# written as FLOAT, so both bounds move to what the row actually reads back as
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'insert_then_retype');
+----
+0.20000000298023224	0.20000000298023224
+
+query III
+SELECT min(c), max(c), count(*) FILTER (WHERE c > 0.2) FROM ducklake.insert_then_retype;
+----
+0.20000000298023224	0.20000000298023224	1
+
+# a later insert must not re-seed the global from its own file alone - the 0.2 row is still there
+statement ok
+INSERT INTO ducklake.insert_then_retype VALUES (100.0);
+
+query II
+SELECT min(c), count(*) FILTER (WHERE c < 50) FROM ducklake.insert_then_retype;
+----
+0.20000000298023224	1
+
+statement ok
+CREATE TABLE ducklake.retype_then_insert(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.retype_then_insert VALUES (NULL);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE ducklake.retype_then_insert ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+INSERT INTO ducklake.retype_then_insert VALUES (0.2);
+
+statement ok
+COMMIT;
+
+# written as DOUBLE, so 0.2 is already exact and must be left alone entirely
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'retype_then_insert');
+----
+0.2	0.2
+
+query III
+SELECT min(c), max(c), count(*) FILTER (WHERE c > 0.2) FROM ducklake.retype_then_insert;
+----
+0.2	0.2	0
+
+statement ok
+CREATE TABLE ducklake.retype_then_insert_empty(c FLOAT);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE ducklake.retype_then_insert_empty ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+INSERT INTO ducklake.retype_then_insert_empty VALUES (0.3);
+
+statement ok
+COMMIT;
+
+query II
+SELECT min(c), max(c) FROM ducklake.retype_then_insert_empty;
+----
+0.3	0.3
+
+# A committed bound in the merge means the catalog's source type is only a guess (a promotion chain
+# or a compaction can outdate it), so that correction stays widened rather than exact.
+
+statement ok
+CREATE TABLE ducklake.chain_plus_new(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.chain_plus_new VALUES (16777217);
+
+statement ok
+ALTER TABLE ducklake.chain_plus_new ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.chain_plus_new VALUES (5);
+
+statement ok
+ALTER TABLE ducklake.chain_plus_new ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+# the file still holds INT32 16777217, and the widened max keeps covering it
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query II
+SELECT count(*) FILTER (WHERE c = 16777217.0), count(*) FROM ducklake.chain_plus_new;
+----
+1	2
+
+statement ok
+RESET disabled_optimizers;
+
+# Committed data plus a post-ALTER insert in one transaction. The committed file is corrected by the
+# SQL pass while the new file keeps its exact bound; the merged global goes unknown because the two
+# renderings cannot be compared, which is pre-existing MergeStats behaviour and falls back to a scan.
+
+statement ok
+CREATE TABLE ducklake.committed_plus_new(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.committed_plus_new VALUES (0.03), (0.1);
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE ducklake.committed_plus_new ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+INSERT INTO ducklake.committed_plus_new VALUES (0.5);
+
+statement ok
+COMMIT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'committed_plus_new') ORDER BY data_file_id;
+----
+0.029999999329447746	0.10000000149011612
+0.5	0.5
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query III
+SELECT count(*) FILTER (WHERE c < 0.03), count(*) FILTER (WHERE c > 0.1), count(*) FROM ducklake.committed_plus_new;
+----
+1	2	3
+
+query I
+SELECT min(c) FROM ducklake.committed_plus_new;
+----
+0.029999999329447746
+
+statement ok
+RESET disabled_optimizers;
+
+# The table is created in the same transaction as the ALTER, so there is no committed schema row to read
+# the pre-ALTER type from. The type is carried on the change info instead (GH #1307).
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE ducklake.created_and_retyped(c FLOAT);
+
+statement ok
+INSERT INTO ducklake.created_and_retyped VALUES (0.03), (0.05), (0.07), (0.1);
+
+statement ok
+ALTER TABLE ducklake.created_and_retyped ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'created_and_retyped');
+----
+0.029999999329447746	0.10000000149011612
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query III
+SELECT count(*) FILTER (WHERE c > 0.1), count(*) FILTER (WHERE c < 0.03), count(*) FROM ducklake.created_and_retyped;
+----
+1	1	4
+
+statement ok
+RESET disabled_optimizers;
+
+# An exact-source promotion is skipped entirely, so it stays a metadata-only operation. Nothing to correct:
+# an integer renders the same text under either type.
+
+statement ok
+CREATE TABLE ducklake.exact_promotion(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.exact_promotion VALUES (1), (16777217);
+
+statement ok
+ALTER TABLE ducklake.exact_promotion ALTER COLUMN c SET DATA TYPE BIGINT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'exact_promotion');
+----
+1	16777217
+
+query I
+SELECT count(*) FROM ducklake.exact_promotion WHERE c = 16777217;
+----
+1
+
+# Two retypes in one transaction, with no committed bound. The plan collapses to the last ALTER, so
+# its source is FLOAT, an intermediate the file never held. The correction has to cast through the
+# file's own write-time type instead, or the recorded max drops below the INT32 the file still holds.
+#
+# This also pins the Appender interaction: write_data_files_sql inserts new file rows eagerly, so they
+# are visible to the SQL pass that runs later in the commit. That pass must skip them, or it re-applies
+# the widened correction over the exact one and puts the intermediate rounding back.
+
+statement ok
+CREATE TABLE ducklake.chain_one_txn(c INTEGER);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO ducklake.chain_one_txn VALUES (16777217);
+
+statement ok
+ALTER TABLE ducklake.chain_one_txn ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+ALTER TABLE ducklake.chain_one_txn ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'chain_one_txn');
+----
+16777217	16777217
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'chain_one_txn');
+----
+16777217	16777217
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query III
+SELECT min(c), max(c), count(*) FILTER (WHERE c = 16777217.0) FROM ducklake.chain_one_txn;
+----
+16777217.0	16777217.0	1
+
+statement ok
+RESET disabled_optimizers;
+
+# and the same chain with the CREATE inside the transaction too
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE TABLE ducklake.chain_one_txn_create(c INTEGER);
+
+statement ok
+INSERT INTO ducklake.chain_one_txn_create VALUES (16777217);
+
+statement ok
+ALTER TABLE ducklake.chain_one_txn_create ALTER COLUMN c SET DATA TYPE FLOAT;
+
+statement ok
+ALTER TABLE ducklake.chain_one_txn_create ALTER COLUMN c SET DATA TYPE DOUBLE;
+
+statement ok
+COMMIT;
+
+query II
+SELECT min_value, max_value FROM metadata.ducklake_table_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'chain_one_txn_create');
+----
+16777217	16777217
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query III
+SELECT min(c), max(c), count(*) FILTER (WHERE c = 16777217.0) FROM ducklake.chain_one_txn_create;
+----
+16777217.0	16777217.0	1
+
+statement ok
+RESET disabled_optimizers;
+
+
+# A file written before ADD COLUMN has no stats row for the new column at all, so the recast's
+# per-file read never returns it. Nothing to correct there is the right answer, but the column filter
+# is what makes the row disappear, so the skip is worth pinning: the reader still has to see the
+# pre-ADD file's rows as NULL and the retyped bound still has to widen on the file that does have one.
+
+statement ok
+CREATE TABLE ducklake.added_then_retyped(a FLOAT);
+
+statement ok
+INSERT INTO ducklake.added_then_retyped VALUES (0.1);
+
+statement ok
+ALTER TABLE ducklake.added_then_retyped ADD COLUMN b FLOAT;
+
+statement ok
+INSERT INTO ducklake.added_then_retyped VALUES (0.2, 0.3);
+
+query II
+SELECT column_id, count(*) FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'added_then_retyped') GROUP BY column_id ORDER BY column_id;
+----
+1	2
+2	1
+
+statement ok
+ALTER TABLE ducklake.added_then_retyped ALTER COLUMN b SET DATA TYPE DOUBLE;
+
+# only the one file that carries a bound for b is corrected, and column a is untouched
+query III
+SELECT column_id, min_value, max_value FROM metadata.ducklake_file_column_stats WHERE table_id = (SELECT table_id FROM metadata.ducklake_table WHERE table_name = 'added_then_retyped') ORDER BY column_id, min_value;
+----
+1	0.1	0.1
+1	0.2	0.2
+2	0.3	0.30000001192092896
+
+statement ok
+SET disabled_optimizers='filter_pushdown';
+
+query III
+SELECT count(*), count(*) FILTER (WHERE b > 0.3), count(*) FILTER (WHERE b IS NULL) FROM ducklake.added_then_retyped;
+----
+2	1	1
+
+statement ok
+RESET disabled_optimizers;


### PR DESCRIPTION
Closes #1307

Column min/max are persisted as strings written under the column's type, so a catalog-only `ALTER COLUMN c TYPE DOUBLE` on a FLOAT column reinterprets them under the new type on reload. `"0.1"` reparsed as DOUBLE is `0.1`, while the real FLOAT `0.1` widened is `0.10000000149011612`. The recorded bound stops covering the data and the zone map prunes live rows, so queries return wrong results with no error.

The bound is taken conservatively, as the wider of two candidate readings, rather than the value cast through the source type, because which type the data is physically stored as cannot be recovered from the catalog: a promotion chain leaves intermediate types no file ever had, compaction carries the sources' physical type forward, and time travel reads the same rows back under an older type. Widening can only over-cover, never prune. The cast also runs in C++ rather than in SQL, because a SQL cast would be a silent no-op on SQLite, which maps FLOAT and DOUBLE both to VARCHAR.

Cost: this makes a retyping ALTER O(number of files) where it was O(1), measured at 1.4s for 2000 files on a FLOAT to DOUBLE change. Only approximate source types can produce a rewrite at all, so every integer, decimal and temporal widening is skipped entirely and stays O(1).

A transaction that both retypes and inserts can stage its file on either side of the ALTER, and only one of those needs correcting. File stats are built with the field's type as of the write, so that type is the provenance: a file staged before the ALTER is corrected, one staged after is already exact and is left alone. Where that type is trustworthy the correction is exact rather than widened, which matters because MIN and MAX are answered from these bounds when no row has been deleted, and a widened bound would make them report a value no row holds.

`alter_type_stats_recast.test` fails on main both on the persisted `min_value` and on a wrong-result probe that returns 0 rows where 1 qualifies. The correction also has to survive a commit that loses a race and replays its batch, and a writer that lands a file underneath it; `alter_type_stats_recast_concurrent.test` covers both and is red on main on the same wrong-result probe. The probes run with `filter_pushdown` disabled for an unrelated reason: pushdown narrows the constant to the file's physical type and drops the boundary row whatever the stats say. That is duckdb/duckdb#24900, fixed by duckdb/duckdb#24901, which is not yet in the pinned DuckDB.