### PR TITLE
Retry SQLite catalog commits when the database is locked

### DIFF
--- a/src/include/storage/ducklake_transaction.hpp
+++ b/src/include/storage/ducklake_transaction.hpp
@@ -186,7 +186,7 @@ public:
 	virtual void Commit();
 	virtual void Rollback();
 
-	//! Returns true if `message` indicates a retryable conflict (PK/unique/conflict/concurrent).
+	//! Returns true if `message` indicates a retryable conflict.
 	static bool RetryOnError(const string &message);
 
 	DuckLakeCatalog &GetCatalog() {

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -30,6 +30,10 @@ struct DuckLakeCommitContext {
 	std::function<DuckLakeSnapshot()> get_snapshot;
 	//! Executes the batched snapshot/changes SQL against the metadata DB.
 	std::function<unique_ptr<QueryResult>(DuckLakeSnapshot, string &)> execute_commit_batch;
+	//! Classifies metadata-catalog errors that are safe to retry.
+	std::function<bool(const string &)> is_retryable_metadata_error = [](const string &) {
+		return false;
+	};
 	//! Optional hooks below default to a no-op/constant; callers override only the ones they need.
 	//! Clears the metadata manager cache if a clear was pending.
 	std::function<void()> flush_cache_if_pending = []() {
@@ -100,6 +104,9 @@ struct DuckLakeCommitContext {
 	std::function<void(idx_t)> set_committed_snapshot_id;
 	//! Invalidates the cached stats entry for a table after a stats-affecting file drop.
 	std::function<void(idx_t, TableIndex)> invalidate_table_stats_cache = [](idx_t, TableIndex) {
+	};
+	//! Reports a failure after the metadata commit is already durable.
+	std::function<void(const string &)> report_post_commit_error = [](const string &) {
 	};
 	//! Author / message / extra info for the snapshot row.
 	DuckLakeSnapshotCommit commit_info;

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1362,6 +1362,10 @@ bool DuckLakeTransaction::RetryOnError(const string &original_message) {
 	if (StringUtil::Contains(message, "concurrent")) {
 		return true;
 	}
+	// SQLite can skip its busy handler when waiting would deadlock.
+	if (StringUtil::Contains(message, "database is locked")) {
+		return true;
+	}
 	return false;
 }
 

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1362,10 +1362,6 @@ bool DuckLakeTransaction::RetryOnError(const string &original_message) {
 	if (StringUtil::Contains(message, "concurrent")) {
 		return true;
 	}
-	// SQLite can skip its busy handler when waiting would deadlock.
-	if (StringUtil::Contains(message, "database is locked")) {
-		return true;
-	}
 	return false;
 }
 
@@ -1448,6 +1444,16 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.execute_commit_batch = [&](DuckLakeSnapshot snapshot, string &query) {
 		return metadata_manager->Execute(snapshot, query);
+	};
+	context.is_retryable_metadata_error = [&](const string &message) {
+		auto &metadata_type = ducklake_catalog.MetadataType();
+		if (metadata_type != "sqlite" && metadata_type != "sqlite_scanner") {
+			return false;
+		}
+		auto lower_message = StringUtil::Lower(message);
+		StringUtil::Trim(lower_message);
+		return StringUtil::EndsWith(lower_message, "database is locked") &&
+		       !StringUtil::Contains(lower_message, "failed to execute query \"commit\": database is locked");
 	};
 	context.flush_cache_if_pending = [&]() {
 		if (metadata_manager->TakePendingCacheClear()) {
@@ -1554,6 +1560,9 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	};
 	context.invalidate_table_stats_cache = [&](idx_t next_file_id, TableIndex table_id) {
 		ducklake_catalog.InvalidateTableStatsCache(next_file_id, table_id);
+	};
+	context.report_post_commit_error = [&](const string &message) {
+		DUCKDB_LOG_WARNING(db, StringUtil::Format("DuckLake post-commit cleanup failed: %s", message));
 	};
 	context.commit_info = state->commit_info;
 	context.supports_v1_1_metadata = ducklake_catalog.SupportsV1_1Metadata();

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1921,8 +1921,10 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 	SnapshotAndStats commit_stats_snapshot;
 	auto &commit_snapshot = commit_stats_snapshot.snapshot;
 	optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats;
+	bool flushed_inlined = false;
 	for (idx_t i = 0; i < retry_config.max_retry_count + 1; i++) {
 		bool can_retry;
+		bool retryable_metadata_error = false;
 		auto attempt_changes = transaction_changes;
 		auto attempt_dropped_file_stats = dropped_file_stats;
 		try {
@@ -1949,34 +1951,24 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			batch_queries += WriteSnapshotChanges(commit_state, attempt_changes, context.commit_info);
 			auto res = context.execute_commit_batch(commit_snapshot, batch_queries);
 			if (res->HasError()) {
-				res->GetErrorObject().Throw("Failed to flush changes into DuckLake: ");
+				auto &commit_error = res->GetErrorObject();
+				retryable_metadata_error = context.is_retryable_metadata_error(commit_error.RawMessage());
+				commit_error.Throw("Failed to flush changes into DuckLake: ");
 			}
-			bool flushed_inlined = !flushed_inlined_tables.empty();
+			flushed_inlined = !flushed_inlined_tables.empty();
 			context.flush_cache_if_pending();
 			context.commit_connection();
-			for (auto &entry : dropped_file_stats) {
-				context.invalidate_table_stats_cache(commit_snapshot.next_file_id, entry.first);
-			}
-			if (flushed_inlined && !context.skip_drop_empty_inlined) {
-				DropEmptySupersededInlinedTables(context);
-			}
-			context.set_catalog_version(commit_snapshot.schema_version);
-			if (SchemaChangesMade()) {
-				// No-op if the previous schema version doesn't exist in cache.
-				context.invalidate_schema_cache(commit_snapshot.schema_version - 1);
-			}
-
-			// finished writing
 			break;
 		} catch (std::exception &ex) {
 			ErrorData error(ex);
 			// rollback if there is an active transaction
 			context.try_rollback();
-			bool retry_on_error = DuckLakeTransaction::RetryOnError(error.Message());
+			retryable_metadata_error = retryable_metadata_error || context.is_retryable_metadata_error(error.Message());
+			bool retry_on_error = retryable_metadata_error || DuckLakeTransaction::RetryOnError(error.Message());
 			// We perform one initial attempt plus up to max_retry_count retries. Since i is the
 			// zero-based attempt index, we are done retrying once i reaches max_retry_count.
 			bool finished_retrying = i >= retry_config.max_retry_count;
-			if (!can_retry || !retry_on_error || finished_retrying) {
+			if ((!can_retry && !retryable_metadata_error) || !retry_on_error || finished_retrying) {
 				// we abort after the max retry count
 				CleanupFiles();
 				// Add additional information on the number of retries and suggest to increase it
@@ -2007,6 +1999,21 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 	}
 	// If we got here, this snapshot was successful
 	context.set_committed_snapshot_id(commit_snapshot.snapshot_id);
+	try {
+		for (auto &entry : dropped_file_stats) {
+			context.invalidate_table_stats_cache(commit_snapshot.next_file_id, entry.first);
+		}
+		if (flushed_inlined && !context.skip_drop_empty_inlined) {
+			DropEmptySupersededInlinedTables(context);
+		}
+		context.set_catalog_version(commit_snapshot.schema_version);
+		if (SchemaChangesMade()) {
+			// No-op if the previous schema version doesn't exist in cache.
+			context.invalidate_schema_cache(commit_snapshot.schema_version - 1);
+		}
+	} catch (std::exception &ex) {
+		context.report_post_commit_error(ErrorData(ex).Message());
+	}
 }
 
 } // namespace duckdb

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1968,7 +1968,16 @@ void DuckLakeTransactionState::Commit(DuckLakeSnapshot transaction_snapshot,
 			// We perform one initial attempt plus up to max_retry_count retries. Since i is the
 			// zero-based attempt index, we are done retrying once i reaches max_retry_count.
 			bool finished_retrying = i >= retry_config.max_retry_count;
-			if ((!can_retry && !retryable_metadata_error) || !retry_on_error || finished_retrying) {
+			bool should_abort = finished_retrying;
+			if (!retry_on_error) {
+				should_abort = true;
+			}
+			if (!can_retry) {
+				if (!retryable_metadata_error) {
+					should_abort = true;
+				}
+			}
+			if (should_abort) {
 				// we abort after the max retry count
 				CleanupFiles();
 				// Add additional information on the number of retries and suggest to increase it

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -38,27 +38,6 @@
       ]
     },
     {
-      "reason": "Failed to execute query COMMIT: database is locked",
-      "paths": [
-        "test/sql/compaction/compaction_delete_conflict.test",
-        "test/sql/concurrent/concurrent_insert_conflict.test",
-        "test/sql/concurrent/concurrent_insert_data_inlining.test",
-        "test/sql/rewrite_data_files/test_rewrite_concurrency.test",
-        "test/sql/rewrite_data_files/test_rewrite_transaction_conflict.test",
-        "test/sql/settings/max_retry_count.test",
-        "test/sql/snapshot_info/ducklake_current_commit.test",
-        "test/sql/snapshot_info/ducklake_last_commit.test",
-        "test/sql/stats/global_stats_transactions.test",
-        "test/sql/transaction/concurrent_table_creation.test",
-        "test/sql/transaction/transaction_conflict_cleanup.test",
-        "test/sql/transaction/transaction_conflicts.test",
-        "test/sql/transaction/transaction_conflicts_delete.test",
-        "test/sql/transaction/transaction_conflicts_view.test",
-        "test/sql/concurrent/file_level_conflict.test",
-        "test/sql/transaction/transaction_conflict_inlining.test"
-      ]
-    },
-    {
       "reason": "Require DATA_PATH",
       "paths": [
         "test/sql/general/default_path.test",

--- a/test/sql/issues/issue_1309.test
+++ b/test/sql/issues/issue_1309.test
@@ -1,0 +1,102 @@
+# name: test/sql/issues/issue_1309.test
+# description: Retry SQLite catalog locks without repeating the DuckLake write
+# group: [issues]
+
+require ducklake
+
+require parquet
+
+require sqlite_scanner
+
+test-env CATALOG_PATH {TEST_DIR}/{UUID}.sqlite
+
+test-env DATA_PATH {TEST_DIR}/issue_1309_data
+
+statement ok
+ATTACH 'ducklake:sqlite:{CATALOG_PATH}' AS lake (
+    DATA_PATH '{DATA_PATH}',
+    METADATA_CATALOG 'meta',
+    META_BUSY_TIMEOUT 10000
+)
+
+statement ok
+CREATE TABLE lake.items(id INTEGER)
+
+statement ok
+CREATE TABLE meta.application_lease(id INTEGER PRIMARY KEY, value INTEGER)
+
+statement ok
+INSERT INTO meta.application_lease VALUES (1, 0)
+
+statement ok
+SET ducklake_max_retry_count=100
+
+statement ok
+SET ducklake_retry_wait_ms=50
+
+statement ok
+SET ducklake_retry_backoff=1.0
+
+concurrentloop threadid 0 2
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(1000)
+
+onlyif threadid=0
+statement ok
+BEGIN
+
+onlyif threadid=0
+statement ok
+INSERT INTO lake.items VALUES (42)
+
+onlyif threadid=0
+statement ok
+SELECT sleep_ms(2000)
+
+onlyif threadid=1
+statement ok
+BEGIN
+
+onlyif threadid=1
+statement ok
+UPDATE meta.application_lease SET value=value+1 WHERE id=1
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(3000)
+
+onlyif threadid=0
+statement ok
+COMMIT
+
+onlyif threadid=1
+statement ok
+COMMIT
+
+endloop
+
+query I
+SELECT count(*) FROM lake.items
+----
+1
+
+query I
+SELECT value FROM meta.application_lease
+----
+1
+
+statement ok
+SET ducklake_max_retry_count=2
+
+statement ok
+SET ducklake_retry_wait_ms=1
+
+statement ok
+DROP TABLE meta.ducklake_snapshot_changes
+
+statement error
+INSERT INTO lake.items VALUES (126)
+----
+<REGEX>:.*Failed to commit DuckLake transaction\.\nFailed to flush changes into DuckLake: Table with name ducklake_snapshot_changes does not exist!.*

--- a/test/sql/issues/issue_1309.test
+++ b/test/sql/issues/issue_1309.test
@@ -29,6 +29,61 @@ statement ok
 INSERT INTO meta.application_lease VALUES (1, 0)
 
 statement ok
+SET ducklake_max_retry_count=0
+
+concurrentloop threadid 0 2
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(1000)
+
+onlyif threadid=0
+statement ok
+BEGIN
+
+onlyif threadid=0
+statement ok
+INSERT INTO lake.items VALUES (84)
+
+onlyif threadid=0
+statement ok
+SELECT sleep_ms(2000)
+
+onlyif threadid=1
+statement ok
+BEGIN
+
+onlyif threadid=1
+statement ok
+UPDATE meta.application_lease SET value=value+1 WHERE id=1
+
+onlyif threadid=1
+statement ok
+SELECT sleep_ms(3000)
+
+onlyif threadid=0
+statement error
+COMMIT
+----
+<REGEX>:.*Exceeded the maximum retry count of 0 set by the ducklake_max_retry_count setting\.\n\. Consider increasing the value with: e\.g\., "SET ducklake_max_retry_count = 0;"\nFailed to flush changes into DuckLake: database is locked.*
+
+onlyif threadid=1
+statement ok
+COMMIT
+
+endloop
+
+query I
+SELECT count(*) FROM lake.items
+----
+0
+
+query I
+SELECT value FROM meta.application_lease
+----
+1
+
+statement ok
 SET ducklake_max_retry_count=100
 
 statement ok
@@ -85,7 +140,7 @@ SELECT count(*) FROM lake.items
 query I
 SELECT value FROM meta.application_lease
 ----
-1
+2
 
 statement ok
 SET ducklake_max_retry_count=2


### PR DESCRIPTION
A DuckLake write using a SQLite catalog can fail during `COMMIT` with `database is locked`, even with a long SQLite busy timeout and DuckLake retries enabled. This happens when the transaction has read the catalog and another connection becomes the pending writer before the DuckLake commit upgrades to a write lock.

SQLite can skip its busy handler for this read-to-write deadlock. The bounded commit loop now retries SQLite metadata-lock errors only while rollback is safe, excludes failed `COMMIT` wrappers, and keeps post-commit cleanup outside the retry scope. The retry predicate uses simple branches because Emscripten 3.1.71 crashes while optimizing the equivalent compound expression.

Fixes https://github.com/duckdb/ducklake/issues/1309

## Testing

The regression uses two real DuckDB connections against one SQLite catalog. A zero-retry control requires the exact lock error, then the retry path commits the staged row once. An unrelated metadata error remains non-retryable.

<details>
<summary>Raw before/after output</summary>

```console
$ SOURCE=src/storage/ducklake_transaction.cpp
$ TEST=test/sql/issues/issue_1309.test
$ TESTER=build/release/test/unittest
$ RUNNER=duckdb/scripts/ci/run_tests.py
$ git checkout origin/main -- "$SOURCE"
$ cmake --build build/release --config Release -j8
$ "$TESTER" "$TEST"
Query unexpectedly failed! (test/sql/issues/issue_1309.test:71)!
COMMIT;
TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
Failed to flush changes into DuckLake: database is locked
test cases: 1 | 0 passed | 1 failed

$ git checkout HEAD -- "$SOURCE"
$ cmake --build build/release --config Release -j8
$ "$TESTER" "$TEST"
All tests passed (34 assertions in 1 test case)

$ python "$RUNNER" --stabilize-tests --workers 1 --batch-size 1 "$TESTER" "$TEST"
stabilization rerun 9/9 for fast tests
all tests passed in 9s

$ "$TESTER" --test-config test/configs/sqlite.json --test-dir ./ "$TEST"
All tests passed (34 assertions in 1 test case)

$ make wasm_eh  # Emscripten 3.1.71, before the predicate rewrite
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/
Running pass "instcombine<max-iterations=1;no-verify-fixpoint>" on function "DuckLakeTransactionState::Commit"
clang++: error: clang frontend command failed with exit code 139

$ make wasm_eh  # after the predicate rewrite
[ 69%] Built target ducklake_storage
[100%] Built target duckdb_local_extension_repo
```

</details>

The regular DuckLake suite also passes.
