### PR TITLE
Inline table cleanup sqlite

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -347,6 +347,7 @@ public:
 	DuckLakeInlinedColNames InlinedColNames() const;
 	static string InlinedTableRegistrationTuple(idx_t table_id, const string &table_name, idx_t schema_version);
 	static string LatestInlinedTableQuery(idx_t table_id);
+	static string InlinedDataTableCleanupTargetsSql(bool superseded_only);
 	static string DropDataFiles(const set<DataFileIndex> &dropped_files);
 	static string DropDeleteFiles(const set<DataFileIndex> &dropped_files);
 	//! Caller supplies one resolved path per overwritten file, in the same order.
@@ -416,6 +417,9 @@ public:
 
 	virtual vector<DuckLakeSnapshotInfo> GetAllSnapshots(const string &filter = string());
 	virtual void DeleteSnapshots(const vector<DuckLakeSnapshotInfo> &snapshots);
+	//! After snapshots are expired, empty inlined-data tables can be dropped even if they are the latest
+	//! schema_version for their table.
+	virtual void DropEmptyInlinedTables();
 	//! After a flush has emptied inlined-data rows, drop any (tid, sv) physical
 	//! table that is superseded by a newer schema_version on the same table_id
 	//! and is now empty. No more writes can land in such an entry, so the drop
@@ -541,6 +545,7 @@ private:
 	virtual string GenerateConstantFilterDouble(ExpressionType comparison_type, const Value &constant,
 	                                            const LogicalType &type, unordered_set<string> &referenced_stats);
 	virtual string GenerateFilterPushdown(const ExpressionFilter &filter, unordered_set<string> &referenced_stats);
+	void DropEmptyInlinedTablesInternal(bool superseded_only);
 
 public:
 	//! Read inlined file deletions for regular table scans (no snapshot info per row)

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -5637,8 +5637,8 @@ void DuckLakeMetadataManager::DropEmptyInlinedTablesInternal(bool superseded_onl
 	// Only drop tables that are actually empty (data was flushed to files).
 	string drops;
 	for (auto &candidate : candidates) {
-		auto count_result =
-		    Query(StringUtil::Format("SELECT COUNT(*) FROM {METADATA_CATALOG}.%s", SQLIdentifier(candidate.table_name)));
+		auto count_result = Query(
+		    StringUtil::Format("SELECT COUNT(*) FROM {METADATA_CATALOG}.%s", SQLIdentifier(candidate.table_name)));
 		if (count_result->HasError()) {
 			count_result->GetErrorObject().Throw("Failed to check emptiness of inlined-data table in DuckLake: ");
 		}

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2842,6 +2842,22 @@ string DuckLakeMetadataManager::LatestInlinedTableQuery(idx_t table_id) {
 	    table_id, table_id);
 }
 
+string DuckLakeMetadataManager::InlinedDataTableCleanupTargetsSql(bool superseded_only) {
+	string sql = R"(
+SELECT idt.table_id, idt.schema_version, idt.table_name
+FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt)";
+	if (superseded_only) {
+		sql += R"(
+WHERE idt.schema_version < (
+    SELECT MAX(idt2.schema_version)
+    FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt2
+    WHERE idt2.table_id = idt.table_id
+))";
+	}
+	sql += ";";
+	return sql;
+}
+
 string DuckLakeMetadataManager::GetInlinedTableQuery(const DuckLakeTableInfo &table, const string &table_name) {
 	string column_defs;
 	for (auto &col : table.columns) {
@@ -5594,6 +5610,8 @@ WHERE NOT EXISTS (
 		}
 	}
 
+	DropEmptyInlinedTables();
+
 	for (auto &snapshot : snapshots) {
 		for (auto &table_id : stats_table_ids) {
 			catalog.InvalidateTableStatsCache(snapshot.next_file_id, table_id);
@@ -5601,30 +5619,28 @@ WHERE NOT EXISTS (
 	}
 }
 
-void DuckLakeMetadataManager::DropEmptySupersededInlinedTables() {
-	// Find inlined tables that have been superseded by a newer schema version.
-	auto targets = Query(R"(
-SELECT idt.table_id, idt.schema_version, idt.table_name
-FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt
-WHERE idt.schema_version < (
-    SELECT MAX(idt2.schema_version)
-    FROM {METADATA_CATALOG}.ducklake_inlined_data_tables idt2
-    WHERE idt2.table_id = idt.table_id
-);)");
+void DuckLakeMetadataManager::DropEmptyInlinedTablesInternal(bool superseded_only) {
+	auto targets = Query(InlinedDataTableCleanupTargetsSql(superseded_only));
 	if (targets->HasError()) {
-		targets->GetErrorObject().Throw("Failed to identify superseded inlined-data tables in DuckLake: ");
+		targets->GetErrorObject().Throw("Failed to identify empty inlined-data tables in DuckLake: ");
 	}
+	struct InlinedTableCleanupTarget {
+		idx_t table_id;
+		idx_t schema_version;
+		string table_name;
+	};
+	vector<InlinedTableCleanupTarget> candidates;
+	for (auto &row : *targets) {
+		candidates.push_back({row.GetValue<idx_t>(0), row.GetValue<idx_t>(1), row.GetValue<string>(2)});
+	}
+
 	// Only drop tables that are actually empty (data was flushed to files).
 	string drops;
-	for (auto &row : *targets) {
-		auto table_id = row.GetValue<idx_t>(0);
-		auto schema_version = row.GetValue<idx_t>(1);
-		auto table_name = row.GetValue<string>(2);
+	for (auto &candidate : candidates) {
 		auto count_result =
-		    Query(StringUtil::Format("SELECT COUNT(*) FROM {METADATA_CATALOG}.%s", SQLIdentifier(table_name)));
+		    Query(StringUtil::Format("SELECT COUNT(*) FROM {METADATA_CATALOG}.%s", SQLIdentifier(candidate.table_name)));
 		if (count_result->HasError()) {
-			count_result->GetErrorObject().Throw(
-			    "Failed to check emptiness of superseded inlined-data table in DuckLake: ");
+			count_result->GetErrorObject().Throw("Failed to check emptiness of inlined-data table in DuckLake: ");
 		}
 		if ((*count_result->begin()).GetValue<idx_t>(0) != 0) {
 			continue;
@@ -5632,14 +5648,14 @@ WHERE idt.schema_version < (
 		drops += StringUtil::Format(
 		    "DELETE FROM {METADATA_CATALOG}.ducklake_inlined_data_tables WHERE table_id=%d AND schema_version=%d;"
 		    "DROP TABLE IF EXISTS {METADATA_CATALOG}.%s;",
-		    table_id, schema_version, SQLIdentifier(table_name));
+		    candidate.table_id, candidate.schema_version, SQLIdentifier(candidate.table_name));
 	}
 	if (drops.empty()) {
 		return;
 	}
 	auto res = Execute(drops);
 	if (res->HasError()) {
-		res->GetErrorObject().Throw("Failed to drop superseded inlined-data tables in DuckLake: ");
+		res->GetErrorObject().Throw("Failed to drop empty inlined-data tables in DuckLake: ");
 	}
 	// We also need to invalidate the existing schema versions in our catalog
 	auto &catalog = transaction.GetCatalog();
@@ -5650,6 +5666,14 @@ WHERE idt.schema_version < (
 	for (auto &row : *snapshot_versions) {
 		catalog.InvalidateSchemaCache(row.GetValue<idx_t>(0));
 	}
+}
+
+void DuckLakeMetadataManager::DropEmptyInlinedTables() {
+	DropEmptyInlinedTablesInternal(false);
+}
+
+void DuckLakeMetadataManager::DropEmptySupersededInlinedTables() {
+	DropEmptyInlinedTablesInternal(true);
 }
 
 void DuckLakeMetadataManager::DeleteInlinedData(const DuckLakeInlinedTableInfo &inlined_table) {

--- a/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
+++ b/test/sql/data_inlining/empty_inlined_tables_alter_cleanup.test
@@ -31,29 +31,40 @@ ALTER TABLE ducklake.a ADD COLUMN c4 INTEGER
 statement ok
 ALTER TABLE ducklake.a ADD COLUMN c5 INTEGER
 
+# each statement adds an empty inlined data table
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+6
+
+# flushing the inlined data drops previous inlined tables
+# but keeps the last one which might still be needed
 statement ok
 CALL ducklake_flush_inlined_data('ducklake')
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+1
 
 statement ok
 CHECKPOINT ducklake
 
+# expiring snapshots deletes the final inlined data if it has already been
+# flushed
 statement ok
 CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+0
 
 statement ok
 CALL ducklake_cleanup_old_files('ducklake', cleanup_all => true)
 
 query I
 SELECT COUNT(*) FROM ducklake_meta.ducklake_snapshot
-----
-1
-
-# only the inlined table for the current schema version may remain.
-# The registry row and its physical table are dropped together in one batch, so the
-# registry count is the backend-portable source of truth (duckdb_tables() cannot see
-# a remote quack-backed metadata catalog).
-query I
-SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
 ----
 1
 
@@ -64,3 +75,8 @@ query IIIIII
 SELECT c0, c1, c2, c3, c4, c5 FROM ducklake.a
 ----
 1	2	3	4	5	6
+
+query I
+SELECT COUNT(*) FROM ducklake_meta.ducklake_inlined_data_tables
+----
+1

--- a/test/sql/data_inlining/sqlite_checkpoint_expire_inlined_data_cleanup.test
+++ b/test/sql/data_inlining/sqlite_checkpoint_expire_inlined_data_cleanup.test
@@ -1,0 +1,43 @@
+# name: test/sql/data_inlining/sqlite_checkpoint_expire_inlined_data_cleanup.test
+# description: SQLite catalogs should drop empty inlined-data metadata after checkpoint and snapshot expiry
+# group: [data_inlining]
+
+require ducklake
+
+require parquet
+
+require sqlite_scanner
+
+statement ok
+ATTACH 'ducklake:sqlite:{TEST_DIR}/sqlite_checkpoint_expire_inlined_data_cleanup.db' AS ducklake (DATA_PATH '{TEST_DIR}/sqlite_checkpoint_expire_inlined_data_cleanup_files')
+
+statement ok
+USE ducklake
+
+statement ok
+CREATE TABLE test1 AS FROM test_vector_types(NULL::FLOAT, NULL::INT, NULL::FLOAT)
+
+statement ok
+CREATE TABLE test2 AS FROM test_vector_types(NULL::FLOAT, NULL::INT, NULL::FLOAT)
+
+statement ok
+CREATE TABLE test3 AS FROM test_vector_types(NULL::FLOAT, NULL::INT, NULL::FLOAT)
+
+query I
+SELECT COUNT(*) FROM sqlite_scan('{TEST_DIR}/sqlite_checkpoint_expire_inlined_data_cleanup.db', 'ducklake_inlined_data_tables')
+----
+3
+
+statement ok
+CHECKPOINT
+
+statement ok
+CALL ducklake_expire_snapshots('ducklake', older_than => now())
+
+statement ok
+CHECKPOINT
+
+query I
+SELECT COUNT(*) FROM sqlite_scan('{TEST_DIR}/sqlite_checkpoint_expire_inlined_data_cleanup.db', 'ducklake_inlined_data_tables')
+----
+0


### PR DESCRIPTION
This PR allows for inline data tables that already have been flushed to be dropped, even if they are on the latest schema version. This prevents (empty) inline table accumulation for tables that don't suffer schema changes.