### PR TITLE
Rewrite deletes candidate filter

### DIFF
--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2427,28 +2427,24 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 		string inlined_candidates;
 		if (!inlined_deletion_table.empty()) {
 			inlined_candidates = StringUtil::Format(
-				R"(
+			    R"(
 					UNION
 					SELECT file_id AS data_file_id
 					FROM {METADATA_CATALOG}.%s
 					WHERE begin_snapshot <= %llu
 				)",
-				SQLIdentifier(inlined_deletion_table),
-				snapshot.snapshot_id
-			);
+			    SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
 		}
 
 		candidate_files_cte = StringUtil::Format(
-			R"(
+		    R"(
 				candidate_files AS (
 					SELECT data_file_id
 					FROM {METADATA_CATALOG}.ducklake_delete_file
 					WHERE table_id=%d AND end_snapshot IS NULL%s
 				),
 			)",
-			table_id.index,
-			inlined_candidates
-		);
+		    table_id.index, inlined_candidates);
 
 		data_file_source = R"(candidate_files candidates
 JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id))";
@@ -2494,8 +2490,8 @@ LEFT JOIN (
 WHERE data.table_id=%d %s
 ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
 	)",
-		candidate_files_cte, table_id.index, select_list, data_file_source, table_id.index, delete_file_filter,
-		partition_value_filter, table_id.index, file_filter_clause);
+	                                candidate_files_cte, table_id.index, select_list, data_file_source, table_id.index,
+	                                delete_file_filter, partition_value_filter, table_id.index, file_filter_clause);
 	auto result = Query(query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get compaction file list from DuckLake: ");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2419,7 +2419,10 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			                       timestamp_filter);
 		}
 	}
-	string query;
+	string candidate_files_cte;
+	string data_file_source = "{METADATA_CATALOG}.ducklake_data_file data";
+	string delete_file_filter;
+	string partition_value_filter;
 	if (type == CompactionType::REWRITE_DELETES) {
 		string inlined_candidates;
 		if (!inlined_deletion_table.empty()) {
@@ -2428,94 +2431,60 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	SELECT file_id AS data_file_id
 	FROM {METADATA_CATALOG}.%s
 	WHERE begin_snapshot <= %llu)",
-			                                              SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
+			SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
 		}
-		query = StringUtil::Format(R"(
-WITH candidate_files AS (
+		candidate_files_cte = StringUtil::Format(R"(candidate_files AS (
 	SELECT data_file_id
 	FROM {METADATA_CATALOG}.ducklake_delete_file
 	WHERE table_id=%d AND end_snapshot IS NULL%s
 ),
-snapshot_ranges AS (
-  SELECT
-    begin_snapshot,
-    COALESCE(
-      LEAD(begin_snapshot) OVER (ORDER BY begin_snapshot),
-      9223372036854775807
-    ) AS end_snapshot,
-	schema_version
+)",
+			table_id.index, inlined_candidates);
+		data_file_source = R"(candidate_files candidates
+JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id))";
+		delete_file_filter = " AND end_snapshot IS NULL";
+		partition_value_filter = "\n\tWHERE data_file_id IN (SELECT data_file_id FROM candidate_files)";
+		file_filter_clause = " AND data.end_snapshot IS NULL";
+	}
+	auto query = StringUtil::Format(R"(
+WITH %ssnapshot_ranges AS (
+	SELECT
+		begin_snapshot,
+		COALESCE(
+			LEAD(begin_snapshot) OVER (ORDER BY begin_snapshot),
+			9223372036854775807
+		) AS end_snapshot,
+		schema_version
 	FROM {METADATA_CATALOG}.ducklake_schema_versions
 	WHERE table_id=%d
 	ORDER BY begin_snapshot
 )
 SELECT %s
-FROM candidate_files candidates
-JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id)
+FROM %s
 LEFT JOIN snapshot_ranges sr
-  ON data.begin_snapshot >= sr.begin_snapshot AND data.begin_snapshot < sr.end_snapshot
+	ON data.begin_snapshot >= sr.begin_snapshot AND data.begin_snapshot < sr.end_snapshot
 LEFT JOIN {METADATA_CATALOG}.ducklake_partition_info partition_spec
-  ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
+	ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
 LEFT JOIN snapshot_ranges partition_sr
-  ON partition_spec.partition_id IS NOT NULL
- AND (partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot)
- AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
- AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
+	ON partition_spec.partition_id IS NOT NULL
+	AND (partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot)
+	AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
+	AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
 LEFT JOIN (
 	SELECT *
-    FROM {METADATA_CATALOG}.ducklake_delete_file
-    WHERE table_id=%d AND end_snapshot IS NULL
+	FROM {METADATA_CATALOG}.ducklake_delete_file
+	WHERE table_id=%d%s
 ) del USING (data_file_id)
 LEFT JOIN (
-   SELECT data_file_id, ARRAY_AGG(partition_value ORDER BY partition_key_index) keys
-   FROM {METADATA_CATALOG}.ducklake_file_partition_value
-   WHERE data_file_id IN (SELECT data_file_id FROM candidate_files)
-   GROUP BY data_file_id
-) partition_info USING (data_file_id)
-WHERE data.table_id=%d AND data.end_snapshot IS NULL
-ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
-		)",
-		                           table_id.index, inlined_candidates, table_id.index, select_list, table_id.index,
-		                           table_id.index);
-	} else {
-		query = StringUtil::Format(R"(
-WITH snapshot_ranges AS (
-  SELECT
-    begin_snapshot,
-    COALESCE(
-      LEAD(begin_snapshot) OVER (ORDER BY begin_snapshot),
-      9223372036854775807
-    ) AS end_snapshot,
-	schema_version
-	FROM {METADATA_CATALOG}.ducklake_schema_versions
-	WHERE table_id=%d
-	ORDER BY begin_snapshot
-)
-SELECT %s
-FROM {METADATA_CATALOG}.ducklake_data_file data
-LEFT JOIN snapshot_ranges sr
-  ON data.begin_snapshot >= sr.begin_snapshot AND data.begin_snapshot < sr.end_snapshot
-LEFT JOIN {METADATA_CATALOG}.ducklake_partition_info partition_spec
-  ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
-LEFT JOIN snapshot_ranges partition_sr
-  ON partition_spec.partition_id IS NOT NULL
- AND (partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot)
- AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
- AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
-LEFT JOIN (
-	SELECT *
-    FROM {METADATA_CATALOG}.ducklake_delete_file
-    WHERE table_id=%d
-) del USING (data_file_id)
-LEFT JOIN (
-   SELECT data_file_id, ARRAY_AGG(partition_value ORDER BY partition_key_index) keys
-   FROM {METADATA_CATALOG}.ducklake_file_partition_value
-   GROUP BY data_file_id
+	SELECT data_file_id, ARRAY_AGG(partition_value ORDER BY partition_key_index) keys
+	FROM {METADATA_CATALOG}.ducklake_file_partition_value%s
+	GROUP BY data_file_id
 ) partition_info USING (data_file_id)
 WHERE data.table_id=%d %s
 ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
-		)",
-		                           table_id.index, select_list, table_id.index, table_id.index, file_filter_clause);
-	}
+	)",
+		candidate_files_cte, table_id.index, select_list, data_file_source, table_id.index, delete_file_filter,
+		partition_value_filter, table_id.index, file_filter_clause);
 	auto result = Query(query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get compaction file list from DuckLake: ");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2390,16 +2390,16 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	                            "del.partial_max AS del_partial_max, " +
 	                            GetDeleteFileSelectList("del");
 	string select_list = data_select_list + ", " + delete_select_list;
-	map<idx_t, set<idx_t>> inlined_deletions;
-	string inlined_deletion_table;
-	if (type == CompactionType::REWRITE_DELETES) {
-		// REWRITE_DELETES only needs files with an active delete file or visible inlined deletions. Load the
-		// inlined row IDs up front so they can both drive candidate selection and be attached to the selected files.
-		inlined_deletion_table = GetInlinedDeletionTableName(table_id, snapshot);
-		inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
-	}
-	// Add file filtering for MERGE_ADJACENT_TABLES compaction
+
+	string candidate_files_cte;
+	string data_file_source = "{METADATA_CATALOG}.ducklake_data_file data";
+	string delete_file_filter;
 	string file_filter_clause;
+	string partition_value_filter;
+
+	map<idx_t, set<idx_t>> inlined_deletions;
+
+	// Add file filtering for MERGE_ADJACENT_TABLES compaction
 	if (type == CompactionType::MERGE_ADJACENT_TABLES) {
 		if (options.min_file_size.IsValid()) {
 			file_filter_clause +=
@@ -2418,34 +2418,45 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			                       "snapshot_time::TIMESTAMPTZ >= '%s')",
 			                       timestamp_filter);
 		}
-	}
-	string candidate_files_cte;
-	string data_file_source = "{METADATA_CATALOG}.ducklake_data_file data";
-	string delete_file_filter;
-	string partition_value_filter;
-	if (type == CompactionType::REWRITE_DELETES) {
+	} else if (type == CompactionType::REWRITE_DELETES) {
+		// REWRITE_DELETES only needs files with an active delete file or visible inlined deletions. Load the
+		// inlined row IDs up front so they can both drive candidate selection and be attached to the selected files.
+		string inlined_deletion_table = GetInlinedDeletionTableName(table_id, snapshot);
+		inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
+
 		string inlined_candidates;
 		if (!inlined_deletion_table.empty()) {
-			inlined_candidates = StringUtil::Format(R"(
-	UNION
-	SELECT file_id AS data_file_id
-	FROM {METADATA_CATALOG}.%s
-	WHERE begin_snapshot <= %llu)",
-			SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
+			inlined_candidates = StringUtil::Format(
+				R"(
+					UNION
+					SELECT file_id AS data_file_id
+					FROM {METADATA_CATALOG}.%s
+					WHERE begin_snapshot <= %llu
+				)",
+				SQLIdentifier(inlined_deletion_table),
+				snapshot.snapshot_id
+			);
 		}
-		candidate_files_cte = StringUtil::Format(R"(candidate_files AS (
-	SELECT data_file_id
-	FROM {METADATA_CATALOG}.ducklake_delete_file
-	WHERE table_id=%d AND end_snapshot IS NULL%s
-),
-)",
-			table_id.index, inlined_candidates);
+
+		candidate_files_cte = StringUtil::Format(
+			R"(
+				candidate_files AS (
+					SELECT data_file_id
+					FROM {METADATA_CATALOG}.ducklake_delete_file
+					WHERE table_id=%d AND end_snapshot IS NULL%s
+				),
+			)",
+			table_id.index,
+			inlined_candidates
+		);
+
 		data_file_source = R"(candidate_files candidates
 JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id))";
 		delete_file_filter = " AND end_snapshot IS NULL";
 		partition_value_filter = "\n\tWHERE data_file_id IN (SELECT data_file_id FROM candidate_files)";
 		file_filter_clause = " AND data.end_snapshot IS NULL";
 	}
+
 	auto query = StringUtil::Format(R"(
 WITH %ssnapshot_ranges AS (
 	SELECT

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2390,11 +2390,13 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	                            "del.partial_max AS del_partial_max, " +
 	                            GetDeleteFileSelectList("del");
 	string select_list = data_select_list + ", " + delete_select_list;
-	string deletion_threshold_clause;
+	map<idx_t, set<idx_t>> inlined_deletions;
+	string inlined_deletion_table;
 	if (type == CompactionType::REWRITE_DELETES) {
-		// Filter current data files in SQL, then apply the delete threshold in C++ so we can include
-		// metadata-only inlined file deletions as rewrite candidates.
-		deletion_threshold_clause = " AND data.end_snapshot is null";
+		// REWRITE_DELETES only needs files with an active delete file or visible inlined deletions. Load the
+		// inlined row IDs up front so they can both drive candidate selection and be attached to the selected files.
+		inlined_deletion_table = GetInlinedDeletionTableName(table_id, snapshot);
+		inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
 	}
 	// Add file filtering for MERGE_ADJACENT_TABLES compaction
 	string file_filter_clause;
@@ -2417,7 +2419,65 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			                       timestamp_filter);
 		}
 	}
-	auto query = StringUtil::Format(R"(
+	string query;
+	if (type == CompactionType::REWRITE_DELETES) {
+		string inlined_candidates;
+		if (!inlined_deletion_table.empty()) {
+			inlined_candidates = StringUtil::Format(R"(
+	UNION
+	SELECT file_id AS data_file_id
+	FROM {METADATA_CATALOG}.%s
+	WHERE begin_snapshot <= %llu)",
+			                                              SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
+		}
+		query = StringUtil::Format(R"(
+WITH candidate_files AS (
+	SELECT data_file_id
+	FROM {METADATA_CATALOG}.ducklake_delete_file
+	WHERE table_id=%d AND end_snapshot IS NULL%s
+),
+snapshot_ranges AS (
+  SELECT
+    begin_snapshot,
+    COALESCE(
+      LEAD(begin_snapshot) OVER (ORDER BY begin_snapshot),
+      9223372036854775807
+    ) AS end_snapshot,
+	schema_version
+	FROM {METADATA_CATALOG}.ducklake_schema_versions
+	WHERE table_id=%d
+	ORDER BY begin_snapshot
+)
+SELECT %s
+FROM candidate_files candidates
+JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id)
+LEFT JOIN snapshot_ranges sr
+  ON data.begin_snapshot >= sr.begin_snapshot AND data.begin_snapshot < sr.end_snapshot
+LEFT JOIN {METADATA_CATALOG}.ducklake_partition_info partition_spec
+  ON data.partition_id = partition_spec.partition_id AND data.table_id = partition_spec.table_id
+LEFT JOIN snapshot_ranges partition_sr
+  ON partition_spec.partition_id IS NOT NULL
+ AND (partition_spec.end_snapshot IS NULL OR partition_spec.begin_snapshot < partition_spec.end_snapshot)
+ AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) >= partition_sr.begin_snapshot
+ AND COALESCE(partition_spec.end_snapshot - 1, data.begin_snapshot) < partition_sr.end_snapshot
+LEFT JOIN (
+	SELECT *
+    FROM {METADATA_CATALOG}.ducklake_delete_file
+    WHERE table_id=%d AND end_snapshot IS NULL
+) del USING (data_file_id)
+LEFT JOIN (
+   SELECT data_file_id, ARRAY_AGG(partition_value ORDER BY partition_key_index) keys
+   FROM {METADATA_CATALOG}.ducklake_file_partition_value
+   WHERE data_file_id IN (SELECT data_file_id FROM candidate_files)
+   GROUP BY data_file_id
+) partition_info USING (data_file_id)
+WHERE data.table_id=%d AND data.end_snapshot IS NULL
+ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
+		)",
+		                           table_id.index, inlined_candidates, table_id.index, select_list, table_id.index,
+		                           table_id.index);
+	} else {
+		query = StringUtil::Format(R"(
 WITH snapshot_ranges AS (
   SELECT
     begin_snapshot,
@@ -2451,11 +2511,11 @@ LEFT JOIN (
    FROM {METADATA_CATALOG}.ducklake_file_partition_value
    GROUP BY data_file_id
 ) partition_info USING (data_file_id)
-WHERE data.table_id=%d %s%s
+WHERE data.table_id=%d %s
 ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_snapshot
 		)",
-	                                table_id.index, select_list, table_id.index, table_id.index,
-	                                deletion_threshold_clause, file_filter_clause);
+		                           table_id.index, select_list, table_id.index, table_id.index, file_filter_clause);
+	}
 	auto result = Query(query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get compaction file list from DuckLake: ");
@@ -2523,8 +2583,6 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 	}
 
 	if (type == CompactionType::REWRITE_DELETES) {
-		// Full row-ID payload needed to compute delete ratio and perform the rewrite.
-		auto inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
 		for (auto &file : files) {
 			auto entry = inlined_deletions.find(file.file.id.index);
 			if (entry != inlined_deletions.end()) {
@@ -2548,8 +2606,9 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 	}
 
 	if (type == CompactionType::REWRITE_DELETES) {
-		for (idx_t file_idx = 0; file_idx < files.size(); file_idx++) {
-			auto &file = files[file_idx];
+		vector<DuckLakeCompactionFileEntry> rewrite_candidates;
+		rewrite_candidates.reserve(files.size());
+		for (auto &file : files) {
 			idx_t active_delete_count = 0;
 			if (!file.delete_files.empty() && !file.delete_files.back().end_snapshot.IsValid()) {
 				active_delete_count = file.delete_files.back().row_count;
@@ -2558,11 +2617,11 @@ ORDER BY data.begin_snapshot, data.row_id_start, data.data_file_id, del.begin_sn
 			if (file.file.row_count > 0) {
 				file.delete_ratio = static_cast<double>(total_delete_count) / static_cast<double>(file.file.row_count);
 			}
-			if (total_delete_count == 0 || file.delete_ratio < deletion_threshold) {
-				files.erase_at(file_idx);
-				file_idx--;
+			if (total_delete_count > 0 && file.delete_ratio >= deletion_threshold) {
+				rewrite_candidates.push_back(std::move(file));
 			}
 		}
+		return rewrite_candidates;
 	}
 
 	return files;

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -2394,7 +2394,7 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 	string candidate_files_cte;
 	string data_file_source = "{METADATA_CATALOG}.ducklake_data_file data";
 	string delete_file_filter;
-	string file_filter_clause;
+	string file_filter_clause = " AND data.end_snapshot IS NULL";
 	string partition_value_filter;
 
 	map<idx_t, set<idx_t>> inlined_deletions;
@@ -2406,7 +2406,6 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			    StringUtil::Format(" AND data.file_size_bytes >= %llu", options.min_file_size.GetIndex());
 		}
 		file_filter_clause += StringUtil::Format(" AND data.file_size_bytes < %llu", effective_max_file_size);
-		file_filter_clause += " AND data.end_snapshot IS NULL";
 		if (!options.newer_than.IsNull()) {
 			// only consider files written at or after this timestamp - the timestamp is mapped to the first
 			// snapshot created at or after it, and files are filtered on their begin_snapshot
@@ -2419,13 +2418,11 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			                       timestamp_filter);
 		}
 	} else if (type == CompactionType::REWRITE_DELETES) {
-		// REWRITE_DELETES only needs files with an active delete file or visible inlined deletions. Load the
-		// inlined row IDs up front so they can both drive candidate selection and be attached to the selected files.
-		string inlined_deletion_table = GetInlinedDeletionTableName(table_id, snapshot);
+		// Load inlined row IDs before selecting rewrite candidates.
 		inlined_deletions = ReadInlinedFileDeletions(table_id, snapshot);
 
 		string inlined_candidates;
-		if (!inlined_deletion_table.empty()) {
+		if (!inlined_deletions.empty()) {
 			inlined_candidates = StringUtil::Format(
 			    R"(
 					UNION
@@ -2433,7 +2430,7 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 					FROM {METADATA_CATALOG}.%s
 					WHERE begin_snapshot <= %llu
 				)",
-			    SQLIdentifier(inlined_deletion_table), snapshot.snapshot_id);
+			    InlinedFileDeletionTableName(table_id), snapshot.snapshot_id);
 		}
 
 		candidate_files_cte = StringUtil::Format(
@@ -2446,11 +2443,10 @@ vector<DuckLakeCompactionFileEntry> DuckLakeMetadataManager::GetFilesForCompacti
 			)",
 		    table_id.index, inlined_candidates);
 
-		data_file_source = R"(candidate_files candidates
+		data_file_source = R"(candidate_files
 JOIN {METADATA_CATALOG}.ducklake_data_file data USING (data_file_id))";
 		delete_file_filter = " AND end_snapshot IS NULL";
 		partition_value_filter = "\n\tWHERE data_file_id IN (SELECT data_file_id FROM candidate_files)";
-		file_filter_clause = " AND data.end_snapshot IS NULL";
 	}
 
 	auto query = StringUtil::Format(R"(

--- a/test/configs/postgres.json
+++ b/test/configs/postgres.json
@@ -34,6 +34,7 @@
         "test/sql/general/metadata_parameters.test",
         "test/sql/issues/corrupted_catalog_fault_isolation.test",
         "test/sql/metadata/ducklake_settings.test",
+        "test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test",
         "test/sql/remove_orphans/metadata_in_data_path.test"
       ]
     },

--- a/test/configs/quack.json
+++ b/test/configs/quack.json
@@ -69,7 +69,8 @@
     {
       "reason": "Test issues UPDATE against the metadata catalog directly",
       "paths": [
-        "test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test"
+        "test/sql/delete/delete_legacy_missing_mapping_after_rename_add_files.test",
+        "test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -72,9 +72,9 @@
         "test/sql/general/paths.test",
         "test/sql/issues/corrupted_catalog_fault_isolation.test",
         "test/sql/secrets/ducklake_secrets.test",
-		"test/sql/secrets/ducklake_secret_storages.test",
-		"test/sql/remove_orphans/metadata_in_data_path.test",
-		"test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test"
+        "test/sql/secrets/ducklake_secret_storages.test",
+        "test/sql/remove_orphans/metadata_in_data_path.test",
+        "test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test"
       ]
     },
     {

--- a/test/configs/sqlite.json
+++ b/test/configs/sqlite.json
@@ -72,8 +72,9 @@
         "test/sql/general/paths.test",
         "test/sql/issues/corrupted_catalog_fault_isolation.test",
         "test/sql/secrets/ducklake_secrets.test",
-        "test/sql/secrets/ducklake_secret_storages.test",
-        "test/sql/remove_orphans/metadata_in_data_path.test"
+		"test/sql/secrets/ducklake_secret_storages.test",
+		"test/sql/remove_orphans/metadata_in_data_path.test",
+		"test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test"
       ]
     },
     {

--- a/test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test
+++ b/test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test
@@ -20,15 +20,16 @@ ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
 statement ok
 USE ducklake
 
-# This table has the same order of magnitude of active data-file metadata as the production regression.
-# The additional rows reuse one valid Parquet path because rewrite_deletes must never try to read them.
+# this table will have many small data files, but is unrelated to the deletes
 statement ok
 CREATE TABLE many_files AS SELECT 42 AS id
 
 statement ok
 INSERT INTO ducklake_meta.ducklake_data_file
-SELECT 1000000 + i AS data_file_id, data.* EXCLUDE (data_file_id)
-FROM ducklake_meta.ducklake_data_file data, range(1, 670000) files(i)
+SELECT
+    1000000 + i AS data_file_id,
+    data.* EXCLUDE (data_file_id)
+FROM ducklake_meta.ducklake_data_file data, range(1, 500000) files(i)
 WHERE data.table_id = (
     SELECT table_id
     FROM ducklake_meta.ducklake_table
@@ -41,9 +42,9 @@ FROM ducklake_meta.ducklake_data_file data
 JOIN ducklake_meta.ducklake_table tables USING (table_id)
 WHERE tables.table_name = 'many_files' AND data.end_snapshot IS NULL
 ----
-670000
+500000
 
-# Keep a real delete candidate in the same catalog to verify the optimized lookup still performs rewrites.
+# create a real delete candidate in the same catalog to verify the optimized lookup still performs rewrites.
 statement ok
 CREATE TABLE rewrite_me AS SELECT i AS id FROM range(10) rows(i)
 
@@ -67,4 +68,4 @@ FROM ducklake_meta.ducklake_data_file data
 JOIN ducklake_meta.ducklake_table tables USING (table_id)
 WHERE tables.table_name = 'many_files' AND data.end_snapshot IS NULL
 ----
-670000
+500000

--- a/test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test
+++ b/test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test
@@ -1,0 +1,70 @@
+# name: test/sql/rewrite_data_files/test_rewrite_many_non_candidate_files.test
+# description: Rewrite deletes should not load or filter unrelated data files
+# group: [rewrite_data_files]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (
+    DATA_PATH '{DATA_PATH}/rewrite_many_non_candidate_files',
+    DATA_INLINING_ROW_LIMIT 0,
+    METADATA_CATALOG 'ducklake_meta'
+)
+
+statement ok
+USE ducklake
+
+# This table has the same order of magnitude of active data-file metadata as the production regression.
+# The additional rows reuse one valid Parquet path because rewrite_deletes must never try to read them.
+statement ok
+CREATE TABLE many_files AS SELECT 42 AS id
+
+statement ok
+INSERT INTO ducklake_meta.ducklake_data_file
+SELECT 1000000 + i AS data_file_id, data.* EXCLUDE (data_file_id)
+FROM ducklake_meta.ducklake_data_file data, range(1, 670000) files(i)
+WHERE data.table_id = (
+    SELECT table_id
+    FROM ducklake_meta.ducklake_table
+    WHERE table_name = 'many_files' AND end_snapshot IS NULL
+)
+
+query I
+SELECT count(*)
+FROM ducklake_meta.ducklake_data_file data
+JOIN ducklake_meta.ducklake_table tables USING (table_id)
+WHERE tables.table_name = 'many_files' AND data.end_snapshot IS NULL
+----
+670000
+
+# Keep a real delete candidate in the same catalog to verify the optimized lookup still performs rewrites.
+statement ok
+CREATE TABLE rewrite_me AS SELECT i AS id FROM range(10) rows(i)
+
+statement ok
+DELETE FROM rewrite_me WHERE id = 5
+
+query III
+SELECT table_name, files_processed, files_created
+FROM ducklake_rewrite_data_files('ducklake', delete_threshold => 0)
+----
+rewrite_me	1	1
+
+query I
+SELECT count(*) FROM rewrite_me
+----
+9
+
+query I
+SELECT count(*)
+FROM ducklake_meta.ducklake_data_file data
+JOIN ducklake_meta.ducklake_table tables USING (table_id)
+WHERE tables.table_name = 'many_files' AND data.end_snapshot IS NULL
+----
+670000


### PR DESCRIPTION
This is an optimization for the REWRITE_DELETES compation on ducklakes with many unrelated tables/files.
With the patch the test case runs in a few ms, without it doesn't finish in 30mins.