### PR TITLE
Test linux arm64/amd64 musl in CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -32,6 +32,7 @@ jobs:
       duckdb_version: ${{ needs.get-duckdb-version.outputs.duckdb_version }}
       ci_tools_version: v1.5-variegata
       extension_name: ducklake
+      opt_in_archs: 'linux_arm64_musl;linux_amd64_musl'
 
   # Regression test, see https://github.com/duckdb/ducklake/pull/1256 for more details.
   gcc12-compatibility-build:


### PR DESCRIPTION
There are multiple test [failures](https://github.com/duckdb/duckdb/actions/runs/32540385326/job/96949958060#step:11:95) in CI:
```
retrying failed test /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/stats/filter_stress.test (attempt 1/2, retry 1/4)
retrying failed test /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/stats/filter_stress.test (attempt 2/2, retry 2/4)
================================================================
error: FAIL /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/stats/filter_stress.test

SIGSEGV - Segmentation fault

reproduce:
./build/release/test/unittest /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/stats/filter_stress.test

......................................
retrying failed test /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_max_files.test (attempt 1/2, retry 4/4)
error: timeout (300s) for /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_max_files.test.

recovered: passed on retry 1/2

reproduce:
./build/release/test/unittest /duckdb_build_dir/build/release/_deps/ducklake_extension_fc-src/test/sql/compaction/merge_adjacent_max_files.test
```

- `test/sql/stats/filter_stress.test` crashed three times with a segfault.
- `test/sql/compaction/merge_adjacent_max_files.test` recovered after 1 retry.

This PR adds linux amd64/arm64 musl to the CI pipeline so we can find these issues in this repo instead of failing on duckdb main (because linux amd64/arm64 musl only run on main).

I created a tracking [issue](https://github.com/duckdblabs/duckdb-internal/issues/10511) for the PEG parser, that likely caused the stack overflow -> segfault on musl.