### PR TITLE
Reuse file-list query assembly

### DIFF
--- a/src/include/metadata_manager/postgres_metadata_manager.hpp
+++ b/src/include/metadata_manager/postgres_metadata_manager.hpp
@@ -40,6 +40,8 @@ public:
 protected:
 	string GetLatestSnapshotQuery() const override;
 	string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id) override;
+	string GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
+	                             const vector<DuckLakeFileListDynamicFilter> &dynamic_filters) override;
 
 private:
 	unique_ptr<QueryResult> ExecuteQuery(DuckLakeSnapshot snapshot, string &query, string command);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -544,6 +544,16 @@ protected:
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info,
 	                                                   const ColumnStatsFilterSQL *filter_sql = nullptr);
 	using FileColumnStatsCTEBodyGenerator = std::function<string(const CTERequirement &, TableIndex)>;
+	using FileListStatsCastGenerator = std::function<string(const string &, const LogicalType &)>;
+	FilterSQLResult GenerateFileListFilterResult(
+	    DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
+	    const ColumnStatsFilterSQL *filter_sql = nullptr,
+	    const string &partition_value_table = "{METADATA_CATALOG}.ducklake_file_partition_value");
+	string AssembleFileListQuery(DuckLakeTableEntry &table, FilterSQLResult filter_result,
+	                             const vector<DuckLakeFileListDynamicFilter> &dynamic_filters,
+	                             const string &metadata_table_prefix,
+	                             const FileColumnStatsCTEBodyGenerator &generate_cte_body,
+	                             const FileListStatsCastGenerator &cast_stats);
 	string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
 	                                          TableIndex table_id,
 	                                          const FileColumnStatsCTEBodyGenerator &generate_body);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -131,6 +131,12 @@ struct FilterPushdownQueryComponents {
 	string order_by_clause;
 };
 
+struct DuckLakeFileListDynamicFilter {
+	idx_t column_field_index;
+	ExpressionType comparison_type;
+	LogicalType column_type;
+};
+
 //! The DuckLake metadata manger is the communication layer between the system and the metadata catalog
 class DuckLakeMetadataManager {
 public:
@@ -445,6 +451,8 @@ protected:
 	virtual string GetLatestSnapshotQuery() const;
 
 	virtual string GenerateFileColumnStatsCTEBody(const CTERequirement &req, TableIndex table_id);
+	virtual string GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
+	                                     const vector<DuckLakeFileListDynamicFilter> &dynamic_filters);
 
 	//! Wrap field selections with list aggregation of struct objects (DBMS-specific)
 	//! For DuckDB: LIST({'key1': val1, 'key2': val2, ...})
@@ -517,30 +525,50 @@ private:
 	DuckLakeFileData ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted);
 
 	bool IsEncrypted() const;
+
+protected:
+	struct ColumnStatsFilterSQL {
+		std::function<string(const Value &, const LogicalType &)> cast_value;
+		std::function<string(const string &, const LogicalType &, bool)> cast_stats;
+	};
+
 	string GetFileSelectList(const string &prefix);
 	string GetDeleteFileSelectList(const string &prefix);
-	FilterPushdownQueryComponents GenerateFilterPushdownComponents(const FilterPushdownInfo &filter_info,
-	                                                               DuckLakeTableEntry &table);
 	//! Build an additional WHERE fragment that prunes files by bucket() partition value.
 	//! Returns "" when no foldable equality / IN-list predicate exists on a bucket-partitioned column.
 	//! The fragment uses only string equality against ducklake_file_partition_value, so it works against
 	//! any metadata backend (DuckDB / Postgres / SQLite). Bucket hashes are pre-computed in C++.
-	string BuildBucketPartitionPruningClause(DuckLakeTableEntry &table, const FilterPushdownInfo &filter_info);
-	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);
+	string BuildBucketPartitionPruningClause(
+	    DuckLakeTableEntry &table, const FilterPushdownInfo &filter_info,
+	    const string &partition_value_table = "{METADATA_CATALOG}.ducklake_file_partition_value");
+	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info,
+	                                                   const ColumnStatsFilterSQL *filter_sql = nullptr);
+	using FileColumnStatsCTEBodyGenerator = std::function<string(const CTERequirement &, TableIndex)>;
+	string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
+	                                          TableIndex table_id,
+	                                          const FileColumnStatsCTEBodyGenerator &generate_body);
+
+private:
+	FilterPushdownQueryComponents GenerateFilterPushdownComponents(const FilterPushdownInfo &filter_info,
+	                                                               DuckLakeTableEntry &table);
 	virtual string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
 	                                                  TableIndex table_id);
 	virtual string GenerateFilterFromTableFilter(const ExpressionFilter &filter, const LogicalType &type,
 	                                             unordered_set<string> &referenced_stats);
 	virtual string GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
-	                                            unordered_set<string> &referenced_stats);
+	                                            unordered_set<string> &referenced_stats,
+	                                            const ColumnStatsFilterSQL *filter_sql = nullptr);
 	virtual bool ValueIsFinite(const Value &val);
 	virtual string CastValueToTarget(const Value &val, const LogicalType &type);
 	virtual string CastStatsToTarget(const string &stats, const LogicalType &type);
 	virtual string GenerateConstantFilter(ExpressionType comparison_type, const Value &constant,
-	                                      const LogicalType &type, unordered_set<string> &referenced_stats);
+	                                      const LogicalType &type, unordered_set<string> &referenced_stats,
+	                                      const ColumnStatsFilterSQL *filter_sql = nullptr);
 	virtual string GenerateConstantFilterDouble(ExpressionType comparison_type, const Value &constant,
-	                                            const LogicalType &type, unordered_set<string> &referenced_stats);
-	virtual string GenerateFilterPushdown(const ExpressionFilter &filter, unordered_set<string> &referenced_stats);
+	                                            const LogicalType &type, unordered_set<string> &referenced_stats,
+	                                            const ColumnStatsFilterSQL *filter_sql = nullptr);
+	virtual string GenerateFilterPushdown(const ExpressionFilter &filter, unordered_set<string> &referenced_stats,
+	                                      const ColumnStatsFilterSQL *filter_sql = nullptr);
 
 public:
 	//! Read inlined file deletions for regular table scans (no snapshot info per row)

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -4,8 +4,166 @@
 #include "storage/ducklake_catalog.hpp"
 #include "storage/ducklake_transaction.hpp"
 #include "storage/ducklake_metadata_info.hpp"
+#include "storage/ducklake_table_entry.hpp"
 
 namespace duckdb {
+
+static bool IsDigit(char c) {
+	return c >= '0' && c <= '9';
+}
+
+static bool HasFourDigitDatePrefix(const string &value) {
+	return value.size() >= 10 && IsDigit(value[0]) && IsDigit(value[1]) && IsDigit(value[2]) && IsDigit(value[3]) &&
+	       value[4] == '-' && IsDigit(value[5]) && IsDigit(value[6]) && value[7] == '-' && IsDigit(value[8]) &&
+	       IsDigit(value[9]);
+}
+
+static string WithPostgresBinaryCollation(const string &expression) {
+	return "(" + expression + " COLLATE \"C\")";
+}
+
+static bool IsPostgresTemporalStatsType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static string GetPostgresStatsType(const LogicalType &type) {
+	switch (type.id()) {
+	case LogicalTypeId::BOOLEAN:
+		return "BOOLEAN";
+	case LogicalTypeId::TINYINT:
+	case LogicalTypeId::SMALLINT:
+		return "SMALLINT";
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::UTINYINT:
+	case LogicalTypeId::USMALLINT:
+		return "INTEGER";
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::UINTEGER:
+		return "BIGINT";
+	case LogicalTypeId::UBIGINT:
+	case LogicalTypeId::HUGEINT:
+	case LogicalTypeId::UHUGEINT:
+		return "NUMERIC";
+	case LogicalTypeId::FLOAT:
+		return "REAL";
+	case LogicalTypeId::DOUBLE:
+		return "DOUBLE PRECISION";
+	case LogicalTypeId::DATE:
+		return "DATE";
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_SEC:
+	case LogicalTypeId::TIMESTAMP_MS:
+		return "TIMESTAMP";
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return "TIMESTAMPTZ";
+	case LogicalTypeId::DECIMAL:
+		return type.ToString();
+	default:
+		return string();
+	}
+}
+
+static bool CanCastPostgresStatsForValueComparison(const LogicalType &type) {
+	return type.IsNumeric() || type.id() == LogicalTypeId::BOOLEAN || IsPostgresTemporalStatsType(type);
+}
+
+static bool CanCastPostgresTemporalValue(const Value &value, const LogicalType &type) {
+	auto string_value = value.ToString();
+	if (!HasFourDigitDatePrefix(string_value)) {
+		return false;
+	}
+	return type.id() != LogicalTypeId::DATE || string_value.size() == 10;
+}
+
+static string PostgresCastValueToTarget(const Value &value, const LogicalType &type) {
+	if (value.IsNull() || value.ToString().find('\0') != string::npos || type.id() == LogicalTypeId::BLOB) {
+		return string();
+	}
+	if (RequiresValueComparison(type) &&
+	    (!CanCastPostgresStatsForValueComparison(type) ||
+	     ((value.type().id() == LogicalTypeId::FLOAT || value.type().id() == LogicalTypeId::DOUBLE) &&
+	      !Value::IsFinite(value.GetValue<double>())))) {
+		return string();
+	}
+	if (!RequiresValueComparison(type) && type.id() != LogicalTypeId::VARCHAR) {
+		return string();
+	}
+	if (IsPostgresTemporalStatsType(type) && !CanCastPostgresTemporalValue(value, type)) {
+		return string();
+	}
+	if (type.IsNumeric()) {
+		return value.ToString();
+	}
+	auto literal = DuckLakeUtil::SQLLiteralToString(value.ToString());
+	if (type.id() == LogicalTypeId::VARCHAR) {
+		return WithPostgresBinaryCollation(literal);
+	}
+	if (IsPostgresTemporalStatsType(type)) {
+		return literal + "::" + GetPostgresStatsType(type);
+	}
+	if (type.id() == LogicalTypeId::BOOLEAN) {
+		return literal + "::BOOLEAN";
+	}
+	return string();
+}
+
+static string PostgresSafeTemporalStatsCast(const string &stats, const LogicalType &type) {
+	string regex;
+	if (type.id() == LogicalTypeId::DATE) {
+		regex = "'^[0-9]{4}-(0[1-9]|1[0-2])-([0][1-9]|[12][0-9]|3[01])$'";
+	} else if (type.id() == LogicalTypeId::TIMESTAMP_TZ) {
+		regex = "'^[0-9]{4}-(0[1-9]|1[0-2])-([0][1-9]|[12][0-9]|3[01]) "
+		        "([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{1,6})?"
+		        "(Z|[+-](0[0-9]|1[0-5])(:[0-5][0-9])?)$'";
+	} else {
+		regex = "'^[0-9]{4}-(0[1-9]|1[0-2])-([0][1-9]|[12][0-9]|3[01])"
+		        "( ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{1,6})?)?$'";
+	}
+
+	auto year = StringUtil::Format("substring(%s FROM 1 FOR 4)::INTEGER", stats);
+	auto month = StringUtil::Format("substring(%s FROM 6 FOR 2)::INTEGER", stats);
+	auto day = StringUtil::Format("substring(%s FROM 9 FOR 2)::INTEGER", stats);
+	auto max_day = StringUtil::Format(
+	    "(CASE WHEN %s = 2 THEN CASE WHEN mod(%s, 4) = 0 AND (mod(%s, 100) <> 0 OR mod(%s, 400) = 0) "
+	    "THEN 29 ELSE 28 END WHEN %s IN (4, 6, 9, 11) THEN 30 ELSE 31 END)",
+	    month, year, year, year, month);
+	auto valid_date = StringUtil::Format("%s > 0 AND %s <= %s", year, day, max_day);
+	return StringUtil::Format("(CASE WHEN %s ~ %s THEN CASE WHEN %s THEN %s::%s END END)", stats, regex, valid_date,
+	                          stats, GetPostgresStatsType(type));
+}
+
+static string PostgresCastStatsToTarget(const string &stats, const LogicalType &type) {
+	if (IsPostgresTemporalStatsType(type)) {
+		return PostgresSafeTemporalStatsCast(stats, type);
+	}
+	if (CanCastPostgresStatsForValueComparison(type)) {
+		return stats + "::" + GetPostgresStatsType(type);
+	}
+	if (type.id() == LogicalTypeId::VARCHAR) {
+		return WithPostgresBinaryCollation(stats);
+	}
+	return string();
+}
+
+static string GeneratePostgresNativeFileColumnStatsCTEBody(const CTERequirement &requirement, TableIndex table_id) {
+	string select_list = "data_file_id";
+	for (const auto &stat : requirement.referenced_stats) {
+		select_list += ", " + stat;
+	}
+	return StringUtil::Format("  SELECT %s\n"
+	                          "  FROM {METADATA_SCHEMA_ESCAPED}.ducklake_file_column_stats\n"
+	                          "  WHERE column_id = %d AND table_id = %d\n",
+	                          select_list, requirement.column_field_index, table_id.index);
+}
 
 PostgresMetadataManager::PostgresMetadataManager(DuckLakeTransaction &transaction)
     : DuckLakeMetadataManager(transaction) {
@@ -141,6 +299,103 @@ string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 	                          "     FROM {METADATA_SCHEMA_ESCAPED}.ducklake_file_column_stats\n"
 	                          "     WHERE column_id = %d AND table_id = %d')\n",
 	                          select_list, req.column_field_index, table_id.index);
+}
+
+string PostgresMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
+                                                      const vector<DuckLakeFileListDynamicFilter> &dynamic_filters) {
+	auto table_id = table.GetTableId();
+	FilterSQLResult filter_result;
+	if (filter_info && !filter_info->column_filters.empty()) {
+		ColumnStatsFilterSQL filter_sql;
+		filter_sql.cast_value = PostgresCastValueToTarget;
+		filter_sql.cast_stats = [](const string &stats, const LogicalType &type, bool is_min) {
+			auto cast = PostgresCastStatsToTarget(stats, type);
+			if (cast.empty() || !IsPostgresTemporalStatsType(type)) {
+				return cast;
+			}
+			return StringUtil::Format("COALESCE(%s, '%s'::%s)", cast, is_min ? "-infinity" : "infinity",
+			                          GetPostgresStatsType(type));
+		};
+		filter_result = ConvertFilterPushdownToSQL(*filter_info, &filter_sql);
+
+		auto bucket_clause = BuildBucketPartitionPruningClause(
+		    table, *filter_info, "{METADATA_SCHEMA_ESCAPED}.ducklake_file_partition_value");
+		if (!bucket_clause.empty()) {
+			if (!filter_result.where_conditions.empty()) {
+				filter_result.where_conditions += " AND ";
+			}
+			filter_result.where_conditions += bucket_clause;
+		}
+	}
+
+	for (const auto &dynamic_filter : dynamic_filters) {
+		auto entry = filter_result.required_ctes.find(dynamic_filter.column_field_index);
+		if (entry == filter_result.required_ctes.end()) {
+			filter_result.required_ctes.emplace(
+			    dynamic_filter.column_field_index,
+			    CTERequirement(dynamic_filter.column_field_index, {"min_value", "max_value"}));
+		} else {
+			entry->second.referenced_stats.insert("min_value");
+			entry->second.referenced_stats.insert("max_value");
+			entry->second.reference_count++;
+		}
+	}
+
+	string remote_query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id,
+	                                                         GeneratePostgresNativeFileColumnStatsCTEBody);
+	string stats_select_list;
+	string stats_join_list;
+	string order_by_clause;
+	for (const auto &dynamic_filter : dynamic_filters) {
+		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dynamic_filter.column_field_index));
+		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
+		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
+		                                      cte_name.c_str());
+
+		if (order_by_clause.empty() && (dynamic_filter.column_type.id() == LogicalTypeId::VARCHAR ||
+		                                CanCastPostgresStatsForValueComparison(dynamic_filter.column_type))) {
+			const bool seeking_high_values =
+			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+			const bool seeking_low_values = dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+			                                dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+			if (seeking_high_values) {
+				auto stats_expression = PostgresCastStatsToTarget(cte_name + ".max_value", dynamic_filter.column_type);
+				if (!stats_expression.empty()) {
+					order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", stats_expression);
+				}
+			} else if (seeking_low_values) {
+				auto stats_expression = PostgresCastStatsToTarget(cte_name + ".min_value", dynamic_filter.column_type);
+				if (!stats_expression.empty()) {
+					order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", stats_expression);
+				}
+			}
+		}
+	}
+
+	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
+	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
+	                     GetDeleteFileSelectList("del") + stats_select_list;
+	remote_query += StringUtil::Format(R"(
+SELECT %s
+FROM {METADATA_SCHEMA_ESCAPED}.ducklake_data_file data
+%s
+LEFT JOIN (
+    SELECT *
+    FROM {METADATA_SCHEMA_ESCAPED}.ducklake_delete_file
+    WHERE table_id=%d AND {SNAPSHOT_ID} >= begin_snapshot
+          AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
+    ) del ON del.data_file_id = data.data_file_id
+WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
+		)",
+	                                   select_list, stats_join_list, table_id.index, table_id.index);
+	if (!filter_result.where_conditions.empty()) {
+		remote_query += "\nAND " + filter_result.where_conditions;
+	}
+	remote_query += order_by_clause;
+
+	return StringUtil::Format("SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, %s)",
+	                          SQLString(remote_query));
 }
 
 // We need a specialized function here to do a reinterpret for postgres from BLOB to VARCHAR

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -8,14 +8,11 @@
 
 namespace duckdb {
 
-static bool IsDigit(char c) {
-	return c >= '0' && c <= '9';
-}
-
 static bool HasFourDigitDatePrefix(const string &value) {
-	return value.size() >= 10 && IsDigit(value[0]) && IsDigit(value[1]) && IsDigit(value[2]) && IsDigit(value[3]) &&
-	       value[4] == '-' && IsDigit(value[5]) && IsDigit(value[6]) && value[7] == '-' && IsDigit(value[8]) &&
-	       IsDigit(value[9]);
+	return value.size() >= 10 && StringUtil::CharacterIsDigit(value[0]) && StringUtil::CharacterIsDigit(value[1]) &&
+	       StringUtil::CharacterIsDigit(value[2]) && StringUtil::CharacterIsDigit(value[3]) && value[4] == '-' &&
+	       StringUtil::CharacterIsDigit(value[5]) && StringUtil::CharacterIsDigit(value[6]) && value[7] == '-' &&
+	       StringUtil::CharacterIsDigit(value[8]) && StringUtil::CharacterIsDigit(value[9]);
 }
 
 static string WithPostgresBinaryCollation(const string &expression) {

--- a/src/metadata_manager/postgres_metadata_manager.cpp
+++ b/src/metadata_manager/postgres_metadata_manager.cpp
@@ -300,96 +300,21 @@ string PostgresMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 
 string PostgresMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
                                                       const vector<DuckLakeFileListDynamicFilter> &dynamic_filters) {
-	auto table_id = table.GetTableId();
-	FilterSQLResult filter_result;
-	if (filter_info && !filter_info->column_filters.empty()) {
-		ColumnStatsFilterSQL filter_sql;
-		filter_sql.cast_value = PostgresCastValueToTarget;
-		filter_sql.cast_stats = [](const string &stats, const LogicalType &type, bool is_min) {
-			auto cast = PostgresCastStatsToTarget(stats, type);
-			if (cast.empty() || !IsPostgresTemporalStatsType(type)) {
-				return cast;
-			}
-			return StringUtil::Format("COALESCE(%s, '%s'::%s)", cast, is_min ? "-infinity" : "infinity",
-			                          GetPostgresStatsType(type));
-		};
-		filter_result = ConvertFilterPushdownToSQL(*filter_info, &filter_sql);
-
-		auto bucket_clause = BuildBucketPartitionPruningClause(
-		    table, *filter_info, "{METADATA_SCHEMA_ESCAPED}.ducklake_file_partition_value");
-		if (!bucket_clause.empty()) {
-			if (!filter_result.where_conditions.empty()) {
-				filter_result.where_conditions += " AND ";
-			}
-			filter_result.where_conditions += bucket_clause;
+	ColumnStatsFilterSQL filter_sql;
+	filter_sql.cast_value = PostgresCastValueToTarget;
+	filter_sql.cast_stats = [](const string &stats, const LogicalType &type, bool is_min) {
+		auto cast = PostgresCastStatsToTarget(stats, type);
+		if (cast.empty() || !IsPostgresTemporalStatsType(type)) {
+			return cast;
 		}
-	}
-
-	for (const auto &dynamic_filter : dynamic_filters) {
-		auto entry = filter_result.required_ctes.find(dynamic_filter.column_field_index);
-		if (entry == filter_result.required_ctes.end()) {
-			filter_result.required_ctes.emplace(
-			    dynamic_filter.column_field_index,
-			    CTERequirement(dynamic_filter.column_field_index, {"min_value", "max_value"}));
-		} else {
-			entry->second.referenced_stats.insert("min_value");
-			entry->second.referenced_stats.insert("max_value");
-			entry->second.reference_count++;
-		}
-	}
-
-	string remote_query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id,
-	                                                         GeneratePostgresNativeFileColumnStatsCTEBody);
-	string stats_select_list;
-	string stats_join_list;
-	string order_by_clause;
-	for (const auto &dynamic_filter : dynamic_filters) {
-		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dynamic_filter.column_field_index));
-		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
-		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
-		                                      cte_name.c_str());
-
-		if (order_by_clause.empty() && (dynamic_filter.column_type.id() == LogicalTypeId::VARCHAR ||
-		                                CanCastPostgresStatsForValueComparison(dynamic_filter.column_type))) {
-			const bool seeking_high_values =
-			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
-			const bool seeking_low_values = dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-			                                dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
-			if (seeking_high_values) {
-				auto stats_expression = PostgresCastStatsToTarget(cte_name + ".max_value", dynamic_filter.column_type);
-				if (!stats_expression.empty()) {
-					order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", stats_expression);
-				}
-			} else if (seeking_low_values) {
-				auto stats_expression = PostgresCastStatsToTarget(cte_name + ".min_value", dynamic_filter.column_type);
-				if (!stats_expression.empty()) {
-					order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", stats_expression);
-				}
-			}
-		}
-	}
-
-	string select_list = "data.data_file_id, " + GetFileSelectList("data") +
-	                     ", data.row_id_start, data.begin_snapshot, data.partial_max, data.mapping_id, " +
-	                     GetDeleteFileSelectList("del") + stats_select_list;
-	remote_query += StringUtil::Format(R"(
-SELECT %s
-FROM {METADATA_SCHEMA_ESCAPED}.ducklake_data_file data
-%s
-LEFT JOIN (
-    SELECT *
-    FROM {METADATA_SCHEMA_ESCAPED}.ducklake_delete_file
-    WHERE table_id=%d AND {SNAPSHOT_ID} >= begin_snapshot
-          AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
-    ) del ON del.data_file_id = data.data_file_id
-WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
-		)",
-	                                   select_list, stats_join_list, table_id.index, table_id.index);
-	if (!filter_result.where_conditions.empty()) {
-		remote_query += "\nAND " + filter_result.where_conditions;
-	}
-	remote_query += order_by_clause;
+		return StringUtil::Format("COALESCE(%s, '%s'::%s)", cast, is_min ? "-infinity" : "infinity",
+		                          GetPostgresStatsType(type));
+	};
+	auto filter_result = GenerateFileListFilterResult(table, filter_info, &filter_sql,
+	                                                  "{METADATA_SCHEMA_ESCAPED}.ducklake_file_partition_value");
+	auto remote_query =
+	    AssembleFileListQuery(table, std::move(filter_result), dynamic_filters, "{METADATA_SCHEMA_ESCAPED}",
+	                          GeneratePostgresNativeFileColumnStatsCTEBody, PostgresCastStatsToTarget);
 
 	return StringUtil::Format("SELECT * FROM postgres_query({METADATA_CATALOG_NAME_LITERAL}, %s)",
 	                          SQLString(remote_query));

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1336,14 +1336,16 @@ string DuckLakeMetadataManager::CastColumnToTarget(const string &column, const L
 }
 
 string DuckLakeMetadataManager::GenerateConstantFilter(ExpressionType comparison_type, const Value &constant,
-                                                       const LogicalType &type,
-                                                       unordered_set<string> &referenced_stats) {
-	auto constant_str = CastValueToTarget(constant, type);
-	if (constant_str.find('\0') != string::npos) {
+                                                       const LogicalType &type, unordered_set<string> &referenced_stats,
+                                                       const ColumnStatsFilterSQL *filter_sql) {
+	auto constant_str = filter_sql ? filter_sql->cast_value(constant, type) : CastValueToTarget(constant, type);
+	auto min_value =
+	    filter_sql ? filter_sql->cast_stats("min_value", type, true) : CastStatsToTarget("min_value", type);
+	auto max_value =
+	    filter_sql ? filter_sql->cast_stats("max_value", type, false) : CastStatsToTarget("max_value", type);
+	if (constant_str.empty() || min_value.empty() || max_value.empty() || constant_str.find('\0') != string::npos) {
 		return string();
 	}
-	auto min_value = CastStatsToTarget("min_value", type);
-	auto max_value = CastStatsToTarget("max_value", type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		// x = constant
@@ -1385,7 +1387,8 @@ string DuckLakeMetadataManager::GenerateConstantFilter(ExpressionType comparison
 
 string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comparison_type, const Value &constant,
                                                              const LogicalType &type,
-                                                             unordered_set<string> &referenced_stats) {
+                                                             unordered_set<string> &referenced_stats,
+                                                             const ColumnStatsFilterSQL *filter_sql) {
 	double constant_val = constant.GetValue<double>();
 	bool constant_is_nan = Value::IsNan(constant_val);
 	switch (comparison_type) {
@@ -1397,7 +1400,7 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return "contains_nan";
 		}
 		// else check as if this is a numeric
-		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats, filter_sql);
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 	case ExpressionType::COMPARE_GREATERTHAN: {
 		if (constant_is_nan) {
@@ -1407,7 +1410,7 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// generate the numeric filter
-		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats, filter_sql);
 		if (filter.empty()) {
 			return string();
 		}
@@ -1422,7 +1425,7 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// these are equivalent to the numeric filter
-		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats, filter_sql);
 	case ExpressionType::COMPARE_NOTEQUAL: {
 		// x <> constant
 		if (constant_is_nan) {
@@ -1432,7 +1435,7 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// generate the numeric filter
-		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats, filter_sql);
 		if (filter.empty()) {
 			return string();
 		}
@@ -1447,7 +1450,8 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 }
 
 string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
-                                                             unordered_set<string> &referenced_stats) {
+                                                             unordered_set<string> &referenced_stats,
+                                                             const ColumnStatsFilterSQL *filter_sql) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
 		auto &comparison = expr.Cast<BoundFunctionExpression>();
 		auto &left = BoundComparisonExpression::Left(comparison);
@@ -1469,9 +1473,10 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		case LogicalTypeId::FLOAT:
 		case LogicalTypeId::DOUBLE:
 			return GenerateConstantFilterDouble(comparison_type, constant_expr->GetValue(), target_type,
-			                                    referenced_stats);
+			                                    referenced_stats, filter_sql);
 		default:
-			return GenerateConstantFilter(comparison_type, constant_expr->GetValue(), target_type, referenced_stats);
+			return GenerateConstantFilter(comparison_type, constant_expr->GetValue(), target_type, referenced_stats,
+			                              filter_sql);
 		}
 	}
 	switch (expr.GetExpressionClass()) {
@@ -1512,11 +1517,11 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 				case LogicalTypeId::FLOAT:
 				case LogicalTypeId::DOUBLE:
 					next_filter = GenerateConstantFilterDouble(ExpressionType::COMPARE_EQUAL, constant_value,
-					                                           target_type, referenced_stats);
+					                                           target_type, referenced_stats, filter_sql);
 					break;
 				default:
 					next_filter = GenerateConstantFilter(ExpressionType::COMPARE_EQUAL, constant_value, target_type,
-					                                     referenced_stats);
+					                                     referenced_stats, filter_sql);
 					break;
 				}
 				if (next_filter.empty()) {
@@ -1538,7 +1543,7 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		string result;
 		const auto conjunction_type = expr.GetExpressionType();
 		for (auto &child : conjunction.GetChildren()) {
-			auto child_str = GenerateFilterFromExpression(*child, type, referenced_stats);
+			auto child_str = GenerateFilterFromExpression(*child, type, referenced_stats, filter_sql);
 			if (child_str.empty()) {
 				if (conjunction_type == ExpressionType::CONJUNCTION_OR) {
 					return string();
@@ -1557,13 +1562,13 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		if (func.Function().GetName() == OptionalFilterScalarFun::NAME && func.BindInfo()) {
 			auto &data = func.BindInfo()->Cast<OptionalFilterFunctionData>();
 			return data.child_filter_expr
-			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
+			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats, filter_sql)
 			           : string();
 		}
 		if (func.Function().GetName() == SelectivityOptionalFilterScalarFun::NAME && func.BindInfo()) {
 			auto &data = func.BindInfo()->Cast<SelectivityOptionalFilterFunctionData>();
 			return data.child_filter_expr
-			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
+			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats, filter_sql)
 			           : string();
 		}
 		return string();
@@ -1574,14 +1579,16 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 }
 
 string DuckLakeMetadataManager::GenerateFilterPushdown(const ExpressionFilter &filter,
-                                                       unordered_set<string> &referenced_stats) {
+                                                       unordered_set<string> &referenced_stats,
+                                                       const ColumnStatsFilterSQL *filter_sql) {
 	if (!filter.expr) {
 		return string();
 	}
-	return GenerateFilterFromExpression(*filter.expr, nullptr, referenced_stats);
+	return GenerateFilterFromExpression(*filter.expr, nullptr, referenced_stats, filter_sql);
 }
 
-FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info) {
+FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info,
+                                                                    const ColumnStatsFilterSQL *filter_sql) {
 	FilterSQLResult result;
 	string conditions;
 
@@ -1589,7 +1596,7 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 		const auto &column_filter = entry.second;
 
 		unordered_set<string> referenced_stats;
-		auto filter_condition = GenerateFilterPushdown(*column_filter.table_filter, referenced_stats);
+		auto filter_condition = GenerateFilterPushdown(*column_filter.table_filter, referenced_stats, filter_sql);
 
 		if (filter_condition.empty()) {
 			continue;
@@ -1647,6 +1654,15 @@ string DuckLakeMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 string
 DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
                                                             TableIndex table_id) {
+	return GenerateCTESectionFromRequirements(requirements, table_id, [this](const CTERequirement &req, TableIndex id) {
+		return GenerateFileColumnStatsCTEBody(req, id);
+	});
+}
+
+string
+DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
+                                                            TableIndex table_id,
+                                                            const FileColumnStatsCTEBodyGenerator &generate_body) {
 	if (requirements.empty()) {
 		return "";
 	}
@@ -1664,7 +1680,7 @@ DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<
 
 		string materialized_hint = (req.reference_count > 1) ? " AS MATERIALIZED" : " AS NOT MATERIALIZED";
 		cte_section += StringUtil::Format("col_%d_stats%s (\n", req.column_field_index, materialized_hint.c_str());
-		cte_section += GenerateFileColumnStatsCTEBody(req, table_id);
+		cte_section += generate_body(req, table_id);
 		cte_section += ")";
 	}
 
@@ -1688,12 +1704,6 @@ DuckLakeMetadataManager::GenerateFilterPushdownComponents(const FilterPushdownIn
 
 	return result;
 }
-
-struct DynamicFilterColumn {
-	idx_t column_field_index;
-	ExpressionType comparison_type;
-	LogicalType column_type;
-};
 
 //! Fold a single constant through the bucket() transform, returning the resulting partition_value
 //! string ("6", "3", ...) that matches what the writer stores. Returns empty optional on any failure
@@ -1808,7 +1818,8 @@ static bool CollectBucketEqualityValues(ClientContext &context, const Expression
 }
 
 string DuckLakeMetadataManager::BuildBucketPartitionPruningClause(DuckLakeTableEntry &table,
-                                                                  const FilterPushdownInfo &filter_info) {
+                                                                  const FilterPushdownInfo &filter_info,
+                                                                  const string &partition_value_table) {
 	auto partition_data = table.GetPartitionData();
 	if (!partition_data) {
 		return string();
@@ -1850,10 +1861,10 @@ string DuckLakeMetadataManager::BuildBucketPartitionPruningClause(DuckLakeTableE
 			}
 			in_list += StringUtil::Format("%s", SQLString(v));
 		}
-		string clause = StringUtil::Format(
-		    "data.data_file_id IN (SELECT data_file_id FROM {METADATA_CATALOG}.ducklake_file_partition_value "
-		    "WHERE table_id = %d AND partition_key_index = %d AND partition_value IN (%s))",
-		    table_id.index, field.partition_key_index, in_list);
+		string clause =
+		    StringUtil::Format("data.data_file_id IN (SELECT data_file_id FROM %s "
+		                       "WHERE table_id = %d AND partition_key_index = %d AND partition_value IN (%s))",
+		                       partition_value_table, table_id.index, field.partition_key_index, in_list);
 
 		if (!result.empty()) {
 			result += " AND ";
@@ -1863,29 +1874,9 @@ string DuckLakeMetadataManager::BuildBucketPartitionPruningClause(DuckLakeTableE
 	return result;
 }
 
-vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLakeTableEntry &table,
-                                                                        DuckLakeSnapshot snapshot,
-                                                                        const FilterPushdownInfo *filter_info) {
+string DuckLakeMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
+                                                      const vector<DuckLakeFileListDynamicFilter> &dynamic_filters) {
 	auto table_id = table.GetTableId();
-
-	// If we have Top-N dynamic filter pushdown, include file-level min/max stats for pruning and ordering
-	vector<DynamicFilterColumn> dynamic_filter_columns;
-	if (filter_info) {
-		for (auto &entry : filter_info->column_filters) {
-			auto &col_filter = entry.second;
-			auto dynamic_filter_data = DuckLakeUtil::GetOptionalDynamicFilterData(*col_filter.table_filter);
-			if (dynamic_filter_data) {
-				ExpressionType comparison_type;
-				{
-					lock_guard<mutex> l(dynamic_filter_data->lock);
-					comparison_type = dynamic_filter_data->comparison_type;
-				}
-				dynamic_filter_columns.push_back(
-				    {col_filter.column_field_index, comparison_type, col_filter.column_type});
-			}
-		}
-	}
-
 	string query;
 	string where_clause;
 	FilterSQLResult filter_result;
@@ -1908,7 +1899,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		}
 	}
 
-	for (auto &dfc : dynamic_filter_columns) {
+	for (const auto &dfc : dynamic_filters) {
 		auto entry = filter_result.required_ctes.find(dfc.column_field_index);
 		if (entry == filter_result.required_ctes.end()) {
 			filter_result.required_ctes.emplace(dfc.column_field_index,
@@ -1925,7 +1916,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 	string stats_select_list;
 	string stats_join_list;
 	string order_by_clause;
-	for (auto &dfc : dynamic_filter_columns) {
+	for (const auto &dfc : dynamic_filters) {
 		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
 		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
 		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
@@ -1971,12 +1962,36 @@ WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_I
 		)",
 	                            select_list, stats_join_list, table_id.index, table_id.index);
 
-	// Add WHERE clause from filters if it was generated
 	if (!where_clause.empty()) {
 		query += "\nAND " + where_clause;
 	}
-	// Add ORDER BY clause for Top-N optimization if generated
-	query += order_by_clause;
+	return query + order_by_clause;
+}
+
+vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLakeTableEntry &table,
+                                                                        DuckLakeSnapshot snapshot,
+                                                                        const FilterPushdownInfo *filter_info) {
+	auto table_id = table.GetTableId();
+
+	// If we have Top-N dynamic filter pushdown, include file-level min/max stats for pruning and ordering
+	vector<DuckLakeFileListDynamicFilter> dynamic_filter_columns;
+	if (filter_info) {
+		for (auto &entry : filter_info->column_filters) {
+			auto &col_filter = entry.second;
+			auto dynamic_filter_data = DuckLakeUtil::GetOptionalDynamicFilterData(*col_filter.table_filter);
+			if (dynamic_filter_data) {
+				ExpressionType comparison_type;
+				{
+					lock_guard<mutex> l(dynamic_filter_data->lock);
+					comparison_type = dynamic_filter_data->comparison_type;
+				}
+				dynamic_filter_columns.push_back(
+				    {col_filter.column_field_index, comparison_type, col_filter.column_type});
+			}
+		}
+	}
+
+	auto query = GenerateFileListQuery(table, filter_info, dynamic_filter_columns);
 	auto result = Query(snapshot, query);
 	if (result->HasError()) {
 		result->GetErrorObject().Throw("Failed to get data file list from DuckLake: ");

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1876,34 +1876,50 @@ string DuckLakeMetadataManager::BuildBucketPartitionPruningClause(DuckLakeTableE
 
 string DuckLakeMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table, const FilterPushdownInfo *filter_info,
                                                       const vector<DuckLakeFileListDynamicFilter> &dynamic_filters) {
-	auto table_id = table.GetTableId();
-	string query;
-	string where_clause;
+	auto filter_result = GenerateFileListFilterResult(table, filter_info);
+	return AssembleFileListQuery(
+	    table, std::move(filter_result), dynamic_filters, "{METADATA_CATALOG}",
+	    [this](const CTERequirement &req, TableIndex table_id) {
+		    return GenerateFileColumnStatsCTEBody(req, table_id);
+	    },
+	    [this](const string &stats, const LogicalType &type) { return CastStatsToTarget(stats, type); });
+}
+
+FilterSQLResult DuckLakeMetadataManager::GenerateFileListFilterResult(DuckLakeTableEntry &table,
+                                                                      const FilterPushdownInfo *filter_info,
+                                                                      const ColumnStatsFilterSQL *filter_sql,
+                                                                      const string &partition_value_table) {
 	FilterSQLResult filter_result;
-
-	// Collect static filter CTE requirements before adding Top-N dynamic filter requirements.
-	if (filter_info && !filter_info->column_filters.empty()) {
-		filter_result = ConvertFilterPushdownToSQL(*filter_info);
-		where_clause = filter_result.where_conditions;
-
-		// Add bucket-partition pruning for equality / IN-list predicates on bucket()-partitioned columns.
-		// Composes with the zone-map clause above — pruning narrows files, zone maps stay as a backstop.
-		if (table.GetPartitionData()) {
-			string bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info);
-			if (!bucket_clause.empty()) {
-				if (!where_clause.empty()) {
-					where_clause += " AND ";
-				}
-				where_clause += bucket_clause;
-			}
-		}
+	if (!filter_info || filter_info->column_filters.empty()) {
+		return filter_result;
 	}
 
-	for (const auto &dfc : dynamic_filters) {
-		auto entry = filter_result.required_ctes.find(dfc.column_field_index);
+	filter_result = ConvertFilterPushdownToSQL(*filter_info, filter_sql);
+	if (table.GetPartitionData()) {
+		auto bucket_clause = BuildBucketPartitionPruningClause(table, *filter_info, partition_value_table);
+		if (!bucket_clause.empty()) {
+			if (!filter_result.where_conditions.empty()) {
+				filter_result.where_conditions += " AND ";
+			}
+			filter_result.where_conditions += bucket_clause;
+		}
+	}
+	return filter_result;
+}
+
+string DuckLakeMetadataManager::AssembleFileListQuery(DuckLakeTableEntry &table, FilterSQLResult filter_result,
+                                                      const vector<DuckLakeFileListDynamicFilter> &dynamic_filters,
+                                                      const string &metadata_table_prefix,
+                                                      const FileColumnStatsCTEBodyGenerator &generate_cte_body,
+                                                      const FileListStatsCastGenerator &cast_stats) {
+	auto table_id = table.GetTableId();
+
+	for (const auto &dynamic_filter : dynamic_filters) {
+		auto entry = filter_result.required_ctes.find(dynamic_filter.column_field_index);
 		if (entry == filter_result.required_ctes.end()) {
-			filter_result.required_ctes.emplace(dfc.column_field_index,
-			                                    CTERequirement(dfc.column_field_index, {"min_value", "max_value"}));
+			filter_result.required_ctes.emplace(
+			    dynamic_filter.column_field_index,
+			    CTERequirement(dynamic_filter.column_field_index, {"min_value", "max_value"}));
 		} else {
 			entry->second.referenced_stats.insert("min_value");
 			entry->second.referenced_stats.insert("max_value");
@@ -1911,13 +1927,13 @@ string DuckLakeMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table,
 			entry->second.reference_count++;
 		}
 	}
-	query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id);
+	string query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id, generate_cte_body);
 
 	string stats_select_list;
 	string stats_join_list;
 	string order_by_clause;
-	for (const auto &dfc : dynamic_filters) {
-		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
+	for (const auto &dynamic_filter : dynamic_filters) {
+		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dynamic_filter.column_field_index));
 		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
 		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
 		                                      cte_name.c_str());
@@ -1927,18 +1943,23 @@ string DuckLakeMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table,
 		// We only order by the first dynamic filter column: Top-N typically has a single ordering column,
 		// and multiple columns would have conflicting requirements (e.g., ORDER BY a DESC, b ASC).
 		if (order_by_clause.empty()) {
-			const bool seeking_high_values = dfc.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
-			                                 dfc.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
-			const bool seeking_low_values = dfc.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
-			                                dfc.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
+			const bool seeking_high_values =
+			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHAN ||
+			    dynamic_filter.comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+			const bool seeking_low_values = dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHAN ||
+			                                dynamic_filter.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
 			if (seeking_high_values) {
 				// For DESC Top-N (seeking high values), order by max_value DESC so files with highest values come first
-				auto cast_expr = CastStatsToTarget(cte_name + ".max_value", dfc.column_type);
-				order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", cast_expr);
+				auto cast_expr = cast_stats(cte_name + ".max_value", dynamic_filter.column_type);
+				if (!cast_expr.empty()) {
+					order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", cast_expr);
+				}
 			} else if (seeking_low_values) {
 				// For ASC Top-N (seeking low values), order by min_value ASC so files with lowest values come first
-				auto cast_expr = CastStatsToTarget(cte_name + ".min_value", dfc.column_type);
-				order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", cast_expr);
+				auto cast_expr = cast_stats(cte_name + ".min_value", dynamic_filter.column_type);
+				if (!cast_expr.empty()) {
+					order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", cast_expr);
+				}
 			}
 		}
 	}
@@ -1950,20 +1971,21 @@ string DuckLakeMetadataManager::GenerateFileListQuery(DuckLakeTableEntry &table,
 	// Add base query
 	query += StringUtil::Format(R"(
 SELECT %s
-FROM {METADATA_CATALOG}.ducklake_data_file data
+FROM %s.ducklake_data_file data
 %s
 LEFT JOIN (
     SELECT *
-    FROM {METADATA_CATALOG}.ducklake_delete_file
+    FROM %s.ducklake_delete_file
     WHERE table_id=%d  AND {SNAPSHOT_ID} >= begin_snapshot
           AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
     ) del ON del.data_file_id = data.data_file_id
 WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
 		)",
-	                            select_list, stats_join_list, table_id.index, table_id.index);
+	                            select_list, metadata_table_prefix, stats_join_list, metadata_table_prefix,
+	                            table_id.index, table_id.index);
 
-	if (!where_clause.empty()) {
-		query += "\nAND " + where_clause;
+	if (!filter_result.where_conditions.empty()) {
+		query += "\nAND " + filter_result.where_conditions;
 	}
 	return query + order_by_clause;
 }

--- a/test/sql/stats/file_list_metadata_query.test
+++ b/test/sql/stats/file_list_metadata_query.test
@@ -154,3 +154,36 @@ WHERE ts = TIMESTAMP '2026-01-05' AND score IS NULL
 ORDER BY score DESC LIMIT 1
 ----
 2026-01-05 00:00:00
+
+# FLOAT stats must use PostgreSQL's REAL type for both static pruning and Top-N ordering.
+statement ok
+CREATE TABLE float_events(value FLOAT)
+
+statement ok
+INSERT INTO float_events VALUES (0.25)
+
+statement ok
+INSERT INTO float_events VALUES (2.5)
+
+query I
+SELECT value = 2.5::FLOAT FROM float_events
+WHERE value > 1
+ORDER BY value DESC LIMIT 1
+----
+true
+
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COUNT(*) = 1
+     FROM (
+         SELECT lower(regexp_replace(query, '\s+', '', 'g')) AS query
+         FROM duckdb_logs_parsed('DuckLakeMetadata')
+     ) logs
+     WHERE query LIKE 'select*frompostgres_query(%'
+       AND query LIKE '%wherecolumn_id=1andtable_id=3%'
+       AND query LIKE '%col_1_statsasmaterialized%'
+       AND query LIKE '%max_value::real>%'
+       AND query LIKE '%orderbycol_1_stats.max_value::realdescnullslast%')
+    ELSE true END
+----
+true

--- a/test/sql/stats/file_list_metadata_query.test
+++ b/test/sql/stats/file_list_metadata_query.test
@@ -1,0 +1,156 @@
+# name: test/sql/stats/file_list_metadata_query.test
+# description: Route the complete file-list metadata read through PostgreSQL
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/file_list_metadata_query', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.events(ts TIMESTAMP, bucket_key VARCHAR)
+
+statement ok
+ALTER TABLE ducklake.events SET PARTITIONED BY (bucket(4, bucket_key))
+
+statement ok
+INSERT INTO ducklake.events VALUES (TIMESTAMP '2026-01-01', 'bucket')
+
+statement ok
+INSERT INTO ducklake.events VALUES
+    (TIMESTAMP '2026-01-02', 'bucket'),
+    (TIMESTAMP '2026-01-03', 'bucket'),
+    (TIMESTAMP '2026-01-04', 'other')
+
+statement ok
+SET VARIABLE before_delete = (SELECT max(snapshot_id) FROM ducklake.snapshots())
+
+statement ok
+DELETE FROM ducklake.events WHERE ts = TIMESTAMP '2026-01-03'
+
+# The current snapshot must honor the partial delete file.
+query T
+SELECT ts FROM ducklake.events
+WHERE ts >= TIMESTAMP '2026-01-02' AND bucket_key = 'bucket'
+ORDER BY ts DESC LIMIT 1
+----
+2026-01-02 00:00:00
+
+# The same file list at the earlier snapshot must not apply the later delete.
+query T
+SELECT ts FROM ducklake.events AT (VERSION => getvariable('before_delete'))
+WHERE ts >= TIMESTAMP '2026-01-02' AND bucket_key = 'bucket'
+ORDER BY ts DESC LIMIT 1
+----
+2026-01-03 00:00:00
+
+statement ok
+USE ducklake
+
+statement ok
+CALL enable_logging('DuckLakeMetadata')
+
+query T
+SELECT ts FROM events
+WHERE ts >= TIMESTAMP '2026-01-02' AND bucket_key = 'bucket'
+ORDER BY ts DESC LIMIT 1
+----
+2026-01-02 00:00:00
+
+# PostgreSQL must receive exactly one complete, selective statement for the file-list operation.
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COALESCE(SUM(
+         (length(query) - length(replace(query, 'postgres_query', ''))) / length('postgres_query')
+     ), 0) = 1
+     FROM (
+         SELECT lower(regexp_replace(query, '\s+', '', 'g')) AS query
+         FROM duckdb_logs_parsed('DuckLakeMetadata')
+     ) logs
+     WHERE query LIKE '%ducklake_data_file%'
+        OR query LIKE '%ducklake_delete_file%'
+        OR query LIKE '%ducklake_file_column_stats%'
+        OR query LIKE '%ducklake_file_partition_value%')
+    ELSE true END
+----
+true
+
+# The static and Top-N timestamp filters share col_1_stats and one PostgreSQL stats-table read.
+# The bucket-key filter independently requires col_2_stats, so the remote query has two stats reads total.
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COUNT(*) = 1
+     FROM (
+         SELECT lower(regexp_replace(query, '\s+', '', 'g')) AS query
+         FROM duckdb_logs_parsed('DuckLakeMetadata')
+     ) logs
+     WHERE query LIKE 'select*frompostgres_query(%'
+       AND length(query) - length(replace(query, 'postgres_query', '')) = length('postgres_query')
+       AND query LIKE '%ducklake_data_file%'
+       AND query LIKE '%ducklake_delete_file%'
+       AND query LIKE '%ducklake_file_column_stats%'
+       AND query LIKE '%ducklake_file_partition_value%'
+       AND query LIKE '%wheredata.table_id=1and%>=data.begin_snapshotand(%<data.end_snapshotordata.end_snapshotisnull)%'
+       AND query LIKE '%wheretable_id=1and%>=begin_snapshotand(%<end_snapshotorend_snapshotisnull)%'
+       AND query LIKE '%wherecolumn_id=1andtable_id=1%'
+       AND query LIKE '%wheretable_id=1andpartition_key_index=0andpartition_valuein(%'
+       AND query LIKE '%del.data_file_id=data.data_file_id%'
+       AND query LIKE '%data.data_file_idin(selectdata_file_idfrom%ducklake_file_partition_value%'
+       AND query LIKE '%2026-01-02%'
+       AND query LIKE '%orderby(casewhencol_1_stats.max_value~%descnullslast%'
+       AND length(query) - length(replace(query, '2026-01-02', '')) = length('2026-01-02')
+       AND length(query) - length(replace(query, 'ducklake_file_column_stats', '')) =
+           2 * length('ducklake_file_column_stats')
+       AND length(query) - length(replace(query, 'wherecolumn_id=1andtable_id=1', '')) =
+           length('wherecolumn_id=1andtable_id=1')
+       AND length(query) - length(replace(query, 'wherecolumn_id=2andtable_id=1', '')) =
+           length('wherecolumn_id=2andtable_id=1')
+       AND length(query) - length(replace(query, 'col_1_statsasmaterialized', '')) =
+           length('col_1_statsasmaterialized'))
+    ELSE true END
+----
+true
+
+# None of the four relations may remain as an attached PostgreSQL scan outside that statement.
+query I
+SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
+    (SELECT COUNT(*) = 0
+     FROM (
+         SELECT lower(regexp_replace(query, '\s+', '', 'g')) AS query
+         FROM duckdb_logs_parsed('DuckLakeMetadata')
+     ) logs
+     WHERE query LIKE '%"__ducklake_metadata_%ducklake_data_file%'
+        OR query LIKE '%"__ducklake_metadata_%ducklake_delete_file%'
+        OR query LIKE '%"__ducklake_metadata_%ducklake_file_column_stats%'
+        OR query LIKE '%"__ducklake_metadata_%ducklake_file_partition_value%')
+    ELSE true END
+----
+true
+
+# Files written before a column was added have no stats row for it and must remain eligible.
+statement ok
+ALTER TABLE events ADD COLUMN score INTEGER
+
+query T
+SELECT ts FROM events
+WHERE ts = TIMESTAMP '2026-01-01' AND score IS NULL
+ORDER BY score DESC LIMIT 1
+----
+2026-01-01 00:00:00
+
+# An all-NULL column has NULL min/max stats and must likewise remain eligible.
+statement ok
+INSERT INTO events VALUES (TIMESTAMP '2026-01-05', 'bucket', NULL)
+
+query T
+SELECT ts FROM events
+WHERE ts = TIMESTAMP '2026-01-05' AND score IS NULL
+ORDER BY score DESC LIMIT 1
+----
+2026-01-05 00:00:00


### PR DESCRIPTION
Stacked on #1416.

Extract shared file-list filter preparation and SQL assembly so the default and PostgreSQL metadata managers reuse CTE requirement merging, stats joins, Top-N ordering, snapshot/delete joins, and filter composition. PostgreSQL continues to provide its native stats CTE body, casts, relation prefix, and outer `postgres_query` wrapper.

No behavior change is intended.

Tests:
- focused file-list/filter/Top-N/delete/bucket tests with DuckDB metadata
- focused tests with SQLite metadata
- focused tests with PostgreSQL metadata
- format check and `git diff --check`