### PR TITLE
KMS-agnostic envelope encryption: abstract provider interface

### DIFF
--- a/src/include/storage/ducklake_encryption_provider.hpp
+++ b/src/include/storage/ducklake_encryption_provider.hpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_encryption_provider.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/vector.hpp"
+
+#include <functional>
+
+namespace duckdb {
+class DatabaseInstance;
+
+//! What a per-file encryption key is cryptographically bound to, so a wrapped blob minted for one
+//! file cannot be used as the key for another.
+struct DuckLakeFileIdentity {
+	string lake_id;
+	int64_t table_id = 0;
+	//! Data files and delete files have independent id spaces and separate catalog tables, so the
+	//! kind of file is part of the binding.
+	bool is_delete_file = false;
+	//! The path as stored in ducklake_data_file / ducklake_delete_file, before it is resolved
+	//! against the table's data path - which is a mutable table property.
+	string stored_path;
+};
+
+//! One entry of a rewrap batch reply.
+struct DuckLakeRewrapResult {
+	//! The value the row should carry from now on. When `rewrapped` is false this is the value that
+	//! was sent, so a converged sweep writes nothing.
+	string wrapped;
+	//! Whether the provider moved this entry onto its active key.
+	bool rewrapped = false;
+};
+
+//! Envelope encryption provider: wraps the per-file DEKs DuckLake stores in `encryption_key` so the
+//! metadata catalog never holds a usable key. One instance per attached lake.
+//!
+//! Every operation takes a batch: a scan materialises its whole file-and-key list before reading any
+//! file, so one round trip serves a scan.
+//!
+//! `encryption_key` stays an opaque VARCHAR, so no catalog schema change is required.
+class DuckLakeEncryptionProvider {
+public:
+	//! Lifetime of a cached unwrapped DEK when ATTACH does not specify one.
+	static constexpr int64_t DEFAULT_CACHE_TTL_SECONDS = 300;
+	//! Ceiling for a configured cache TTL, so it cannot be raised to an effectively unbounded one.
+	static constexpr int64_t MAX_CACHE_TTL_SECONDS = 3600;
+
+	virtual ~DuckLakeEncryptionProvider() = default;
+
+	//! Wrap one commit's worth of keys. `deks` are raw key bytes; the returned strings are the
+	//! values the `encryption_key` column will carry.
+	virtual vector<string> WrapKeys(const vector<DuckLakeFileIdentity> &identities, const vector<string> &deks) = 0;
+
+	//! Unwrap a single stored value into raw DEK bytes. Must refuse a value that is not an envelope
+	//! blob: on an enveloped lake a plaintext key is a pre-envelope leftover or a downgrade attempt.
+	virtual string UnwrapKey(const DuckLakeFileIdentity &identity, const string &stored_value) = 0;
+
+	//! Move a batch of stored values onto the provider's active key - the sweep step of a key
+	//! rotation, which never exposes the plaintext DEK to the caller.
+	virtual vector<DuckLakeRewrapResult> RewrapKeys(const vector<DuckLakeFileIdentity> &identities,
+	                                                const vector<string> &blobs) = 0;
+
+	//! Assert the key service is reachable and report what it is rooted in. Called at ATTACH so a
+	//! misconfiguration surfaces there rather than mid-scan.
+	virtual string SelfTest() = 0;
+
+	//! The configured lake id that scopes every key in this lake.
+	virtual const string &GetLakeId() const = 0;
+
+	//! True when `stored_value` carries the wrapped-value header, which is fixed at this interface
+	//! level rather than chosen per provider. Lets a reader that has no provider tell a wrapped row
+	//! from a plaintext one without a service call, and refuse it instead of handing ciphertext to
+	//! the Parquet reader as a key.
+	static bool LooksWrapped(const string &stored_value);
+
+	//! True when `value` is non-empty and every character is in the base64 alphabet. Alphabet only:
+	//! length and padding are the provider's to judge.
+	static bool IsBase64(const string &value);
+
+	//! Creates the provider for one attached lake. A build that integrates a key service registers a
+	//! factory; with none registered the catalog refuses ENCRYPTION_SOCKET at ATTACH.
+	//!
+	//! `db` is the attaching database: a provider takes its crypto primitives from it rather than
+	//! choosing its own, so it follows whatever policy that database is configured with.
+	using Factory = std::function<unique_ptr<DuckLakeEncryptionProvider>(
+	    DatabaseInstance &db, const string &encryption_socket, const string &encryption_lake_id,
+	    idx_t cache_ttl_seconds)>;
+	//! Throws when a factory is already registered: a second one would make the provider a lake gets
+	//! depend on extension load order.
+	static void RegisterFactory(Factory factory);
+	//! Whether a provider factory is already registered.
+	static bool HasFactory();
+	static const Factory &GetFactory();
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(
   ducklake_transaction.cpp
   ducklake_transaction_state.cpp
   ducklake_view_entry.cpp
-  ducklake_transaction_changes.cpp)
+  ducklake_transaction_changes.cpp
+  ducklake_encryption_provider.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_storage>
     PARENT_SCOPE)

--- a/src/storage/ducklake_encryption_provider.cpp
+++ b/src/storage/ducklake_encryption_provider.cpp
@@ -1,0 +1,69 @@
+#include "storage/ducklake_encryption_provider.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+namespace {
+
+//! Base64 of a 32-byte key: the longest `encryption_key` a lake without an envelope stores. A
+//! wrapped value carries a header and an authentication tag on top of the key, so it is longer.
+constexpr idx_t LONGEST_PLAINTEXT_KEY_LENGTH = 44;
+
+//! Registered once for the life of the process so a factory survives ATTACH/DETACH; never freed,
+//! hence a raw pointer rather than a global with an exit-time destructor.
+DuckLakeEncryptionProvider::Factory *global_factory = nullptr;
+
+} // namespace
+
+// Out-of-line definitions: the constants are ODR-used (e.g. passed by reference into a variadic
+// exception constructor), and under C++11 an ODR-used static constexpr member needs a definition.
+constexpr int64_t DuckLakeEncryptionProvider::DEFAULT_CACHE_TTL_SECONDS;
+constexpr int64_t DuckLakeEncryptionProvider::MAX_CACHE_TTL_SECONDS;
+
+bool DuckLakeEncryptionProvider::LooksWrapped(const string &stored_value) {
+	// A wrapped value starts with the fixed header "DLK1", whose first three bytes base64 as the
+	// literal prefix "RExL". The length floor is part of the test: without it a plaintext key that
+	// happens to start with those three bytes would be misread as wrapped and refused forever.
+	if (stored_value.size() <= LONGEST_PLAINTEXT_KEY_LENGTH) {
+		return false;
+	}
+	return stored_value.compare(0, 4, "RExL") == 0;
+}
+
+bool DuckLakeEncryptionProvider::IsBase64(const string &value) {
+	if (value.empty()) {
+		return false;
+	}
+	for (auto character : value) {
+		auto c = static_cast<unsigned char>(character);
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '+' || c == '/' ||
+		    c == '=') {
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+void DuckLakeEncryptionProvider::RegisterFactory(Factory factory) {
+	if (global_factory) {
+		throw InvalidInputException("a DuckLake encryption provider factory is already registered - registering a "
+		                            "second one would make the provider a lake gets depend on extension load order");
+	}
+	global_factory = new Factory(std::move(factory));
+}
+
+bool DuckLakeEncryptionProvider::HasFactory() {
+	return global_factory != nullptr;
+}
+
+const DuckLakeEncryptionProvider::Factory &DuckLakeEncryptionProvider::GetFactory() {
+	static Factory empty;
+	if (!global_factory) {
+		return empty;
+	}
+	return *global_factory;
+}
+
+} // namespace duckdb


### PR DESCRIPTION
## What this is

An abstract `DuckLakeEncryptionProvider` interface plus the ATTACH options that will drive it (`ENCRYPTION_SOCKET`, `ENCRYPTION_LAKE_ID`, `ENCRYPTION_CACHE_TTL_SECONDS`). It lets a build that links a key-management service wrap the per-file DEKs DuckLake stores in `encryption_key`, so the metadata catalog at rest never holds a usable key — while keeping DuckLake itself free of any dependency on a particular KMS.

This commit is inert on its own: nothing constructs a provider, no behavior changes, and with no factory registered the new ATTACH options are refused. The catalog wiring, fail-closed guards, key-rotation sweep, and an executable reference provider with end-to-end SQL tests are in the follow-up PR #1424 (built on this branch; the two can be reviewed together and merged as one if preferred).

## Design notes

**The factory takes `DatabaseInstance &`.** A provider needs crypto primitives (AEAD, random). Taking them from the attaching database via `GetEncryptionUtil()` means a provider inherits whatever crypto policy that database is configured with — OpenSSL when httpfs is loaded, mbedtls otherwise, and the `force_mbedtls_unsafe` escape hatch when a test asks for it. A provider that instantiated its own crypto would silently ignore that policy.

**Process-global factory slot.** The smallest mechanism that lets an integrating extension make a provider selectable at ATTACH time without DuckLake depending on it. `RegisterFactory` refuses a second registration rather than overwriting — otherwise the provider a lake gets would depend on extension load order. `HasFactory()` lets a loader that runs once per `DatabaseInstance` skip re-registration, since registration is per-process. If you'd rather hang this off `DBConfig` or an extension callback, the interface is unchanged; only `RegisterFactory`/`GetFactory`/`HasFactory` move.

**`LooksWrapped` is static, not virtual**, because the reader that needs it may have no provider at all — that is exactly the fail-closed case: a lake re-attached without envelope options must recognize "this stored key is a wrapped blob I cannot open" without a service call, and refuse rather than hand ciphertext to the Parquet reader as an AES key. The check is base64 prefix `RExL` (the first three bytes of the `DLK1` header) **and** length > 44 (the base64 length of a 32-byte key, the longest a plain lake stores), so no plaintext key can be misclassified.

**Batch-first API.** Every operation takes a batch: a scan materializes its whole file-and-key list before reading any file, so one KMS round trip serves a scan.

**`encryption_key` stays an opaque VARCHAR** — no catalog schema change.

## Verification

- Builds clean standalone on this base.
- Exercised end to end (wrap/unwrap, fail-closed re-attach, rotation sweep) by the SQL test suite in #1424 — all green, run against the built extension.
- Related: #1403 (CSPRNG for key generation) is independent of this interface.
