### PR TITLE
Catalog wiring for the KMS-agnostic encryption provider (#1423 follow-up)

### DIFF
--- a/src/common/ducklake_util.cpp
+++ b/src/common/ducklake_util.cpp
@@ -489,6 +489,21 @@ string DuckLakeUtil::EncryptionKeyLiteral(const string &key) {
 	return "'" + Blob::ToBase64(string_t(key)) + "'";
 }
 
+string DuckLakeUtil::StoredEncryptionKeyLiteral(const string &stored_key) {
+	if (stored_key.empty()) {
+		return "NULL";
+	}
+	return SQLLiteralToString(stored_key);
+}
+
+void DuckLakeUtil::EncodeStoredEncryptionKeys(vector<string> &keys) {
+	for (auto &key : keys) {
+		if (!key.empty()) {
+			key = Blob::ToBase64(string_t(key));
+		}
+	}
+}
+
 const char *DuckLakeUtil::BoolLiteral(bool v) {
 	return v ? "true" : "false";
 }

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -124,6 +124,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	// Register murmur3_32 scalar function for Iceberg-compatible bucket partitioning
 	auto murmur3_func = DuckLakeMurmur3Function();
 	loader.RegisterFunction(murmur3_func);
+
+	auto rewrap_keys = DuckLakeRewrapKeysFunction();
+	loader.RegisterFunction(rewrap_keys);
+	auto self_test = DuckLakeSelfTestFunction();
+	loader.RegisterFunction(self_test);
 }
 
 void DucklakeExtension::Load(ExtensionLoader &loader) {

--- a/src/ducklake_extension.cpp
+++ b/src/ducklake_extension.cpp
@@ -12,6 +12,8 @@
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "storage/ducklake_log_type.hpp"
+#include "storage/ducklake_reference_encryption_provider.hpp"
+#include <cstdlib>
 
 namespace duckdb {
 
@@ -129,6 +131,15 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterFunction(rewrap_keys);
 	auto self_test = DuckLakeSelfTestFunction();
 	loader.RegisterFunction(self_test);
+
+	// Test fixture only, and opt-in: a build that does not set the variable registers no factory, so an
+	// ATTACH with encryption_socket is refused rather than served by a provider with a public key.
+	auto *reference_provider = std::getenv("DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER");
+	if (reference_provider && string(reference_provider) == "1") {
+		RegisterDuckLakeReferenceEncryptionProviderForTests();
+		auto set_active_version = DuckLakeReferenceProviderSetActiveVersionFunction();
+		loader.RegisterFunction(set_active_version);
+	}
 }
 
 void DucklakeExtension::Load(ExtensionLoader &loader) {

--- a/src/functions/CMakeLists.txt
+++ b/src/functions/CMakeLists.txt
@@ -18,7 +18,9 @@ add_library(
   ducklake_table_changes.cpp
   ducklake_table_info.cpp
   ducklake_table_insertions.cpp
-  ducklake_murmur3.cpp)
+  ducklake_murmur3.cpp
+  ducklake_rewrap_keys.cpp
+  ducklake_self_test.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_functions>
     PARENT_SCOPE)

--- a/src/functions/ducklake_flush_inlined_data.cpp
+++ b/src/functions/ducklake_flush_inlined_data.cpp
@@ -498,8 +498,11 @@ LEFT JOIN (
 					file_info.existing_delete_path_is_relative = chunk->GetValue(7, row_idx).GetValue<bool>();
 					file_info.existing_delete_begin_snapshot = chunk->GetValue(8, row_idx).GetValue<idx_t>();
 					if (!chunk->GetValue(9, row_idx).IsNull()) {
-						file_info.existing_delete_encryption_key =
-						    Blob::FromBase64(chunk->GetValue(9, row_idx).GetValue<string>());
+						auto resolved = file_info.existing_delete_path_is_relative
+						                    ? table.DataPath() + file_info.existing_delete_path
+						                    : file_info.existing_delete_path;
+						file_info.existing_delete_encryption_key = transaction.GetCatalog().ResolveStoredEncryptionKey(
+						    table_id, file_info.existing_delete_path, resolved, true, chunk->GetValue(9, row_idx));
 					}
 					if (!chunk->GetValue(10, row_idx).IsNull()) {
 						file_info.existing_delete_format =

--- a/src/functions/ducklake_rewrap_keys.cpp
+++ b/src/functions/ducklake_rewrap_keys.cpp
@@ -1,0 +1,242 @@
+#include "common/ducklake_util.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_encryption_provider.hpp"
+#include "storage/ducklake_transaction.hpp"
+
+#include <limits>
+
+namespace duckdb {
+
+//! One row of the sweep's report. Carries no key material, old or new.
+struct RewrapReportRow {
+	string file_kind;
+	int64_t table_id = 0;
+	int64_t file_id = 0;
+	string stored_path;
+	bool rewrapped = false;
+};
+
+struct RewrapKeysBindData : public TableFunctionData {
+	explicit RewrapKeysBindData(Catalog &catalog) : catalog(catalog) {
+	}
+
+	Catalog &catalog;
+	bool dry_run = false;
+	idx_t batch_size = 128;
+};
+
+struct RewrapKeysGlobalState : public GlobalTableFunctionState {
+	idx_t offset = 0;
+	bool executed = false;
+	vector<RewrapReportRow> report;
+};
+
+//! The catalog tables that carry an encryption_key. Both must be swept: a delete file whose key is
+//! left on the retired version breaks every read of the rows it deletes.
+struct RewrapTarget {
+	const char *table_name;
+	const char *id_column;
+	bool is_delete_file;
+};
+
+static const RewrapTarget REWRAP_TARGETS[] = {
+    {"ducklake_data_file", "data_file_id", false},
+    {"ducklake_delete_file", "delete_file_id", true},
+};
+
+static unique_ptr<FunctionData> DuckLakeRewrapKeysBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<Identifier> &names) {
+	auto &catalog = DuckLakeBaseMetadataFunction::GetCatalog(context, input.inputs[0]);
+	auto &ducklake_catalog = catalog.Cast<DuckLakeCatalog>();
+	auto result = make_uniq<RewrapKeysBindData>(catalog);
+
+	for (auto &entry : input.named_parameters) {
+		if (entry.first == "dry_run") {
+			result->dry_run = BooleanValue::Get(entry.second);
+		} else if (entry.first == "batch_size") {
+			auto requested = entry.second.GetValue<int64_t>();
+			if (requested <= 0) {
+				throw InvalidInputException("ducklake_rewrap_keys: batch_size must be positive, got %lld",
+				                            static_cast<long long>(requested));
+			}
+			result->batch_size = NumericCast<idx_t>(requested);
+		} else {
+			throw InternalException("Unsupported named parameter for ducklake_rewrap_keys");
+		}
+	}
+
+	// Refused at bind rather than reported as an empty sweep: an empty sweep reads as "nothing left to
+	// do", which is the reading under which the outgoing key gets retired.
+	if (!ducklake_catalog.EncryptionProvider()) {
+		throw InvalidInputException("ducklake_rewrap_keys: this DuckLake was attached without encryption_socket, so "
+		                            "its encryption keys are unwrapped and there is nothing to rewrap");
+	}
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("file_kind");
+	return_types.emplace_back(LogicalType::BIGINT);
+	names.emplace_back("table_id");
+	return_types.emplace_back(LogicalType::BIGINT);
+	names.emplace_back("file_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("path");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("rewrapped");
+	return std::move(result);
+}
+
+static unique_ptr<GlobalTableFunctionState> DuckLakeRewrapKeysInit(ClientContext &context,
+                                                                   TableFunctionInitInput &input) {
+	return make_uniq<RewrapKeysGlobalState>();
+}
+
+//! `"catalog"."schema"`, spelled out because the sweep runs on its own connection and so never goes
+//! through DuckLakeMetadataManager::Query, which is what expands {METADATA_CATALOG}.
+static string MetadataCatalogPrefix(DuckLakeCatalog &catalog) {
+	return DuckLakeUtil::SQLIdentifierToString(catalog.MetadataDatabaseName()) + "." +
+	       DuckLakeUtil::SQLIdentifierToString(catalog.MetadataSchemaName());
+}
+
+static void RequireSuccess(QueryResult &result, const string &what) {
+	if (result.HasError()) {
+		throw IOException("ducklake_rewrap_keys: %s failed: %s", what, result.GetError());
+	}
+}
+
+//! Sweeps one catalog table, appending to `report`. `connection` is the sweep's own connection in
+//! autocommit, so an interrupted sweep leaves a committed prefix rather than nothing.
+static void SweepTable(Connection &connection, DuckLakeCatalog &catalog, DuckLakeEncryptionProvider &provider,
+                       const RewrapTarget &target, const RewrapKeysBindData &bind_data,
+                       vector<RewrapReportRow> &report) {
+	auto prefix = MetadataCatalogPrefix(catalog);
+	// Keyset pagination, not OFFSET: the sweep only ever replaces encryption_key, so neither the
+	// predicate nor the ordering key moves under the walk.
+	int64_t last_id = std::numeric_limits<int64_t>::min();
+	while (true) {
+		auto select = StringUtil::Format("SELECT %s, table_id, path, encryption_key FROM %s.%s WHERE "
+		                                 "encryption_key IS NOT NULL AND "
+		                                 "encryption_key <> '' AND %s > %lld ORDER BY %s LIMIT %llu",
+		                                 target.id_column, prefix, target.table_name, target.id_column,
+		                                 static_cast<long long>(last_id), target.id_column,
+		                                 static_cast<uint64_t>(bind_data.batch_size));
+		auto page = connection.Query(select);
+		RequireSuccess(*page, StringUtil::Format("reading a page of %s", target.table_name));
+
+		vector<int64_t> file_ids;
+		vector<int64_t> table_ids;
+		vector<string> stored_paths;
+		vector<string> blobs;
+		vector<DuckLakeFileIdentity> identities;
+		for (auto &row : *page) {
+			auto file_id = row.GetValue<int64_t>(0);
+			auto table_id = row.GetValue<int64_t>(1);
+			auto stored_path = row.GetValue<string>(2);
+			auto blob = row.GetValue<string>(3);
+			// An unwrapped key belongs to no key version, so the sweep cannot move it. Walking past it
+			// would report the sweep complete and strand the row when the outgoing version is retired.
+			if (!DuckLakeEncryptionProvider::LooksWrapped(blob)) {
+				throw IOException("ducklake_rewrap_keys: %s file %s (table %lld) carries an unwrapped encryption key, "
+				                  "so there is no key version to move it from. Resolve the row, then re-run the sweep",
+				                  target.is_delete_file ? "delete" : "data", stored_path,
+				                  static_cast<long long>(table_id));
+			}
+			// LooksWrapped only discriminates wrapped from unwrapped; a value outside the base64 alphabet
+			// can never be a wrapped key and is not worth sending to the key service.
+			if (!DuckLakeEncryptionProvider::IsBase64(blob)) {
+				throw IOException("ducklake_rewrap_keys: %s file %s (table %lld) carries an encryption key that is not "
+				                  "base64, so it is corrupt rather than wrapped",
+				                  target.is_delete_file ? "delete" : "data", stored_path,
+				                  static_cast<long long>(table_id));
+			}
+			file_ids.push_back(file_id);
+			table_ids.push_back(table_id);
+			stored_paths.push_back(stored_path);
+			blobs.push_back(blob);
+			// Built from the same row the blob came from, using the stored path rather than a resolved
+			// one, because that is what the key was bound to when it was minted.
+			identities.push_back(catalog.BuildEncryptionIdentity(TableIndex(NumericCast<idx_t>(table_id)), stored_path,
+			                                                     target.is_delete_file));
+			last_id = file_id;
+		}
+		if (identities.empty()) {
+			return;
+		}
+
+		auto results = provider.RewrapKeys(identities, blobs);
+		if (results.size() != identities.size()) {
+			throw IOException("ducklake_rewrap_keys: the encryption provider answered %llu items for %llu files",
+			                  static_cast<uint64_t>(results.size()), static_cast<uint64_t>(identities.size()));
+		}
+
+		for (idx_t i = 0; i < results.size(); i++) {
+			RewrapReportRow entry;
+			entry.file_kind = target.is_delete_file ? "delete" : "data";
+			entry.table_id = table_ids[i];
+			entry.file_id = file_ids[i];
+			entry.stored_path = stored_paths[i];
+			entry.rewrapped = results[i].rewrapped;
+			if (!results[i].rewrapped || bind_data.dry_run) {
+				report.push_back(entry);
+				continue;
+			}
+			if (results[i].wrapped.empty()) {
+				throw IOException("ducklake_rewrap_keys: the encryption provider returned an empty wrapped key for %s, "
+				                  "which would discard the key the file was written with",
+				                  stored_paths[i]);
+			}
+			// Compare-and-swap: written by primary key, and only while encryption_key still holds the
+			// value that was sent. A row another writer changed is left alone for the next pass.
+			auto update = StringUtil::Format(
+			    "UPDATE %s.%s SET encryption_key = %s WHERE %s = %lld AND encryption_key = %s", prefix,
+			    target.table_name, DuckLakeUtil::SQLLiteralToString(results[i].wrapped), target.id_column,
+			    static_cast<long long>(file_ids[i]), DuckLakeUtil::SQLLiteralToString(blobs[i]));
+			auto written = connection.Query(update);
+			RequireSuccess(*written, StringUtil::Format("rewriting a key in %s", target.table_name));
+			report.push_back(entry);
+		}
+	}
+}
+
+static void DuckLakeRewrapKeysExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<RewrapKeysBindData>();
+	auto &state = data_p.global_state->Cast<RewrapKeysGlobalState>();
+
+	if (!state.executed) {
+		auto &ducklake_catalog = data.catalog.Cast<DuckLakeCatalog>();
+		auto provider = ducklake_catalog.EncryptionProvider();
+		if (!provider) {
+			throw InvalidInputException("ducklake_rewrap_keys: this DuckLake has no encryption provider");
+		}
+		// The sweep's own connection, in autocommit, so each batch is durable when it returns.
+		auto &db = DatabaseInstance::GetDatabase(context);
+		Connection connection(db);
+		for (auto &target : REWRAP_TARGETS) {
+			SweepTable(connection, ducklake_catalog, *provider, target, data, state.report);
+		}
+		state.executed = true;
+	}
+
+	idx_t count = 0;
+	while (state.offset < state.report.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = state.report[state.offset++];
+		output.data[0].Append(Value(entry.file_kind));
+		output.data[1].Append(Value::BIGINT(entry.table_id));
+		output.data[2].Append(Value::BIGINT(entry.file_id));
+		output.data[3].Append(Value(entry.stored_path));
+		output.data[4].Append(Value::BOOLEAN(entry.rewrapped));
+		count++;
+	}
+	output.SetChildCardinality(count);
+}
+
+DuckLakeRewrapKeysFunction::DuckLakeRewrapKeysFunction()
+    : TableFunction("ducklake_rewrap_keys", {LogicalType::VARCHAR}, DuckLakeRewrapKeysExecute, DuckLakeRewrapKeysBind,
+                    DuckLakeRewrapKeysInit) {
+	named_parameters["dry_run"] = LogicalType::BOOLEAN;
+	named_parameters["batch_size"] = LogicalType::BIGINT;
+}
+
+} // namespace duckdb

--- a/src/functions/ducklake_self_test.cpp
+++ b/src/functions/ducklake_self_test.cpp
@@ -1,0 +1,103 @@
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "functions/ducklake_table_functions.hpp"
+#include "storage/ducklake_catalog.hpp"
+#include "storage/ducklake_encryption_provider.hpp"
+
+namespace duckdb {
+
+struct SelfTestBindData : public TableFunctionData {
+	optional_ptr<DuckLakeCatalog> catalog;
+};
+
+struct SelfTestGlobalState : public GlobalTableFunctionState {
+	bool finished = false;
+};
+
+static unique_ptr<FunctionData> DuckLakeSelfTestBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types, vector<Identifier> &names) {
+	auto result = make_uniq<SelfTestBindData>();
+
+	if (input.inputs.size() > 1) {
+		throw InvalidInputException("ducklake_self_test takes at most one argument: the name of an attached DuckLake");
+	}
+	if (!input.inputs.empty() && !input.inputs[0].IsNull()) {
+		auto db_name = input.inputs[0].GetValue<string>();
+		auto &db_manager = DatabaseManager::Get(context);
+		auto db = db_manager.GetDatabase(context, Identifier(db_name));
+		if (!db) {
+			throw InvalidInputException("ducklake_self_test: failed to find attached database \"%s\"", db_name);
+		}
+		auto &catalog_obj = db->GetCatalog();
+		if (catalog_obj.GetCatalogType() != "ducklake") {
+			throw InvalidInputException("ducklake_self_test: \"%s\" is a %s catalog, not a ducklake catalog", db_name,
+			                            catalog_obj.GetCatalogType());
+		}
+		result->catalog = catalog_obj.Cast<DuckLakeCatalog>();
+	}
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("extension_name");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("extension_version");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("duckdb_version");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("provider_kind");
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("load_ok");
+	return std::move(result);
+}
+
+static unique_ptr<GlobalTableFunctionState> DuckLakeSelfTestInit(ClientContext &context,
+                                                                 TableFunctionInitInput &input) {
+	return make_uniq<SelfTestGlobalState>();
+}
+
+static void DuckLakeSelfTestExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<SelfTestBindData>();
+	auto &gstate = data_p.global_state->Cast<SelfTestGlobalState>();
+	if (gstate.finished) {
+		output.SetChildCardinality(0);
+		return;
+	}
+	gstate.finished = true;
+
+#ifdef EXT_VERSION_DUCKLAKE
+	string extension_version = EXT_VERSION_DUCKLAKE;
+#else
+	string extension_version = "(dev)";
+#endif
+	// With no DuckLake named this only reports that the extension is loaded and callable.
+	string provider_kind = "not_checked";
+	bool load_ok = true;
+
+	if (data.catalog) {
+		auto provider = data.catalog->EncryptionProvider();
+		if (!provider) {
+			// A lake with no envelope is healthy; there is nothing to check.
+			provider_kind = "catalog_has_no_provider";
+		} else {
+			try {
+				provider_kind = provider->SelfTest();
+			} catch (std::exception &e) {
+				provider_kind = StringUtil::Format("error: %s", e.what());
+				load_ok = false;
+			}
+		}
+	}
+
+	output.data[0].Append(Value("ducklake"));
+	output.data[1].Append(Value(extension_version));
+	output.data[2].Append(Value(DuckDB::LibraryVersion()));
+	output.data[3].Append(Value(provider_kind));
+	output.data[4].Append(Value::BOOLEAN(load_ok));
+	output.SetChildCardinality(1);
+}
+
+DuckLakeSelfTestFunction::DuckLakeSelfTestFunction()
+    : TableFunction("ducklake_self_test", {}, DuckLakeSelfTestExecute, DuckLakeSelfTestBind, DuckLakeSelfTestInit) {
+	varargs = LogicalType::VARCHAR;
+}
+
+} // namespace duckdb

--- a/src/functions/ducklake_set_option.cpp
+++ b/src/functions/ducklake_set_option.cpp
@@ -135,6 +135,11 @@ static unique_ptr<FunctionData> DuckLakeSetOptionBind(ClientContext &context, Ta
 		auto data_inlining_row_limit = val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
 		value = to_string(data_inlining_row_limit);
 		if (data_inlining_row_limit > 0) {
+			if (catalog.Cast<DuckLakeCatalog>().EncryptionProvider()) {
+				throw InvalidInputException("data_inlining_row_limit must stay 0 on a DuckLake attached with "
+				                            "encryption_socket - inlined rows are stored in the metadata catalog, "
+				                            "which no per-file key covers");
+			}
 			ValidateNoReservedInliningColumns(context, catalog, input);
 		}
 	} else if (option == "require_commit_message") {

--- a/src/include/common/ducklake_options.hpp
+++ b/src/include/common/ducklake_options.hpp
@@ -39,6 +39,18 @@ struct DuckLakeOptions {
 	map<TableIndex, option_map_t> table_options;
 	idx_t busy_timeout = 5000;
 	DuckLakeVersion ducklake_version = DuckLakeVersion::UNSET;
+
+	//! Encryption envelope: address of the key service. Unset means no envelope.
+	string encryption_socket;
+	//! Scopes every key in this lake; required whenever encryption_socket is set.
+	string encryption_lake_id;
+	//! Distinguishes an option supplied as empty from an option not supplied.
+	bool encryption_socket_supplied = false;
+	bool encryption_lake_id_supplied = false;
+	//! How long an unwrapped key may stay cached; the default lives in
+	//! DuckLakeEncryptionProvider, hence the flag rather than a pre-set value.
+	int64_t encryption_cache_ttl_seconds = 0;
+	bool encryption_cache_ttl_seconds_supplied = false;
 };
 
 } // namespace duckdb

--- a/src/include/common/ducklake_util.hpp
+++ b/src/include/common/ducklake_util.hpp
@@ -60,7 +60,14 @@ public:
 
 	static string MappingIdOrNull(const MappingIndex &m);
 
+	//! SQL literal for an encryption_key column, base64-encoding the raw key.
 	static string EncryptionKeyLiteral(const string &key);
+
+	//! SQL literal for an encryption_key column whose value is already in its stored form.
+	static string StoredEncryptionKeyLiteral(const string &stored_key);
+
+	//! Puts raw encryption keys into the form stored in encryption_key columns. Empty keys stay empty.
+	static void EncodeStoredEncryptionKeys(vector<string> &keys);
 
 	static const char *BoolLiteral(bool v);
 

--- a/src/include/functions/ducklake_table_functions.hpp
+++ b/src/include/functions/ducklake_table_functions.hpp
@@ -141,4 +141,14 @@ public:
 	DuckLakeCommitFunction();
 };
 
+class DuckLakeRewrapKeysFunction : public TableFunction {
+public:
+	DuckLakeRewrapKeysFunction();
+};
+
+class DuckLakeSelfTestFunction : public TableFunction {
+public:
+	DuckLakeSelfTestFunction();
+};
+
 } // namespace duckdb

--- a/src/include/storage/ducklake_catalog.hpp
+++ b/src/include/storage/ducklake_catalog.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "common/ducklake_encryption.hpp"
+#include "storage/ducklake_encryption_provider.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -226,6 +227,35 @@ public:
 	//! Generate an encryption key for writing (or empty if encryption is disabled)
 	string GenerateEncryptionKey(ClientContext &context) const;
 
+	//! The encryption envelope provider for this lake, or nullptr when none is configured.
+	optional_ptr<DuckLakeEncryptionProvider> EncryptionProvider() const {
+		return encryption_provider.get();
+	}
+	//! `stored_path` must be the path as persisted in the catalog, not one resolved against the data path.
+	DuckLakeFileIdentity BuildEncryptionIdentity(TableIndex table_id, const string &stored_path,
+	                                             bool is_delete_file) const;
+	//! Throws if `stored_key` is a wrapped value while this lake has no provider, so ciphertext is
+	//! never handed to the Parquet reader as a key.
+	void RefuseWrappedKeyWithoutProvider(const string &file_path, const string &stored_key) const;
+	//! Throws if this lake is ENCRYPTED and the stored key is NULL. A NULL is the ordinary case on an
+	//! unencrypted lake, where this returns.
+	void RefuseMissingEncryptionKey(const string &file_path) const;
+	//! Throws unless `decoded_key` is a length AES accepts: 16, 24 or 32 bytes.
+	void RefuseUnusableEncryptionKey(const string &file_path, const string &decoded_key) const;
+	//! The key-resolution choke point: turns a stored `encryption_key` value into the raw key bytes
+	//! the Parquet reader wants, through the provider when one is configured.
+	string ResolveStoredEncryptionKey(TableIndex table_id, const string &stored_path, const string &resolved_path,
+	                                  bool is_delete_file, const Value &stored_key) const;
+	//! Turns each non-empty raw key in `keys` into the value `encryption_key` must carry, in place.
+	//! One commit is one `WrapKeys` call. Empty keys are left empty.
+	void PrepareFileKeysForCommit(const vector<TableIndex> &table_ids, const vector<string> &stored_paths,
+	                              bool is_delete_file, vector<string> &keys) const;
+	//! Turns on `temp_file_encryption` at ATTACH for an enveloped lake, refusing the ATTACH if it
+	//! cannot be turned on.
+	void RequireEncryptedTempSpill(ClientContext &context);
+	//! Refuses to touch an enveloped lake's key material while this process would spill in the clear.
+	void RefuseUnencryptedTempSpill(const string &what) const;
+
 	//! The resolved DuckLake spec version of the attached catalog
 	DuckLakeVersion GetDuckLakeVersion() const {
 		return ducklake_version;
@@ -326,6 +356,8 @@ private:
 	mutable mutex config_lock;
 	//! The DuckLake options
 	DuckLakeOptions options;
+	//! The encryption envelope provider, or nullptr when none is configured
+	unique_ptr<DuckLakeEncryptionProvider> encryption_provider;
 	//! The path separator
 	string separator = "/";
 	//! A unique tracker for catalog changes in uncommitted transactions.

--- a/src/include/storage/ducklake_encryption_provider.hpp
+++ b/src/include/storage/ducklake_encryption_provider.hpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_encryption_provider.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/vector.hpp"
+
+#include <functional>
+
+namespace duckdb {
+class DatabaseInstance;
+
+//! What a per-file encryption key is cryptographically bound to, so a wrapped blob minted for one
+//! file cannot be used as the key for another.
+struct DuckLakeFileIdentity {
+	string lake_id;
+	int64_t table_id = 0;
+	//! Data files and delete files have independent id spaces and separate catalog tables, so the
+	//! kind of file is part of the binding.
+	bool is_delete_file = false;
+	//! The path as stored in ducklake_data_file / ducklake_delete_file, before it is resolved
+	//! against the table's data path - which is a mutable table property.
+	string stored_path;
+};
+
+//! One entry of a rewrap batch reply.
+struct DuckLakeRewrapResult {
+	//! The value the row should carry from now on. When `rewrapped` is false this is the value that
+	//! was sent, so a converged sweep writes nothing.
+	string wrapped;
+	//! Whether the provider moved this entry onto its active key.
+	bool rewrapped = false;
+};
+
+//! Envelope encryption provider: wraps the per-file DEKs DuckLake stores in `encryption_key` so the
+//! metadata catalog never holds a usable key. One instance per attached lake.
+//!
+//! Every operation takes a batch: a scan materialises its whole file-and-key list before reading any
+//! file, so one round trip serves a scan.
+//!
+//! `encryption_key` stays an opaque VARCHAR, so no catalog schema change is required.
+class DuckLakeEncryptionProvider {
+public:
+	//! Lifetime of a cached unwrapped DEK when ATTACH does not specify one.
+	static constexpr int64_t DEFAULT_CACHE_TTL_SECONDS = 300;
+	//! Ceiling for a configured cache TTL, so it cannot be raised to an effectively unbounded one.
+	static constexpr int64_t MAX_CACHE_TTL_SECONDS = 3600;
+
+	virtual ~DuckLakeEncryptionProvider() = default;
+
+	//! Wrap one commit's worth of keys. `deks` are raw key bytes; the returned strings are the
+	//! values the `encryption_key` column will carry.
+	virtual vector<string> WrapKeys(const vector<DuckLakeFileIdentity> &identities, const vector<string> &deks) = 0;
+
+	//! Unwrap a single stored value into raw DEK bytes. Must refuse a value that is not an envelope
+	//! blob: on an enveloped lake a plaintext key is a pre-envelope leftover or a downgrade attempt.
+	virtual string UnwrapKey(const DuckLakeFileIdentity &identity, const string &stored_value) = 0;
+
+	//! Move a batch of stored values onto the provider's active key - the sweep step of a key
+	//! rotation, which never exposes the plaintext DEK to the caller.
+	virtual vector<DuckLakeRewrapResult> RewrapKeys(const vector<DuckLakeFileIdentity> &identities,
+	                                                const vector<string> &blobs) = 0;
+
+	//! Assert the key service is reachable and report what it is rooted in. Called at ATTACH so a
+	//! misconfiguration surfaces there rather than mid-scan.
+	virtual string SelfTest() = 0;
+
+	//! The configured lake id that scopes every key in this lake.
+	virtual const string &GetLakeId() const = 0;
+
+	//! True when `stored_value` carries the wrapped-value header, which is fixed at this interface
+	//! level rather than chosen per provider. Lets a reader that has no provider tell a wrapped row
+	//! from a plaintext one without a service call, and refuse it instead of handing ciphertext to
+	//! the Parquet reader as a key.
+	static bool LooksWrapped(const string &stored_value);
+
+	//! True when `value` is non-empty and every character is in the base64 alphabet. Alphabet only:
+	//! length and padding are the provider's to judge.
+	static bool IsBase64(const string &value);
+
+	//! Creates the provider for one attached lake. A build that integrates a key service registers a
+	//! factory; with none registered the catalog refuses ENCRYPTION_SOCKET at ATTACH.
+	//!
+	//! `db` is the attaching database: a provider takes its crypto primitives from it rather than
+	//! choosing its own, so it follows whatever policy that database is configured with.
+	using Factory = std::function<unique_ptr<DuckLakeEncryptionProvider>(
+	    DatabaseInstance &db, const string &encryption_socket, const string &encryption_lake_id,
+	    idx_t cache_ttl_seconds)>;
+	//! Throws when a factory is already registered: a second one would make the provider a lake gets
+	//! depend on extension load order.
+	static void RegisterFactory(Factory factory);
+	//! Whether a provider factory is already registered.
+	static bool HasFactory();
+	static const Factory &GetFactory();
+};
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -512,7 +512,8 @@ private:
 	template <class T>
 	static string FlushDrop(const string &metadata_table_name, const string &id_name, const set<T> &dropped_entries);
 	template <class T>
-	DuckLakeFileData ReadDataFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted);
+	DuckLakeFileData ReadDataFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted,
+	                              bool is_delete_file = false);
 	template <class T>
 	DuckLakeFileData ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx, bool is_encrypted);
 

--- a/src/include/storage/ducklake_reference_encryption_provider.hpp
+++ b/src/include/storage/ducklake_reference_encryption_provider.hpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/ducklake_reference_encryption_provider.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+#include "storage/ducklake_encryption_provider.hpp"
+
+namespace duckdb {
+class DatabaseInstance;
+
+//! A test fixture, never a KMS. It wraps DEKs with real AES-256-GCM, but under a key-encryption key
+//! derived from a seed published in this file's source, and the tests that drive it run with
+//! force_mbedtls_unsafe on, which makes GCM nonces come from a non-cryptographic PRNG. Both are
+//! disqualifying for production; a deployment supplies its own DuckLakeEncryptionProvider.
+//! Each lake_id carries a process-wide active key version so a test can rotate keys and watch
+//! ducklake_rewrap_keys move every blob onto the new version. The cache TTL is ignored: nothing is
+//! cached.
+class DuckLakeReferenceEncryptionProvider : public DuckLakeEncryptionProvider {
+public:
+	DuckLakeReferenceEncryptionProvider(DatabaseInstance &db, string lake_id);
+
+	vector<string> WrapKeys(const vector<DuckLakeFileIdentity> &identities, const vector<string> &deks) override;
+	string UnwrapKey(const DuckLakeFileIdentity &identity, const string &base64_value) override;
+	vector<DuckLakeRewrapResult> RewrapKeys(const vector<DuckLakeFileIdentity> &identities,
+	                                        const vector<string> &blobs) override;
+	string SelfTest() override;
+	const string &GetLakeId() const override;
+
+	//! Sets the active key version for a lake id, so the next rewrap sweep has work to do.
+	static int64_t SetActiveVersionForTests(const string &lake_id, int64_t version);
+	static int64_t GetActiveVersionForTests(const string &lake_id);
+
+private:
+	DatabaseInstance &db;
+	string lake_id;
+};
+
+//! Installs the reference provider as the process-wide encryption provider factory. Idempotent, since
+//! the extension is loaded once per DatabaseInstance and a test binary creates many.
+void RegisterDuckLakeReferenceEncryptionProviderForTests();
+
+//! `ducklake_reference_provider_set_active_version(lake_id, version) -> BIGINT`, so a .test file can
+//! drive a key rotation without new SQL syntax.
+ScalarFunction DuckLakeReferenceProviderSetActiveVersionFunction();
+
+} // namespace duckdb

--- a/src/include/storage/ducklake_transaction_state.hpp
+++ b/src/include/storage/ducklake_transaction_state.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "common/ducklake_util.hpp"
 #include "storage/ducklake_stats.hpp"
 #include "storage/ducklake_transaction.hpp"
 
@@ -53,6 +54,12 @@ struct DuckLakeCommitContext {
 	    try_append_data_files = [](DuckLakeSnapshot &, const vector<DuckLakeFileInfo> &,
 	                               const vector<DuckLakeTableInfo> &, vector<DuckLakeSchemaInfo> &) {
 		    return false;
+	    };
+	//! Puts per-file encryption keys into the form stored in the catalog. A wrapped key is bound to the
+	//! path it is stored under, so this runs once paths are resolved and before any writer emits them.
+	std::function<void(const vector<TableIndex> &, const vector<string> &, bool, vector<string> &)> prepare_file_keys =
+	    [](const vector<TableIndex> &, const vector<string> &, bool, vector<string> &keys) {
+		    DuckLakeUtil::EncodeStoredEncryptionKeys(keys);
 	    };
 	//! Emits the SQL that registers new inlined data tables (CREATE TABLE + ducklake_inlined_data_tables INSERT).
 	std::function<string(DuckLakeSnapshot, const vector<DuckLakeTableInfo> &)> write_inlined_tables =

--- a/src/metadata_manager/quack_metadata_manager.cpp
+++ b/src/metadata_manager/quack_metadata_manager.cpp
@@ -98,6 +98,11 @@ bool QuackMetadataManager::CanSkipSnapshotFetch(const TransactionChangeInformati
 		// the server-side commit cannot create the inlined-data table, take the client-side path instead
 		return false;
 	}
+	if (transaction.GetCatalog().EncryptionProvider()) {
+		// the server assigns the stored path, and a wrapped key is bound to it, so the wrap has to happen
+		// on the client-side path
+		return false;
+	}
 	return ExecuteRetrialsServerSide() && IsDataOnlyCommit(changes);
 }
 
@@ -105,7 +110,8 @@ void QuackMetadataManager::FlushChangesServerSide(DuckLakeTransaction &flush_tra
                                                   DuckLakeSnapshot transaction_snapshot,
                                                   const TransactionChangeInformation &transaction_changes,
                                                   const DuckLakeRetryConfig &retry_config) {
-	if (!IsDataOnlyCommit(transaction_changes) || flush_transaction.GetRequiresNewInlinedTable()) {
+	if (!IsDataOnlyCommit(transaction_changes) || flush_transaction.GetRequiresNewInlinedTable() ||
+	    flush_transaction.GetCatalog().EncryptionProvider()) {
 		flush_transaction.RunCommitLoop(transaction_snapshot, transaction_changes, retry_config);
 		return;
 	}

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(
   ducklake_transaction.cpp
   ducklake_transaction_state.cpp
   ducklake_view_entry.cpp
-  ducklake_transaction_changes.cpp)
+  ducklake_transaction_changes.cpp
+  ducklake_encryption_provider.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_storage>
     PARENT_SCOPE)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -38,7 +38,8 @@ add_library(
   ducklake_view_entry.cpp
   ducklake_transaction_changes.cpp
   ducklake_encryption_provider.cpp
-  ducklake_envelope_guards.cpp)
+  ducklake_envelope_guards.cpp
+  ducklake_reference_encryption_provider.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_storage>
     PARENT_SCOPE)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(
   ducklake_transaction_state.cpp
   ducklake_view_entry.cpp
   ducklake_transaction_changes.cpp
-  ducklake_encryption_provider.cpp)
+  ducklake_encryption_provider.cpp
+  ducklake_envelope_guards.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:ducklake_storage>
     PARENT_SCOPE)

--- a/src/storage/ducklake_catalog.cpp
+++ b/src/storage/ducklake_catalog.cpp
@@ -191,6 +191,55 @@ void DuckLakeCatalog::EnsureCommitInfoProvided(const DuckLakeSnapshotCommit &com
 DuckLakeCatalog::DuckLakeCatalog(AttachedDatabase &db_p, DuckLakeOptions options_p)
     : Catalog(db_p), options(std::move(options_p)), last_uncommitted_catalog_version(TRANSACTION_ID_START),
       instance_id(UUID::ToString(UUID::GenerateRandomUUID())) {
+	// Checked outside the socket gate: encryption_cache_ttl_seconds does not itself turn the envelope
+	// on, so supplying it alone would be silently ignored.
+	if (options.encryption_cache_ttl_seconds_supplied && !options.encryption_socket_supplied) {
+		throw InvalidInputException(
+		    "encryption_cache_ttl_seconds requires encryption_socket - drop it, or configure an encryption envelope");
+	}
+	if (options.encryption_socket_supplied || options.encryption_lake_id_supplied) {
+		if (!options.encryption_socket_supplied) {
+			throw InvalidInputException("encryption_lake_id requires encryption_socket - supply both, or neither");
+		}
+		if (options.encryption_socket.empty()) {
+			throw InvalidInputException("encryption_socket was set to an empty string - supply the address of the key "
+			                            "service, or omit the option to run without an encryption envelope");
+		}
+		if (options.encryption_lake_id.empty()) {
+			throw InvalidInputException("encryption_socket requires a non-empty encryption_lake_id - without it keys "
+			                            "are interchangeable between lakes");
+		}
+		if (options.encryption_cache_ttl_seconds < 0 ||
+		    options.encryption_cache_ttl_seconds > DuckLakeEncryptionProvider::MAX_CACHE_TTL_SECONDS) {
+			throw InvalidInputException("encryption_cache_ttl_seconds must be between 0 and %lld, not %lld",
+			                            DuckLakeEncryptionProvider::MAX_CACHE_TTL_SECONDS,
+			                            options.encryption_cache_ttl_seconds);
+		}
+		if (options.encryption == DuckLakeEncryption::UNENCRYPTED) {
+			throw InvalidInputException("an encryption envelope was configured on an UNENCRYPTED DuckLake - there are "
+			                            "no per-file keys to wrap. Add ENCRYPTED, or drop the envelope options");
+		}
+		// Refuse an explicit limit rather than silently forcing it to 0; DataInliningRowLimit() below
+		// forces the shipped default.
+		auto inlining_entry = options.config_options.find("data_inlining_row_limit");
+		if (inlining_entry != options.config_options.end() && Value(inlining_entry->second).GetValue<idx_t>() > 0) {
+			throw InvalidInputException("data_inlining_row_limit=%s cannot be combined with an encryption envelope - "
+			                            "inlined rows are stored as cleartext literals in the metadata catalog, which "
+			                            "the envelope does not cover. Set data_inlining_row_limit to 0",
+			                            inlining_entry->second);
+		}
+		auto ttl_seconds = options.encryption_cache_ttl_seconds_supplied
+		                       ? options.encryption_cache_ttl_seconds
+		                       : DuckLakeEncryptionProvider::DEFAULT_CACHE_TTL_SECONDS;
+		auto &factory = DuckLakeEncryptionProvider::GetFactory();
+		if (!factory) {
+			throw InvalidInputException("encryption_socket was set but this build has no encryption provider - link an "
+			                            "implementation of DuckLakeEncryptionProvider, or drop the envelope options to "
+			                            "store the per-file keys unwrapped");
+		}
+		encryption_provider = factory(db_p.GetDatabase(), options.encryption_socket, options.encryption_lake_id,
+		                              NumericCast<idx_t>(ttl_seconds));
+	}
 	// figure out the metadata server type
 	auto entry = options.metadata_parameters.find("type");
 	if (entry != options.metadata_parameters.end()) {
@@ -221,6 +270,12 @@ void DuckLakeCatalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 		con->BeginTransaction();
 		context = con->context.get();
 	}
+	// Both no-ops without a provider. The self-test runs at ATTACH so an unreachable key service
+	// surfaces here rather than on the first read.
+	RequireEncryptedTempSpill(*context);
+	if (encryption_provider) {
+		encryption_provider->SelfTest();
+	}
 	if (options.config_options.find("write_deletion_vectors") == options.config_options.end()) {
 		Value setting_val;
 		if (context->TryGetCurrentSetting("ducklake_write_deletion_vectors", setting_val)) {
@@ -229,6 +284,16 @@ void DuckLakeCatalog::FinalizeLoad(optional_ptr<ClientContext> context) {
 	}
 	DuckLakeInitializer initializer(*context, *this, options);
 	initializer.Initialize();
+	// Only the initializer resolves an AUTOMATIC encryption mode, so this cannot move up to the
+	// constructor alongside the explicit-UNENCRYPTED refusal.
+	if (encryption_provider && Encryption() != DuckLakeEncryption::ENCRYPTED) {
+		if (options.encryption == DuckLakeEncryption::ENCRYPTED) {
+			throw InvalidInputException("encryption_socket was set, but this DuckLake already exists and is "
+			                            "unencrypted - ATTACH cannot change that. Drop the envelope options");
+		}
+		throw InvalidInputException("encryption_socket was set, but this DuckLake is unencrypted - there are no "
+		                            "per-file keys to wrap. Add ENCRYPTED, or drop the envelope options");
+	}
 	db.tags["data_path"] = DataPath();
 	if (con) {
 		con->Commit();
@@ -1010,11 +1075,19 @@ bool DuckLakeCatalog::TryGetConfigOption(const string &option, string &result, D
 }
 
 idx_t DuckLakeCatalog::DataInliningRowLimit(SchemaIndex schema_index, TableIndex table_index) const {
+	// An enveloped lake never inlines rows: inlined rows and their stats live in the metadata catalog
+	// in cleartext, which no per-file key covers. Every inlining decision funnels through here.
+	if (EncryptionProvider()) {
+		return 0;
+	}
 	return GetConfigOption<idx_t>("data_inlining_row_limit", schema_index, table_index, 10);
 }
 
 idx_t DuckLakeCatalog::DataInliningRowLimit(ClientContext &context, SchemaIndex schema_index,
                                             TableIndex table_index) const {
+	if (EncryptionProvider()) {
+		return 0;
+	}
 	string value_str;
 	if (TryGetConfigOption("data_inlining_row_limit", value_str, schema_index, table_index)) {
 		return Value(value_str).GetValue<idx_t>();

--- a/src/storage/ducklake_encryption_provider.cpp
+++ b/src/storage/ducklake_encryption_provider.cpp
@@ -1,0 +1,69 @@
+#include "storage/ducklake_encryption_provider.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+namespace {
+
+//! Base64 of a 32-byte key: the longest `encryption_key` a lake without an envelope stores. A
+//! wrapped value carries a header and an authentication tag on top of the key, so it is longer.
+constexpr idx_t LONGEST_PLAINTEXT_KEY_LENGTH = 44;
+
+//! Registered once for the life of the process so a factory survives ATTACH/DETACH; never freed,
+//! hence a raw pointer rather than a global with an exit-time destructor.
+DuckLakeEncryptionProvider::Factory *global_factory = nullptr;
+
+} // namespace
+
+// Out-of-line definitions: the constants are ODR-used (e.g. passed by reference into a variadic
+// exception constructor), and under C++11 an ODR-used static constexpr member needs a definition.
+constexpr int64_t DuckLakeEncryptionProvider::DEFAULT_CACHE_TTL_SECONDS;
+constexpr int64_t DuckLakeEncryptionProvider::MAX_CACHE_TTL_SECONDS;
+
+bool DuckLakeEncryptionProvider::LooksWrapped(const string &stored_value) {
+	// A wrapped value starts with the fixed header "DLK1", whose first three bytes base64 as the
+	// literal prefix "RExL". The length floor is part of the test: without it a plaintext key that
+	// happens to start with those three bytes would be misread as wrapped and refused forever.
+	if (stored_value.size() <= LONGEST_PLAINTEXT_KEY_LENGTH) {
+		return false;
+	}
+	return stored_value.compare(0, 4, "RExL") == 0;
+}
+
+bool DuckLakeEncryptionProvider::IsBase64(const string &value) {
+	if (value.empty()) {
+		return false;
+	}
+	for (auto character : value) {
+		auto c = static_cast<unsigned char>(character);
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '+' || c == '/' ||
+		    c == '=') {
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+void DuckLakeEncryptionProvider::RegisterFactory(Factory factory) {
+	if (global_factory) {
+		throw InvalidInputException("a DuckLake encryption provider factory is already registered - registering a "
+		                            "second one would make the provider a lake gets depend on extension load order");
+	}
+	global_factory = new Factory(std::move(factory));
+}
+
+bool DuckLakeEncryptionProvider::HasFactory() {
+	return global_factory != nullptr;
+}
+
+const DuckLakeEncryptionProvider::Factory &DuckLakeEncryptionProvider::GetFactory() {
+	static Factory empty;
+	if (!global_factory) {
+		return empty;
+	}
+	return *global_factory;
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_envelope_guards.cpp
+++ b/src/storage/ducklake_envelope_guards.cpp
@@ -1,0 +1,158 @@
+#include "storage/ducklake_catalog.hpp"
+
+#include "common/ducklake_util.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/blob.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/settings.hpp"
+
+namespace duckdb {
+
+DuckLakeFileIdentity DuckLakeCatalog::BuildEncryptionIdentity(TableIndex table_id, const string &stored_path,
+                                                              bool is_delete_file) const {
+	DuckLakeFileIdentity identity;
+	identity.lake_id = options.encryption_lake_id;
+	identity.table_id = NumericCast<int64_t>(table_id.index);
+	identity.is_delete_file = is_delete_file;
+	identity.stored_path = stored_path;
+	return identity;
+}
+
+void DuckLakeCatalog::RefuseWrappedKeyWithoutProvider(const string &file_path, const string &stored_key) const {
+	if (encryption_provider) {
+		// A lake with a provider unwraps rather than refuses; that is the caller's job.
+		return;
+	}
+	if (!DuckLakeEncryptionProvider::LooksWrapped(stored_key)) {
+		return;
+	}
+	throw IOException("File %s carries a wrapped encryption key, but this DuckLake was attached without "
+	                  "encryption_socket - re-attach with the envelope options",
+	                  file_path);
+}
+
+void DuckLakeCatalog::RefuseMissingEncryptionKey(const string &file_path) const {
+	if (!IsEncrypted()) {
+		// On an unencrypted lake a row without a key is the ordinary case.
+		return;
+	}
+	throw InvalidInputException("Database is encrypted, but file %s does not have an encryption key", file_path);
+}
+
+void DuckLakeCatalog::RefuseUnusableEncryptionKey(const string &file_path, const string &decoded_key) const {
+	// The accepted lengths are read off ParquetCrypto::ValidKey, which rejects everything else.
+	if (decoded_key.size() == 16 || decoded_key.size() == 24 || decoded_key.size() == 32) {
+		return;
+	}
+	throw InvalidInputException("File %s carries an encryption key of %llu bytes, and AES accepts only 16, 24 or 32 - "
+	                            "the stored encryption_key for this row is corrupt",
+	                            file_path, static_cast<uint64_t>(decoded_key.size()));
+}
+
+void DuckLakeCatalog::RequireEncryptedTempSpill(ClientContext &context) {
+	if (!encryption_provider) {
+		return;
+	}
+	if (Settings::Get<TempFileEncryptionSetting>(context)) {
+		return;
+	}
+	auto option = DBConfig::GetOptionByName("temp_file_encryption");
+	if (!option) {
+		throw InvalidInputException("This DuckDB build has no temp_file_encryption setting, which an encrypted "
+		                            "DuckLake requires - an out-of-core query would spill decrypted rows in the clear");
+	}
+	auto &config = DBConfig::GetConfig(context);
+	try {
+		config.SetOption(context.db.get(), *option, Value::BOOLEAN(true));
+	} catch (std::exception &ex) {
+		// DuckDB refuses to encrypt a temp directory that already holds plaintext files.
+		throw InvalidInputException("temp_file_encryption must be on before an encrypted DuckLake is attached, and "
+		                            "turning it on failed: %s. Attach the lake before running work that spills, or "
+		                            "start a fresh process",
+		                            string(ex.what()));
+	}
+}
+
+void DuckLakeCatalog::RefuseUnencryptedTempSpill(const string &what) const {
+	if (!encryption_provider) {
+		return;
+	}
+	if (Settings::Get<TempFileEncryptionSetting>(db.GetDatabase())) {
+		return;
+	}
+	throw IOException("Refusing %s on an encrypted DuckLake while temp_file_encryption is off - decrypted rows would "
+	                  "spill to temp_directory in the clear. Run SET temp_file_encryption = true",
+	                  what);
+}
+
+string DuckLakeCatalog::ResolveStoredEncryptionKey(TableIndex table_id, const string &stored_path,
+                                                   const string &resolved_path, bool is_delete_file,
+                                                   const Value &stored_key_value) const {
+	if (stored_key_value.IsNull()) {
+		RefuseMissingEncryptionKey(resolved_path);
+		return string();
+	}
+	auto stored_key = stored_key_value.GetValue<string>();
+	if (stored_key.empty()) {
+		// An empty string says what NULL says, so it gets the same refusal.
+		RefuseMissingEncryptionKey(resolved_path);
+		return string();
+	}
+	string decoded_key;
+	if (encryption_provider) {
+		// Checked before the unwrap: once this returns, the rows this key opens are on their way into
+		// the buffer manager and can be evicted to temp_directory.
+		RefuseUnencryptedTempSpill("a read");
+		decoded_key =
+		    encryption_provider->UnwrapKey(BuildEncryptionIdentity(table_id, stored_path, is_delete_file), stored_key);
+	} else {
+		RefuseWrappedKeyWithoutProvider(resolved_path, stored_key);
+		decoded_key = Blob::FromBase64(string_t(stored_key));
+	}
+	RefuseUnusableEncryptionKey(resolved_path, decoded_key);
+	return decoded_key;
+}
+
+void DuckLakeCatalog::PrepareFileKeysForCommit(const vector<TableIndex> &table_ids, const vector<string> &stored_paths,
+                                               bool is_delete_file, vector<string> &keys) const {
+	D_ASSERT(table_ids.size() == keys.size() && stored_paths.size() == keys.size());
+	if (!encryption_provider) {
+		DuckLakeUtil::EncodeStoredEncryptionKeys(keys);
+		return;
+	}
+	// Checked once per commit rather than per file: a wrap hands back key material this process holds.
+	RefuseUnencryptedTempSpill("a commit");
+	vector<DuckLakeFileIdentity> wrap_identities;
+	vector<string> deks;
+	vector<idx_t> positions;
+	for (idx_t i = 0; i < keys.size(); i++) {
+		if (keys[i].empty()) {
+			continue;
+		}
+		if (DuckLakeEncryptionProvider::LooksWrapped(keys[i])) {
+			// Already wrapped: wrapping again would make UnwrapKey return ciphertext rather than the key.
+			continue;
+		}
+		wrap_identities.push_back(BuildEncryptionIdentity(table_ids[i], stored_paths[i], is_delete_file));
+		deks.push_back(keys[i]);
+		positions.push_back(i);
+	}
+	if (deks.empty()) {
+		return;
+	}
+	auto wrapped = encryption_provider->WrapKeys(wrap_identities, deks);
+	if (wrapped.size() != deks.size()) {
+		throw IOException("The encryption provider returned %llu wrapped keys for %llu files",
+		                  static_cast<uint64_t>(wrapped.size()), static_cast<uint64_t>(deks.size()));
+	}
+	for (idx_t i = 0; i < positions.size(); i++) {
+		if (wrapped[i].empty()) {
+			throw IOException("The encryption provider returned an empty wrapped key for file %s",
+			                  wrap_identities[i].stored_path);
+		}
+		keys[positions[i]] = wrapped[i];
+	}
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1242,7 +1242,7 @@ string DuckLakeMetadataManager::GetDeleteFileSelectList(const string &prefix) {
 
 template <class T>
 DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx,
-                                                       bool is_encrypted) {
+                                                       bool is_encrypted, bool is_delete_file) {
 	DuckLakeFileData data;
 	if (row.IsNull(col_idx)) {
 		// file is not there
@@ -1263,11 +1263,11 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table
 	}
 	col_idx++;
 	if (is_encrypted) {
-		if (row.IsNull(col_idx)) {
-			throw InvalidInputException("Database is encrypted, but file %s does not have an encryption key",
-			                            data.path);
-		}
-		data.encryption_key = Blob::FromBase64(row.template GetValue<string>(col_idx++));
+		// The identity a wrapped key is bound to is built from the stored path, not the resolved one.
+		auto stored_key = row.IsNull(col_idx) ? Value() : Value(row.template GetValue<string>(col_idx));
+		col_idx++;
+		data.encryption_key = transaction.GetCatalog().ResolveStoredEncryptionKey(
+		    table.GetTableId(), path.path, data.path, is_delete_file, stored_key);
 	}
 	return data;
 }
@@ -1275,7 +1275,7 @@ DuckLakeFileData DuckLakeMetadataManager::ReadDataFile(DuckLakeTableEntry &table
 template <class T>
 DuckLakeFileData DuckLakeMetadataManager::ReadDeleteFile(DuckLakeTableEntry &table, T &row, idx_t &col_idx,
                                                          bool is_encrypted) {
-	auto data = ReadDataFile(table, row, col_idx, is_encrypted);
+	auto data = ReadDataFile(table, row, col_idx, is_encrypted, true);
 	if (!row.IsNull(col_idx)) {
 		data.format = DeleteFileFormatFromString(row.template GetValue<string>(col_idx));
 	}
@@ -3993,8 +3993,8 @@ string DuckLakeMetadataManager::WriteNewDataFilesWithAppender(DuckLakeSnapshot &
 			data_file_appender.Append(Value());
 		}
 		if (!file.encryption_key.empty()) {
-			data_file_appender.Append<string_t>(
-			    string_t(Blob::ToBase64(string_t(file.encryption_key)))); // encryption_key
+			// Already in its stored form: PrepareFileKeysForCommit ran before any writer.
+			data_file_appender.Append<string_t>(string_t(file.encryption_key)); // encryption_key
 		} else {
 			data_file_appender.Append(Value());
 		}
@@ -4217,7 +4217,7 @@ string DuckLakeMetadataManager::WriteNewDataFilesSqlBatch(const vector<DuckLakeF
 		    file.begin_snapshot.IsValid() ? to_string(file.begin_snapshot.GetIndex()) : "{SNAPSHOT_ID}";
 		auto data_file_index = file.id.index;
 		auto table_id = file.table_id.index;
-		auto encryption_key = DuckLakeUtil::EncryptionKeyLiteral(file.encryption_key);
+		auto encryption_key = DuckLakeUtil::StoredEncryptionKeyLiteral(file.encryption_key);
 		string partial_max = DuckLakeUtil::OptionalIdxOrNull(file.max_partial_file_snapshot);
 		string footer_size = DuckLakeUtil::OptionalIdxOrNull(file.footer_size);
 		string mapping = DuckLakeUtil::MappingIdOrNull(file.mapping_id);
@@ -4358,7 +4358,7 @@ string DuckLakeMetadataManager::WriteNewDeleteFiles(const vector<DuckLakeDeleteF
 		auto delete_file_index = file.id.index;
 		auto table_id = file.table_id.index;
 		auto data_file_index = file.data_file_id.index;
-		auto encryption_key = DuckLakeUtil::EncryptionKeyLiteral(file.encryption_key);
+		auto encryption_key = DuckLakeUtil::StoredEncryptionKeyLiteral(file.encryption_key);
 		// Use explicit begin_snapshot if set (for flush operations), otherwise use commit snapshot
 		string begin_snapshot_str =
 		    file.begin_snapshot.IsValid() ? std::to_string(file.begin_snapshot.GetIndex()) : "{SNAPSHOT_ID}";

--- a/src/storage/ducklake_reference_encryption_provider.cpp
+++ b/src/storage/ducklake_reference_encryption_provider.cpp
@@ -1,0 +1,291 @@
+#include "storage/ducklake_reference_encryption_provider.hpp"
+
+#include "duckdb/common/encryption_state.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/mutex.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/blob.hpp"
+#include "duckdb/common/unordered_map.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <cstring>
+
+namespace duckdb {
+
+namespace {
+
+constexpr idx_t KEK_BYTES = 32;
+constexpr idx_t NONCE_BYTES = 12;
+constexpr idx_t TAG_BYTES = 16;
+constexpr idx_t HEADER_BYTES = 5;
+//! Envelope magic; base64 of these bytes is what DuckLakeEncryptionProvider::LooksWrapped matches.
+constexpr char MAGIC[4] = {'D', 'L', 'K', '1'};
+
+//! Published on purpose: the KEKs of a test fixture are not secrets.
+constexpr const char *REFERENCE_TEST_SEED = "ducklake-reference-provider-TEST-ONLY-NOT-FOR-PRODUCTION-v1";
+
+mutex g_version_mutex;
+unordered_map<string, int64_t> g_active_version; // NOLINT
+
+int64_t GetActiveVersionLocked(const string &lake_id) {
+	auto it = g_active_version.find(lake_id);
+	if (it == g_active_version.end()) {
+		g_active_version[lake_id] = 1;
+		return 1;
+	}
+	return it->second;
+}
+
+//! Length-prefixed so the concatenation is injective: no field's contents can imitate a separator and
+//! make two different identities serialize the same way.
+void AppendField(string &out, const string &field) {
+	out += to_string(field.size());
+	out += ':';
+	out += field;
+}
+
+//! SHA-256(seed || lake_id || version), so every connection agrees on the KEK for a given version.
+string DeriveKek(EncryptionUtil &util, const string &lake_id, int64_t version) {
+	string material;
+	AppendField(material, REFERENCE_TEST_SEED);
+	AppendField(material, lake_id);
+	AppendField(material, to_string(version));
+	data_t digest[KEK_BYTES];
+	util.Hash(CryptoHashFunction::SHA256, const_data_ptr_cast(material.data()), material.size(), digest);
+	return string(const_char_ptr_cast(digest), KEK_BYTES);
+}
+
+//! The AAD a wrapped key is bound to. Unwrapping under a different table, path, or file kind fails GCM
+//! tag verification rather than handing back a key.
+string SerializeIdentity(const DuckLakeFileIdentity &identity) {
+	string aad;
+	AppendField(aad, identity.lake_id);
+	AppendField(aad, to_string(identity.table_id));
+	AppendField(aad, identity.is_delete_file ? "D" : "F");
+	AppendField(aad, identity.stored_path);
+	return aad;
+}
+
+shared_ptr<EncryptionState> MakeAesGcmState(EncryptionUtil &util, idx_t key_len) {
+	auto metadata =
+	    make_uniq<EncryptionStateMetadata>(EncryptionTypes::GCM, key_len, EncryptionTypes::EncryptionVersion::V0_1);
+	return util.CreateEncryptionState(std::move(metadata));
+}
+
+//! MAGIC(4) || version:uint8(1) || nonce(12) || ciphertext(N) || tag(16)
+string EnvelopeEncrypt(EncryptionUtil &util, const string &plaintext, const string &kek, int64_t version,
+                       const string &aad) {
+	if (version < 0 || version > 255) {
+		throw InvalidInputException("ducklake reference encryption provider: key version %lld is outside the test "
+		                            "range [0,255]",
+		                            static_cast<long long>(version));
+	}
+	auto aes = MakeAesGcmState(util, kek.size());
+	EncryptionNonce nonce;
+	D_ASSERT(nonce.size() == NONCE_BYTES);
+	aes->GenerateRandomData(nonce.data(), nonce.size());
+
+	aes->InitializeEncryption(nonce, const_data_ptr_cast(kek.data()), const_data_ptr_cast(aad.data()), aad.size());
+
+	string ciphertext(plaintext.size(), '\0');
+	auto written = aes->Process(const_data_ptr_cast(plaintext.data()), plaintext.size(), data_ptr_cast(&ciphertext[0]),
+	                            ciphertext.size());
+	ciphertext.resize(written);
+
+	data_t tail[64];
+	data_t tag[TAG_BYTES];
+	auto tail_written = aes->Finalize(tail, 0, tag, TAG_BYTES);
+	ciphertext.append(const_char_ptr_cast(tail), tail_written);
+
+	string blob;
+	blob.append(MAGIC, 4);
+	blob.push_back(static_cast<char>(static_cast<uint8_t>(version)));
+	blob.append(const_char_ptr_cast(nonce.data()), nonce.size());
+	blob.append(ciphertext);
+	blob.append(const_char_ptr_cast(tag), TAG_BYTES);
+	return blob;
+}
+
+//! Inverse of EnvelopeEncrypt. Throws on a malformed blob, and on a tag mismatch, which is what a wrong
+//! key version or a tampered identity produces.
+string EnvelopeDecrypt(EncryptionUtil &util, const string &blob, const string &lake_id, const string &aad,
+                       int64_t *version_out) {
+	if (blob.size() < HEADER_BYTES + NONCE_BYTES + TAG_BYTES || std::memcmp(blob.data(), MAGIC, 4) != 0) {
+		throw InvalidInputException("ducklake reference encryption provider: the stored value is not a DLK1 envelope");
+	}
+	int64_t version = static_cast<uint8_t>(blob[4]);
+	idx_t ct_len = blob.size() - HEADER_BYTES - NONCE_BYTES - TAG_BYTES;
+	auto ciphertext = blob.substr(HEADER_BYTES + NONCE_BYTES, ct_len);
+	data_t expected_tag[TAG_BYTES];
+	std::memcpy(expected_tag, blob.data() + blob.size() - TAG_BYTES, TAG_BYTES);
+
+	auto kek = DeriveKek(util, lake_id, version);
+	auto aes = MakeAesGcmState(util, kek.size());
+	EncryptionNonce nonce;
+	D_ASSERT(nonce.size() == NONCE_BYTES);
+	std::memcpy(nonce.data(), blob.data() + HEADER_BYTES, NONCE_BYTES);
+
+	aes->InitializeDecryption(nonce, const_data_ptr_cast(kek.data()), const_data_ptr_cast(aad.data()), aad.size());
+
+	string plaintext(ct_len, '\0');
+	auto written =
+	    aes->Process(const_data_ptr_cast(ciphertext.data()), ct_len, data_ptr_cast(&plaintext[0]), plaintext.size());
+	plaintext.resize(written);
+
+	data_t tail[64];
+	auto tail_written = aes->Finalize(tail, 0, expected_tag, TAG_BYTES);
+	plaintext.append(const_char_ptr_cast(tail), tail_written);
+
+	if (version_out) {
+		*version_out = version;
+	}
+	return plaintext;
+}
+
+} // namespace
+
+DuckLakeReferenceEncryptionProvider::DuckLakeReferenceEncryptionProvider(DatabaseInstance &db, string lake_id_p)
+    : db(db), lake_id(std::move(lake_id_p)) {
+}
+
+vector<string> DuckLakeReferenceEncryptionProvider::WrapKeys(const vector<DuckLakeFileIdentity> &identities,
+                                                             const vector<string> &deks) {
+	if (identities.size() != deks.size()) {
+		throw InternalException("ducklake reference encryption provider: WrapKeys identity/key count mismatch");
+	}
+	auto util = db.GetEncryptionUtil(false);
+	vector<string> out;
+	out.reserve(deks.size());
+	for (idx_t i = 0; i < deks.size(); i++) {
+		int64_t version;
+		{
+			lock_guard<mutex> lock(g_version_mutex);
+			version = GetActiveVersionLocked(identities[i].lake_id);
+		}
+		auto kek = DeriveKek(*util, identities[i].lake_id, version);
+		auto blob = EnvelopeEncrypt(*util, deks[i], kek, version, SerializeIdentity(identities[i]));
+		out.push_back(Blob::ToBase64(string_t(blob)));
+	}
+	return out;
+}
+
+string DuckLakeReferenceEncryptionProvider::UnwrapKey(const DuckLakeFileIdentity &identity,
+                                                      const string &base64_value) {
+	auto util = db.GetEncryptionUtil(true);
+	auto raw = Blob::FromBase64(base64_value);
+	return EnvelopeDecrypt(*util, raw, identity.lake_id, SerializeIdentity(identity), nullptr);
+}
+
+vector<DuckLakeRewrapResult>
+DuckLakeReferenceEncryptionProvider::RewrapKeys(const vector<DuckLakeFileIdentity> &identities,
+                                                const vector<string> &blobs) {
+	if (identities.size() != blobs.size()) {
+		throw InternalException("ducklake reference encryption provider: RewrapKeys identity/blob count mismatch");
+	}
+	auto util = db.GetEncryptionUtil(false);
+	vector<DuckLakeRewrapResult> out;
+	out.reserve(blobs.size());
+	for (idx_t i = 0; i < blobs.size(); i++) {
+		auto raw = Blob::FromBase64(blobs[i]);
+		int64_t stored_version;
+		auto aad = SerializeIdentity(identities[i]);
+		auto dek = EnvelopeDecrypt(*util, raw, identities[i].lake_id, aad, &stored_version);
+
+		int64_t active_version;
+		{
+			lock_guard<mutex> lock(g_version_mutex);
+			active_version = GetActiveVersionLocked(identities[i].lake_id);
+		}
+		if (stored_version == active_version) {
+			out.push_back(DuckLakeRewrapResult {blobs[i], false});
+			continue;
+		}
+		auto kek = DeriveKek(*util, identities[i].lake_id, active_version);
+		auto new_blob = EnvelopeEncrypt(*util, dek, kek, active_version, aad);
+		out.push_back(DuckLakeRewrapResult {Blob::ToBase64(string_t(new_blob)), true});
+	}
+	return out;
+}
+
+string DuckLakeReferenceEncryptionProvider::SelfTest() {
+	DuckLakeFileIdentity identity;
+	identity.lake_id = lake_id;
+	identity.table_id = 0;
+	identity.is_delete_file = false;
+	identity.stored_path = "__ducklake_reference_provider_self_test__";
+
+	string plaintext_dek(32, '\0');
+	for (idx_t i = 0; i < plaintext_dek.size(); i++) {
+		plaintext_dek[i] = static_cast<char>(i);
+	}
+
+	auto wrapped = WrapKeys({identity}, {plaintext_dek});
+	auto unwrapped = UnwrapKey(identity, wrapped[0]);
+	if (unwrapped != plaintext_dek) {
+		throw InternalException("ducklake reference encryption provider: self-test round-trip mismatch");
+	}
+
+	// Proves the AAD binding is load-bearing rather than merely computed.
+	DuckLakeFileIdentity other = identity;
+	other.stored_path = "__ducklake_reference_provider_self_test_other__";
+	bool refused = false;
+	try {
+		UnwrapKey(other, wrapped[0]);
+	} catch (const std::exception &) {
+		refused = true;
+	}
+	if (!refused) {
+		throw InternalException(
+		    "ducklake reference encryption provider: self-test blob was accepted under a different identity");
+	}
+
+	int64_t active_version;
+	{
+		lock_guard<mutex> lock(g_version_mutex);
+		active_version = GetActiveVersionLocked(lake_id);
+	}
+	return StringUtil::Format("ducklake reference encryption provider ok (lake_id=%s, active_version=%lld)", lake_id,
+	                          static_cast<long long>(active_version));
+}
+
+const string &DuckLakeReferenceEncryptionProvider::GetLakeId() const {
+	return lake_id;
+}
+
+int64_t DuckLakeReferenceEncryptionProvider::SetActiveVersionForTests(const string &lake_id_p, int64_t version) {
+	lock_guard<mutex> lock(g_version_mutex);
+	g_active_version[lake_id_p] = version;
+	return version;
+}
+
+int64_t DuckLakeReferenceEncryptionProvider::GetActiveVersionForTests(const string &lake_id_p) {
+	lock_guard<mutex> lock(g_version_mutex);
+	return GetActiveVersionLocked(lake_id_p);
+}
+
+static void SetActiveVersionScalarFun(DataChunk &args, ExpressionState &state, Vector &result) {
+	BinaryExecutor::Execute<string_t, int64_t, int64_t>(
+	    args.data[0], args.data[1], result, args.size(), [&](string_t lake_id_val, int64_t version) {
+		    return DuckLakeReferenceEncryptionProvider::SetActiveVersionForTests(lake_id_val.GetString(), version);
+	    });
+}
+
+ScalarFunction DuckLakeReferenceProviderSetActiveVersionFunction() {
+	return ScalarFunction("ducklake_reference_provider_set_active_version", {LogicalType::VARCHAR, LogicalType::BIGINT},
+	                      LogicalType::BIGINT, SetActiveVersionScalarFun);
+}
+
+void RegisterDuckLakeReferenceEncryptionProviderForTests() {
+	if (DuckLakeEncryptionProvider::HasFactory()) {
+		// LoadInternal runs once per DatabaseInstance, and RegisterFactory refuses to overwrite.
+		return;
+	}
+	DuckLakeEncryptionProvider::RegisterFactory([](DatabaseInstance &db, const string &encryption_socket,
+	                                               const string &encryption_lake_id,
+	                                               idx_t cache_ttl_seconds) -> unique_ptr<DuckLakeEncryptionProvider> {
+		return make_uniq<DuckLakeReferenceEncryptionProvider>(db, encryption_lake_id);
+	});
+}
+
+} // namespace duckdb

--- a/src/storage/ducklake_storage.cpp
+++ b/src/storage/ducklake_storage.cpp
@@ -59,6 +59,15 @@ static void HandleDuckLakeOption(DuckLakeOptions &options, const string &option,
 		options.automatic_migration = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
 	} else if (lcase == "busy_timeout") {
 		options.busy_timeout = UBigIntValue::Get(value.DefaultCastAs(LogicalType::UBIGINT));
+	} else if (lcase == "encryption_socket") {
+		options.encryption_socket = value.ToString();
+		options.encryption_socket_supplied = true;
+	} else if (lcase == "encryption_lake_id") {
+		options.encryption_lake_id = value.ToString();
+		options.encryption_lake_id_supplied = true;
+	} else if (lcase == "encryption_cache_ttl_seconds") {
+		options.encryption_cache_ttl_seconds = value.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+		options.encryption_cache_ttl_seconds_supplied = true;
 	} else if (lcase == "ducklake_version") {
 		auto version = DuckLakeVersionFromString(value.ToString());
 		if (version < DuckLakeVersion::V1_0) {

--- a/src/storage/ducklake_transaction.cpp
+++ b/src/storage/ducklake_transaction.cpp
@@ -1474,6 +1474,10 @@ void DuckLakeTransaction::RunCommitLoop(DuckLakeSnapshot transaction_snapshot,
 	                                    vector<DuckLakeSchemaInfo> &new_schemas) {
 		return metadata_manager->TryAppendDataFiles(snapshot, files, new_tables, new_schemas);
 	};
+	context.prepare_file_keys = [&](const vector<TableIndex> &table_ids, const vector<string> &stored_paths,
+	                                bool is_delete_file, vector<string> &keys) {
+		ducklake_catalog.PrepareFileKeysForCommit(table_ids, stored_paths, is_delete_file, keys);
+	};
 	context.write_inlined_tables = [&](DuckLakeSnapshot snapshot, const vector<DuckLakeTableInfo> &tables) {
 		return metadata_manager->WriteNewInlinedTables(snapshot, tables);
 	};

--- a/src/storage/ducklake_transaction_state.cpp
+++ b/src/storage/ducklake_transaction_state.cpp
@@ -1572,6 +1572,29 @@ vector<DuckLakeSchemaInfo> DuckLakeTransactionState::GetNewSchemas(DuckLakeCommi
 	return schemas;
 }
 
+//! Hands every file's key to the commit context together with the path it will be stored under, and
+//! writes the stored form back. FILE is DuckLakeFileInfo or DuckLakeDeleteFileInfo.
+template <class FILE>
+static void PrepareFileKeys(const DuckLakeCommitContext &context, vector<FILE> &files,
+                            const vector<DuckLakePath> &resolved_paths, bool is_delete_file) {
+	D_ASSERT(files.size() == resolved_paths.size());
+	vector<TableIndex> table_ids;
+	vector<string> stored_paths;
+	vector<string> keys;
+	table_ids.reserve(files.size());
+	stored_paths.reserve(files.size());
+	keys.reserve(files.size());
+	for (idx_t i = 0; i < files.size(); i++) {
+		table_ids.push_back(files[i].table_id);
+		stored_paths.push_back(resolved_paths[i].path);
+		keys.push_back(files[i].encryption_key);
+	}
+	context.prepare_file_keys(table_ids, stored_paths, is_delete_file, keys);
+	for (idx_t i = 0; i < files.size(); i++) {
+		files[i].encryption_key = keys[i];
+	}
+}
+
 string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state,
                                                TransactionChangeInformation &transaction_changes,
                                                optional_ptr<vector<DuckLakeGlobalStatsInfo>> stats,
@@ -1684,13 +1707,8 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 		batch_queries += DuckLakeMetadataManager::WriteNewColumnMappings(result.new_column_mappings);
 	}
 
-	auto write_data_files_sql = [&](const vector<DuckLakeFileInfo> &files) {
+	auto write_data_files_sql = [&](vector<DuckLakeFileInfo> &files) {
 		if (files.empty()) {
-			return string();
-		}
-		if (context.try_append_data_files &&
-		    context.try_append_data_files(commit_snapshot, files, new_tables_result, new_schemas_result)) {
-			// fast-path: files were written directly via Appender, skip SQL emission
 			return string();
 		}
 		vector<DuckLakePath> resolved_paths;
@@ -1699,6 +1717,13 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			resolved_paths.push_back(DuckLakeMetadataManager::GetRelativePath(
 			    file.table_id, file.file_name, new_tables_result, new_schemas_result, context.query_metadata, data_path,
 			    separator));
+		}
+		// Before the Appender fast-path too: both writers emit encryption_key verbatim.
+		PrepareFileKeys(context, files, resolved_paths, false);
+		if (context.try_append_data_files &&
+		    context.try_append_data_files(commit_snapshot, files, new_tables_result, new_schemas_result)) {
+			// fast-path: files were written directly via Appender, skip SQL emission
+			return string();
 		}
 		return DuckLakeMetadataManager::WriteNewDataFilesSqlBatch(files, resolved_paths,
 		                                                          context.supports_v1_1_metadata);
@@ -1747,6 +1772,7 @@ string DuckLakeTransactionState::CommitChanges(DuckLakeCommitState &commit_state
 			    file.table_id, file.path, new_tables_result, new_schemas_result, context.query_metadata, data_path,
 			    separator));
 		}
+		PrepareFileKeys(context, file_list, resolved_delete_paths, true);
 		batch_queries += DuckLakeMetadataManager::WriteNewDeleteFiles(file_list, resolved_delete_paths,
 		                                                              context.supports_v1_1_metadata);
 

--- a/test/sql/encryption_provider/attach_options.test
+++ b/test/sql/encryption_provider/attach_options.test
@@ -1,0 +1,42 @@
+# name: test/sql/encryption_provider/attach_options.test
+# description: ATTACH refuses malformed encryption envelope options
+# group: [encryption_provider]
+
+require ducklake
+
+require parquet
+
+require-env DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER 1
+
+# a lake id on its own configures nothing
+statement error
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_opts_lakeid.db' AS bad (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_opts_lakeid_files',
+    ENCRYPTED,
+    ENCRYPTION_LAKE_ID 'orphan_lake'
+)
+----
+encryption_lake_id requires encryption_socket
+
+# an empty socket is a misconfiguration, not a request to run without an envelope
+statement error
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_opts_empty.db' AS bad (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_opts_empty_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET '',
+    ENCRYPTION_LAKE_ID 'empty_socket_lake'
+)
+----
+encryption_socket was set to an empty string
+
+# the cache TTL is capped so it cannot be raised to an effectively unbounded one
+statement error
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_opts_ttl.db' AS bad (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_opts_ttl_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'ttl_lake',
+    ENCRYPTION_CACHE_TTL_SECONDS 4000
+)
+----
+must be between 0 and 3600

--- a/test/sql/encryption_provider/fail_closed_no_provider.test
+++ b/test/sql/encryption_provider/fail_closed_no_provider.test
@@ -1,0 +1,91 @@
+# name: test/sql/encryption_provider/fail_closed_no_provider.test
+# description: Fail-closed guards on an enveloped DuckLake - missing provider, missing ENCRYPTED, data inlining
+# group: [encryption_provider]
+
+require ducklake
+
+require parquet
+
+require-env DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER 1
+
+# The reference provider takes its crypto from the database. Without an OpenSSL-backed
+# implementation loaded, only the mbedtls one can generate the GCM nonces it needs.
+statement ok
+SET force_mbedtls_unsafe = true;
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_failclosed.db' AS lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_failclosed_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'failclosed_lake'
+)
+
+statement ok
+CREATE TABLE lake.t AS SELECT i id FROM range(20) t(i);
+
+query II
+SELECT COUNT(*), SUM(id) FROM lake.t
+----
+20	190
+
+statement ok
+DETACH lake
+
+# the same catalog, attached with no envelope options: the stored keys are still wrapped, and
+# nothing here can unwrap them
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_failclosed.db' AS lake
+
+statement error
+SELECT * FROM lake.t
+----
+carries a wrapped encryption key
+
+statement ok
+DETACH lake
+
+# contrast: ENCRYPTED on its own needs no provider, so a lake that never had one still reads. More
+# than data_inlining_row_limit rows, so this writes a real data file with a real key.
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_failclosed_plain.db' AS plain_lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_failclosed_plain_files',
+    ENCRYPTED
+)
+
+statement ok
+CREATE TABLE plain_lake.t AS SELECT i id FROM range(20) t(i);
+
+query II
+SELECT COUNT(*), SUM(id) FROM plain_lake.t
+----
+20	190
+
+statement ok
+DETACH plain_lake
+
+# a new lake with envelope options but no ENCRYPTED has no per-file keys to wrap, so the envelope
+# would protect nothing. Only a fresh lake: an existing one adopts its stored encryption tag.
+statement error
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_notencrypted.db' AS not_encrypted (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_notencrypted_files',
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'not_encrypted_lake'
+)
+----
+this DuckLake is unencrypted
+
+# inlined rows live in the metadata catalog as cleartext literals, which no per-file key covers, so
+# the limit cannot be raised back up on an enveloped lake
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_inlining.db' AS inlining_lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_inlining_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'inlining_lake'
+)
+
+statement error
+CALL inlining_lake.set_option('data_inlining_row_limit', 100)
+----
+data_inlining_row_limit must stay 0

--- a/test/sql/encryption_provider/rewrap_keys.test
+++ b/test/sql/encryption_provider/rewrap_keys.test
@@ -1,0 +1,77 @@
+# name: test/sql/encryption_provider/rewrap_keys.test
+# description: ducklake_rewrap_keys() sweeps every stored key onto the provider's active key version
+# group: [encryption_provider]
+
+require ducklake
+
+require parquet
+
+require-env DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER 1
+
+# The reference provider takes its crypto from the database. Without an OpenSSL-backed
+# implementation loaded, only the mbedtls one can generate the GCM nonces it needs.
+statement ok
+SET force_mbedtls_unsafe = true;
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_rewrap.db' AS lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_rewrap_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'rewrap_lake'
+)
+
+statement ok
+CREATE TABLE lake.t AS SELECT i id, 'row_' || i val FROM range(100) t(i);
+
+statement ok
+DELETE FROM lake.t WHERE id % 3 = 0;
+
+query II
+SELECT COUNT(*), SUM(id) FROM lake.t
+----
+66	3267
+
+# every data/delete file was wrapped under the reference provider's default
+# active version (1). Rotate the KEK: bump the active version.
+query I
+SELECT ducklake_reference_provider_set_active_version('rewrap_lake', 2)
+----
+2
+
+# sweep: every previously-wrapped key (both the data file and the delete
+# file backing this table) must move onto version 2 - none are left behind
+query I
+SELECT COUNT(*) > 0 AND COUNT(*) FILTER (WHERE NOT rewrapped) = 0 FROM ducklake_rewrap_keys('lake')
+----
+true
+
+# data written under the OLD key version still reads correctly after rewrap -
+# the sweep must never lose access to what it just rotated
+query II
+SELECT COUNT(*), SUM(id) FROM lake.t
+----
+66	3267
+
+# running the sweep again against the SAME active version is a no-op: nothing
+# left to rewrap
+query I
+SELECT COUNT(*) FROM ducklake_rewrap_keys('lake') WHERE rewrapped
+----
+0
+
+statement ok
+DETACH lake
+
+# reattaching from scratch still decrypts everything correctly under the
+# rotated (version 2) key
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_rewrap.db' AS lake (
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'rewrap_lake'
+)
+
+query II
+SELECT COUNT(*), SUM(id) FROM lake.t
+----
+66	3267

--- a/test/sql/encryption_provider/round_trip.test
+++ b/test/sql/encryption_provider/round_trip.test
@@ -1,0 +1,82 @@
+# name: test/sql/encryption_provider/round_trip.test
+# description: End-to-end round trip through a DuckLakeEncryptionProvider - the catalog holds wrapped keys
+# group: [encryption_provider]
+
+require ducklake
+
+require parquet
+
+require-env DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER 1
+
+# The reference provider takes its crypto from the database. Without an OpenSSL-backed
+# implementation loaded, only the mbedtls one can generate the GCM nonces it needs.
+statement ok
+SET force_mbedtls_unsafe = true;
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_roundtrip.db' AS lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_roundtrip_files',
+    METADATA_CATALOG 'lake_meta',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'roundtrip_lake',
+    ENCRYPTION_CACHE_TTL_SECONDS 60
+)
+
+statement ok
+CREATE TABLE lake.t (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO lake.t VALUES (1, 'alpha'), (2, 'beta'), (3, 'gamma');
+
+query II
+SELECT id, val FROM lake.t ORDER BY id
+----
+1	alpha
+2	beta
+3	gamma
+
+# the catalog holds wrapped keys, not keys: every stored value carries the envelope header and is
+# longer than the base64 of a raw 32-byte key
+query III
+SELECT count(*), count(*) FILTER (WHERE starts_with(encryption_key, 'RExL')), count(*) FILTER (WHERE length(encryption_key) > 44) FROM lake_meta.ducklake_data_file
+----
+1	1	1
+
+# the parquet files really are encrypted
+statement error
+SELECT * FROM '{TEST_DIR}/ducklake_ref_provider_roundtrip_files/**/*.parquet'
+----
+encrypted
+
+# delete files get their own wrapped key. Reading the rows back proves the file-kind bit reaches the
+# provider the same way on the write and the read side: were it not, unwrapping would fail the tag check.
+statement ok
+DELETE FROM lake.t WHERE id = 2
+
+query III
+SELECT count(*), count(*) FILTER (WHERE starts_with(encryption_key, 'RExL')), count(*) FILTER (WHERE length(encryption_key) > 44) FROM lake_meta.ducklake_delete_file
+----
+1	1	1
+
+query II
+SELECT id, val FROM lake.t ORDER BY id
+----
+1	alpha
+3	gamma
+
+statement ok
+DETACH lake
+
+# a fresh attach still decrypts, so it is the stored wrapped keys doing the work, not a cache
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_roundtrip.db' AS lake (
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'roundtrip_lake'
+)
+
+query II
+SELECT id, val FROM lake.t ORDER BY id
+----
+1	alpha
+3	gamma

--- a/test/sql/encryption_provider/self_test.test
+++ b/test/sql/encryption_provider/self_test.test
@@ -1,0 +1,55 @@
+# name: test/sql/encryption_provider/self_test.test
+# description: ducklake_self_test() with no lake named, an enveloped lake, and a lake with no envelope
+# group: [encryption_provider]
+
+require ducklake
+
+require parquet
+
+require-env DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER 1
+
+# The reference provider takes its crypto from the database. Without an OpenSSL-backed
+# implementation loaded, only the mbedtls one can generate the GCM nonces it needs.
+statement ok
+SET force_mbedtls_unsafe = true;
+
+# no lake named - cheap pass, extension loaded and callable
+query I
+SELECT load_ok FROM ducklake_self_test()
+----
+true
+
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_selftest.db' AS lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_selftest_files',
+    ENCRYPTED,
+    ENCRYPTION_SOCKET 'reference-test-socket',
+    ENCRYPTION_LAKE_ID 'selftest_lake'
+)
+
+# lake named, provider configured and reachable - full health check passes
+query I
+SELECT load_ok FROM ducklake_self_test('lake')
+----
+true
+
+query I
+SELECT starts_with(provider_kind, 'ducklake reference encryption provider ok') FROM ducklake_self_test('lake')
+----
+true
+
+statement ok
+DETACH lake
+
+# a plain (non-enveloped) lake reports load_ok = true with provider_kind
+# 'catalog_has_no_provider' - it never claims a KMS health check it did not
+# perform.
+statement ok
+ATTACH 'ducklake:{TEST_DIR}/ducklake_ref_provider_selftest_plain.db' AS plain_lake (
+    DATA_PATH '{TEST_DIR}/ducklake_ref_provider_selftest_plain_files'
+)
+
+query II
+SELECT load_ok, provider_kind FROM ducklake_self_test('plain_lake')
+----
+true	catalog_has_no_provider


### PR DESCRIPTION
## What this is

The working half of #1423: the `DuckLakeEncryptionProvider` interface wired into the catalog, commit, and read paths, with fail-closed guards, a `ducklake_rewrap_keys` rotation sweep, a `ducklake_self_test` health check — and a reference provider (test fixture) that makes the whole path executable end to end in SQL, with no external KMS, wire protocol, or network. Two commits: the wiring, then the fixture + tests. Built on #1423's branch; happy to merge the two PRs as one if that reviews easier.

## How it wires — two symmetric choke points

**Write.** `DuckLakeCatalog::PrepareFileKeysForCommit` turns each raw DEK into the value the `encryption_key` column will carry — a wrapped blob when a provider is configured, plain base64 otherwise. It runs once per commit via the `DuckLakeCommitContext::prepare_file_keys` hook, after stored paths are resolved and before either writer (Appender fast path or SQL batch) emits a row.

**Read.** `DuckLakeCatalog::ResolveStoredEncryptionKey` turns the stored value back into raw key bytes, through the provider when one is configured. Every table-scan read routes through it via `ReadDataFile`.

**Encode symmetry.** The invariant is: the value handed to a writer is already in its stored form, so a writer only quotes it. The new `StoredEncryptionKeyLiteral` quotes without encoding; the Appender fast path stopped base64-encoding; on a lake with no provider the default hook does exactly the `Blob::ToBase64` the writers used to do — emitted SQL and appended rows are byte-identical to before, which is what makes this a no-op for existing lakes.

**Server-side commits are routed, not wrapped.** A wrapped key is bound to the *stored* path (AAD), which on the server-side commit path only the server knows. So an enveloped lake takes the existing client-side commit fallback instead — a route change, not a refusal; unencrypted lakes are untouched.

## What the key is bound to

`DuckLakeFileIdentity` = `{lake_id, table_id, is_delete_file, stored_path}`. A blob minted for one file is useless as the key for another: swap the table, the path, or a data file for a delete file, and the unwrap fails rather than returning something. `stored_path` (the `path` column value, not the resolved path) keeps keys stable under data-path moves; `is_delete_file` is needed because data and delete files have independent id spaces.

## Fail-closed guards

Each refusal covers a specific way this could silently degrade into "encrypted, but not really":

- Re-attach without a provider and a wrapped key → refused (never hands ciphertext to the Parquet reader as a key).
- Missing/empty stored key on an encrypted lake → refused.
- Decoded key of a length `ParquetCrypto` won't accept → refused as corrupt, plainly.
- Temp spill: ATTACH turns `temp_file_encryption` on and refuses if it can't; read and commit paths re-check, since the setting can be flipped after ATTACH. Note: `temp_file_encryption` is a database-wide setting, so attaching an enveloped lake enables it for the process.
- Data inlining is forced off (inlined rows and their min/max would land in the catalog as cleartext literals, covered by no file key): `DataInliningRowLimit` returns 0, ATTACH refuses an explicit non-zero limit, and `ducklake_set_option` refuses to raise it later.

Pre-existing behavior worth knowing: `ducklake_list_files` reconstructs live DEKs for a session attached with the provider, exactly as it always has for plain `ENCRYPTED` lakes. The envelope's claim is about the catalog at rest, which now holds only wrapped blobs.

## `ducklake_rewrap_keys`

The consumer half of key rotation: moves every stored blob onto the provider's current key so the outgoing key can be retired. Runs on its own autocommit connection (an interrupted sweep leaves a committed prefix), keyset pagination, compare-and-swap updates (concurrent writers are left for the next pass, never clobbered), refuses at bind on a lake with no provider, throws on an unwrapped row rather than silently stranding it, sweeps delete files too, and reports no key material.

## The reference provider is a test fixture, not a KMS

Stated in its class doc so it cannot be mistaken for production-grade:

- KEKs derive from a seed published in the source file.
- The tests run with `force_mbedtls_unsafe = true`, so GCM nonces come from a non-cryptographic PRNG — fine for a fixture, disqualifying for anything else.
- It registers only when `DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER=1` is set; without it no factory exists and runtime behavior is identical to a build without the file.

What it does exercise is real: AES-256-GCM through the database's `GetEncryptionUtil()`, AAD binding with length-prefixed (injective) identity serialization, and a genuine key-version rotation driven through `ducklake_rewrap_keys`. Its `SelfTest` proves the AAD binding is load-bearing: round-trip, then assert that unwrapping the same blob under a different identity is refused.

## Tests (executed, green)

`DUCKLAKE_TEST_REFERENCE_ENCRYPTION_PROVIDER=1 ./build/release/test/unittest "test/sql/encryption_provider/*"`

```
All tests passed (72 assertions in 5 test cases)
```

- `round_trip.test` — write, read back, assert the catalog holds a **wrapped** key (envelope prefix and longer than any raw key's base64) for both data and delete files, assert the Parquet files are really encrypted, assert a fresh ATTACH still decrypts.
- `fail_closed_no_provider.test` — re-attach without envelope options refuses the read; a fresh lake with envelope options but no ENCRYPTED is refused; raising `data_inlining_row_limit` on an enveloped lake is refused. The contrast block writes past the inlining limit so a real data file with a real key exists.
- `attach_options.test` — `ENCRYPTION_LAKE_ID` without `ENCRYPTION_SOCKET`, an empty `ENCRYPTION_SOCKET`, and a cache TTL above the ceiling are each refused at ATTACH.
- `rewrap_keys.test` — rotate, sweep, old data still reads, second sweep is a no-op, fresh ATTACH reads under the rotated key.
- `self_test.test` — no lake, enveloped lake, plain lake (a plain lake reports healthy).

Every refusal test is proven load-bearing: with the guards disabled in a mutant build, each guarded scenario succeeds — so each `statement error` block fails against a build missing its guard.

Each commit builds standalone; the full unittest suite is green at both the wiring commit (provider absent — the regression case for existing lakes) and the tip. The four new tests self-skip when the env var is unset, so CI without the fixture is unaffected.
