### PR TITLE
Stats filter left join

### DIFF
--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -127,6 +127,7 @@ struct FilterPushdownInfo {
 
 struct FilterPushdownQueryComponents {
 	string cte_section;
+	string join_clause;
 	string where_clause;
 	string order_by_clause;
 };
@@ -529,18 +530,23 @@ private:
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);
 	virtual string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
 	                                                  TableIndex table_id);
+	//! Join in the stats of every column a filter reads, once per column
+	static string GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements);
 	virtual string GenerateFilterFromTableFilter(const ExpressionFilter &filter, const LogicalType &type,
-	                                             unordered_set<string> &referenced_stats);
+	                                             unordered_set<string> &referenced_stats, const string &stats_alias);
 	virtual string GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
-	                                            unordered_set<string> &referenced_stats);
+	                                            unordered_set<string> &referenced_stats, const string &stats_alias);
 	virtual bool ValueIsFinite(const Value &val);
 	virtual string CastValueToTarget(const Value &val, const LogicalType &type);
 	virtual string CastStatsToTarget(const string &stats, const LogicalType &type);
 	virtual string GenerateConstantFilter(ExpressionType comparison_type, const Value &constant,
-	                                      const LogicalType &type, unordered_set<string> &referenced_stats);
+	                                      const LogicalType &type, unordered_set<string> &referenced_stats,
+	                                      const string &stats_alias);
 	virtual string GenerateConstantFilterDouble(ExpressionType comparison_type, const Value &constant,
-	                                            const LogicalType &type, unordered_set<string> &referenced_stats);
-	virtual string GenerateFilterPushdown(const ExpressionFilter &filter, unordered_set<string> &referenced_stats);
+	                                            const LogicalType &type, unordered_set<string> &referenced_stats,
+	                                            const string &stats_alias);
+	virtual string GenerateFilterPushdown(const ExpressionFilter &filter, unordered_set<string> &referenced_stats,
+	                                      const string &stats_alias);
 
 public:
 	//! Read inlined file deletions for regular table scans (no snapshot info per row)

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -526,7 +526,8 @@ private:
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);
 	virtual string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
 	                                                  TableIndex table_id);
-	//! Join in the stats of every column a filter reads, once per column
+	//! Join each column's stats CTE once. Leading newline per join, empty when there are none, so it
+	//! concatenates straight onto the FROM line.
 	static string GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements);
 	virtual string GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
 	                                            unordered_set<string> &referenced_stats, const string &stats_alias);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -69,7 +69,6 @@ struct DuckLakeInlinedColNames {
 struct CTERequirement {
 	idx_t column_field_index;
 	unordered_set<string> referenced_stats;
-	idx_t reference_count = 1;
 
 	CTERequirement(idx_t col_idx, unordered_set<string> stats)
 	    : column_field_index(col_idx), referenced_stats(std::move(stats)) {
@@ -81,8 +80,6 @@ struct FilterSQLResult {
 	unordered_map<idx_t, CTERequirement> required_ctes;
 
 	FilterSQLResult() = default;
-	FilterSQLResult(string conditions) : where_conditions(std::move(conditions)) {
-	}
 };
 
 struct ColumnFilterInfo {
@@ -129,7 +126,6 @@ struct FilterPushdownQueryComponents {
 	string cte_section;
 	string join_clause;
 	string where_clause;
-	string order_by_clause;
 };
 
 //! The DuckLake metadata manger is the communication layer between the system and the metadata catalog
@@ -532,8 +528,6 @@ private:
 	                                                  TableIndex table_id);
 	//! Join in the stats of every column a filter reads, once per column
 	static string GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements);
-	virtual string GenerateFilterFromTableFilter(const ExpressionFilter &filter, const LogicalType &type,
-	                                             unordered_set<string> &referenced_stats, const string &stats_alias);
 	virtual string GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
 	                                            unordered_set<string> &referenced_stats, const string &stats_alias);
 	virtual bool ValueIsFinite(const Value &val);

--- a/src/include/storage/ducklake_metadata_manager.hpp
+++ b/src/include/storage/ducklake_metadata_manager.hpp
@@ -77,7 +77,8 @@ struct CTERequirement {
 
 struct FilterSQLResult {
 	string where_conditions;
-	unordered_map<idx_t, CTERequirement> required_ctes;
+	//! Ordered by column field index so the generated SQL does not depend on hash iteration order
+	map<idx_t, CTERequirement> required_ctes;
 
 	FilterSQLResult() = default;
 };
@@ -524,11 +525,11 @@ private:
 	//! any metadata backend (DuckDB / Postgres / SQLite). Bucket hashes are pre-computed in C++.
 	string BuildBucketPartitionPruningClause(DuckLakeTableEntry &table, const FilterPushdownInfo &filter_info);
 	virtual FilterSQLResult ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info);
-	virtual string GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
+	virtual string GenerateCTESectionFromRequirements(const map<idx_t, CTERequirement> &requirements,
 	                                                  TableIndex table_id);
 	//! Join each column's stats CTE once. Leading newline per join, empty when there are none, so it
 	//! concatenates straight onto the FROM line.
-	static string GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements);
+	static string GenerateStatsJoinList(const map<idx_t, CTERequirement> &requirements);
 	virtual string GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
 	                                            unordered_set<string> &referenced_stats, const string &stats_alias);
 	virtual bool ValueIsFinite(const Value &val);

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1,4 +1,6 @@
 #include "storage/ducklake_metadata_manager.hpp"
+
+#include <algorithm>
 #include "duckdb/common/file_system.hpp"
 #include "functions/ducklake_table_functions.hpp"
 #include "storage/ducklake_transaction.hpp"
@@ -1292,17 +1294,23 @@ static void SetSnapshotFilter(const DuckLakeSnapshot &snapshot, idx_t max_partia
 	file_entry.snapshot_filter_max = snapshot.snapshot_id;
 }
 
+//! Reference a stats column through the join that brought it in
+static string StatsColumn(const string &stats_alias, const string &stat) {
+	return stats_alias + "." + stat;
+}
+
 static bool IsSimpleFilterSubject(const Expression &expr) {
 	return expr.GetExpressionClass() == ExpressionClass::BOUND_REF ||
 	       expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
 }
 
 string DuckLakeMetadataManager::GenerateFilterFromTableFilter(const ExpressionFilter &filter, const LogicalType &type,
-                                                              unordered_set<string> &referenced_stats) {
+                                                              unordered_set<string> &referenced_stats,
+                                                              const string &stats_alias) {
 	if (!filter.expr) {
 		return string();
 	}
-	return GenerateFilterFromExpression(*filter.expr, &type, referenced_stats);
+	return GenerateFilterFromExpression(*filter.expr, &type, referenced_stats, stats_alias);
 }
 
 bool DuckLakeMetadataManager::ValueIsFinite(const Value &val) {
@@ -1336,14 +1344,14 @@ string DuckLakeMetadataManager::CastColumnToTarget(const string &column, const L
 }
 
 string DuckLakeMetadataManager::GenerateConstantFilter(ExpressionType comparison_type, const Value &constant,
-                                                       const LogicalType &type,
-                                                       unordered_set<string> &referenced_stats) {
+                                                       const LogicalType &type, unordered_set<string> &referenced_stats,
+                                                       const string &stats_alias) {
 	auto constant_str = CastValueToTarget(constant, type);
 	if (constant_str.find('\0') != string::npos) {
 		return string();
 	}
-	auto min_value = CastStatsToTarget("min_value", type);
-	auto max_value = CastStatsToTarget("max_value", type);
+	auto min_value = CastStatsToTarget(StatsColumn(stats_alias, "min_value"), type);
+	auto max_value = CastStatsToTarget(StatsColumn(stats_alias, "max_value"), type);
 	switch (comparison_type) {
 	case ExpressionType::COMPARE_EQUAL:
 		// x = constant
@@ -1385,7 +1393,8 @@ string DuckLakeMetadataManager::GenerateConstantFilter(ExpressionType comparison
 
 string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comparison_type, const Value &constant,
                                                              const LogicalType &type,
-                                                             unordered_set<string> &referenced_stats) {
+                                                             unordered_set<string> &referenced_stats,
+                                                             const string &stats_alias) {
 	double constant_val = constant.GetValue<double>();
 	bool constant_is_nan = Value::IsNan(constant_val);
 	switch (comparison_type) {
@@ -1394,10 +1403,10 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 		if (constant_is_nan) {
 			// x = NAN - check for `contains_nan`
 			referenced_stats.insert("contains_nan");
-			return "contains_nan";
+			return StatsColumn(stats_alias, "contains_nan");
 		}
 		// else check as if this is a numeric
-		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats, stats_alias);
 	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
 	case ExpressionType::COMPARE_GREATERTHAN: {
 		if (constant_is_nan) {
@@ -1407,13 +1416,13 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// generate the numeric filter
-		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats, stats_alias);
 		if (filter.empty()) {
 			return string();
 		}
 		// since NaN is bigger than anything - we also need to check for contains_nan
 		referenced_stats.insert("contains_nan");
-		return filter + " OR contains_nan";
+		return filter + " OR " + StatsColumn(stats_alias, "contains_nan");
 	}
 	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
 	case ExpressionType::COMPARE_LESSTHAN:
@@ -1422,7 +1431,7 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// these are equivalent to the numeric filter
-		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		return GenerateConstantFilter(comparison_type, constant, type, referenced_stats, stats_alias);
 	case ExpressionType::COMPARE_NOTEQUAL: {
 		// x <> constant
 		if (constant_is_nan) {
@@ -1432,13 +1441,13 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 			return string();
 		}
 		// generate the numeric filter
-		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats);
+		string filter = GenerateConstantFilter(comparison_type, constant, type, referenced_stats, stats_alias);
 		if (filter.empty()) {
 			return string();
 		}
 		// NaN <> constant is always true, so we must also keep files that contain NaN
 		referenced_stats.insert("contains_nan");
-		return filter + " OR contains_nan";
+		return filter + " OR " + StatsColumn(stats_alias, "contains_nan");
 	}
 	default:
 		// unsupported
@@ -1447,7 +1456,8 @@ string DuckLakeMetadataManager::GenerateConstantFilterDouble(ExpressionType comp
 }
 
 string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &expr, const LogicalType *type,
-                                                             unordered_set<string> &referenced_stats) {
+                                                             unordered_set<string> &referenced_stats,
+                                                             const string &stats_alias) {
 	if (BoundComparisonExpression::IsComparison(expr)) {
 		auto &comparison = expr.Cast<BoundFunctionExpression>();
 		auto &left = BoundComparisonExpression::Left(comparison);
@@ -1469,9 +1479,10 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		case LogicalTypeId::FLOAT:
 		case LogicalTypeId::DOUBLE:
 			return GenerateConstantFilterDouble(comparison_type, constant_expr->GetValue(), target_type,
-			                                    referenced_stats);
+			                                    referenced_stats, stats_alias);
 		default:
-			return GenerateConstantFilter(comparison_type, constant_expr->GetValue(), target_type, referenced_stats);
+			return GenerateConstantFilter(comparison_type, constant_expr->GetValue(), target_type, referenced_stats,
+			                              stats_alias);
 		}
 	}
 	switch (expr.GetExpressionClass()) {
@@ -1483,13 +1494,13 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 				return string();
 			}
 			referenced_stats.insert("null_count");
-			return "null_count > 0";
+			return StatsColumn(stats_alias, "null_count") + " > 0";
 		case ExpressionType::OPERATOR_IS_NOT_NULL:
 			if (op_expr.GetChildren().size() != 1 || !IsSimpleFilterSubject(*op_expr.GetChildren()[0])) {
 				return string();
 			}
 			referenced_stats.insert("value_count");
-			return "value_count > 0";
+			return StatsColumn(stats_alias, "value_count") + " > 0";
 		case ExpressionType::COMPARE_IN: {
 			if (op_expr.GetChildren().size() < 2 || !IsSimpleFilterSubject(*op_expr.GetChildren()[0])) {
 				return string();
@@ -1512,11 +1523,11 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 				case LogicalTypeId::FLOAT:
 				case LogicalTypeId::DOUBLE:
 					next_filter = GenerateConstantFilterDouble(ExpressionType::COMPARE_EQUAL, constant_value,
-					                                           target_type, referenced_stats);
+					                                           target_type, referenced_stats, stats_alias);
 					break;
 				default:
 					next_filter = GenerateConstantFilter(ExpressionType::COMPARE_EQUAL, constant_value, target_type,
-					                                     referenced_stats);
+					                                     referenced_stats, stats_alias);
 					break;
 				}
 				if (next_filter.empty()) {
@@ -1538,7 +1549,7 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		string result;
 		const auto conjunction_type = expr.GetExpressionType();
 		for (auto &child : conjunction.GetChildren()) {
-			auto child_str = GenerateFilterFromExpression(*child, type, referenced_stats);
+			auto child_str = GenerateFilterFromExpression(*child, type, referenced_stats, stats_alias);
 			if (child_str.empty()) {
 				if (conjunction_type == ExpressionType::CONJUNCTION_OR) {
 					return string();
@@ -1557,13 +1568,13 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 		if (func.Function().GetName() == OptionalFilterScalarFun::NAME && func.BindInfo()) {
 			auto &data = func.BindInfo()->Cast<OptionalFilterFunctionData>();
 			return data.child_filter_expr
-			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
+			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats, stats_alias)
 			           : string();
 		}
 		if (func.Function().GetName() == SelectivityOptionalFilterScalarFun::NAME && func.BindInfo()) {
 			auto &data = func.BindInfo()->Cast<SelectivityOptionalFilterFunctionData>();
 			return data.child_filter_expr
-			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats)
+			           ? GenerateFilterFromExpression(*data.child_filter_expr, type, referenced_stats, stats_alias)
 			           : string();
 		}
 		return string();
@@ -1574,11 +1585,12 @@ string DuckLakeMetadataManager::GenerateFilterFromExpression(const Expression &e
 }
 
 string DuckLakeMetadataManager::GenerateFilterPushdown(const ExpressionFilter &filter,
-                                                       unordered_set<string> &referenced_stats) {
+                                                       unordered_set<string> &referenced_stats,
+                                                       const string &stats_alias) {
 	if (!filter.expr) {
 		return string();
 	}
-	return GenerateFilterFromExpression(*filter.expr, nullptr, referenced_stats);
+	return GenerateFilterFromExpression(*filter.expr, nullptr, referenced_stats, stats_alias);
 }
 
 FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const FilterPushdownInfo &filter_info) {
@@ -1588,18 +1600,18 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 	for (const auto &entry : filter_info.column_filters) {
 		const auto &column_filter = entry.second;
 
+		string cte_name = StringUtil::Format("col_%d_stats", column_filter.column_field_index);
+
 		unordered_set<string> referenced_stats;
-		auto filter_condition = GenerateFilterPushdown(*column_filter.table_filter, referenced_stats);
+		auto filter_condition = GenerateFilterPushdown(*column_filter.table_filter, referenced_stats, cte_name);
 
 		if (filter_condition.empty()) {
 			continue;
 		}
 
-		string cte_name = StringUtil::Format("col_%d_stats", column_filter.column_field_index);
-
 		string null_checks;
 		for (const auto &stat : referenced_stats) {
-			null_checks += stat + " IS NULL OR ";
+			null_checks += StatsColumn(cte_name, stat) + " IS NULL OR ";
 		}
 
 		const bool needs_value_count_guard =
@@ -1611,21 +1623,21 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 		if (!conditions.empty()) {
 			conditions += " AND ";
 		}
-		// Files that have no stats entry for this column (i.e., written before the column was added) must
-		// NOT be pruned, we cannot determine filter satisfaction without stats.
+		// Files that have no stats entry for this column (i.e., written before the column was added) join to
+		// NULL and must NOT be pruned, we cannot determine filter satisfaction without stats.
 		if (needs_value_count_guard) {
-			conditions += StringUtil::Format("(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
-			                                 "data.data_file_id IN (SELECT data_file_id FROM %s WHERE "
-			                                 "(value_count IS NULL OR value_count > 0) AND (%s(%s))))",
-			                                 cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
+			auto value_count = StatsColumn(cte_name, "value_count");
+			conditions += StringUtil::Format("(%s.data_file_id IS NULL OR ((%s IS NULL OR %s > 0) AND (%s(%s))))",
+			                                 cte_name.c_str(), value_count.c_str(), value_count.c_str(),
+			                                 null_checks.c_str(), filter_condition.c_str());
 		} else {
-			conditions += StringUtil::Format("(data.data_file_id NOT IN (SELECT data_file_id FROM %s) OR "
-			                                 "data.data_file_id IN (SELECT data_file_id FROM %s WHERE %s(%s)))",
-			                                 cte_name, cte_name, null_checks.c_str(), filter_condition.c_str());
+			conditions += StringUtil::Format("(%s.data_file_id IS NULL OR (%s(%s)))", cte_name.c_str(),
+			                                 null_checks.c_str(), filter_condition.c_str());
 		}
 
+		// the stats are joined in once per column, however many conditions end up reading them
 		CTERequirement req(column_filter.column_field_index, referenced_stats);
-		req.reference_count = 2;
+		req.reference_count = 1;
 		result.required_ctes.emplace(column_filter.column_field_index, std::move(req));
 	}
 
@@ -1642,6 +1654,23 @@ string DuckLakeMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 	                          "  FROM {METADATA_CATALOG}.ducklake_file_column_stats\n"
 	                          "  WHERE column_id = %d AND table_id = %d\n",
 	                          select_list, req.column_field_index, table_id.index);
+}
+
+string DuckLakeMetadataManager::GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements) {
+	// sorted so the generated query is stable across runs - the requirements live in a hash map
+	vector<idx_t> field_indexes;
+	for (const auto &entry : requirements) {
+		field_indexes.push_back(entry.first);
+	}
+	std::sort(field_indexes.begin(), field_indexes.end());
+
+	string result;
+	for (auto field_index : field_indexes) {
+		auto cte_name = StringUtil::Format("col_%d_stats", field_index);
+		result += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
+		                             cte_name.c_str());
+	}
+	return result;
 }
 
 string
@@ -1684,6 +1713,7 @@ DuckLakeMetadataManager::GenerateFilterPushdownComponents(const FilterPushdownIn
 
 	auto filter_result = ConvertFilterPushdownToSQL(filter_info);
 	result.cte_section = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id);
+	result.join_clause = GenerateStatsJoinList(filter_result.required_ctes);
 	result.where_clause = filter_result.where_conditions;
 
 	return result;
@@ -1916,20 +1946,17 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 		} else {
 			entry->second.referenced_stats.insert("min_value");
 			entry->second.referenced_stats.insert("max_value");
-			// The static filter has two references to this CTE; the Top-N stats join adds one more.
-			entry->second.reference_count++;
 		}
 	}
 	query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id);
+	// one join per column serves both the filter conditions and the Top-N stats below
+	string stats_join_list = GenerateStatsJoinList(filter_result.required_ctes);
 
 	string stats_select_list;
-	string stats_join_list;
 	string order_by_clause;
 	for (auto &dfc : dynamic_filter_columns) {
 		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
 		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
-		stats_join_list += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
-		                                      cte_name.c_str());
 
 		// Generate ORDER BY clause to optimize Top-N queries - order files by their min/max stats
 		// so we find satisfying rows early and can skip remaining files via dynamic filter pruning.
@@ -2293,12 +2320,14 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 	                     GetDeleteFileSelectList("del") + ", del.begin_snapshot";
 
 	string query;
+	string join_clause;
 	string where_clause;
 
 	// Generate CTE section and WHERE clause if we have filter pushdown info
 	if (filter_info && !filter_info->column_filters.empty()) {
 		auto components = GenerateFilterPushdownComponents(*filter_info, table);
 		query = components.cte_section;
+		join_clause = components.join_clause;
 		where_clause = components.where_clause;
 
 		// Add bucket-partition pruning (see GetFilesForTable for rationale).
@@ -2317,15 +2346,16 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 	query += StringUtil::Format(R"(
 SELECT data.data_file_id, del.delete_file_id, data.record_count, %s
 FROM {METADATA_CATALOG}.ducklake_data_file data
+%s
 LEFT JOIN (
 	SELECT *
     FROM {METADATA_CATALOG}.ducklake_delete_file
     WHERE table_id=%d  AND {SNAPSHOT_ID} >= begin_snapshot
           AND ({SNAPSHOT_ID} < end_snapshot OR end_snapshot IS NULL)
-    ) del USING (data_file_id)
+    ) del ON del.data_file_id = data.data_file_id
 WHERE data.table_id=%d AND {SNAPSHOT_ID} >= data.begin_snapshot AND ({SNAPSHOT_ID} < data.end_snapshot OR data.end_snapshot IS NULL)
 		)",
-	                            select_list, table_id.index, table_id.index);
+	                            select_list, join_clause, table_id.index, table_id.index);
 
 	// Add WHERE clause from filters if it was generated
 	if (!where_clause.empty()) {

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1,6 +1,4 @@
 #include "storage/ducklake_metadata_manager.hpp"
-
-#include <algorithm>
 #include "duckdb/common/file_system.hpp"
 #include "functions/ducklake_table_functions.hpp"
 #include "storage/ducklake_transaction.hpp"
@@ -1653,27 +1651,18 @@ string DuckLakeMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 	                          select_list, req.column_field_index, table_id.index);
 }
 
-string DuckLakeMetadataManager::GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements) {
-	// sorted so the generated query is stable across runs - the requirements live in a hash map
-	vector<idx_t> field_indexes;
-	field_indexes.reserve(requirements.size());
-	for (const auto &entry : requirements) {
-		field_indexes.push_back(entry.first);
-	}
-	std::sort(field_indexes.begin(), field_indexes.end());
-
+string DuckLakeMetadataManager::GenerateStatsJoinList(const map<idx_t, CTERequirement> &requirements) {
 	string result;
-	for (auto field_index : field_indexes) {
-		auto cte_name = StatsCteName(field_index);
+	for (const auto &entry : requirements) {
+		auto cte_name = StatsCteName(entry.first);
 		result += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
 		                             cte_name.c_str());
 	}
 	return result;
 }
 
-string
-DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<idx_t, CTERequirement> &requirements,
-                                                            TableIndex table_id) {
+string DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const map<idx_t, CTERequirement> &requirements,
+                                                                   TableIndex table_id) {
 	if (requirements.empty()) {
 		return "";
 	}
@@ -1689,7 +1678,7 @@ DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<
 		}
 		first_cte = false;
 
-		// each CTE is joined exactly once, so DuckDB inlines it either way - no hint to give
+		// each CTE is referenced by exactly one join, so there is nothing for a materialization hint to buy
 		cte_section += StatsCteName(req.column_field_index) + " AS (\n";
 		cte_section += GenerateFileColumnStatsCTEBody(req, table_id);
 		cte_section += ")";
@@ -1937,14 +1926,11 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 	}
 
 	for (auto &dfc : dynamic_filter_columns) {
-		auto entry = filter_result.required_ctes.find(dfc.column_field_index);
-		if (entry == filter_result.required_ctes.end()) {
-			filter_result.required_ctes.emplace(dfc.column_field_index,
-			                                    CTERequirement(dfc.column_field_index, {"min_value", "max_value"}));
-		} else {
-			entry->second.referenced_stats.insert("min_value");
-			entry->second.referenced_stats.insert("max_value");
-		}
+		auto entry =
+		    filter_result.required_ctes.emplace(dfc.column_field_index, CTERequirement(dfc.column_field_index, {}))
+		        .first;
+		entry->second.referenced_stats.insert("min_value");
+		entry->second.referenced_stats.insert("max_value");
 	}
 	query = GenerateCTESectionFromRequirements(filter_result.required_ctes, table_id);
 	// one join per column serves both the filter conditions and the Top-N stats below

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1304,15 +1304,6 @@ static bool IsSimpleFilterSubject(const Expression &expr) {
 	       expr.GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF;
 }
 
-string DuckLakeMetadataManager::GenerateFilterFromTableFilter(const ExpressionFilter &filter, const LogicalType &type,
-                                                              unordered_set<string> &referenced_stats,
-                                                              const string &stats_alias) {
-	if (!filter.expr) {
-		return string();
-	}
-	return GenerateFilterFromExpression(*filter.expr, &type, referenced_stats, stats_alias);
-}
-
 bool DuckLakeMetadataManager::ValueIsFinite(const Value &val) {
 	if (val.type().id() != LogicalTypeId::FLOAT && val.type().id() != LogicalTypeId::DOUBLE) {
 		return true;
@@ -1621,7 +1612,7 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 		}
 
 		if (!conditions.empty()) {
-			conditions += " AND ";
+			conditions += "\n  AND ";
 		}
 		// Files that have no stats entry for this column (i.e., written before the column was added) join to
 		// NULL and must NOT be pruned, we cannot determine filter satisfaction without stats.
@@ -1635,10 +1626,8 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 			                                 null_checks.c_str(), filter_condition.c_str());
 		}
 
-		// the stats are joined in once per column, however many conditions end up reading them
-		CTERequirement req(column_filter.column_field_index, referenced_stats);
-		req.reference_count = 1;
-		result.required_ctes.emplace(column_filter.column_field_index, std::move(req));
+		result.required_ctes.emplace(column_filter.column_field_index,
+		                             CTERequirement(column_filter.column_field_index, referenced_stats));
 	}
 
 	result.where_conditions = conditions;
@@ -1691,8 +1680,8 @@ DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<
 		}
 		first_cte = false;
 
-		string materialized_hint = (req.reference_count > 1) ? " AS MATERIALIZED" : " AS NOT MATERIALIZED";
-		cte_section += StringUtil::Format("col_%d_stats%s (\n", req.column_field_index, materialized_hint.c_str());
+		// each CTE is joined exactly once, so DuckDB inlines it either way - no hint to give
+		cte_section += StringUtil::Format("col_%d_stats AS (\n", req.column_field_index);
 		cte_section += GenerateFileColumnStatsCTEBody(req, table_id);
 		cte_section += ")";
 	}
@@ -1956,7 +1945,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 	string order_by_clause;
 	for (auto &dfc : dynamic_filter_columns) {
 		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
-		stats_select_list += StringUtil::Format(", %s.min_value, %s.max_value", cte_name.c_str(), cte_name.c_str());
+		stats_select_list += ", " + StatsColumn(cte_name, "min_value") + ", " + StatsColumn(cte_name, "max_value");
 
 		// Generate ORDER BY clause to optimize Top-N queries - order files by their min/max stats
 		// so we find satisfying rows early and can skip remaining files via dynamic filter pruning.
@@ -1969,11 +1958,11 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 			                                dfc.comparison_type == ExpressionType::COMPARE_LESSTHANOREQUALTO;
 			if (seeking_high_values) {
 				// For DESC Top-N (seeking high values), order by max_value DESC so files with highest values come first
-				auto cast_expr = CastStatsToTarget(cte_name + ".max_value", dfc.column_type);
+				auto cast_expr = CastStatsToTarget(StatsColumn(cte_name, "max_value"), dfc.column_type);
 				order_by_clause = StringUtil::Format("\nORDER BY %s DESC NULLS LAST", cast_expr);
 			} else if (seeking_low_values) {
 				// For ASC Top-N (seeking low values), order by min_value ASC so files with lowest values come first
-				auto cast_expr = CastStatsToTarget(cte_name + ".min_value", dfc.column_type);
+				auto cast_expr = CastStatsToTarget(StatsColumn(cte_name, "min_value"), dfc.column_type);
 				order_by_clause = StringUtil::Format("\nORDER BY %s ASC NULLS LAST", cast_expr);
 			}
 		}
@@ -1986,8 +1975,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 	// Add base query
 	query += StringUtil::Format(R"(
 SELECT %s
-FROM {METADATA_CATALOG}.ducklake_data_file data
-%s
+FROM {METADATA_CATALOG}.ducklake_data_file data%s
 LEFT JOIN (
     SELECT *
     FROM {METADATA_CATALOG}.ducklake_delete_file
@@ -2345,8 +2333,7 @@ DuckLakeMetadataManager::GetExtendedFilesForTable(DuckLakeTableEntry &table, Duc
 	// Add base query
 	query += StringUtil::Format(R"(
 SELECT data.data_file_id, del.delete_file_id, data.record_count, %s
-FROM {METADATA_CATALOG}.ducklake_data_file data
-%s
+FROM {METADATA_CATALOG}.ducklake_data_file data%s
 LEFT JOIN (
 	SELECT *
     FROM {METADATA_CATALOG}.ducklake_delete_file

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1294,6 +1294,11 @@ static void SetSnapshotFilter(const DuckLakeSnapshot &snapshot, idx_t max_partia
 	file_entry.snapshot_filter_max = snapshot.snapshot_id;
 }
 
+//! The CTE a column's stats are read from - definition, join and conditions must agree
+static string StatsCteName(idx_t field_index) {
+	return StringUtil::Format("col_%d_stats", field_index);
+}
+
 //! Reference a stats column through the join that brought it in
 static string StatsColumn(const string &stats_alias, const string &stat) {
 	return stats_alias + "." + stat;
@@ -1591,7 +1596,7 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 	for (const auto &entry : filter_info.column_filters) {
 		const auto &column_filter = entry.second;
 
-		string cte_name = StringUtil::Format("col_%d_stats", column_filter.column_field_index);
+		auto cte_name = StatsCteName(column_filter.column_field_index);
 
 		unordered_set<string> referenced_stats;
 		auto filter_condition = GenerateFilterPushdown(*column_filter.table_filter, referenced_stats, cte_name);
@@ -1648,6 +1653,7 @@ string DuckLakeMetadataManager::GenerateFileColumnStatsCTEBody(const CTERequirem
 string DuckLakeMetadataManager::GenerateStatsJoinList(const unordered_map<idx_t, CTERequirement> &requirements) {
 	// sorted so the generated query is stable across runs - the requirements live in a hash map
 	vector<idx_t> field_indexes;
+	field_indexes.reserve(requirements.size());
 	for (const auto &entry : requirements) {
 		field_indexes.push_back(entry.first);
 	}
@@ -1655,7 +1661,7 @@ string DuckLakeMetadataManager::GenerateStatsJoinList(const unordered_map<idx_t,
 
 	string result;
 	for (auto field_index : field_indexes) {
-		auto cte_name = StringUtil::Format("col_%d_stats", field_index);
+		auto cte_name = StatsCteName(field_index);
 		result += StringUtil::Format("\nLEFT JOIN %s ON %s.data_file_id = data.data_file_id", cte_name.c_str(),
 		                             cte_name.c_str());
 	}
@@ -1681,7 +1687,7 @@ DuckLakeMetadataManager::GenerateCTESectionFromRequirements(const unordered_map<
 		first_cte = false;
 
 		// each CTE is joined exactly once, so DuckDB inlines it either way - no hint to give
-		cte_section += StringUtil::Format("col_%d_stats AS (\n", req.column_field_index);
+		cte_section += StatsCteName(req.column_field_index) + " AS (\n";
 		cte_section += GenerateFileColumnStatsCTEBody(req, table_id);
 		cte_section += ")";
 	}
@@ -1944,7 +1950,7 @@ vector<DuckLakeFileListEntry> DuckLakeMetadataManager::GetFilesForTable(DuckLake
 	string stats_select_list;
 	string order_by_clause;
 	for (auto &dfc : dynamic_filter_columns) {
-		auto cte_name = StringUtil::Format("col_%d_stats", NumericCast<int64_t>(dfc.column_field_index));
+		auto cte_name = StatsCteName(dfc.column_field_index);
 		stats_select_list += ", " + StatsColumn(cte_name, "min_value") + ", " + StatsColumn(cte_name, "max_value");
 
 		// Generate ORDER BY clause to optimize Top-N queries - order files by their min/max stats

--- a/src/storage/ducklake_metadata_manager.cpp
+++ b/src/storage/ducklake_metadata_manager.cpp
@@ -1610,8 +1610,11 @@ FilterSQLResult DuckLakeMetadataManager::ConvertFilterPushdownToSQL(const Filter
 			null_checks += StatsColumn(cte_name, stat) + " IS NULL OR ";
 		}
 
+		// a filter that a NULL row can satisfy must not prune files that only hold NULLs, even though their
+		// min/max are absent - only a purely value-based filter may use the guard
+		const bool matches_null_rows = referenced_stats.count("null_count") > 0;
 		const bool needs_value_count_guard =
-		    referenced_stats.count("min_value") > 0 || referenced_stats.count("max_value") > 0;
+		    !matches_null_rows && (referenced_stats.count("min_value") > 0 || referenced_stats.count("max_value") > 0);
 		if (needs_value_count_guard) {
 			referenced_stats.insert("value_count");
 		}

--- a/test/sql/stats/filter_pushdown_all_null_files.test
+++ b/test/sql/stats/filter_pushdown_all_null_files.test
@@ -1,0 +1,49 @@
+# name: test/sql/stats/filter_pushdown_all_null_files.test
+# description: Test that files holding only NULLs are kept for filters a NULL row satisfies
+# group: [stats]
+
+require ducklake
+
+require parquet
+
+test-env DUCKLAKE_CONNECTION {TEST_DIR}/{UUID}.db
+
+test-env DATA_PATH {TEST_DIR}
+
+statement ok
+ATTACH 'ducklake:{DUCKLAKE_CONNECTION}' AS ducklake (DATA_PATH '{DATA_PATH}/ducklake_all_null_files', DATA_INLINING_ROW_LIMIT 0)
+
+statement ok
+CREATE TABLE ducklake.t(a INTEGER);
+
+statement ok
+INSERT INTO ducklake.t SELECT i FROM range(1, 101) t(i);
+
+statement ok
+INSERT INTO ducklake.t SELECT i FROM range(101, 201) t(i);
+
+# a file with no values at all - min/max are absent and value_count is 0
+statement ok
+INSERT INTO ducklake.t VALUES (NULL);
+
+# the value predicate alone cannot be satisfied by a NULL, so the all-NULL file is pruned
+query II
+EXPLAIN ANALYZE SELECT COUNT(*) FROM ducklake.t WHERE a = 50;
+----
+analyzed_plan	<REGEX>:.*Total Files Read: 1.*
+
+# once a branch matches NULLs the file has to be read, even though it has no min/max
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE a >= 30 OR a IS NULL;
+----
+172
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE a = 50 OR a IS NULL;
+----
+2
+
+query I
+SELECT COUNT(*) FROM ducklake.t WHERE a IS NULL;
+----
+1

--- a/test/sql/stats/topn_file_pruning.test
+++ b/test/sql/stats/topn_file_pruning.test
@@ -84,6 +84,7 @@ query I
 SELECT COUNT(*) = 1
 FROM duckdb_logs_parsed('DuckLakeMetadata')
 WHERE query LIKE '%LEFT JOIN col_1_stats%'
+  AND query LIKE '%ORDER BY%'
   AND query LIKE '%2026-01-02 00:00:00%'
   AND length(query) - length(replace(query, '2026-01-02 00:00:00', '')) =
       length('2026-01-02 00:00:00');

--- a/test/sql/stats/topn_file_pruning.test
+++ b/test/sql/stats/topn_file_pruning.test
@@ -102,13 +102,13 @@ SELECT CASE WHEN (SELECT catalog_type FROM settings()) = 'postgres' THEN
      WHERE query LIKE '%postgres_query%'
        AND query LIKE '%ducklake_file_column_stats%'
        AND query LIKE '%WHERE column_id = 1 AND table_id = 1%'
-       AND query LIKE '%col_1_stats AS MATERIALIZED%'
+       AND query LIKE '%col_1_stats AS (%'
        AND query LIKE '%LEFT JOIN col_1_stats%'
        AND query LIKE '%min_value%'
        AND query LIKE '%max_value%'
        AND query LIKE '%value_count%'
-       AND length(query) - length(replace(query, 'col_1_stats AS MATERIALIZED', '')) =
-           length('col_1_stats AS MATERIALIZED'))
+       AND length(query) - length(replace(query, 'col_1_stats AS (', '')) =
+           length('col_1_stats AS ('))
     ELSE true END;
 ----
 true


### PR DESCRIPTION
Splits a piece out of #1421 that stands on its own: join each column's stats CTE once instead of testing membership against it with a pair of `IN (SELECT ...)` subqueries. A file with no stats row for the column becomes `col_N_stats.data_file_id IS NULL` rather than a `NOT IN`.

Once several stats CTEs are in scope the stat names are ambiguous, so the existing virtual leaf methods take the CTE alias and qualify what they emit. No metadata backend needs changes.

Behaviour is unchanged. Measured against a copy of a 590k-file catalog (11.4M rows in `ducklake_file_column_stats`), filtering one table on N columns - one condition per column, which is the shape `main` already generates:

| filtered columns | before | after |
| --- | --- | --- |
| 1 | 17 ms | 15 ms |
| 2 | 27 ms | 26 ms |
| 4 | 51 ms | 30 ms |
| 6 | 74 ms | 30 ms |
| 8 | 102 ms | 32 ms |
| 10 | 126 ms | 32 ms |

Roughly 12 ms per filtered column before, flat after. It matters more under #1421, where one column can carry many conditions: on the same filter tree a 40 branch disjunction goes from 730 ms to 52 ms.

Every stats CTE is now referenced exactly once, so `reference_count` and the `MATERIALIZED` hint it drove are both gone - `cte_inlining` inlines at a reference count of one regardless of the hint, and `MATERIALIZED` would have blocked the inline. Also drops three things in this path that turned out to be dead: `GenerateFilterFromTableFilter`, `FilterPushdownQueryComponents::order_by_clause` and the single-argument `FilterSQLResult` constructor.

`ducklake_file_column_stats` holds at most one row per `(table_id, column_id, data_file_id)`, so the join cannot duplicate a data file row. The Top-N path already depended on this; it is now load-bearing for every filtered scan, which seems worth stating in the spec.

`topn_file_pruning.test` used `LEFT JOIN col_1_stats` to pick out the Top-N query, which no longer identifies it now that every filtered query has that join, and its PostgreSQL-only assertion matched on `col_1_stats AS MATERIALIZED`.

Done with AI help