### PR TITLE
Exclude 3 core tests

### DIFF
--- a/test/configs/attach_ducklake.json
+++ b/test/configs/attach_ducklake.json
@@ -160,7 +160,8 @@
         "test/sql/cte/materialized/materialized_cte_order_preservation.test",
         "test/sql/cte/materialized/materialized_cte_parallel_buffered.test",
         "test/optimizer/partial_aggregate_pushdown.test",
-        "test/sql/optimizer/pushdown_extract_reapplied.test"
+        "test/sql/optimizer/pushdown_extract_reapplied.test",
+        "test/sql/optimizer/topn_window_elimination_multiplicity.test"
       ]
     },
     {
@@ -934,6 +935,13 @@
       "reason": "DuckLake MERGE INTO plans use an extension sink instead of the native Insert operator.",
       "paths": [
         "test/sql/merge/merge_into_explain_analyze.test"
+      ]
+    },
+    {
+      "reason": "Nested schemas handling",
+      "paths": [
+        "test/sql/attach/attach_enums.test",
+        "test/sql/attach/deeply_nested_entries.test"
       ]
     }
   ]


### PR DESCRIPTION
This PR adds the following core tests to the exclusion list:

 - `test/sql/attach/attach_enums.test`
 - `test/sql/attach/deeply_nested_entries.test`
 - `test/sql/optimizer/topn_window_elimination_multiplicity.test`

Failures details just for the record:

```
test/sql/attach/attach_enums.test:21
================================================================================

Error: Query failed, but error message did not match expected error message: Type with name "xx.db1.main.mood" does not exist because schema "xx.db1.main" does not exist. (test/sql/attach/attach_enums.test:21)!
================================================================================
SELECT enum_range(NULL::xx.db1.main.mood) AS my_enum_range;
================================================================================
Actual result:
================================================================================
Catalog Error: Type with name mood does not exist!
Did you mean "db1.mood"?

LINE 1: SELECT enum_range(NULL::xx.db1.main.mood) AS my_enum_range;
                                ^^^^^^^^^^^^^^^^
```
```
test/sql/catalog/nested_schema/deeply_nested_entries.test:17
================================================================================

Error: Wrong result in query! (test/sql/catalog/nested_schema/deeply_nested_entries.test:17)!
================================================================================
SELECT schema_name, parent_schema FROM duckdb_schemas() WHERE schema_name IN ('s1','s2','s3','s4') ORDER BY schema_name;
================================================================================
Mismatch on row 2, column parent_schema(index 2)
NULL <> s1
================================================================================
Expected result:
================================================================================
s1	NULL
s2	s1
s3	s2
s4	s3

================================================================================
Actual result:
================================================================================
s1	NULL
s2	NULL
s3	NULL
s4	NULL

```
```
test/sql/optimizer/topn_window_elimination_multiplicity.test:110
================================================================================
Wrong result in query! (test/sql/optimizer/topn_window_elimination_multiplicity.test:110)!
================================================================================
EXPLAIN SELECT id, p
FROM topn_unique_rowids
QUALIFY ROW_NUMBER() OVER (ORDER BY s DESC NULLS LAST) <= 2;
================================================================================
Mismatch on row 1, column explain_value(index 2)
╭─ Projection ───────────────────────────────╮
│ Expressions: id, p                         │
│ ~0 rows                                    │
╰──────────────────────┬─────────────────────╯
╭─ Projection ─────────┴─────────────────────╮
│ Expressions: #0, #1                        │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Projection ─────────┴─────────────────────╮
│ Expressions: #[0.1], #[0.2]                │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Unnest ─────────────┴─────────────────────╮
│ Expressions: UNNEST(#0)                    │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Aggregate ──────────┴─────────────────────╮
│ Expressions:                               │
│ arg_max(struct_pack(#[0.1], #[0.2]), s, 2) │
╰──────────────────────┬─────────────────────╯
╭─ Ducklake Scan ──────┴─────────────────────╮
│ Table: topn_unique_rowids                  │
│ ~3 rows                                    │
╰────────────────────────────────────────────╯
 <> <REGEX>:.*Join Type: SEMI.*
================================================================================
Expected result:
================================================================================
logical_opt	<REGEX>:.*Join Type: SEMI.*

================================================================================
Actual result:
================================================================================
logical_opt	╭─ Projection ───────────────────────────────╮
│ Expressions: id, p                         │
│ ~0 rows                                    │
╰──────────────────────┬─────────────────────╯
╭─ Projection ─────────┴─────────────────────╮
│ Expressions: #0, #1                        │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Projection ─────────┴─────────────────────╮
│ Expressions: #[0.1], #[0.2]                │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Unnest ─────────────┴─────────────────────╮
│ Expressions: UNNEST(#0)                    │
│ ~1 row                                     │
╰──────────────────────┬─────────────────────╯
╭─ Aggregate ──────────┴─────────────────────╮
│ Expressions:                               │
│ arg_max(struct_pack(#[0.1], #[0.2]), s, 2) │
╰──────────────────────┬─────────────────────╯
╭─ Ducklake Scan ──────┴─────────────────────╮
│ Table: topn_unique_rowids                  │
│ ~3 rows                                    │
╰────────────────────────────────────────────╯
```